### PR TITLE
Fix Menu key over the boot copyright screen + UNSUPPORTED IMAGE false positive on slow media

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -649,9 +649,10 @@ worse maintenance burden than targeted in-place edits. So:
   Menus Off = Phase-3 behaviour exactly. Punted: angles, PTT exactness (Phase 6),
   GPRM counter tick, UOPs, parental.
   - **⚠ BOOT-CHAIN MENU SHORTCUT — the one deliberate deviation from libdvdnav
-    (2026-08-25, user decision; ⏳ HW-confirm pending).** Menu pressed over the
-    First Play copyright screen used to hand the key to the PLAYING title's VTSM
-    Root, which on a DVD-game disc is a DISPATCHER, not a menu: Atmosfear's sets
+    (2026-08-25, user decision) — ✅ HW-CONFIRMED 2026-08-25 (user report).**
+    Menu pressed over the First Play copyright screen used to hand the key to
+    the PLAYING title's VTSM Root, which on a DVD-game disc is a DISPATCHER,
+    not a menu: Atmosfear's sets
     `g[2]=7` → VMGM 6 → VTSM(1) Root → (g2≠0) PGCN 5 → 48 → `rnd 6; JumpTT 1` =
     a random ~35 s Gatekeeper clip. **libdvdnav does the same** (verified with its
     own `trace_menuearly` on the real ISO) and the disc sets **no UOP bits**, so a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -647,7 +647,23 @@ worse maintenance burden than targeted in-place edits. So:
   title-entry scan, P_PMAP program-map walk; emu's Phase-2/3 proto-nav/micro-bridge
   glue is DELETED (VM owns jumps; nav_pci gained `sel_force` for SetHL_BTNN).
   Menus Off = Phase-3 behaviour exactly. Punted: angles, PTT exactness (Phase 6),
-  GPRM counter tick, UOPs, parental. Tests: dvd_vm_tb (27 vectors + 9 scenarios),
+  GPRM counter tick, UOPs, parental.
+  - **⚠ BOOT-CHAIN MENU SHORTCUT — the one deliberate deviation from libdvdnav
+    (2026-08-25, user decision; ⏳ HW-confirm pending).** Menu pressed over the
+    First Play copyright screen used to hand the key to the PLAYING title's VTSM
+    Root, which on a DVD-game disc is a DISPATCHER, not a menu: Atmosfear's sets
+    `g[2]=7` → VMGM 6 → VTSM(1) Root → (g2≠0) PGCN 5 → 48 → `rnd 6; JumpTT 1` =
+    a random ~35 s Gatekeeper clip. **libdvdnav does the same** (verified with its
+    own `trace_menuearly` on the real ISO) and the disc sets **no UOP bits**, so a
+    faithful VM cannot help — hence the deviation. While `menu_seen == 0` (no
+    menu-domain PGC loaded since the mount) the Menu key targets `best_menu_vts`
+    Root instead; `g[2]` stays 0 and Atmosfear lands on its real main menu.
+    Self-limiting (that press latches `menu_seen`), inert when
+    `best_menu_vts ∈ {0, cur_vts}`, and new `fb=FB_BOOTM` falls back to the SPEC
+    path (own-VTS Root) before VMGM. **141-disc sweep: 135 unchanged, 6 changed —
+    all from a TITLE landing to a MENU landing.** Tests `dvd_vm_tb` [S2]/[S21];
+    golden model in lockstep. Full trace + table: `docs/dvd_vm.md` "Boot-chain
+    menu shortcut". Tests: dvd_vm_tb (27 vectors + 9 scenarios),
   iso_reader_vm_tb (command-driven boot→menu→loop→resume→post), all reader/demux/
   nav suites green. Design: **`docs/dvd_vm.md`**. **HW gate: BBB boots FP→menu→
   correct feature; MiB trampoline/Play/resume; SetSTN switches streams.**

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ that path. The rest (`Debug Overlay`, `Title VTS`, `Audio Genlock`, `Force 4:3 S
 | Message | Meaning |
 |---|---|
 | `CSS ENCRYPTED` | The image is an undecrypted rip. Audio is muted; re-rip the disc. |
-| `UNSUPPORTED IMAGE` | Not an ISO9660 DVD image (e.g. UDF-only), or not a playable stream. |
+| `UNSUPPORTED IMAGE` | Not an ISO9660 DVD image (e.g. UDF-only), or not a playable stream. Only raised after ~20 s of *actual streaming* with no picture, so slow media (a NAS spinning up) does not trigger it; it clears itself if a picture does appear. |
 | `AUDIO UNSUPPORTED` | The selected audio track is in a format the core cannot decode. |
 | `TITLE VTS nn` | Which title was auto-selected (shown only with Disc Menus Off). |
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ Notes:
 
 A USB keyboard's number keys select menu buttons directly.
 
+**Menu during the disc's opening chain.** Pressing Menu over a copyright/warning screen —
+before the disc has shown you any menu — goes straight to the disc's main menu. Some discs
+(DVD games especially) author their per-title Root "menu" as a dispatcher that routes on
+where you pressed Menu from, which would otherwise drop you into a random clip rather than
+the menu. After you have been to a menu once, Menu behaves exactly as the disc specifies.
+
 ## Settings
 
 Defaults are chosen to be correct for most users; the first value listed is the default.

--- a/bench/dvd/dvd_vm_tb.sv
+++ b/bench/dvd/dvd_vm_tb.sv
@@ -439,15 +439,20 @@ module dvd_vm_tb;
         $display("S1 boot chain PASS");
 
         // ---------------- [S2] MENU KEY in a title --------------------------
+        // This is the FIRST menu invocation of the mount (no menu-domain PGC has
+        // loaded yet), so the BOOT-CHAIN MENU SHORTCUT applies: the target is
+        // best_menu_vts (2), NOT the playing title's own VTS (4). See the
+        // FB_BOOTM note in dvd_vm.sv. RSM still records the playing title.
         menu_active = 0;
         cur_vts = 8'd4; cur_pgcn = 8'd1; cur_cell = 8'd2;
         clear_actions;
         @(negedge clk); key_menu = 1;
         @(negedge clk); key_menu = 0;
         wait_settled;
-        if (!saw_jump || cap_jdom != 2'd2 || cap_jvts != 8'd4 ||
+        if (!saw_jump || cap_jdom != 2'd2 || cap_jvts != best_menu_vts ||
             cap_jentry != 4'd3)
-            fail("S2: expected VTSM Root jump");
+            fail("S2: expected boot-shortcut VTSM Root jump to best_menu_vts");
+        if (dut.fb !== 3'd7) fail("S2: expected fb = FB_BOOTM");
         if (dut.rsm_vts !== 8'd4 || dut.rsm_cell !== 8'd2)
             fail("S2: RSM not saved");
         // reader answers: 0-cell root stub, pre = LinkPGCN 2
@@ -1231,6 +1236,60 @@ module dvd_vm_tb;
         if (saw_jump)
             fail("S20b: round-2 pre must NOT jump (infinite boot loop)");
         $display("S20 Hobbit VTSM PGC1 pre (trampoline round + menu round) PASS");
+
+        // -------- [S21] BOOT-CHAIN MENU SHORTCUT (Atmosfear, 2026-08-25) -----
+        // Three properties of the deviation documented at FB_BOOTM in dvd_vm.sv:
+        //   (a) the FIRST menu invocation of a mount targets best_menu_vts, not
+        //       the playing title's own VTS  (also covered inline by S2);
+        //   (b) if that target has no Root menu, FB_BOOTM falls back to the SPEC
+        //       path -- this title's own VTSM Root -- BEFORE widening to VMGM, so
+        //       a bad best_menu_vts guess can never cost a menu that used to work;
+        //   (c) it is SELF-LIMITING: once a menu-domain PGC has loaded
+        //       (menu_seen), every later Menu press is the unmodified spec path.
+        menu_active = 0;
+        vm_restart;
+        nav_ready = 1;
+        nr_pre = 0; nr_post = 0; nr_cell = 0;
+        cur_vts = 8'd7; cur_pgcn = 8'd3; cur_cell = 8'd1; cell_count = 8'd4;
+        dut.vm_dom = 2'd3;                       // DOM_TT: a title is playing
+        // (a) first Menu press of the mount -> best_menu_vts (2), not cur_vts (7)
+        clear_actions;
+        @(negedge clk); key_menu = 1;
+        @(negedge clk); key_menu = 0;
+        wait_settled;
+        if (!saw_jump || cap_jdom != 2'd2 || cap_jvts != best_menu_vts ||
+            cap_jentry != 4'd3)
+            fail("S21a: first Menu press must target best_menu_vts Root");
+        // (b) that VTS has no Root menu -> fall back to the OWN-VTS Root (7)
+        clear_actions; pulse_error; wait_settled;
+        if (!saw_jump || cap_jdom != 2'd2 || cap_jvts != 8'd7 ||
+            cap_jentry != 4'd3)
+            fail("S21b: FB_BOOTM must fall back to the own-VTS Root");
+        // ... and only then widen to the VMGM Title menu
+        clear_actions; pulse_error; wait_settled;
+        if (!saw_jump || cap_jdom != 2'd1 || cap_jentry != 4'd2)
+            fail("S21b: FB_BOOTM -> VMGM Title fallback");
+        // the VMGM menu loads: menu_seen latches here
+        nr_pre = 0; cell_count = 8'd2;
+        menu_active = 1;
+        cur_vts = 8'd0; cur_pgcn = 8'd1; cur_cell = 8'd0;
+        pulse_loaded;
+        wait_idle;
+        if (dut.menu_seen !== 1'b1) fail("S21c: menu_seen must latch on a menu load");
+        // (c) back to a title, press Menu again -> spec path, targets cur_vts (7)
+        menu_active = 0;
+        dut.vm_dom = 2'd3;
+        dut.came_via_menukey = 1'b0;             // a title played: toggle dropped
+        cur_vts = 8'd7; cur_pgcn = 8'd3; cur_cell = 8'd1; cell_count = 8'd4;
+        clear_actions;
+        @(negedge clk); key_menu = 1;
+        @(negedge clk); key_menu = 0;
+        wait_settled;
+        if (!saw_jump || cap_jdom != 2'd2 || cap_jvts != 8'd7 ||
+            cap_jentry != 4'd3)
+            fail("S21c: after a menu was seen, Menu must use the spec path (cur_vts)");
+        if (dut.fb !== 3'd2) fail("S21c: expected fb = FB_VTSM (spec path)");
+        $display("S21 boot-chain menu shortcut (target/fallback/self-limit) PASS");
     end
     endtask
 

--- a/docs/dvd_vm.md
+++ b/docs/dvd_vm.md
@@ -239,10 +239,76 @@ Events, serviced one at a time from V_IDLE (all latched):
 | `vm_pgc_end` | run the POST block (the reader has already **drained** — its stream cache AND, for a title-domain PGC, the decoder VBUF via the tail-drain wait; see `docs/dvd_nav.md` "Natural-transition tail drain") |
 | `vm_cell_cmd` | run that one cell command |
 | `btn_cmd_valid` | run the button's command (directly from the 64-bit register) |
-| `key_menu` | title: synthesized `CallSS VTSM Root` (sets `came_via_menukey`); menu: `LinkRSM` **only if `came_via_menukey`** (the movie menu↔title toggle), else re-invoke `CallSS VTSM Root` |
+| `key_menu` | title: synthesized `CallSS VTSM Root` (sets `came_via_menukey`); menu: `LinkRSM` **only if `came_via_menukey`** (the movie menu↔title toggle), else re-invoke `CallSS VTSM Root`. The **first** menu invocation of a mount retargets to `best_menu_vts` — see "Boot-chain menu shortcut" below |
 | `key_resume` | `LinkRSM` (Select with no buttons armed) — **only if `came_via_menukey`**, same gate as `key_menu` (see the Cluedo note below) |
 | `key_title` | B12 "Title" (the real-remote **Top Menu** key) — **✅ HW-CONFIRMED 2026-07-31 (PR fj#152)**: jump to the **VMGM Title menu** (entry 2) from anywhere. From a playing title also saves RSM + sets `came_via_menukey` (Menu/Select toggle back, like `key_menu`); from a menu it jumps **without touching RSM or the toggle** — a disc-driven menu's RSM is the boot trampoline and must not be re-blessed. `fb=FB_VMGM` (no VMGM Title entry → resume/auto-title). Tests: `dvd_vm_tb` [S17], `iso_reader_cluedo_menu_tb` [B] |
 | `key_return` | B13 "Return" (**GoUp**, libdvdnav `dvdnav_go_up`) — **✅ HW-CONFIRMED 2026-07-31 (PR fj#152)**: in-domain jump to the loaded PGC's authored `goup_pgcn` — the menu hierarchy's "one level up" pointer; mirrors the `LinkGoUpPGC` command exec (`fb=FB_NONE`). `goup_pgcn==0` (no authored parent — most discs, 16/22 in the library census) = strict no-op. HW: Atmosfear submenus return properly; Akira's goup targets its Root DISPATCHER whose fall-through is `RSM`, so Return there resumes the title (mid-film) or replays the boot warning (post-boot) — **authored**, identical under libdvdnav. Test: `dvd_vm_tb` [S18] |
+
+### Boot-chain menu shortcut — ⚠ DELIBERATE DEVIATION from libdvdnav (2026-08-25)
+
+**Symptom (user report, Atmosfear).** Press Menu while the copyright/warning screen the
+disc's First Play chain puts up is on screen, and instead of the main menu you get a clip
+that looks like it came from the end of the game.
+
+**It is the disc, not us — and that is exactly why we had to deviate.** Traced on the real
+ISO:
+
+```
+FP: g5=0x2000; g5=1; g3=0x44; JumpTT 68        <- VTS_68 = the FBI warning card (5 s)
+Menu -> menu_call(Root) on the PLAYING VTS, per spec
+VTSM(68) PGC1 pre:  ... g2 = 7 ; JumpSS VMGM 6
+VMGM  PGC6  pre:    g2 < 0x2c -> JumpSS VTSM(1, Root)
+VTSM(1)  PGC1 pre:  g2 != 0 -> LinkPGCN 5 -> (dispatch on g2==7) -> LinkPGCN 48
+VTSM(1)  PGC48 pre: g15 = rnd 6 ; g5 = g15 ; g3 = 1 ; JumpSS VMGM 2  -> JumpTT 1
+TT(1) plays program g5 = a random ~35 s Gatekeeper clip in the lava cavern
+  ...then its cell command (CallSS VMGM 9) finally reaches the main menu.
+```
+
+Every VTS's VTSM Root on this disc sets `g[2] = 7` — that PGC is **not a menu**, it is a
+dispatcher that records *"the player pressed Menu inside a VTS"* and routes on it. The
+disc's own VMGM Title entry (0x82) does the same thing, so `key_title` lands there too.
+**libdvdnav behaves identically** — verified by building its `examples/trace_menuearly.c`
+against the real ISO: `[CELL #1] Title=68` → `menu_call(Root)` → `[CELL #2] Title=1` → menu
+domain. There are **no UOP bits** to lean on either: the PGC `prohibited_ops` word and every
+PCI `vobu_uop_ctl` on this disc are zero, so nothing tells a player to refuse the key. A
+faithful VM cannot help the user here; only a deviation can.
+
+**The deviation, and how its blast radius is bounded.** While **no menu-domain PGC has
+loaded since the mount** (`menu_seen == 0` — the disc has never yet shown the user a menu),
+the Menu key skips the playing title's VTSM Root and jumps straight to the Root menu of
+**`best_menu_vts`** (the VTS holding the largest menu VOB — the same heuristic the error
+fallback chain has always trusted). Because the current VTS's Root PGC never runs, `g[2]`
+stays 0 and Atmosfear's `VTSM(1)` Root takes its `g1==0 && g2==0` path → `LinkPGCN 7` = the
+real main menu. Four things keep this safe:
+
+- **Self-limiting.** That very press loads a menu, which latches `menu_seen`, so every
+  subsequent Menu press for the rest of the mount is the unmodified spec path.
+- **Fallback preserves the spec path.** New `fb = FB_BOOTM`: if the shortcut's target has
+  no Root menu, the chain tries **this title's own VTSM Root** *before* widening to VMGM.
+  A bad `best_menu_vts` guess cannot cost a menu that used to work.
+- **Inert where it cannot help.** `best_menu_vts == 0` (no menu VOB) or
+  `best_menu_vts == cur_vts` (the common movie disc, menus in the VTS already playing)
+  → unchanged behaviour.
+- **`menu_seen` latches on the LOAD EVENT** (`pgc_loaded && vm_dom` in a menu domain), not
+  on the bare `menu_active` level — a level still stale from the previous disc for a cycle
+  after a mount would otherwise disable the shortcut for a whole session, silently.
+
+**Library sweep (141 discs, `tools/dvd_vm_ref.py`, old vs new landing).** 135 unchanged;
+**6 changed, all in the same direction** — the old spec path landed the Menu key in the
+**title** domain (the disc bounced it into content), the new one lands in a **menu**:
+
+| disc | old landing | new landing |
+|---|---|---|
+| `ATMOSFEAR_NTSC` | TT vts=1 pgcn=1 (Gatekeeper clip) | VTSM vts=1 pgcn=7 (main menu) |
+| `A_Good_Man` | TT vts=9 pgcn=1 | VTSM vts=1 pgcn=7 |
+| `GMEN_FROM_HELL` | TT vts=2 pgcn=1 | VTSM vts=1 pgcn=8 |
+| `RETURN_OF_THE_LIVING_DEAD` (both rips) | TT vts=8/9 pgcn=1 | VTSM vts=1 pgcn=7 |
+| `STARWARP` | TT vts=3 pgcn=1 | VTSM vts=1 pgcn=9 |
+
+Tests: `dvd_vm_tb` [S2] (first press retargets, `fb == FB_BOOTM`) and **[S21]** (target /
+`FB_BOOTM`→own-VTS fallback → VMGM / self-limiting after a menu load). Mirrored in
+`tools/dvd_vm_ref.py` (`menu_seen`, `_menu_call_root`) so the golden model stays in
+lockstep. ⏳ **HW-confirm pending.**
 
 **Menu key `came_via_menukey` gate (Trivial Pursuit Star Wars).** The Menu key used to
 `LinkRSM` unconditionally from any menu. On a **single-VTS game disc whose VTS1/title1 IS the
@@ -392,6 +458,8 @@ PTT exactness (`VTS_PTT_SRPT` = Phase 6 — PTT ≈ program until then), languag
 python3 tools/dvd_vm_ref.py selftest            # 27/27 golden eval vectors
 python3 tools/dvd_vm_ref.py boot  <disc.iso>    # trace the FP boot chain
 python3 tools/dvd_vm_ref.py menu  <disc.iso> N  # trace a Menu-key press
+# library sweep (old vs new Menu-key landing): force vm.menu_seen = True for the
+# pre-shortcut path and compare -- how the 141-disc table above was produced.
 iverilog -g2012 -o /tmp/v dvd/dvd_vm.sv bench/dvd/dvd_vm_tb.sv && vvp /tmp/v
 iverilog -g2012 -o /tmp/r dvd/dvd_iso_reader.sv dvd/dvd_vm.sv \
     bench/dvd/iso_reader_vm_tb.sv && vvp /tmp/r

--- a/docs/dvd_vm.md
+++ b/docs/dvd_vm.md
@@ -308,7 +308,8 @@ real main menu. Four things keep this safe:
 Tests: `dvd_vm_tb` [S2] (first press retargets, `fb == FB_BOOTM`) and **[S21]** (target /
 `FB_BOOTM`→own-VTS fallback → VMGM / self-limiting after a menu load). Mirrored in
 `tools/dvd_vm_ref.py` (`menu_seen`, `_menu_call_root`) so the golden model stays in
-lockstep. ⏳ **HW-confirm pending.**
+lockstep. **✅ HW-CONFIRMED 2026-08-25** (user report: Menu over Atmosfear's
+copyright screen now reaches the main menu).
 
 **Menu key `came_via_menukey` gate (Trivial Pursuit Star Wars).** The Menu key used to
 `LinkRSM` unconditionally from any menu. On a **single-VTS game disc whose VTS1/title1 IS the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1647,7 +1647,8 @@ it**); warnings re-appear after a user audio/subtitle popup. Two defects found:
    preempted, so the "user popup wins" contract is unchanged. Tests: `transport_hud_tb`
    T17a-e.
 
-**★ HW ROUND 2 (2026-08-25) — `UNSUPPORTED IMAGE` false-positive on slow media.**
+**★ HW ROUND 2 (2026-08-25) — `UNSUPPORTED IMAGE` false-positive on slow media.
+✅ FIXED + HW-CONFIRMED 2026-08-25 (user report).**
 User report: an image served off a NAS whose drives spin up on first access raised
 `UNSUPPORTED IMAGE`, and because the latch is sticky the popup then sat **over correct
 playback** once the image finally loaded. Root cause: `IMG_WD` ran on **wall time from

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1596,8 +1596,10 @@ width change), and the detectors live next to the `css_scrambled` latch in `emu.
    for a bare `.VOB`/`.mpg`/`.m2v` — and those decode within a second. An image the
    reader can't navigate (UDF-only, or truncated/garbage) takes the SAME path and never
    produces a picture. So the test is `~iso_mode & ~video_live` sustained for
-   `IMG_WD` (~5 s), sticky until the next load. This is also strictly more general —
-   it catches any unplayable file, not just UDF.
+   `IMG_WD`, sticky until the next load. This is also strictly more general —
+   it catches any unplayable file, not just UDF. **The window measures STREAMING time,
+   not wall time** (HW round 2 — see below): it advances only while sector data is
+   actually being delivered, and is ~20 s wide.
 2. **Unsupported audio** → persistent **`AUDIO UNSUPPORTED`**, menu-exempt.
    Driven from the IFO's per-track `audio_format` (`attr_a_fmt`, already parsed for
    track enumeration in PR fj#100) rather than by sniffing PES: formats 2 (MPEG-1
@@ -1644,6 +1646,32 @@ it**); warnings re-appear after a user audio/subtitle popup. Two defects found:
    to expire. Preemption is scoped to warnings: user events (types 0-3) are never
    preempted, so the "user popup wins" contract is unchanged. Tests: `transport_hud_tb`
    T17a-e.
+
+**★ HW ROUND 2 (2026-08-25) — `UNSUPPORTED IMAGE` false-positive on slow media.**
+User report: an image served off a NAS whose drives spin up on first access raised
+`UNSUPPORTED IMAGE`, and because the latch is sticky the popup then sat **over correct
+playback** once the image finally loaded. Root cause: `IMG_WD` ran on **wall time from
+the mount**, so the entire 5 s window could be spent before the first byte ever arrived —
+"no video yet" was true, but for a reason that has nothing to do with the image. Fix
+(`dvd/emu.sv`), three parts:
+
+1. **Streaming time, not wall time.** A free-running activity detector (`img_idle_cnt`,
+   re-armed by every `sd_buff_wr`, saturating at ~0.5 s) gates the window: any delivery
+   stall — spin-up, a slow share, a re-seek — **freezes** the count instead of spending
+   it. The watchdog now measures what it always meant: *streamed this long without a
+   picture*.
+2. **Window widened 5 s → ~20 s** of that active streaming. An unplayable image is not
+   urgent to report; a wrong report is expensive.
+3. **The latch self-retracts on `video_live`.** The message asserts "this image never
+   produces a picture", so a decoded frame disproves it by construction — it must not
+   outlive that. Belt-and-braces: even if some future timing surprise trips the window,
+   the popup cannot survive over working playback, which was the actual user-visible
+   harm.
+
+Coverage is unchanged for a genuinely unplayable file that streams (it still latches,
+just later). A junk file that delivers *nothing at all* now stays silent rather than
+being reported — a deliberate trade, since "nothing arrived" is a media/transport
+problem, not an image-format one.
 
 **Side finding: `SCENEIT_JR.iso` is a RAW (CSS-scrambled) rip** — 27.6 % of packs,
 found because it was picked as the MP2-flag test vehicle and the core's own CSS

--- a/dvd/dvd_vm.sv
+++ b/dvd/dvd_vm.sv
@@ -506,8 +506,48 @@ reg [15:0] rsm_r4, rsm_r5, rsm_r6, rsm_r7, rsm_r8;
 // Fallback chain (ported from the Phase-2/3 emu glue). FB_TITLE also tags
 // command-issued title jumps: if one fails, retry once with the auto title.
 localparam [2:0] FB_NONE = 3'd0, FB_FP = 3'd1, FB_VTSM = 3'd2, FB_VTSM2 = 3'd3,
-                 FB_VMGM = 3'd4, FB_TITLE = 3'd5, FB_GAVEUP = 3'd6;
+                 FB_VMGM = 3'd4, FB_TITLE = 3'd5, FB_GAVEUP = 3'd6,
+                 FB_BOOTM = 3'd7;
 reg [2:0] fb;
+
+// ---------------------------------------------------------------------------
+// BOOT-CHAIN MENU SHORTCUT (2026-08-25, Atmosfear).
+//
+// Pressing Menu on the copyright/warning screen a disc's First Play chain puts
+// up used to hand the key to that title's OWN VTSM Root PGC, per spec. On a
+// DVD-game disc that PGC is not a menu - it is a dispatcher that records "the
+// player pressed Menu inside VTS n" and routes on it. ATMOSFEAR: every VTS's
+// VTSM Root sets `g[2] = 7` then JumpSS VMGM 6 -> VTSM(1) Root, whose own PRE
+// reads `g[2] != 0` and links away to PGCN 48 = `rnd 6 -> g[5]; g[3] = 1;
+// JumpSS VMGM 2` = JumpTT 1 = a random ~35 s Gatekeeper clip. Only after that
+// clip's cell command (CallSS VMGM 9) does the main menu appear. libdvdnav does
+// exactly the same (verified on the real ISO with its own trace harness), and
+// the disc sets NO UOP bits, so nothing tells a player to refuse the key: the
+// disc is doing this to itself and a faithful VM cannot help the user here.
+//
+// So, by user decision, this is a DELIBERATE DEVIATION with a deliberately tiny
+// blast radius: only while NO menu-domain PGC has been loaded since the mount
+// (`menu_seen` == 0 - i.e. the disc has never yet shown the user a menu) does
+// the Menu key skip the current title's VTSM Root and jump straight to the Root
+// menu of `best_menu_vts` (the VTS holding the largest menu VOB - the same
+// heuristic the error-fallback chain already trusts). Because it never runs the
+// current VTS's Root PGC, `g[2]` stays 0 and Atmosfear lands directly on its
+// real main menu (VTSM vts=1 PGCN 7 - verified against the disc).
+//
+// Self-limiting by construction: the very first Menu press loads a menu, which
+// sets `menu_seen`, so every subsequent press is the unmodified spec path. Inert
+// on discs with no menu VOB (best_menu_vts == 0) and on the common movie-disc
+// case where the menus live in the VTS that is already playing (best_menu_vts ==
+// cur_vts). On MiB - feature in VTS_21, menus in VTS_02 - it short-circuits a
+// trampoline that already ended at VTS_02's menu anyway.
+//
+// If the shortcut's target has no Root menu, FB_BOOTM falls back to the SPEC
+// path (this title's own VTSM Root) before widening to VMGM, so nothing that
+// used to work can be lost to a bad `best_menu_vts` guess.
+// ---------------------------------------------------------------------------
+reg  menu_seen;    // a menu-domain PGC has been loaded since the last mount
+wire boot_menu = ~menu_seen & (best_menu_vts != 8'd0) & (best_menu_vts != cur_vts);
+wire [7:0] menukey_vts = boot_menu ? best_menu_vts : cur_vts;
 
 // Serial ALU (mul: MSB-first shift-add; div/mod/rnd: restoring divide)
 reg [3:0]  alu_op;
@@ -577,6 +617,7 @@ always @(posedge clk or negedge rst_n) begin
         skip_pre <= 1'b0;
         tt_resolve <= 1'b0;
         came_via_menukey <= 1'b0;
+        menu_seen <= 1'b0;
         deadend_vts <= 8'd0; deadend_pgcn <= 16'd0; deadend_seen <= 1'b0;
         rsm_vts <= 8'd0; rsm_pgcn <= 16'd0; rsm_cell <= 8'd0;
         rsm_r4 <= 16'd0; rsm_r5 <= 16'd0; rsm_r6 <= 16'd0;
@@ -614,6 +655,16 @@ always @(posedge clk or negedge rst_n) begin
         if (sec_tick) tick_pending <= 1'b1;
 
         nav_ready_d <= nav_ready;
+
+        // "the disc has shown the user a menu" - gates the boot-chain menu
+        // shortcut above. Latched on the LOAD EVENT of a menu-domain PGC, not on
+        // the bare menu_active level: a level that is still stale from the last
+        // disc for a cycle or two after a mount would otherwise disable the
+        // shortcut for the whole session, silently. vm_dom is the VM's own
+        // tracked domain (set when the jump is issued), so this is deterministic
+        // and matches the golden model's `_load_pgcn` hook exactly.
+        if (pgc_loaded && (vm_dom == DOM_VMGM || vm_dom == DOM_VTSM))
+            menu_seen <= 1'b1;
 
         // ---- event latching (any state; the FSM consumes by priority) ---
         if (enable) begin
@@ -662,6 +713,7 @@ always @(posedge clk or negedge rst_n) begin
             skip_pre <= 1'b0;
             tt_resolve <= 1'b0;
             came_via_menukey <= 1'b0;
+            menu_seen <= 1'b0;
             deadend_vts <= 8'd0; deadend_pgcn <= 16'd0; deadend_seen <= 1'b0;
             fb <= FB_NONE;
             fuse <= 13'd0; chain <= 7'd0;
@@ -727,6 +779,21 @@ always @(posedge clk or negedge rst_n) begin
                     nat_src   <= 1'b0;
                     if (fb == FB_GAVEUP) begin
                         fb <= FB_NONE;            // never loop on errors
+                    end else if (fb == FB_BOOTM && cur_vts != 8'd0 &&
+                                 cur_vts != vm_vts) begin
+                        // The boot-chain shortcut aimed at best_menu_vts and that
+                        // VTS has no Root menu: fall back to the SPEC path (this
+                        // title's own VTSM Root) before widening to VMGM, so a bad
+                        // best_menu_vts guess can never cost a menu that used to work.
+                        fb <= FB_VTSM2;
+                        vm_dom <= DOM_VTSM; vm_vts <= cur_vts;
+                        jump_domain <= DOM_VTSM;
+                        jump_vts <= cur_vts; jump_pgcn <= 16'd0;
+                        jump_entry <= 4'd3;       // Root
+                        jump_ttn <= 7'd0; jump_pgn <= 8'd0; jump_cell <= 8'd0;
+                        jump_pulse <= 1'b1;
+                        wait_tmr <= 24'd0;
+                        state <= V_WAIT;
                     end else if (fb == FB_VTSM && best_menu_vts != 8'd0 &&
                                  best_menu_vts != vm_vts) begin
                         fb <= FB_VTSM2;
@@ -738,7 +805,8 @@ always @(posedge clk or negedge rst_n) begin
                         jump_pulse <= 1'b1;
                         wait_tmr <= 24'd0;
                         state <= V_WAIT;
-                    end else if (fb == FB_VTSM || fb == FB_VTSM2) begin
+                    end else if (fb == FB_VTSM || fb == FB_VTSM2 ||
+                                 fb == FB_BOOTM) begin
                         fb <= FB_VMGM;
                         vm_dom <= DOM_VMGM; vm_vts <= 8'd0;
                         jump_domain <= DOM_VMGM;
@@ -883,13 +951,17 @@ always @(posedge clk or negedge rst_n) begin
                             // Resuming RSM here would replay the copyright, so instead
                             // RE-INVOKE the Root menu (menu_call(Root) semantics), with
                             // the FB_VTSM fallback chain to a real menu.
-                            vm_dom <= DOM_VTSM; vm_vts <= cur_vts;
+                            // menukey_vts/boot_menu: before the disc has ever shown a
+                            // menu (e.g. Menu pressed while still in the FP chain), aim
+                            // at best_menu_vts instead - see the boot-menu shortcut note
+                            // at the FB_BOOTM declaration.
+                            vm_dom <= DOM_VTSM; vm_vts <= menukey_vts;
                             jump_domain <= DOM_VTSM;
-                            jump_vts <= cur_vts; jump_pgcn <= 16'd0;
+                            jump_vts <= menukey_vts; jump_pgcn <= 16'd0;
                             jump_entry <= 4'd3;   // Root
                             jump_ttn <= 7'd0; jump_pgn <= 8'd0; jump_cell <= 8'd0;
                             jump_pulse <= 1'b1;
-                            fb <= FB_VTSM;
+                            fb <= boot_menu ? FB_BOOTM : FB_VTSM;
                             wait_tmr <= 24'd0;
                             state <= V_WAIT;
                         end
@@ -902,13 +974,17 @@ always @(posedge clk or negedge rst_n) begin
                         rsm_r4 <= sprm4; rsm_r5 <= sprm5; rsm_r6 <= sprm6;
                         rsm_r7 <= sprm7; rsm_r8 <= sprm8_eff;
                         came_via_menukey <= 1'b1;
-                        vm_dom <= DOM_VTSM; vm_vts <= cur_vts;
+                        // menukey_vts/boot_menu: on the FIRST menu invocation of a
+                        // mount, aim at best_menu_vts rather than this title's own
+                        // VTSM Root, which on a DVD-game disc is a dispatcher and not
+                        // a menu (Atmosfear). See the FB_BOOTM declaration note.
+                        vm_dom <= DOM_VTSM; vm_vts <= menukey_vts;
                         jump_domain <= DOM_VTSM;
-                        jump_vts <= cur_vts; jump_pgcn <= 16'd0;
+                        jump_vts <= menukey_vts; jump_pgcn <= 16'd0;
                         jump_entry <= 4'd3;   // Root
                         jump_ttn <= 7'd0; jump_pgn <= 8'd0; jump_cell <= 8'd0;
                         jump_pulse <= 1'b1;
-                        fb <= FB_VTSM;
+                        fb <= boot_menu ? FB_BOOTM : FB_VTSM;
                         wait_tmr <= 24'd0;
                         state <= V_WAIT;
                     end

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -2184,21 +2184,53 @@ end
 // AND no video" trivially, so it latched UNSUPPORTED IMAGE after 5 s every time
 // — the failure message as a boot screen. Sticky from the first mount; the
 // re-arm on each subsequent mount is what actually clears the latch.
-localparam [27:0] IMG_WD = 28'd135_000_000;        // ~5 s @ 27 MHz
-reg [27:0] img_wd_cnt;
+// ⚠ STREAMING TIME, NOT WALL TIME (HW round 2, 2026-08-25): the window used to
+// run on wall time from the mount, so an image served off a slow share (user
+// report: a NAS whose drives spin up on first access) burned the entire 5 s
+// before the FIRST BYTE ever arrived — UNSUPPORTED IMAGE latched, the image then
+// loaded fine, and the sticky popup sat over correct playback. Two changes fix
+// that class of false positive for good:
+//   (1) the window only advances while sector data is ACTUALLY BEING DELIVERED
+//       (a sd_buff_wr write within IMG_IDLE). Any delivery stall — spin-up, a
+//       slow share, a re-seek — freezes the count instead of spending it, so the
+//       watchdog measures "streamed this long without a picture", which is the
+//       thing it was always trying to say.
+//   (2) the window is widened 5 s -> ~20 s of that active streaming. An
+//       unplayable image is not urgent to report; a wrong report is expensive.
+// And the latch now SELF-RETRACTS on video_live: the message asserts "this image
+// never produces a picture", so a decoded frame disproves it by construction and
+// it must not outlive that. Belt-and-braces against any future timing surprise.
+localparam [29:0] IMG_WD   = 30'd540_000_000;      // ~20 s of ACTIVE streaming @ 27 MHz
+localparam [24:0] IMG_IDLE = 25'd13_500_000;       // ~0.5 s with no delivered data = stalled
+reg [29:0] img_wd_cnt;
+reg [24:0] img_idle_cnt;                           // saturating "time since last sector byte"
 reg        img_unplayable;
 reg        media_seen;
+wire       img_streaming = (img_idle_cnt != IMG_IDLE);
 always @(posedge clk_sys or negedge reset_n) begin
     if (!reset_n) begin
-        img_wd_cnt <= 28'd0; img_unplayable <= 1'b0; media_seen <= 1'b0;
-    end else if (start_streaming) begin           // fresh mount: re-arm
-        img_wd_cnt <= 28'd0; img_unplayable <= 1'b0; media_seen <= 1'b1;
-    end else if (!media_seen || video_live_s2 || iso_mode_w) begin
-        img_wd_cnt <= 28'd0;                      // idle, playing, or a real ISO
-    end else if (img_wd_cnt == IMG_WD) begin
-        img_unplayable <= 1'b1;
+        img_wd_cnt <= 30'd0; img_idle_cnt <= IMG_IDLE;
+        img_unplayable <= 1'b0; media_seen <= 1'b0;
     end else begin
-        img_wd_cnt <= img_wd_cnt + 28'd1;
+        // Delivery-activity detector (free-running, mount-independent): every
+        // sector-buffer write re-arms it; it saturates at IMG_IDLE = "nothing has
+        // arrived for ~0.5 s" = the stream is stalled, not slow.
+        if (sd_buff_wr)                     img_idle_cnt <= 25'd0;
+        else if (img_idle_cnt != IMG_IDLE)  img_idle_cnt <= img_idle_cnt + 25'd1;
+
+        if (start_streaming) begin                    // fresh mount: re-arm
+            img_wd_cnt <= 30'd0; img_unplayable <= 1'b0; media_seen <= 1'b1;
+        end else if (!media_seen || video_live_s2 || iso_mode_w) begin
+            img_wd_cnt <= 30'd0;                      // idle, playing, or a real ISO
+            if (video_live_s2) img_unplayable <= 1'b0;   // a picture disproves the verdict
+        end else if (!img_streaming) begin
+            // Delivery stalled: hold the window rather than spend it. This is the
+            // NAS spin-up case and it must not count against the image.
+        end else if (img_wd_cnt == IMG_WD) begin
+            img_unplayable <= 1'b1;
+        end else begin
+            img_wd_cnt <= img_wd_cnt + 30'd1;
+        end
     end
 end
 

--- a/tools/dvd_vm_ref.py
+++ b/tools/dvd_vm_ref.py
@@ -489,6 +489,15 @@ class VM(object):
         # (title -> CallSS VTSM Root). Only then does a second Menu press LinkRSM
         # back to the title (the movie menu<->title toggle). See dvd_vm.sv.
         self.came_via_menukey = False
+        # TRUE once a menu-domain PGC has been loaded since the mount. Gates the
+        # BOOT-CHAIN MENU SHORTCUT - see the long note at FB_BOOTM in dvd_vm.sv.
+        # Deliberate deviation from libdvdnav's vm_jump_menu (user decision,
+        # 2026-08-25, Atmosfear): the FIRST menu invocation of a mount aims at
+        # best_menu_vts instead of the playing title's own VTSM Root, because on a
+        # DVD-game disc that Root PGC is a dispatcher that routes on "which VTS
+        # were you in", not a menu. Self-limiting: that press loads a menu, so
+        # every later press is the unmodified spec path.
+        self.menu_seen = False
         self.trace = []
         self.verbose = verbose
         self.fuse = 0
@@ -529,6 +538,8 @@ class VM(object):
         if pgcn < 1 or pgcn > len(pit):
             return False
         self.dom, self.vts, self.pgcn = dom, vts, pgcn
+        if dom in (DOM_VMGM, DOM_VTSM):
+            self.menu_seen = True           # RTL: `if (menu_active) menu_seen <= 1`
         self.pgc = self.nav.pgc(pit[pgcn - 1][1])
         if pgn and self.pgc["pm"] and pgn <= len(self.pgc["pm"]):
             cell = self.pgc["pm"][pgn - 1] - 1
@@ -714,12 +725,21 @@ class VM(object):
     def _menu_call_root(self):
         """menu_call(Root): jump to the Root menu with the VTSM->best_menu->VMGM
         fallback chain. Used by Menu-in-title AND (the TP_SW case) Menu-in-menu
-        when we did NOT enter this menu via the Menu key."""
-        if not self._load_pgcn(DOM_VTSM, self.vts, 0, entry=ENTRY_ROOT):
-            self.log("  own VTSM failed -> best_menu_vts %d"
-                     % self.nav.best_menu_vts)
-            if not self._load_pgcn(DOM_VTSM, self.nav.best_menu_vts, 0,
-                                   entry=ENTRY_ROOT):
+        when we did NOT enter this menu via the Menu key.
+
+        BOOT-CHAIN SHORTCUT (see __init__): before the disc has ever shown a menu,
+        aim at best_menu_vts and keep the playing title's own VTSM Root as the
+        FALLBACK, so a bad best_menu_vts guess can never cost a menu that worked."""
+        boot_menu = (not self.menu_seen and self.nav.best_menu_vts
+                     and self.nav.best_menu_vts != self.vts)
+        first = self.nav.best_menu_vts if boot_menu else self.vts
+        second = self.vts if boot_menu else self.nav.best_menu_vts
+        if boot_menu:
+            self.log("  boot-chain shortcut: Root of best_menu_vts %d "
+                     "(no menu seen yet)" % first)
+        if not self._load_pgcn(DOM_VTSM, first, 0, entry=ENTRY_ROOT):
+            self.log("  VTSM %d failed -> VTSM %d" % (first, second))
+            if not self._load_pgcn(DOM_VTSM, second, 0, entry=ENTRY_ROOT):
                 if not self._load_pgcn(DOM_VMGM, 0, 0, entry=2):
                     return self._process(("LinkRSM", 0, 0, 0))
         return True

--- a/tools/iso_nav_check.py
+++ b/tools/iso_nav_check.py
@@ -475,7 +475,12 @@ def main(path):
             print("  SRP[%d] = PGCN %d: entry_id=0x%02x%s  cells=%d next=%d prev=%d "
                   "goup=%d mode=0x%02x still=0x%02x  (pgc in-sector off=%d%s)"
                   % (i, i+1, eid, ent, h[3], nxt, prv, gup, mode, still, pgc_off,
-                     " *STRADDLE >1816: RTL skips hdr/palette/cmds*"
+                     # The RTL's Phase-1 "skip straddling PGCs" limitation is
+                     # RETIRED (sector-crossing walker + rbuf shadow fetch, see
+                     # docs/dvd_nav.md "Sector-straddle audit"): a PGC starting
+                     # this late parses fine now. Kept as a note because it is
+                     # still the interesting case to re-check after reader work.
+                     " *straddles the sector boundary (walker handles it)*"
                      if pgc_off > 1816 else ""))
             dump_pgc_cmds("cmds", pa)
             cpo = struct.unpack('>H', h[232:234])[0]


### PR DESCRIPTION
Two user-reported bugs, both HW-confirmed on the board (2026-08-25).

## 1. `UNSUPPORTED IMAGE` appeared over correct playback (`dvd/emu.sv`)

An image served off a NAS whose drives spin up on first access raised
`UNSUPPORTED IMAGE`, and because the latch is sticky the popup then sat over
correct playback once the image finally loaded.

Root cause: `IMG_WD` ran on **wall time from the mount**, so the whole 5 s window
could be spent before the first byte ever arrived. "Flat-file path AND no video
yet" was true — for a reason that has nothing to do with the image.

- **Streaming time, not wall time.** A free-running activity detector
  (`img_idle_cnt`, re-armed by every `sd_buff_wr`, saturating at ~0.5 s) gates the
  window: any delivery stall — spin-up, a slow share, a re-seek — freezes the count
  instead of spending it. The watchdog now measures what it always meant.
- **Window widened 5 s → ~20 s** of that active streaming.
- **The latch self-retracts on `video_live`.** The message asserts "this image never
  produces a picture", so a decoded frame disproves it by construction.

Coverage for a genuinely unplayable file that streams is unchanged (it still
latches, just later). A junk file that delivers *nothing at all* now stays silent —
a deliberate trade: "nothing arrived" is a media/transport problem, not an
image-format one.

## 2. Menu over the copyright screen played a clip, not the menu (`dvd/dvd_vm.sv`)

On Atmosfear, pressing Menu over the First Play copyright screen landed on a random
Gatekeeper clip instead of the main menu.

**It is the disc, not us — which is why this needed a deviation.** Traced on the
real ISO:

```
FP: g5=0x2000; g5=1; g3=0x44; JumpTT 68     <- VTS_68 = the FBI warning (5 s)
Menu -> menu_call(Root) on the PLAYING VTS, per spec
VTSM(68) PGC1: ... g2 = 7 ; JumpSS VMGM 6
VMGM PGC6:     g2 < 0x2c -> JumpSS VTSM(1, Root)
VTSM(1) PGC1:  g2 != 0 -> LinkPGCN 5 -> (g2==7) -> LinkPGCN 48
VTSM(1) PGC48: g15 = rnd 6 ; g5 = g15 ; g3 = 1 ; JumpSS VMGM 2 -> JumpTT 1
```

Every VTS's VTSM Root on this disc sets `g[2]=7`: that PGC is **not a menu**, it is
a dispatcher that routes on *where* Menu was pressed from. **libdvdnav behaves
identically** — verified by building its `examples/trace_menuearly.c` against the
real ISO (`Title=68` → `menu_call(Root)` → `Title=1` → menu domain) — and the disc
sets **no UOP bits** (PGC `prohibited_ops` and every PCI `vobu_uop_ctl` are zero),
so nothing tells a player to refuse the key.

Deviation, with a deliberately bounded blast radius: while **no menu-domain PGC has
loaded since the mount** (`menu_seen == 0`), the Menu key targets the Root menu of
`best_menu_vts` instead of the playing title's own VTSM Root. `g[2]` stays 0 and
Atmosfear's `VTSM(1)` Root takes its clean path to `LinkPGCN 7` = the real main menu.

Bounded by:
- **Self-limiting** — that press loads a menu, latching `menu_seen`; every later
  press is the unmodified spec path.
- **New `fb = FB_BOOTM`** falls back to the SPEC path (this title's own VTSM Root)
  before widening to VMGM, so a bad `best_menu_vts` guess cannot cost a menu that
  worked.
- **Inert** when `best_menu_vts` is 0 or equals `cur_vts` (the common movie disc).
- **`menu_seen` latches on the LOAD EVENT**, not the bare `menu_active` level — a
  level still stale from the previous disc would otherwise disable the shortcut for
  a whole session, silently.

## Test plan

- [x] `dvd_vm_tb` — all pass, incl. updated **[S2]** (first press retargets,
      `fb == FB_BOOTM`) and new **[S21]** (target / `FB_BOOTM`→own-VTS fallback →
      VMGM / self-limiting after a menu load)
- [x] `tools/dvd_vm_ref.py selftest` — 27/27 golden vectors unchanged; golden model
      mirrors the deviation (`menu_seen`, `_menu_call_root`)
- [x] **141-disc library sweep**, old vs new Menu-key landing: 135 unchanged,
      6 changed — all six from a **title** landing to a **menu** landing
      (ATMOSFEAR, A_Good_Man, GMEN_FROM_HELL, RETURN_OF_THE_LIVING_DEAD ×2, STARWARP)
- [x] `dvd_vm_atmos_tb`, `iso_reader_{vm,menu,cluedo_menu,callss_return,seek,straddle,vmgm,zerocell,montage,predispatch,intitle_link,tpsw}_tb` green
- [x] `transport_hud_tb` green (message path unchanged)
- [x] Quartus compile clean
- [x] **HW-confirmed by the user on the board (2026-08-25)** — both fixes

## Notes

- Also retires a stale warning in `tools/iso_nav_check.py` that still claimed the RTL
  skips straddling PGCs; that limitation went away with the sector-crossing walker
  (`docs/dvd_nav.md` "Sector-straddle audit"). It actively misleads on discs whose
  menu PGCs straddle — e.g. Atmosfear's VMGM PGC 9 at in-sector offset 1968.
- **Pre-existing, not from this branch:** `iso_reader_atmos_tb` and
  `iso_reader_tpsw_boot_tb` fail on `main` too (confirmed in a clean worktree at
  `4227908`). Both read `nr_cells=255 / off=2047`, so their `.hex` fixtures look out
  of sync with the reader. Untouched here.
- The branch's own release build came out **MARGINAL** (clk_dec 76.65 MHz vs the
  86.0 target — the known fringe lottery). That is a fit-lottery property of the
  bitstream, not of these sources; a shipping `.rbf` wants a seed sweep.

Docs: `docs/dvd_vm.md` "Boot-chain menu shortcut" (full trace, rationale, sweep
table), `docs/roadmap.md` HW round 2, `CLAUDE.md`, `README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
