### PR TITLE
SIF analog fill: scale MPEG-1 352x240/352x288 to fill the analog output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -826,8 +826,8 @@ the old "unknown" sentinel), reframed by `dvd/mp2_reframer.sv`, decoded by
 ps_demux → reframers → audio_ring → dvd_audio_decode). Suite:
 `bench/dvd/run_mp2.sh`. 44.1 kHz (VCD) decodes bit-correct but plays ~8.8 % fast
 against the fixed 48 kHz NCO (future-VCD item).
-**SIF ANALOG FILL (2026-08-24, branch `feature/sif-analog-fill`, ⏳ HW-confirm
-pending):** SIF content used to show in the upper-left quarter of the ANALOG output
+**SIF ANALOG FILL — ✅ HW-CONFIRMED 2026-08-24 (PR #2):** SIF content used to
+show in the upper-left quarter of the ANALOG output
 (the syncgen DE window tracks the decoded size; `re_interlace` is hardcoded 720-wide).
 Now an in-core 2× fill — `disp_hstretch` 352→720 + the addrgen vscale walk re-armed as
 mode 2 (2× line repeat) + a syncgen-only effective-size mux in `mpeg2video.v` — gated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -836,9 +836,9 @@ True 240p output was REJECTED: no exact-59.94 Hz 240p modeline exists at 1716
 dots/line, so it would drift against the fixed 48 kHz audio NCO — line-doubled 480i
 carries the same content. Sub-D1 MPEG-2 (704/544) intentionally NOT filled (user scope
 decision; one predicate away). Design: `docs/mpeg1.md` §B.3; overlay inverse contract:
-`docs/crt_anamorphic.md` §9b. Sim: `resample_chain_tb +sif=1` variants (`+linetag`
-source map, `+hgrad` blend, `+crt` fields, `+siftog` runtime toggle),
-`crt_ov_map_tb` T1d/T6.
+`docs/crt_anamorphic.md` §9b. Sim: `resample_chain_tb +sif=1` variants (`+sif` runs
+co-sim the addrgen walk vs the 2× closed form; `+hgrad` blend, `+crt` fields,
+`+siftog` runtime toggle), `crt_ov_map_tb` T1d/T6.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -826,6 +826,19 @@ the old "unknown" sentinel), reframed by `dvd/mp2_reframer.sv`, decoded by
 ps_demux → reframers → audio_ring → dvd_audio_decode). Suite:
 `bench/dvd/run_mp2.sh`. 44.1 kHz (VCD) decodes bit-correct but plays ~8.8 % fast
 against the fixed 48 kHz NCO (future-VCD item).
+**SIF ANALOG FILL (2026-08-24, branch `feature/sif-analog-fill`, ⏳ HW-confirm
+pending):** SIF content used to show in the upper-left quarter of the ANALOG output
+(the syncgen DE window tracks the decoded size; `re_interlace` is hardcoded 720-wide).
+Now an in-core 2× fill — `disp_hstretch` 352→720 + the addrgen vscale walk re-armed as
+mode 2 (2× line repeat) + a syncgen-only effective-size mux in `mpeg2video.v` — gated
+on `analog_eff` (HDMI keeps ascal's scale; also fixes direct-video + un-clips the HUD).
+True 240p output was REJECTED: no exact-59.94 Hz 240p modeline exists at 1716
+dots/line, so it would drift against the fixed 48 kHz audio NCO — line-doubled 480i
+carries the same content. Sub-D1 MPEG-2 (704/544) intentionally NOT filled (user scope
+decision; one predicate away). Design: `docs/mpeg1.md` §B.3; overlay inverse contract:
+`docs/crt_anamorphic.md` §9b. Sim: `resample_chain_tb +sif=1` variants (`+linetag`
+source map, `+hgrad` blend, `+crt` fields, `+siftog` runtime toggle),
+`crt_ov_map_tb` T1d/T6.
 
 ---
 

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -531,4 +531,10 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 #   the passing one here. Seeds are tied to the EXACT synth/map netlist — a seed that
 #   passed (or failed) on a previous netlist carries NO information about this one. Always
 #   re-sweep after a change that moves ALMs; never assume a seed's verdict transfers.
-set_global_assignment -name SEED 9
+#
+# SIF-ANALOG-FILL netlist (2026-08-24, feature/sif-analog-fill): the inherited SEED 9
+# came in MARGINAL on `--compile` (clk_dec 78.83 MHz @100C, gate 86.0). Re-swept
+# (USE_DOCKER tools/seed_sweep.sh, FMAX_MIN=86.0): SEED 7 routes + PASSES both corners
+# (clk_dec 88.35 MHz @100C / 86.51 MHz @-40C) — first seed tried. Pinned SEED 7,
+# committed with the branch per the rule above.
+set_global_assignment -name SEED 7

--- a/README.md
+++ b/README.md
@@ -66,9 +66,14 @@ HUD and seek bar.
 - **Only 720×480, 720×576 and the MPEG-1 SIF sizes (352×240, 352×288) are well
   tested.** Other DVD-compliant MPEG-2 resolutions (704×480, 352×480 half-D1) are
   accepted by the spec but have had little or no testing here.
-- **Sub-D1 resolutions on the analog CRT output are untested** — the re-interlacer is
-  built around the 720-wide raster; MPEG-1 content is verified on HDMI (the scaler
-  handles it cleanly).
+- **MPEG-1 SIF content is scaled to fill the analog CRT output in-core** (2×
+  line repeat + a 352→720 stretch, engaged only while the analog output is active;
+  HDMI keeps the framework scaler's cleaner upscale). A true 240p output raster is
+  deliberately not offered: the core's A/V sync requires the raster to run at the
+  exact content rate against the fixed audio clock, and no exact-rate 240p modeline
+  exists at the 27 MHz dot clock — line-doubled 480i carries the same content to a
+  CRT, which is what DVD players do. Wider sub-D1 MPEG-2 (704/544-wide) is not
+  scaled and remains lightly tested on analog.
 - **Very demanding scenes may drop a frame.** The inherited decoder has a motion-comp /
   IDCT throughput ceiling, and on the heaviest content it can fall behind the display
   cadence. The frame-rate governor absorbs this by dropping a B-frame to stay in step —

--- a/bench/dvd/crt_ov_map_tb.sv
+++ b/bench/dvd/crt_ov_map_tb.sv
@@ -27,6 +27,13 @@
  *       map to the nearest-tap source line 2*(k_j + (r_j==2)) + parity (field) /
  *       k_j + (r_j==2) (progressive), bar/blank lines to 0xFFF. A second frame re-run
  *       proves the per-field re-arm.
+ *   T1d SIF fill (DVD-FORK FIX 2026-08-24): the same crop inverse at the SIF-fill
+ *       geometries 352 -> 720 (x0=0) and 256 -> 720 (Crop+SIF, x0=48). Forward geometry
+ *       (exactly hdst px, clean codes) + closed-form inverse with the right-edge clamp
+ *       (cr_near hits hsrc at the very last column at these ratios; both the forward
+ *       stage and the inverse clamp to hsrc-1). The T1a affine-tag exact co-sim is
+ *       ratio-independent and the 8-bit tag wraps at 352 sources, so the value check
+ *       here is the closed form.
  *   T4  Pass-through: both enables low => q_x_out/q_y_out combinationally equal the
  *       inputs (bit-identical wiring for HDMI / CRT-Fit).
  *   T5  spu_decode row-base adder under the mapped walks: the letterbox inverse map
@@ -35,6 +42,12 @@
  *       bmp[q_y*STRIDE + q_x]. Drives a REAL spu_decode (bitmap seeded hierarchically)
  *       with both mapped sequences plus the plain +1/+2 raster walks (regression) and
  *       compares every read against the golden array.
+ *   T6  SIF vertical 2x inverse (DVD-FORK FIX 2026-08-24): the v2x_en post-map vs a
+ *       behavioral model of the addrgen mode-2 walk (v_step=128, rounded):
+ *       progressive y -> min(floor((y+1)/2), v_src_max); interlaced field line i,
+ *       parity p -> min(p + 2*floor((i+1)/2), v_src_max). Four walks: progressive,
+ *       480i both fields, letterbox+v2x compose (progressive + 480i) with the 0xFFF
+ *       bar sentinel preserved.
  *
  * Build:
  *   iverilog -g2012 -D__IVERILOG__ -I rtl/mpeg2 -o bench/dvd/crt_ov_map_sim \
@@ -73,12 +86,15 @@ module crt_ov_map_tb;
     // ------------------------------------------------------------------
     reg         rst_n = 0;
     reg         letterbox_en = 0, crop_en = 0, interlaced = 0;
+    reg         v2x_en = 0;                    // DVD-FORK FIX (SIF analog fill)
+    reg  [11:0] v_src_max = 12'd479;           // decoded vertical_size - 1
     reg  [11:0] h_pos_in = 12'hFFF, v_pos_in = 12'hFFF;
     wire [11:0] q_x_out, q_y_out;
 
     crt_ov_map dut (
         .clk(clk), .rst_n(rst_n),
         .letterbox_en(letterbox_en), .crop_en(crop_en), .interlaced(interlaced),
+        .v2x_en(v2x_en), .v_src_max(v_src_max),
         .v_bar(P_VBAR), .v_band(P_VBAND),
         .hcrop_x0(P_HX0), .hsrc_w(P_HSRC), .hextra(P_HEXTRA),
         .h_pos_in(h_pos_in), .v_pos_in(v_pos_in),
@@ -221,6 +237,17 @@ module crt_ov_map_tb;
         cr_near = (j * HSRC + HDST / 2) / HDST;
     endfunction
 
+    // DVD-FORK FIX (SIF analog fill): behavioral model of the addrgen mode-2 2x walk
+    // (v_step=128, rounded) — output line y -> the source line it repeats.
+    function automatic integer v2x_src(input integer y, input integer il, input integer vmax);
+        integer fi, s;
+        begin
+            if (il) begin fi = y / 2; s = (y % 2) + 2 * ((fi + 1) / 2); end
+            else    s = (y + 1) / 2;
+            v2x_src = (s > vmax) ? vmax : s;
+        end
+    endfunction
+
     // reconfigure the crop geometry; rst_n pulse re-arms the stretcher's phase divider
     task automatic set_geom(input integer s, input integer d, input integer x0);
         begin
@@ -254,7 +281,7 @@ module crt_ov_map_tb;
         end
     endtask
 
-    integer i, j, f, v, expv, got, src;
+    integer i, j, f, v, expv, got, src, g;
     integer err0;
 
     initial begin
@@ -378,6 +405,61 @@ module crt_ov_map_tb;
         err0 = errors;
 
         // ==============================================================
+        // T1d — SIF fill geometries (DVD-FORK FIX): 352->720 (x0=0) and
+        //       256->720 (Crop+SIF, x0=48). Forward geometry + closed-form
+        //       inverse with the right-edge clamp (cr_near reaches hsrc at
+        //       the last column at these ratios; both sides clamp hsrc-1).
+        // ==============================================================
+        for (g = 0; g < 2; g = g + 1) begin
+            if (g == 0) set_geom(352, 720, 0);      // SIF-only fill
+            else        set_geom(256, 720, 48);     // Crop + SIF compose
+
+            send_hs_line(0);
+            if (fwd_n !== HDST) begin
+                errors = errors + 1;
+                $display("T1d FAIL (g%0d): forward resample emitted %0d px (expected exactly %0d)",
+                         g, fwd_n, HDST);
+            end
+            if (fwd_n > 0 && fwd_pos[0] !== ROW_0_COL_0) begin
+                errors = errors + 1;
+                $display("T1d FAIL (g%0d): first output pos %0d (expected ROW_0_COL_0)", g, fwd_pos[0]);
+            end
+            if (fwd_n > 0 && fwd_pos[fwd_n-1] !== ROW_X_COL_LAST) begin
+                errors = errors + 1;
+                $display("T1d FAIL (g%0d): last output pos %0d (expected ROW_X_COL_LAST)", g, fwd_pos[fwd_n-1]);
+            end
+
+            crop_en = 1;
+            h_pos_in = 12'hFFF; repeat (4) @(negedge clk);
+            src = HX0;
+            for (i = 0; i < HDST; i = i + 1) begin
+                step_h(i[11:0]);
+                expv = cr_near(i);
+                if (expv > HSRC - 1) expv = HSRC - 1;   // right-edge clamp (matches the fwd b-tap clamp)
+                expv = HX0 + expv;
+                if (q_x_out !== expv[11:0]) begin
+                    errors = errors + 1;
+                    if (errors < 20)
+                        $display("T1d FAIL (g%0d): display x=%0d mapped %0d, closed form %0d",
+                                 g, i, q_x_out, expv);
+                end
+                if (q_x_out < src) begin
+                    errors = errors + 1;
+                    $display("T1d FAIL (g%0d): mapper went backwards at x=%0d (%0d after %0d)",
+                             g, i, q_x_out, src);
+                end
+                src = q_x_out;
+            end
+            for (i = HDST; i < HDST + 40; i = i + 1) step_h(i[11:0]);
+            crop_en = 0;
+        end
+        $display("T1d SIF fill crop inverse (352->720, 256->720): %s", (errors != err0) ? "FAIL" : "PASS");
+        err0 = errors;
+
+        // restore the T1b geometry so later sections see the classic Crop numbers
+        set_geom(528, 720, 96);
+
+        // ==============================================================
         // T2 — Letterbox forward co-sim: disp_vscale output line i carries
         //      tag 3*k_i + r_i (field path)
         // ==============================================================
@@ -499,6 +581,82 @@ module crt_ov_map_tb;
         end
         $display("T5 spu_decode row-base adder (mapped walks): %s",
                  (errors != err0) ? "FAIL" : "PASS");
+        err0 = errors;
+
+        // ==============================================================
+        // T6 — SIF vertical 2x inverse (DVD-FORK FIX) vs the behavioral
+        //      model of the addrgen mode-2 walk. v_src_max = 239 (NTSC SIF).
+        // ==============================================================
+        v2x_en = 1; v_src_max = 12'd239;
+
+        // (a) progressive, no letterbox: every raster line maps to
+        //     min(floor((v+1)/2), 239) — incl. the clamp rows 480..524
+        letterbox_en = 0; crop_en = 0; interlaced = 0;
+        v_pos_in = 12'hFFF; repeat (4) @(negedge clk);
+        for (v = 0; v < 525; v = v + 1) begin
+            step_v(v[11:0]);
+            expv = v2x_src(v, 0, 239);
+            if (q_y_out !== expv[11:0]) begin
+                errors = errors + 1;
+                if (errors < 40)
+                    $display("T6a FAIL: raster v=%0d mapped %0d expected %0d", v, q_y_out, expv);
+            end
+        end
+
+        // (b) 480i (Native Fields raster), both fields: parity-preserving inverse
+        interlaced = 1;
+        for (f = 0; f < 2; f = f + 1) begin
+            v_pos_in = 12'hFFF; repeat (4) @(negedge clk);
+            for (v = f; v < 525; v = v + 2) begin
+                step_v(v[11:0]);
+                expv = v2x_src(v, 1, 239);
+                if (q_y_out !== expv[11:0]) begin
+                    errors = errors + 1;
+                    if (errors < 40)
+                        $display("T6b FAIL (f%0d): raster v=%0d mapped %0d expected %0d",
+                                 f, v, q_y_out, expv);
+                end
+            end
+        end
+
+        // (c) letterbox + v2x compose (progressive): the letterbox inverse yields a
+        //     DOUBLED-space line, the v2x post-map halves it; bars stay 0xFFF
+        interlaced = 0; letterbox_en = 1;
+        v_pos_in = 12'hFFF; repeat (4) @(negedge clk);
+        for (v = 0; v < 525; v = v + 1) begin
+            step_v(v[11:0]);
+            if (v >= VBAR && v < VBAR + VBAND) begin
+                expv = lb_k(v - VBAR) + ((lb_r(v - VBAR) == 2) ? 1 : 0);
+                expv = v2x_src(expv, 0, 239);
+            end else expv = 'hFFF;
+            if (q_y_out !== expv[11:0]) begin
+                errors = errors + 1;
+                if (errors < 40)
+                    $display("T6c FAIL: raster v=%0d mapped %0d expected %0d", v, q_y_out, expv);
+            end
+        end
+
+        // (d) letterbox + v2x, 480i: doubled-space field walk through both inverses
+        interlaced = 1;
+        for (f = 0; f < 2; f = f + 1) begin
+            v_pos_in = 12'hFFF; repeat (4) @(negedge clk);
+            for (v = f; v < 525; v = v + 2) begin
+                step_v(v[11:0]);
+                if (v >= VBAR && v < VBAR + VBAND) begin
+                    j    = (v - VBAR) >> 1;
+                    expv = 2 * (lb_k(j) + ((lb_r(j) == 2) ? 1 : 0)) + (v & 1);
+                    expv = v2x_src(expv, 1, 239);
+                end else expv = 'hFFF;
+                if (q_y_out !== expv[11:0]) begin
+                    errors = errors + 1;
+                    if (errors < 40)
+                        $display("T6d FAIL (f%0d): raster v=%0d mapped %0d expected %0d",
+                                 f, v, q_y_out, expv);
+                end
+            end
+        end
+        v2x_en = 0; letterbox_en = 0; interlaced = 0;
+        $display("T6 SIF vertical 2x inverse: %s", (errors != err0) ? "FAIL" : "PASS");
 
         if (errors) begin $display("crt_ov_map_tb: FAIL (%0d errors)", errors); $finish; end
         $display("crt_ov_map_tb: ALL TESTS PASS");

--- a/bench/dvd/resample_chain_tb.sv
+++ b/bench/dvd/resample_chain_tb.sv
@@ -137,16 +137,34 @@ module resample_chain_tb;
   // stretches to full width; vertical stays 1:1). Exercises the whole display chain
   // (resample -> disp_hstretch -> pixel_queue -> mixer). report_frame asserts geometry.
   integer vsmode = 0;
-  wire [1:0] rs_vscale_mode = 2'd0;                           // addrgen vertical = Fit (letterbox now downstream)
+  // ---- +sif=1 : SIF analog fill (DVD-FORK FIX 2026-08-24) --------------------------
+  // Reproduces the in-core 2x fill for MPEG-1 SIF content (352x240): content geometry
+  // 352x240 (MB_WIDTH=22, mbh=15) into the WIDE 720x480 modeline, with the emu/
+  // mpeg2video muxes replicated here: addrgen vscale_mode=2 (2x line repeat, v_step
+  // 128), disp_hstretch 352->720 (hcrop_en forced, hdst=720), syncgen fed the
+  // EFFECTIVE sizes (720 / doubled 480) — exactly mpeg2video's eff_horizontal_size /
+  // eff_vertical_size mux. Composes with +vsmode=1 (letterbox over the doubled frame),
+  // +crt=1 (field path) and +hgrad=1 (352->720 blend proof). Every +sif run also
+  // co-sims the addrgen disp_y walk against the 2x closed form (the sif-walk block
+  // below). +siftog=1 starts with the fill OFF and flips it on at a frame
+  // boundary mid-run (the runtime Analog Out toggle case): the chain must re-prime
+  // and settle back to passing geometry with no wedge.
+  integer sif = 0, siftog = 0;
+  integer dumplines = 0;   // +dumplines=1: print the full per-line luma map (debug aid)
+  reg        sif_live = 1'b0;                                 // the live enable (toggled by +siftog)
+  wire [1:0] rs_vscale_mode = sif_live ? 2'd2 : 2'd0;         // addrgen vertical: Fit / SIF 2x line repeat
   wire       rs_vscale_en   = (vsmode == 1);                  // letterbox -> downstream disp_vscale 2-tap blend
   wire       rs_hcrop_en    = (vsmode == 2);                  // crop
-  // letterbox top-bar height (woven frame lines) = vertical_size/8; 0 for fit/crop.
-  wire [11:0] mixer_voff = (vsmode == 1) ? {1'b0, vertical_size[13:3]} : 12'd0;
+  // letterbox top-bar height (woven frame lines) = EFFECTIVE vertical_size/8 (the SIF
+  // doubling happens upstream of disp_vscale, mirroring mpeg2video's eff mux); 0 for fit/crop.
+  wire [13:0] eff_vsz_w  = sif_live ? {vertical_size[12:0], 1'b0} : vertical_size;
+  wire [13:0] sg_hsize   = sif_live ? 14'd720 : HORIZONTAL_SIZE;
+  wire [11:0] mixer_voff = (vsmode == 1) ? {1'b0, eff_vsz_w[13:3]} : 12'd0;
   // crop horizontal stretch params (mirrors mpeg2video): centre 3/4 crop, stretch back to
-  // the full (uncropped) line width MB_WIDTH*16.
+  // the full (uncropped) line width MB_WIDTH*16 — or the 720 raster width under SIF fill.
   wire  [7:0] hcrop_mb_tb = rs_hcrop_en ? ((MB_WIDTH + 8'd4) >> 3) : 8'd0;
   wire [11:0] hsrc_w_tb   = (MB_WIDTH - (hcrop_mb_tb << 1)) << 4;
-  wire [11:0] hdst_w_tb   = MB_WIDTH << 4;
+  wire [11:0] hdst_w_tb   = sif_live ? 12'd720 : (MB_WIDTH << 4);
   reg     dot_ce = 1'b1;                       // /2 CE when +crt, constant 1 otherwise
   always @(posedge dot_clk) dot_ce <= crt ? ~dot_ce : 1'b1;
   reg [11:0] HALFLINE_R = 12'd0;               // syncgen horizontal_halfline
@@ -231,7 +249,7 @@ module resample_chain_tb;
   wire       pq_wr_almost_full;   // pixel_queue -> hstretch
   disp_hstretch disp_hstretch (
     .clk(clk), .clk_en(1'b1), .rst(rst),
-    .hcrop_en(rs_hcrop_en), .hsrc_width(hsrc_w_tb), .hdst_width(hdst_w_tb),
+    .hcrop_en(rs_hcrop_en | sif_live), .hsrc_width(hsrc_w_tb), .hdst_width(hdst_w_tb),
     .in_y(vs_y), .in_u(vs_u), .in_v(vs_v), .in_osd(vs_osd),
     .in_pos(vs_pos), .in_wr(vs_wr), .in_almost_full(hs_in_almost_full),
     .out_y(hs_y), .out_u(hs_u), .out_v(hs_v), .out_osd(hs_osd),
@@ -399,7 +417,7 @@ module resample_chain_tb;
 
   sync_gen sync_gen (
     .clk(dot_clk), .clk_en(dot_ce), .rst(rst),
-    .horizontal_size(HORIZONTAL_SIZE), .vertical_size(vertical_size),
+    .horizontal_size(sg_hsize), .vertical_size(eff_vsz_w),   // SIF fill: the EFFECTIVE (filled) sizes
     .display_horizontal_size(14'd0), .display_vertical_size(14'd0),
     .horizontal_resolution(H_RES), .horizontal_sync_start(H_SS),
     .horizontal_sync_end(H_SE), .horizontal_length(H_LEN),
@@ -455,7 +473,7 @@ module resample_chain_tb;
   task report_frame;
     integer last_video, vis_cnt, nb_cnt, span, hole;
     integer content_woven, exp_vpos_first, exp_vpos_last, exp_nb, TOL;
-    integer dvf, dvl, fr_ok, hfill_ok;
+    integer dvf, dvl, fr_ok, hfill_ok, eff_vsz;
     begin
       last_video = -1; vis_cnt = 0; nb_cnt = 0; first_video = -1;
       for (i = 0; i < MAXLINE; i = i + 1) begin
@@ -476,8 +494,11 @@ module resample_chain_tb;
       // tb's out_line (which carries a raster back-porch offset). content_woven is the
       // woven-frame line count of the picture; nb_cnt (scored per v_sync = per field in
       // crt) is half that in the field path.
-      content_woven  = (vsmode == 1) ? ((vertical_size * 3) / 4) : vertical_size;   // 360 / 480
-      exp_vpos_first = (vsmode == 1) ? (vertical_size >> 3) : 0;                     // 60 / 0
+      // SIF fill: the display-space content height is the DOUBLED size (the addrgen 2x
+      // repeat runs upstream of disp_vscale), mirroring mpeg2video's eff_vertical_size.
+      eff_vsz        = (sif && sif_live) ? (vertical_size * 2) : vertical_size;
+      content_woven  = (vsmode == 1) ? ((eff_vsz * 3) / 4) : eff_vsz;                // 360 / 480
+      exp_vpos_first = (vsmode == 1) ? (eff_vsz >> 3) : 0;                           // 60 / 0
       exp_vpos_last  = exp_vpos_first + content_woven - 1;                           // 419 / 479
       exp_nb         = crt ? (content_woven >> 1) : content_woven;                   // per field in crt
       TOL            = 6;
@@ -534,12 +555,67 @@ module resample_chain_tb;
     end
   endtask
 
+  // ---- SIF source-map check (+sif): addrgen disp_y walk co-sim ----
+  // Samples the ACTUAL source line the addrgen reads for each emitted output line
+  // (hierarchically, at the line-complete state), against the closed form
+  //   src(i) = min(v_base + stride * floor((i+1)/2), vertical_size-1)
+  // (stride 1 progressive, 2 on the field path with v_base = the field parity).
+  // This is the deterministic contract crt_ov_map's v2x inverse replicates.
+  // Two rejected measurement points, recorded so nobody retries them:
+  //  - the MIXER-side per-frame capture: the scan loop free-runs vs the raster in
+  //    this bench (the mixer discards queue entries while hunting after an
+  //    underflow — see the SCANRATE instrument), so displayed frames drop/seam
+  //    lines at wide geometry even in FIT (verified with +dumplines);
+  //  - the +linetag memory-tag path: tags are captured at addr-fifo ACCEPT time,
+  //    which lags the addrgen's disp_y by the elastic issue->accept backlog, so
+  //    the tag<->line pairing is only approximate (fine for the strobe hunting it
+  //    was built for, wrong for an exact co-sim).
+  integer aw_bad = 0, aw_scans = 0, aw_maxline = -1;
+  integer aw_exp, aw_line;
+  reg     aw_armed = 1'b0, aw_done_d = 1'b0;
+  wire    aw_scan_latch = (resample.resample_addrgen.state == 4'h1);                 // STATE_NEXT_IMG
+  wire    aw_line_done  = (resample.resample_addrgen.state == 4'h3) &&               // STATE_NEXT_MB
+                          resample.resample_addrgen.last_mb;
+  always @(posedge clk) if (rst) begin
+    aw_done_d <= aw_line_done;
+    if (aw_scan_latch)
+      aw_armed <= (sif != 0) && sif_live;          // score only scans that START with the fill on
+    else if (aw_armed && aw_line_done && !aw_done_d) begin
+      aw_line = resample.resample_addrgen.oline;   // output line just completed
+      if (aw_line == 0) aw_scans = aw_scans + 1;
+      if (aw_line > aw_maxline) aw_maxline = aw_line;
+      aw_exp = resample.resample_addrgen.v_base
+             + (resample.resample_addrgen.v_stride2 ? 2 : 1) * ((aw_line + 1) / 2);
+      if (aw_exp > vertical_size - 1) aw_exp = vertical_size - 1;
+      if (resample.resample_addrgen.disp_y !== aw_exp[11:0]) begin
+        aw_bad = aw_bad + 1;
+        if (aw_bad <= 12)
+          $display("  [sif-walk] scan %0d line %0d: disp_y %0d expected %0d",
+                   aw_scans, aw_line, resample.resample_addrgen.disp_y, aw_exp);
+      end
+    end
+  end
+
   // LINE-TAG analysis: line_luma[N] = source disp_y&0xFF displayed at output line N.
   // A correct render is monotonic +1 (allowing the small bilinear wobble). Report the
   // mapping at sample points and flag the FIRST big discontinuity (the offset/wrap).
   task linetag_report;
     integer ln, prev, d, firstjump, jumpat;
     begin
+      if (dumplines) begin
+        for (ln = 0; ln < MAXLINE; ln = ln + 16) begin
+          $display("  [dump f%0d] L%0d: %0d %0d %0d %0d %0d %0d %0d %0d %0d %0d %0d %0d %0d %0d %0d %0d",
+                   frame_no, ln,
+                   line_luma_set[ln]    ? line_luma[ln]    : -1, line_luma_set[ln+1]  ? line_luma[ln+1]  : -1,
+                   line_luma_set[ln+2]  ? line_luma[ln+2]  : -1, line_luma_set[ln+3]  ? line_luma[ln+3]  : -1,
+                   line_luma_set[ln+4]  ? line_luma[ln+4]  : -1, line_luma_set[ln+5]  ? line_luma[ln+5]  : -1,
+                   line_luma_set[ln+6]  ? line_luma[ln+6]  : -1, line_luma_set[ln+7]  ? line_luma[ln+7]  : -1,
+                   line_luma_set[ln+8]  ? line_luma[ln+8]  : -1, line_luma_set[ln+9]  ? line_luma[ln+9]  : -1,
+                   line_luma_set[ln+10] ? line_luma[ln+10] : -1, line_luma_set[ln+11] ? line_luma[ln+11] : -1,
+                   line_luma_set[ln+12] ? line_luma[ln+12] : -1, line_luma_set[ln+13] ? line_luma[ln+13] : -1,
+                   line_luma_set[ln+14] ? line_luma[ln+14] : -1, line_luma_set[ln+15] ? line_luma[ln+15] : -1);
+        end
+      end
       firstjump = -1; jumpat = -1; prev = -1;
       for (ln = 0; ln < MAXLINE; ln = ln + 1) begin
         if (line_visible[ln] && line_luma_set[ln]) begin
@@ -641,7 +717,11 @@ module resample_chain_tb;
     void'($value$plusargs("vsmode=%d",   vsmode));
     void'($value$plusargs("vgrad=%d",    vgrad));
     void'($value$plusargs("hgrad=%d",    hgrad));
+    void'($value$plusargs("dumplines=%d", dumplines));
+    void'($value$plusargs("sif=%d",      sif));
+    void'($value$plusargs("siftog=%d",   siftog));
     if (vgrad != 0) linetag = 1;                 // the blend proof rides the linetag side-fifo
+    if (sif) wide = 1;                           // SIF fill targets the wide 720x480 modeline
     if (crt) begin wide = 1; il = 1; end       // CRT implies the wide geometry + field path
     mb_height     = mbh[7:0];
     vertical_size = mbh * 16;
@@ -681,6 +761,16 @@ module resample_chain_tb;
       HALFLINE_R = 12'd429;
       $display("     CRT 480i mode: dot_ce=1/2, halfline=429, per-field 262/263");
     end
+    // ---- SIF content geometry (352x240) into the wide/crt raster chosen above.
+    // The modeline stays 720x480; the fill muxes (sg_hsize/eff_vsz_w, vscale_mode=2,
+    // disp_hstretch 352->720) open the full active region — mirroring emu/mpeg2video.
+    if (sif) begin
+      MB_WIDTH = 8'd22; HORIZONTAL_SIZE = 14'd352;
+      mbh = 15; mb_height = 8'd15; vertical_size = 14'd240;
+      if (!siftog) sif_live = 1'b1;            // +siftog starts OFF, flips mid-run
+      $display("     SIF fill mode: content 352x240, fill %s (vscale_mode=2, hstretch 352->720)",
+               siftog ? "toggled mid-run" : "ON");
+    end
 `ifdef DEEP_DISP
     $display("\n==== resample_chain_tb [DEEP_DISP=2048] mb_height=%0d content=%0dx%0d ====",
              mbh, MB_WIDTH*16, mbh*16);
@@ -708,6 +798,19 @@ module resample_chain_tb;
       if (held_mode) output_frame_valid = 0;
     end
     // (pace mode: pace_driver drives output_frame_valid from reset; nothing here.)
+
+    // ---- +siftog: run a few frames with the fill OFF, then flip it on at a frame
+    // boundary (the runtime Analog Out toggle). The pre-toggle and settling frames are
+    // excluded from the aggregates; the assertion is that the chain re-primes (hstretch
+    // cfg divider, addrgen NEXT_IMG latch, syncgen sizes) and passes geometry after.
+    if (sif && siftog) begin
+      repeat (4) @(negedge v_sync);
+      @(negedge v_sync) sif_live = 1'b1;
+      $display("     SIFTOG: fill enabled at frame %0d", frame_no);
+      repeat (3) @(negedge v_sync);            // settle (one garbled transition frame allowed)
+      vs_good_frames = 0; vs_pass_frames = 0;
+      reported_frames = 0; black_frames = 0;
+    end
 
     // run several raster frames under the held/persistence/pace path
     // (+frames=N overrides for long scan-rate measurements)
@@ -756,15 +859,27 @@ module resample_chain_tb;
     // (vsmode 0) NOTHING resamples horizontally, so the same run is the CONTROL: it must
     // score 0, which proves the pass-through really is a bypass. ----
     if (hgrad != 0) begin
-      integer hp_ok;
-      if (vsmode == 2) hp_ok = (hg_interp_max * 2 > hg_seen_max) && (hg_seen_max > 0);
-      else             hp_ok = (hg_interp_max <= 0);
-      $display("---- BLENDPROOF-H vsmode=%0d crt=%0d : max interpolated pixels=%0d/%0d => %s ----",
-               vsmode, crt, hg_interp_max, hg_seen_max,
-               hp_ok ? ((vsmode == 2) ? "PASS (2-tap real)" : "PASS (control: no h-resample)")
-                     : ((vsmode == 2) ? "*** FAIL (looks like NN) ***"
-                                      : "*** FAIL (pass-through is resampling!) ***"));
+      integer hp_ok, hp_exp;
+      hp_exp = (vsmode == 2) || (sif && sif_live);   // hstretch active: Crop OR the SIF 352->720 fill
+      if (hp_exp) hp_ok = (hg_interp_max * 2 > hg_seen_max) && (hg_seen_max > 0);
+      else        hp_ok = (hg_interp_max <= 0);
+      $display("---- BLENDPROOF-H vsmode=%0d crt=%0d sif=%0d : max interpolated pixels=%0d/%0d => %s ----",
+               vsmode, crt, sif, hg_interp_max, hg_seen_max,
+               hp_ok ? (hp_exp ? "PASS (2-tap real)" : "PASS (control: no h-resample)")
+                     : (hp_exp ? "*** FAIL (looks like NN) ***"
+                               : "*** FAIL (pass-through is resampling!) ***"));
       if (!hp_ok) $fatal(1, "disp_hstretch horizontal 2-tap proof failed (hgrad)");
+    end
+    // ---- SIF source-map verdict (every +sif run): every output line of every
+    // mode-2 scan must read the exact 2x-repeat source line, and scans must reach
+    // the full doubled height (479 progressive / 239 per field). ----
+    if (sif) begin
+      integer slt_ok, exp_last;
+      exp_last = il ? ((vertical_size / 2) * 2 - 1) : (vertical_size * 2 - 1);  // 239 field / 479 frame
+      slt_ok = (aw_scans >= 2) && (aw_bad == 0) && (aw_maxline == exp_last);
+      $display("---- SIF-WALK il=%0d : %0d scans, max line %0d (exp %0d), %0d bad lines => %s ----",
+               il, aw_scans, aw_maxline, exp_last, aw_bad, slt_ok ? "PASS" : "*** FAIL ***");
+      if (!slt_ok) $fatal(1, "SIF 2x line-repeat source walk check failed");
     end
     $display("==== DONE mb_height=%0d (held=%0d) ====\n", mbh, held_mode);
     $finish;

--- a/docs/analog_dual_raster.md
+++ b/docs/analog_dual_raster.md
@@ -216,6 +216,18 @@ regains its same-parity premise in this mode (see the ⚠ note in `dvd/disp_vsca
    `csync`.
 5. `status[14]` (the old `O[14] CRT 480i Out`) is left **dead/reserved for one
    release** so stale per-core saved status can't re-arm anything.
+6. **Sub-D1 sources (2026-08-24 update).** `re_interlace` is a 720-wide re-timer:
+   its 4-line BRAM is only written inside the main raster's DE window, so a
+   narrower/shorter DE window leaves stale columns right of the picture and a
+   4-line smear below it. **MPEG-1 SIF (352×240/352×288) is now FIXED by the
+   in-core SIF analog fill** (`docs/mpeg1.md` §B.3, ⏳ HW-confirm pending): while
+   `analog_eff` is high the decoder's display path stretches 352→720
+   (`disp_hstretch`) and line-doubles 240→480 / 288→576 (addrgen vscale mode 2),
+   and the syncgen opens the full active region — the re-interlacer then needs no
+   change. HDMI trade-off while analog is engaged: ascal sees the in-core-scaled
+   720×480 frame instead of the raw 352×240 (same class as Letterbox/Crop).
+   Wider sub-D1 MPEG-2 (704/544) is NOT filled (user scope decision) — thin
+   stale columns remain there; extending is one predicate away.
 
 ## HW test checklist
 

--- a/docs/analog_dual_raster.md
+++ b/docs/analog_dual_raster.md
@@ -220,7 +220,8 @@ regains its same-parity premise in this mode (see the ⚠ note in `dvd/disp_vsca
    its 4-line BRAM is only written inside the main raster's DE window, so a
    narrower/shorter DE window leaves stale columns right of the picture and a
    4-line smear below it. **MPEG-1 SIF (352×240/352×288) is now FIXED by the
-   in-core SIF analog fill** (`docs/mpeg1.md` §B.3, ⏳ HW-confirm pending): while
+   in-core SIF analog fill** (`docs/mpeg1.md` §B.3, ✅ HW-CONFIRMED 2026-08-24,
+   PR #2): while
    `analog_eff` is high the decoder's display path stretches 352→720
    (`disp_hstretch`) and line-doubles 240→480 / 288→576 (addrgen vscale mode 2),
    and the syncgen opens the full active region — the re-interlacer then needs no

--- a/docs/crt_anamorphic.md
+++ b/docs/crt_anamorphic.md
@@ -346,6 +346,20 @@ overlay clipped at the crop edges; (c) Fit + HDMI: unchanged (pass-through); (d)
 on an anamorphic menu now letterboxes (matches HDMI). Release build gated green:
 clk_dec 91.24/87.58 MHz, `releases/DVD_crtovalign_20260711_0009.rbf`.
 
+## 9b. SIF analog fill reuse (2026-08-24, `feature/sif-analog-fill`)
+
+The MPEG-1 SIF fill (`docs/mpeg1.md` §B.3) reuses this machinery wholesale:
+`disp_hstretch` runs at 352→720 (or 256→720 with Crop stacked; both inside the §8b
+RATIO CONTRACT, no module change), and `crt_ov_map`'s crop inverse serves the stretch
+with `hcrop_x0=0` (emu now gates `ov_hcrop_mb` on `analog_crop` and derives
+`ov_hextra = ov_hdst_w − ov_hsrc_w`). New in `crt_ov_map`: a `v2x_en` closed-form
+post-map inverting the addrgen 2× line repeat (mode-2 vscale walk) —
+progressive `min((y+1)>>1, v_src_max)`, interlaced parity-preserving, 0xFFF bar
+sentinel preserved; it composes AFTER the letterbox inverse (the doubling happens
+upstream of `disp_vscale`). Co-sim: `crt_ov_map_tb` T1d (352→720, 256→720) + T6
+(v2x progressive / 480i / letterbox-composed). The mode-2 inverse formula is part of
+the §9 EXACTNESS contract — change the addrgen walk and this map together.
+
 ## 10. Follow-ups
 
 - ~~`disp_hstretch` 2-tap horizontal blend (Crop edge quality)~~ — **DONE, see §8b.**

--- a/docs/crt_anamorphic.md
+++ b/docs/crt_anamorphic.md
@@ -346,7 +346,7 @@ overlay clipped at the crop edges; (c) Fit + HDMI: unchanged (pass-through); (d)
 on an anamorphic menu now letterboxes (matches HDMI). Release build gated green:
 clk_dec 91.24/87.58 MHz, `releases/DVD_crtovalign_20260711_0009.rbf`.
 
-## 9b. SIF analog fill reuse (2026-08-24, `feature/sif-analog-fill`)
+## 9b. SIF analog fill reuse (✅ HW-CONFIRMED 2026-08-24, PR #2)
 
 The MPEG-1 SIF fill (`docs/mpeg1.md` §B.3) reuses this machinery wholesale:
 `disp_hstretch` runs at 352→720 (or 256→720 with Crop stacked; both inside the §8b

--- a/docs/mpeg1.md
+++ b/docs/mpeg1.md
@@ -288,9 +288,11 @@ gaps at v1 (now closed, see below): analog dual-raster `re_interlace` hardcodes
   `v2x_en` post-map for the line repeat (progressive `min((y+1)>>1, v_src_max)`,
   interlaced parity-preserving; 0xFFF bar sentinel preserved). The HUD un-clips as
   a side effect (full 720-wide DE window).
-- **Sim**: `resample_chain_tb +sif=1` (+`linetag` source-map proof, `+hgrad`
-  352→720 blend proof, `+crt` field path, `+vsmode=1` letterbox compose,
-  `+siftog` mid-run enable toggle) and `crt_ov_map_tb` T1d/T6.
+- **Sim**: `resample_chain_tb +sif=1` (every `+sif` run co-sims the addrgen
+  `disp_y` walk against the 2× closed form — the `+linetag` memory-tag path was
+  measured too elastic for an exact map check, see the TB's sif-walk comment;
+  `+hgrad` 352→720 blend proof, `+crt` field path, `+vsmode=1` letterbox
+  compose, `+siftog` mid-run enable toggle) and `crt_ov_map_tb` T1d/T6.
 - **Accepted quirks**: the field path's final line clamps to vsz−1 and can cross
   field parity for one bottom line; hstretch stretches the mb-padded width (all
   real SIF widths are multiples of 16); one ascal re-init popup on HDMI when the

--- a/docs/mpeg1.md
+++ b/docs/mpeg1.md
@@ -255,11 +255,47 @@ all edits marked `// DVD-FORK FIX (mpeg1)`.
 The syncgen active window tracks the decoded size (`h_size<=horizontal_size`,
 `v_size<=vertical_size`), so 352×240 yields a 352×240 DE window that **ascal
 upscales full-screen on HDMI** — no in-core scaling needed for v1. Known non-HDMI
-gaps (deferred, documented): analog dual-raster `re_interlace` hardcodes 720×480
-(sub-D1 → garbage right/below picture; v1 = force `analog_eff` off for sub-D1 or
-document), HUD/overlay geometry is 720-authored (clipped at 352 — cosmetic),
-direct-video top-left quarter. In-core 2× repeat via `disp_hstretch` retarget +
-addrgen line-repeat is the mapped-out v2 if scaler softness disappoints.
+gaps at v1 (now closed, see below): analog dual-raster `re_interlace` hardcodes
+720×480 (sub-D1 → quarter picture + garbage right/below), HUD/overlay geometry is
+720-authored (clipped at 352), direct-video top-left quarter.
+
+**✅ SIF ANALOG FILL — the mapped-out v2, implemented 2026-08-24 (branch
+`feature/sif-analog-fill`), ⏳ HW-confirm pending.** In-core 2× fill, gated on
+`analog_eff` (HDMI-only rigs keep ascal's polyphase scale — HW-proven for MPEG-1):
+
+- **Detect** (`dvd/emu.sv`): two independent 1-bit flags off the clk_dec size taps,
+  2-FF synced (the `pal_det` pattern): `sif_h` = width ≤360, `sif_v` = height ≤288.
+  `sif_hfill_eff / sif_v2x_eff = analog_eff & flag`. Independence means 352×480
+  half-D1 would get horizontal-only fill, correctly. **Scope decision (user):
+  SIF widths only** — 704/544-wide MPEG-2 keeps today's behaviour (their thin stale
+  re-interlacer columns are a deferred follow-up, one predicate away).
+- **Horizontal** — `disp_hstretch` retarget: `disp_hdst_w = 720` and
+  `hcrop_en |= disp_hfill_en` in `mpeg2video.v`; 352→720 (qstep 125) and Crop+SIF
+  256→720 (qstep 91) both satisfy the module's upscale RATIO CONTRACT — zero
+  changes inside the stretcher.
+- **Vertical** — the dormant addrgen vscale walk armed as **mode 2**
+  (`dvd/resample_addrgen.v`): `v_step=128`, `v_outlines = 2×source-lines` = an
+  exact NN 2× line repeat (240→480 / 288→576; field path 120→240 per field). The
+  rounded walk maps output line i → source `min(floor((i+1)/2), vsz-1)` (src 0
+  once, src N−1 thrice — a half-line shift, invisible on a CRT). Mode 1
+  (letterbox-NN) stays dormant and prunes.
+- **Raster** — `mpeg2video.v` muxes ONLY the `syncgen_intf` size legs to the
+  effective values (720 / doubled height); motcomp / resample / regfile keep the
+  true decoded size (addrgen bounds + motcomp clipping depend on it). The 720×480
+  modeline is untouched — no rate change, the A/V architecture never notices.
+- **Overlay** — `crt_ov_map` reuses the crop inverse for the stretch (x0=0,
+  hsrc=352, hextra=368; identity holds at any upscale ratio) and gains a closed-form
+  `v2x_en` post-map for the line repeat (progressive `min((y+1)>>1, v_src_max)`,
+  interlaced parity-preserving; 0xFFF bar sentinel preserved). The HUD un-clips as
+  a side effect (full 720-wide DE window).
+- **Sim**: `resample_chain_tb +sif=1` (+`linetag` source-map proof, `+hgrad`
+  352→720 blend proof, `+crt` field path, `+vsmode=1` letterbox compose,
+  `+siftog` mid-run enable toggle) and `crt_ov_map_tb` T1d/T6.
+- **Accepted quirks**: the field path's final line clamps to vsz−1 and can cross
+  field parity for one bottom line; hstretch stretches the mb-padded width (all
+  real SIF widths are multiples of 16); one ascal re-init popup on HDMI when the
+  fill engages (Letterbox-engage class); while analog is engaged HDMI sees the
+  in-core 2× instead of ascal (Letterbox/Crop trade-off class).
 
 ### B.4 Verification
 
@@ -309,6 +345,8 @@ in-loop effect of the mismatch-control difference is visible.
 - MP2 passthrough (IEC 61937 Pc=0x0004) not implemented; passthrough mode silences
   MP2 (correct fallback).
 - MPEG-2 multichannel extension (attr format 3) stays unsupported (HUD notice).
-- Analog CRT with sub-D1 sources: see B.3.
+- Analog CRT with SIF sources: ✅ fixed by the in-core 2× fill (B.3, 2026-08-24,
+  ⏳ HW-confirm pending). Wider sub-D1 MPEG-2 (704/544) still shows thin stale
+  re-interlacer columns on analog — deferred follow-up (one predicate away, B.3).
 - MPEG-1 aspect_ratio_information is a pixel-AR table (differs from MPEG-2 DAR
   codes) — v1 maps to 4:3 (DVD MPEG-1 is 4:3 by spec).

--- a/docs/mpeg1.md
+++ b/docs/mpeg1.md
@@ -259,8 +259,8 @@ gaps at v1 (now closed, see below): analog dual-raster `re_interlace` hardcodes
 720×480 (sub-D1 → quarter picture + garbage right/below), HUD/overlay geometry is
 720-authored (clipped at 352), direct-video top-left quarter.
 
-**✅ SIF ANALOG FILL — the mapped-out v2, implemented 2026-08-24 (branch
-`feature/sif-analog-fill`), ⏳ HW-confirm pending.** In-core 2× fill, gated on
+**✅ SIF ANALOG FILL — the mapped-out v2, ✅ HW-CONFIRMED 2026-08-24 (PR #2):
+NTSC + PAL SIF fill the CRT cleanly, normal DVDs unregressed.** In-core 2× fill, gated on
 `analog_eff` (HDMI-only rigs keep ascal's polyphase scale — HW-proven for MPEG-1):
 
 - **Detect** (`dvd/emu.sv`): two independent 1-bit flags off the clk_dec size taps,
@@ -347,8 +347,9 @@ in-loop effect of the mismatch-control difference is visible.
 - MP2 passthrough (IEC 61937 Pc=0x0004) not implemented; passthrough mode silences
   MP2 (correct fallback).
 - MPEG-2 multichannel extension (attr format 3) stays unsupported (HUD notice).
-- Analog CRT with SIF sources: ✅ fixed by the in-core 2× fill (B.3, 2026-08-24,
-  ⏳ HW-confirm pending). Wider sub-D1 MPEG-2 (704/544) still shows thin stale
-  re-interlacer columns on analog — deferred follow-up (one predicate away, B.3).
+- Analog CRT with SIF sources: ✅ fixed by the in-core 2× fill (B.3,
+  ✅ HW-CONFIRMED 2026-08-24, PR #2). Wider sub-D1 MPEG-2 (704/544) still shows
+  thin stale re-interlacer columns on analog — deferred follow-up (one predicate
+  away, B.3).
 - MPEG-1 aspect_ratio_information is a pixel-AR table (differs from MPEG-2 DAR
   codes) — v1 maps to 4:3 (DVD MPEG-1 is 4:3 by spec).

--- a/dvd/crt_ov_map.sv
+++ b/dvd/crt_ov_map.sv
@@ -36,6 +36,13 @@
  *     no divider, no approximation. Output = hcrop_x0 + column (the addrgen crop window
  *     origin), clamped at the window's last column (a blanking guard; inside the active
  *     line the walk lands on hsrc-1 exactly at the last column).
+ *   - SIF fill (DVD-FORK FIX 2026-08-24): the horizontal 352->720 stretch reuses the SAME
+ *     crop inverse with hcrop_x0=0 / hsrc=352 / hextra=368 (the identity above holds at
+ *     any upscale ratio). The vertical 2x line repeat (addrgen vscale_mode==2, v_step=128)
+ *     is inverted by a closed-form post-map on the letterbox mux's candidate:
+ *     progressive y -> min(floor((y+1)/2), v_src_max); interlaced field line i parity p ->
+ *     min(p + 2*floor((i+1)/2), v_src_max) — exactly the forward walk's rounded map,
+ *     0xFFF bar sentinel preserved. See the v2x_en port comment.
  *
  * TIMING: mapped outputs register one clk_sys after a position change. Vertical changes
  * at line rate (irrelevant); horizontal means the mapped x lags the raw query by one
@@ -53,8 +60,19 @@ module crt_ov_map (
     input  wire        rst_n,
 
     input  wire        letterbox_en,   // CRT Letterbox active (disp_vscale_en)
-    input  wire        crop_en,        // CRT Crop active (disp_hcrop_en); exclusive with letterbox
+    input  wire        crop_en,        // CRT Crop OR SIF fill active (analog_crop | sif_hfill_eff)
     input  wire        interlaced,     // CRT 480i: v_pos = absolute frame line, +2 per field line
+
+    /* DVD-FORK FIX (SIF analog fill): invert the addrgen 2x line repeat (vscale_mode==2).
+     * The forward walk (resample_addrgen, v_step=128, rounded) maps output line i to
+     * source line min(floor((i+1)/2), v_src_max) on the progressive path; on the
+     * interlaced (Native Fields) path each field walks its own parity:
+     * field line i, parity p -> min(p + 2*floor((i+1)/2), v_src_max). This stage
+     * post-maps the letterbox mux's candidate (letterbox output is a line in DOUBLED
+     * space — the 2x repeat happens upstream of disp_vscale — so the two inverses
+     * compose in that order), preserving the 0xFFF bar/blanking sentinel. */
+    input  wire        v2x_en,         // SIF vertical 2x active (sif_v2x_eff)
+    input  wire [11:0] v_src_max,      // decoded vertical_size - 1 (239/287): the forward walk's clamp
 
     /* letterbox geometry (quasi-static): mixer bar offset + content band, frame lines */
     input  wire [11:0] v_bar,          // disp_v_offset (60 NTSC / 72 PAL)
@@ -145,8 +163,22 @@ module crt_ov_map (
     end
 
     /* ---------------- output mux (pure pass-through when inactive) ---------------- */
-    assign q_y_out = letterbox_en ? (ly_valid ? ly_eff : 12'hFFF) : v_pos_in;
-    assign q_x_out = crop_en      ? (hcrop_x0 + cx)               : h_pos_in;
+    wire [11:0] q_y_pre = letterbox_en ? (ly_valid ? ly_eff : 12'hFFF) : v_pos_in;
+
+    /* DVD-FORK FIX (SIF analog fill): post-map the vertical candidate through the exact
+     * inverse of the addrgen 2x line-repeat walk (see the v2x_en port comment). The
+     * 0xFFF letterbox-bar sentinel passes through untouched (it must stay outside every
+     * DAREA / button rect). Combinational — v changes at line rate. */
+    wire [11:0] v2x_i    = {1'b0, q_y_pre[11:1]};                    // field-line index i (interlaced)
+    wire [11:0] v2x_prog = (q_y_pre + 12'd1) >> 1;                   // floor((y+1)/2)
+    wire [11:0] v2x_half = (v2x_i + 12'd1) >> 1;                     // floor((i+1)/2)
+    wire [11:0] v2x_il   = {11'd0, q_y_pre[0]} + {v2x_half[10:0], 1'b0}; // p + 2*floor((i+1)/2)
+    wire [11:0] v2x_raw  = interlaced ? v2x_il : v2x_prog;
+    wire [11:0] v2x_clmp = (v2x_raw > v_src_max) ? v_src_max : v2x_raw;
+    wire [11:0] q_y_v2x  = (q_y_pre == 12'hFFF) ? 12'hFFF : v2x_clmp;
+
+    assign q_y_out = v2x_en ? q_y_v2x : q_y_pre;
+    assign q_x_out = crop_en ? (hcrop_x0 + cx) : h_pos_in;
 
 endmodule
 /* not truncated */

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -3013,9 +3013,10 @@ mpeg2video mpeg2video_inst (
     .pause             (pause_dec),                    // DVD-FORK (gamepad transport): freeze frame while paused (clk_dec-synced)
     .freeze_wd         (still_dec),                    // DVD-FORK (disc-menu still): watchdog-suppress only (clk_dec-synced)
     .vbuf_flush        (vbuf_flush_dec),               // DVD-FORK (gamepad transport): discard VBUF on a seek (clk_dec-synced)
-    .disp_vscale_mode  (disp_vscale_mode),             // DVD-FORK (CRT anamorphic vscale): addrgen NN path, dormant (0)
+    .disp_vscale_mode  (disp_vscale_mode),             // DVD-FORK (CRT anamorphic vscale): 0 Fit / 2 SIF 2x line repeat
     .disp_vscale_en    (disp_vscale_en),               // DVD-FORK (CRT anamorphic letterbox AA): downstream 2-tap blend enable
     .disp_hcrop_en     (disp_hcrop_en),                // DVD-FORK (CRT anamorphic horizontal crop / pan-scan)
+    .disp_hfill_en     (disp_hfill_en),                // DVD-FORK FIX (SIF analog fill): 352->720 stretch + 720 DE window
     .menu_ff           (1'b0),                         // DVD-FORK (menu VBUF-lag §5): fast-drain RETIRED (HW-inert); menu_ff=0 = bit-identical governor
     .film24            (filmp_dec),                    // DVD-FORK (Film 24p/25p Out): 1 frame/refresh in the governor; ascal does the pulldown
     .film_det_ntsc     (core_film_det_ntsc),           // DVD-FORK (Film 24p auto-detect): 3:2 telecine verdict (clk_dec)
@@ -3139,11 +3140,47 @@ always @(posedge clk_sys or negedge reset_n) begin
     if (!reset_n) begin hsz_s1 <= 14'd720; hsz_s2 <= 14'd720; end
     else          begin hsz_s1 <= core_horizontal_size; hsz_s2 <= hsz_s1; end
 end
+// DVD-FORK FIX (SIF analog fill, 2026-08-24): sub-D1 detect for the in-core 2x fill.
+// MPEG-1 SIF (352x240/352x288) used to display in the upper-left quarter of the ANALOG
+// output — the syncgen DE window tracks the decoded size while the re-interlacer is
+// hardcoded 720-wide (garbage right/below). Two INDEPENDENT 1-bit flags (so 352x480
+// half-D1 would get horizontal-only fill, correctly), clk_dec compares 2-FF synced into
+// clk_sys (the pal_det pattern). Threshold <=360 = SIF widths only (352/320); wider
+// sub-D1 MPEG-2 (704/544) keeps today's behaviour — deferred follow-up by predicate.
+wire sif_h_dec = (core_horizontal_size != 14'd0) && (core_horizontal_size <= 14'd360);
+wire sif_v_dec = (core_vertical_size  != 14'd0) && (core_vertical_size  <= 14'd288);
+reg  sif_h_s1, sif_h_s2, sif_v_s1, sif_v_s2;
+always @(posedge clk_sys or negedge reset_n) begin
+    if (!reset_n) begin sif_h_s1 <= 1'b0; sif_h_s2 <= 1'b0; sif_v_s1 <= 1'b0; sif_v_s2 <= 1'b0; end
+    else begin
+        sif_h_s1 <= sif_h_dec; sif_h_s2 <= sif_h_s1;
+        sif_v_s1 <= sif_v_dec; sif_v_s2 <= sif_v_s1;
+    end
+end
+// Gated on analog_eff (the Letterbox/Crop pattern): HDMI-only rigs keep the narrow DE
+// window + ascal's polyphase scale (HW-proven for MPEG-1); the fill exists because the
+// analog chain (re_interlace + direct video) needs a true 720-wide raster line.
+wire sif_hfill_eff = analog_eff & sif_h_s2;   // horizontal 352->720 stretch
+wire sif_v2x_eff   = analog_eff & sif_v_s2;   // vertical 2x line repeat (240->480 / 288->576)
+// DVD-FORK FIX (SIF analog fill): decoded height, 2-FF synced (hsz_s2 pattern) — feeds
+// crt_ov_map's v2x inverse clamp (v_src_max = vertical_size-1).
+reg  [13:0] vsz_s1, vsz_s2;
+always @(posedge clk_sys or negedge reset_n) begin
+    if (!reset_n) begin vsz_s1 <= 14'd480; vsz_s2 <= 14'd480; end
+    else          begin vsz_s1 <= core_vertical_size; vsz_s2 <= vsz_s1; end
+end
+// DVD-FORK FIX (SIF analog fill): the overlay-inverse geometry now describes whichever
+// horizontal remap is active. Crop off => hcrop_mb = 0 (window origin 0, full width);
+// the stretch target (ov_hdst_w) is 720 whenever the SIF fill is on. crt_ov_map's
+// crop_en is analog_crop | sif_hfill_eff, so SIF-only gives the pure 352->720 inverse
+// (x0=0, hsrc=352, hextra=368) and Crop+SIF composes (x0=48, hsrc=256, hextra=464) —
+// exactly matching mpeg2video's disp_hsrc_w/disp_hdst_w forward geometry.
 wire [9:0]  ov_mb_width = (hsz_s2 + 14'd15) >> 4;
-wire [7:0]  ov_hcrop_mb = (ov_mb_width[7:0] + 8'd4) >> 3;
-wire [11:0] ov_hcrop_x0 = {ov_hcrop_mb[7:0], 4'b0000};              // crop window origin (96)
-wire [11:0] ov_hextra   = {ov_hcrop_mb[6:0], 5'b00000};             // hdst - hsrc (192)
-wire [11:0] ov_hsrc_w   = {ov_mb_width[7:0], 4'b0000} - ov_hextra;  // cropped width (528)
+wire [7:0]  ov_hcrop_mb = analog_crop ? ((ov_mb_width[7:0] + 8'd4) >> 3) : 8'd0;
+wire [11:0] ov_hcrop_x0 = {ov_hcrop_mb[7:0], 4'b0000};              // crop window origin (96; 0 unless Crop)
+wire [11:0] ov_hsrc_w   = {ov_mb_width[7:0], 4'b0000} - {ov_hcrop_mb[6:0], 5'b00000}; // source width (528 crop / 352 SIF)
+wire [11:0] ov_hdst_w   = sif_hfill_eff ? 12'd720 : {ov_mb_width[7:0], 4'b0000};      // stretch target
+wire [11:0] ov_hextra   = ov_hdst_w - ov_hsrc_w;                    // hdst - hsrc (192 crop / 368 SIF)
 // DVD-FORK FIX (aspect ratio): sequence-header display aspect (clk_dec), 2-FF synced
 // into clk_sys (same CDC pattern as core_vertical_size -> pal_det_s2 above). DVD MPEG-2
 // emits code 2 (4:3) or 3 (16:9). CRITICAL: VIDEO_ARX/ARY must be STABLE — every change
@@ -3208,8 +3245,12 @@ assign analog_letterbox = analog_eff & ((analog_aspect_sel == 2'd2) |
                                 ((analog_aspect_sel == 2'd0) & ar_wide_auto_eff)); // Letterbox or Auto-16:9
 assign analog_crop      = analog_eff &  (analog_aspect_sel == 2'd3);         // Crop (manual)
 wire       disp_vscale_en   = analog_letterbox;                             // downstream 2-tap letterbox
-wire [1:0] disp_vscale_mode = 2'd0;                                         // addrgen vertical = Fit (NN path dormant)
+// DVD-FORK FIX (SIF analog fill): mode 2 = the re-armed addrgen 2x line repeat (v_step
+// 128) for sub-D1 heights on the analog output; bit 0 stays tied (mode 1 letterbox-NN
+// remains dormant and prunes). Quasi-static into clk_dec like the neighbours.
+wire [1:0] disp_vscale_mode = {sif_v2x_eff, 1'b0};                          // 0 Fit / 2 SIF 2x line repeat
 wire       disp_hcrop_en    = analog_crop;
+wire       disp_hfill_en    = sif_hfill_eff;                                // SIF 352->720 stretch (disp_hstretch)
 // DVD-FORK DEBUG (256-line strobe probe): per-output-frame mixer telemetry from
 // the decoder core. No longer surfaced on the overlay (the 256-line strobe is
 // resolved); kept as debug taps for future re-wiring if needed.
@@ -3632,8 +3673,10 @@ crt_ov_map crt_ov_map_inst (
     .clk          (clk_sys),
     .rst_n        (reset_n),
     .letterbox_en (analog_letterbox),
-    .crop_en      (analog_crop),
+    .crop_en      (analog_crop | sif_hfill_eff), // DVD-FORK FIX (SIF analog fill): SIF drives the same inverse (x0=0)
     .interlaced   (il_eff),                // interlaced raster: v_pos = absolute frame line, +2/field-line
+    .v2x_en       (sif_v2x_eff),           // DVD-FORK FIX (SIF analog fill): invert the addrgen 2x line repeat
+    .v_src_max    ((vsz_s2 == 14'd0) ? 12'hfff : (vsz_s2[11:0] - 12'd1)), // decoded height - 1 (239/287)
     .v_bar        (pal_eff ? 12'd72 : 12'd60),   // mixer disp_v_offset (vertical_size/8)
     .v_band       (pal_eff ? 12'd432 : 12'd360), // letterboxed content height (3/4)
     .hcrop_x0     (ov_hcrop_x0),

--- a/dvd/resample_addrgen.v
+++ b/dvd/resample_addrgen.v
@@ -187,7 +187,10 @@ module resample_addrgen (
    * emits the scaled line count + the blend weight). Works on BOTH the progressive FRAME
    * path and the interlaced FIELD path (per-field, parity preserved). See
    * docs/crt_anamorphic.md. (Crop — the horizontal pan-scan mode — is hcrop_en below,
-   * NOT a vscale_mode: it leaves the vertical at Fit/1:1.) */
+   * NOT a vscale_mode: it leaves the vertical at Fit/1:1.)
+   * DVD-FORK FIX (SIF analog fill, 2026-08-24): 2 = SIF 2x LINE REPEAT (v_step=128,
+   * v_outlines=2x source lines) so sub-D1 MPEG-1 fills the analog raster vertically;
+   * see the walk comment below. Mode 1 stays dormant (emu never drives it). */
   input        [1:0] vscale_mode;
 
   /* DVD-FORK (CRT anamorphic horizontal crop / pan-scan): when high, the address
@@ -337,20 +340,32 @@ module resample_addrgen (
    *   source line for output line i = v_base + stride * round(i * step)
    *     stride = 2 on the field path (stay on the field's parity), 1 progressive
    *     step (Q8.8): LETTERBOX 341 (=4/3, downscale 480->360 / field 240->180)
-   *                  ZOOM     192 (=3/4, upscale 360->480 from a centre crop)
-   *     v_base = crop offset (+ field parity): ZOOM skips H/8 source lines top+bottom
+   *                  SIF 2x   128 (=1/2, upscale 240->480 / 288->576 — line repeat)
+   *     v_base = crop offset (+ field parity)
    * Line-index (oline) drives termination and the ROW_0/1/X position codes (via the
    * existing output-index disp_y_sat), so the mixer frame-top pairing is unchanged; the
    * emission height (v_outlines) is <= the raster active region in every mode so nothing
    * spills into the next frame (the 256-line strobe class — docs/history.md).
-   * ------------------------------------------------------------------------- */
-  wire              vscale_en   = (vscale_mode == 2'd1);                    // 1 = LETTERBOX (only vertical mode)
+   *
+   * DVD-FORK FIX (SIF analog fill, 2026-08-24) — vscale_mode==2: the SAME walk with
+   * v_step=128 and v_outlines = 2*source-lines gives an exact nearest-neighbour 2x line
+   * repeat so sub-D1 MPEG-1 (352x240/352x288) fills the analog raster vertically. The
+   * rounded walk maps output line i -> source line min(floor((i+1)/2), vertical_size-1):
+   * source 0 appears once, N-1 three times — a half-line shift, invisible on a CRT, and
+   * replicated EXACTLY by crt_ov_map's inverse (keep them in step). The field path
+   * (analog Native Fields) doubles each 120/144-line field to 240/288 parity-preserved
+   * lines; its final line clamps to vertical_size-1, which can cross field parity for
+   * one bottom line — accepted (see docs/mpeg1.md). Mode 1 (letterbox NN) stays dormant
+   * (emu never drives it) and prunes. */
+  wire              sif2x       = (vscale_mode == 2'd2);                    // 2 = SIF 2x line repeat (DVD-FORK FIX)
+  wire              vscale_en   = (vscale_mode == 2'd1) | sif2x;            // 1 = LETTERBOX (dormant)
   /* per-scan geometry, computed from the INCOMING image (image_0 at STATE_NEXT_IMG) */
   wire              vs_field0   = (image_0 != FRAME);                       // TOP/BOTTOM => field path
   wire       [11:0] vs_H0       = vs_field0 ? vertical_size[11:1] : vertical_size[11:0]; // source lines this scan
   wire       [11:0] vs_par0     = (image_0 == BOTTOM) ? 12'd1 : 12'd0;      // field parity (bottom field = odd lines)
   wire       [11:0] v_base_comb = vs_field0 ? vs_par0 : 12'd0;             // first source line (parity on the field path)
-  wire       [11:0] vs_outlines_comb = ((vs_H0 << 1) + vs_H0) >> 2;        // letterbox: H*3/4 (480->360 / 240->180)
+  wire       [11:0] vs_outlines_comb = sif2x ? {vs_H0[10:0], 1'b0}         // SIF 2x: H*2 (240->480 / field 120->240)
+                                             : (((vs_H0 << 1) + vs_H0) >> 2); // letterbox: H*3/4 (480->360 / 240->180)
 
   reg        [11:0] v_base;      // latched source line of output line 0
   reg        [11:0] v_outlines;  // latched number of output lines (termination bound)
@@ -861,7 +876,7 @@ module resample_addrgen (
       v_base     <= v_base_comb;
       v_outlines <= vs_outlines_comb;
       v_stride2  <= vs_field0;
-      v_step     <= 9'd341;                            // Q8.8: 4/3 letterbox downscale
+      v_step     <= sif2x ? 9'd128 : 9'd341;           // Q8.8: 1/2 SIF 2x repeat / 4/3 letterbox downscale
     end
 
   always @(posedge clk)

--- a/rtl/mpeg2/mpeg2video.v
+++ b/rtl/mpeg2/mpeg2video.v
@@ -74,9 +74,10 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
              pause,                                                // DVD-FORK (gamepad transport): freeze the displayed frame while paused
              freeze_wd,                                            // DVD-FORK (disc-menu still): watchdog-suppress ONLY (no governor freeze)
              vbuf_flush,                                           // DVD-FORK (gamepad transport): discard the buffered bitstream on a seek
-             disp_vscale_mode,                                     // DVD-FORK (CRT anamorphic vscale): 0=fit 1=letterbox (addrgen NN path, now dormant)
+             disp_vscale_mode,                                     // DVD-FORK (CRT anamorphic vscale): 0=fit 1=letterbox(dormant) 2=SIF 2x line repeat
              disp_vscale_en,                                       // DVD-FORK (CRT anamorphic letterbox AA): enable downstream disp_vscale 2-tap blend
              disp_hcrop_en,                                        // DVD-FORK (CRT anamorphic horizontal crop / pan-scan)
+             disp_hfill_en,                                        // DVD-FORK FIX (SIF analog fill): stretch sub-D1 lines to the 720 raster
              menu_ff,                                              // DVD-FORK (menu VBUF-lag §5): fast-drain a deeply-buffered menu
              film24,                                               // DVD-FORK (Film 24p Out): 1 frame/refresh, ascal does the 3:2
              film_det_ntsc, film_det_pal,                          // DVD-FORK (Film 24p auto-detect): cadence verdicts (up to emu)
@@ -206,8 +207,10 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
    * NOTE (2026-07-05): the addrgen nearest-neighbour vscale path (vscale_mode==1) is now
    * DORMANT — Letterbox is done by the downstream disp_vscale 2-tap blender (disp_vscale_en
    * below), which needs the addrgen to emit FIT vertically (all source lines). emu therefore
-   * drives disp_vscale_mode = 0 always; the port stays wired for the six addrgen governor
-   * testbenches (which pass 0) and prunes to nothing under constant 0. */
+   * never drives mode 1; that arm stays unreachable and prunes.
+   * NOTE (2026-08-24, SIF analog fill): mode 2 is LIVE — the same addrgen walk with
+   * v_step=128 gives an exact 2x line repeat (240->480 / 288->576) so sub-D1 MPEG-1
+   * content fills the analog raster vertically. emu drives {sif_v2x_eff, 1'b0}. */
   input      [1:0] disp_vscale_mode;
   /* DVD-FORK (CRT anamorphic Letterbox anti-aliasing, 2026-07-05): 1 => the downstream
    * dvd/disp_vscale.sv 2-tap vertical resampler is active (480->360 / field 240->180 with a
@@ -219,6 +222,15 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
    * centre ~3/4 of the columns and the mixer stretches them to full raster width (Crop
    * mode). 0 outside Crop => full width, mixer stretch off (bit-identical). */
   input            disp_hcrop_en;
+  /* DVD-FORK FIX (SIF analog fill, 2026-08-24): 1 => MPEG-1 SIF (352-wide) content is
+   * stretched to fill the 720-wide raster by the SAME disp_hstretch stage Crop uses
+   * (hsrc = the native mb width, hdst = 720), and the syncgen active region is forced to
+   * 720 so the DE window fills the line. Vertical 2x (240->480 / 288->576) rides
+   * disp_vscale_mode==2 (the re-armed addrgen walk, see resample_addrgen.v). emu gates
+   * both on analog_eff: HDMI-only rigs keep the narrow DE window + ascal's polyphase
+   * scale (HW-proven for MPEG-1); the analog re-interlacer needs a true 720-wide line.
+   * Quasi-static (settles at load/flush boundaries). 0 => bit-identical legacy path. */
+  input            disp_hfill_en;
 
   /* DVD-FORK (menu VBUF-lag §5): fast-drain the display through a deeply-buffered menu
    * transition (governor picks up a new frame every refresh) so the settled still is
@@ -1404,7 +1416,7 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
    * and the pixel queue. Pure combinational pass-through unless disp_hcrop_en. */
   disp_hstretch disp_hstretch (
     .clk(clk), .clk_en(1'b1), .rst(sync_rst),
-    .hcrop_en(disp_hcrop_en),
+    .hcrop_en(disp_hcrop_en | disp_hfill_en),  // DVD-FORK FIX (SIF analog fill): fill reuses the stretch stage
     .hsrc_width(disp_hsrc_w),
     .hdst_width(disp_hdst_w),
     /* from disp_vscale */
@@ -1444,12 +1456,25 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
     .pixel_rd_underflow(pixel_rd_underflow_pqueue)           // to mixer
     );
 
+  /* DVD-FORK FIX (SIF analog fill): the syncgen's active region normally tracks the
+   * DECODED size, so 352x240 SIF gave a quarter-screen DE window at (0,0) of the 720x480
+   * raster (garbage right/below on the analog re-interlacer, which is hardcoded 720-wide).
+   * With the fill active the display path emits a true 720-wide (disp_hstretch) x
+   * line-doubled (addrgen vscale_mode==2) picture, so the syncgen must open the FULL
+   * active region. Mux ONLY these syncgen legs — motcomp, resample and the regfile
+   * readback keep the true decoded size (addrgen bounds / motcomp clipping depend on it).
+   * clip_display_size is always 0 in this fork, so the display_*_size legs are unused.
+   * No N'() size casts (Quartus 17 mangles them — docs/mpeg1.md). */
+  wire        sif_v2x = disp_vscale_mode[1];
+  wire [13:0] eff_horizontal_size = disp_hfill_en ? 14'd720 : horizontal_size;
+  wire [13:0] eff_vertical_size   = sif_v2x ? {vertical_size[12:0], 1'b0} : vertical_size;
+
   syncgen_intf syncgen_intf (
-    .clk(dot_clk), 
-    .clk_en(dot_ce), 
-    .rst(dot_rst), 
-    .horizontal_size(horizontal_size),                       // from vld
-    .vertical_size(vertical_size),                           // from vld
+    .clk(dot_clk),
+    .clk_en(dot_ce),
+    .rst(dot_rst),
+    .horizontal_size(eff_horizontal_size),                   // from vld (SIF fill: forced 720)
+    .vertical_size(eff_vertical_size),                       // from vld (SIF fill: doubled)
     .display_horizontal_size(display_horizontal_size),       // from vld
     .display_vertical_size(display_vertical_size),           // from vld
     .syncgen_rst(syncgen_rst),                               // from regfile
@@ -1479,7 +1504,10 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
    * (60 lines for NTSC 480, 72 for PAL 576), in woven frame lines; 0 unless the display
    * mode is LETTERBOX (Fit/Crop fill from the top, no bars). Quasi-static. Keyed on
    * disp_vscale_en (the downstream 2-tap letterbox), not disp_vscale_mode (dormant). */
-  wire [11:0] disp_v_offset = disp_vscale_en ? {1'b0, vertical_size[13:3]} : 12'd0;
+  /* DVD-FORK FIX (SIF analog fill): key the bar height on the EFFECTIVE (doubled) size so
+   * a manually-forced Letterbox over doubled SIF places the bars where crt_ov_map's
+   * raster-space v_bar constants (60/72) expect them. */
+  wire [11:0] disp_v_offset = disp_vscale_en ? {1'b0, eff_vertical_size[13:3]} : 12'd0;
 
   /* DVD-FORK (CRT anamorphic horizontal crop / pan-scan): the mixer stretches the cropped
    * source line (disp_hsrc_w wide) up to the raster active width (disp_hdst_w) so Crop
@@ -1487,7 +1515,10 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
    * = round(mb_width/8). Off (disp_hcrop_en=0) => hsrc_w == full width, stretch bypassed. */
   wire [7:0]  hcrop_mb_i  = disp_hcrop_en ? ((mb_width + 8'd4) >> 3) : 8'd0;
   wire [11:0] disp_hsrc_w = (mb_width - (hcrop_mb_i << 1)) << 4;   // (mb_width - 2*hcrop)*16
-  wire [11:0] disp_hdst_w = mb_width << 4;                         // full (uncropped) line width = what a Fit line emits
+  /* DVD-FORK FIX (SIF analog fill): with the fill active the stretch target is the 720
+   * raster width, not the native line width — 352->720 (SIF, qstep 125) or 256->720
+   * (Crop+SIF, qstep 91), both inside disp_hstretch's upscale RATIO CONTRACT. */
+  wire [11:0] disp_hdst_w = disp_hfill_en ? 12'd720 : (mb_width << 4); // full raster line width = what a Fit line emits
 
   /* Mixer */
   mixer mixer (


### PR DESCRIPTION
## Summary

MPEG-1 SIF content (352×240 NTSC, 352×288 PAL) displayed in the upper-left quarter of the analog CRT output with garbage right/below: the syncgen DE window tracks the decoded size while `re_interlace` is a hardcoded 720-wide line-buffer re-timer. This implements the in-core 2× fill mapped out in `docs/mpeg1.md` §B.3 as v2, **✅ HW-CONFIRMED 2026-08-24** (NTSC + PAL SIF fill the CRT cleanly, normal DVDs unregressed).

- **Detect** (`dvd/emu.sv`): independent width/height sub-D1 flags off the clk_dec size taps (2-FF `pal_det` pattern), gated on `analog_eff` — HDMI-only rigs keep ascal's polyphase scale; direct-video is covered; the HUD un-clips as a side effect. Scope: SIF widths only (≤360); 704/544-wide MPEG-2 is a deferred follow-up (one predicate away).
- **Horizontal**: `disp_hstretch` retargeted to hdst=720 (352→720 qstep 125; Crop+SIF 256→720 qstep 91 — both inside the upscale RATIO CONTRACT, zero changes inside the stretcher).
- **Vertical**: the dormant addrgen vscale walk armed as mode 2 — exact NN 2× line repeat (`v_step=128`, `v_outlines=2×`), field path parity-preserving. Mode 1 stays dormant and prunes.
- **Raster**: `mpeg2video.v` muxes only the `syncgen_intf` size legs to the effective values; motcomp/resample/regfile keep the true decoded size. Modeline untouched — no rate change.
- **Overlay**: `crt_ov_map` reuses the crop inverse for the stretch and gains a closed-form `v2x_en` post-map (0xFFF bar sentinel preserved), composing after the letterbox inverse.

True 240p output was rejected: no exact-59.94 Hz 240p modeline exists at 1716 dots/line, so it would drift against the fixed 48 kHz audio NCO; line-doubled 480i carries the same content.

Fit: the inherited SEED 9 came in marginal on this netlist; re-swept, **SEED 7** passes both corners (clk_dec 88.35 MHz @100C / 86.51 @-40C, gate 86.0) — pinned with ledger entry. Release: `releases/DVD_sif_fill_20260824_1946.rbf`.

## Test plan

- [x] `resample_chain_tb +sif=1`: 480 full-width lines, geometry 11/12 (known frame-1 startup miss)
- [x] `resample_chain_tb +sif=1` SIF-WALK addrgen co-sim: 0 bad lines (13 progressive scans to line 479)
- [x] `resample_chain_tb +sif=1 +crt=1`: field path, 19 parity-preserving field scans to 239, 0 bad
- [x] `resample_chain_tb +sif=1 +siftog=1`: mid-run enable toggle settles in 2 frames, no wedge
- [x] `resample_chain_tb +sif=1 +hgrad=1`: 352→720 2-tap blend proof (93% interpolated)
- [x] `resample_chain_tb +sif=1 +vsmode=1`: letterbox compose 12/12
- [x] `crt_ov_map_tb` T1d (352→720, 256→720 inverses) + T6 (v2x vertical inverse, 4 walks) + T1a–T5 regressions
- [x] Controls unregressed: chain FIT/Letterbox/Crop, 7 addrgen governor TBs, `re_interlace_tb`, `crt_syncgen_tb`
- [x] Quartus fit closes: SEED 7, clk_dec 88.35/86.51 MHz both corners
- [x] HW: SIF fills the analog output, no right/below garbage; unregressed elsewhere (user-confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
