### PR TITLE
dvd_iso_reader: round the C_PBTM frame field into the cell hold duration

### DIFF
--- a/DVD.qsf
+++ b/DVD.qsf
@@ -550,4 +550,12 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # tools/seed_sweep.sh, FMAX_MIN=86.0): SEED 7 routes + PASSES both corners
 # (clk_dec 86.54 MHz @100C / 87.73 MHz @-40C) - first seed tried ->
 # releases/DVD_celldurfrm_20260825_1652.rbf. Pinned SEED 7.
-set_global_assignment -name SEED 7
+#
+# WL-ENTROPY netlist (2026-08-25, same branch, + the TIMESTAMP seed hardening): the
+# hps_io TIMESTAMP plumbing reshuffled placement again -> SEED 7 fell to 73.58 MHz @100C.
+# Re-swept (USE_DOCKER tools/seed_sweep.sh, FMAX_MIN=86.0): 7 73.58, 9 85.68 (0.32 under),
+# 11 68.24, 13 75.61, 5 77.62 -- then SEED 8 routes + PASSES both corners with real margin
+# (clk_dec 90.56 MHz @100C / 90.56 MHz @-40C) -> releases/DVD_wlentropy_20260825_2010.rbf.
+# Pinned SEED 8. Note the scatter: on this congested placement one seed lands and the rest
+# come in 10+ MHz low - sweep, never assume a neighbouring seed transfers.
+set_global_assignment -name SEED 8

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -543,4 +543,11 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # gate). Re-swept (USE_DOCKER tools/seed_sweep.sh, FMAX_MIN=86.0): seeds 9/11/13
 # FAILED (75-86 range); SEED 5 routes + PASSES both corners (87.70 @100C /
 # 88.88 @-40C) -> releases/DVD_vcdsvcd_20260825_0131.rbf. Pinned SEED 5.
-set_global_assignment -name SEED 5
+#
+# CELL-DURATION-FRAMES netlist (2026-08-25, fix/cell-duration-frames): the C_PBTM
+# frame-rounding wires reshuffled placement -> the inherited SEED 5 came in badly
+# MARGINAL (clk_dec 75.95 MHz @100C / 77.7 @-40C). Re-swept (USE_DOCKER
+# tools/seed_sweep.sh, FMAX_MIN=86.0): SEED 7 routes + PASSES both corners
+# (clk_dec 86.54 MHz @100C / 87.73 MHz @-40C) - first seed tried ->
+# releases/DVD_celldurfrm_20260825_1652.rbf. Pinned SEED 7.
+set_global_assignment -name SEED 7

--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ HUD and seek bar.
   practice this is not something you notice. PAL has less headroom because the frames are
   taller.
 - **Interactive DVD games are incomplete.** Several game discs mis-navigate their
-  dispatcher logic. Film and TV discs are the supported path.
+  dispatcher logic. Film and TV discs are the supported path. Note also that some game
+  discs put their randomisation setup in the boot sequence and jump past it when you press
+  **Menu** to skip the intro — the game then repeats one question. That is how the disc is
+  authored (a real player and libdvdnav do the same); let the intro play.
 - **No DTS decode** — S/PDIF passthrough to a receiver only.
 - **Audio formats:** AC-3, MPEG-1 Layer II (MP2), LPCM, and DTS (passthrough only).
   The one gap left is the MPEG-2 multichannel *extension* (a rare 5.1 variant of MP2):

--- a/bench/dvd/dvd_vm_tb.sv
+++ b/bench/dvd/dvd_vm_tb.sv
@@ -1359,6 +1359,18 @@ module dvd_vm_tb;
         if (dut.lfsr === 16'd0) fail("T4: zero seed locked the LFSR at 0");
         rnd_seed = 16'hACE1;
         $display("T4 nonzero-seed guard PASS");
+
+        // ---- T5: a stir that XORs the LFSR to ZERO must not lock it --------
+        // entropy_val is the free-running entropy counter, so it lands on the
+        // LFSR's own value eventually (1 in 65536 per stir). An all-zero LFSR
+        // never leaves 0, and every later rnd would return 1 forever.
+        vm_restart;                          // lfsr = 0xACE1
+        @(negedge clk); ent_val = 16'hACE1; ent_stir = 1;   // XOR -> 0
+        @(negedge clk); ent_stir = 0;
+        repeat (3) @(negedge clk);
+        if (dut.lfsr === 16'd0) fail("T5: self-XOR stir locked the LFSR at 0");
+        ent_val = 16'd0;
+        $display("T5 stir zero-lock guard PASS (lfsr=%04h)", dut.lfsr);
     end
     endtask
 

--- a/bench/dvd/iso_reader_celldur_tb.sv
+++ b/bench/dvd/iso_reader_celldur_tb.sv
@@ -32,6 +32,17 @@
 // T4: cell 3 (last) ends with 6 s unspent -> PGC-end hold (STILL_PGEND), then
 //     vm_pgc_end dispatches POST.
 //
+// T8-T10 (2026-08-25): the C_PBTM FRAME FIELD. Interactive discs author their
+// short screens as "N s + (fps-1) frames" - Weakest Link's correct/wrong answer
+// reveal and its money-banked screen are 1 s + 24 f @25 fps = 1.96 s. Dropping
+// the frames stored 1 s, whose residual (1) sits under RESID_MIN, so those
+// screens took NO hold at all and flashed by in ~0.2 s. Title 3 vectors it:
+//     cell 0: pbtime 1 s + 24 f @25 fps, cmd 1  (0xB0) -> rounds to 2 s: HOLDS
+//     cell 1: pbtime 1 s +  2 f @25 fps, cmd 2  (0xB1) -> stays 1 s: NO hold
+//                                                         (sub-second cells on
+//                                                          other discs unchanged)
+//     cell 2: pbtime 3 s + 23 f @25 fps, last   (0xB2) -> rounds to 4 s: PGC-end
+//
 // SEC_DIV(1000): 1 hold-second = 1000 clk. disp_fps=4: 4 disp_ticks = 1
 // display-second (the tb is the "raster").
 //
@@ -166,6 +177,7 @@ module iso_reader_celldur_tb;
     reg [7:0] cap [0:131071];
     reg saw_b1 = 0, saw_b2 = 0;
     reg plain_hold_viol = 0;
+    reg frac_hold_viol = 0;      // T9: title-3 cell 1 must never hold
     always @(posedge clk) begin
         if (stream_valid) begin
             cap[cap_n] = stream_data;
@@ -175,6 +187,10 @@ module iso_reader_celldur_tb;
         end
         // the cell1 (plain, 9 s unspent) -> cell2 advance must never hold
         if (still_active && saw_b1 && !saw_b2) plain_hold_viol = 1;
+        // T9: title 3's cell 1 (1 s + 2 f = 1.08 s, rounds DOWN to 1 s) must
+        // stay under RESID_MIN - sub-second cells keep their no-hold behaviour.
+        if (still_active && dut.cur_pgcn == 16'd3 && cur_cell == 8'd1)
+            frac_hold_viol = 1;
     end
 
     // ---- event counters ----
@@ -376,11 +392,13 @@ module iso_reader_celldur_tb;
 
             // TT_SRPT @20: 2 titles -> VTS_01 ttn 1 / ttn 2 (t2 = Phase-6
             // spec-max-duration vectors)
-            be16(20*2048+0, 16'd2);
+            be16(20*2048+0, 16'd3);
             img[20*2048+14] = 8'd1;               // TT_SRP[0].title_set_nr
             img[20*2048+15] = 8'd1;               // TT_SRP[0].vts_ttn
             img[20*2048+26] = 8'd1;               // TT_SRP[1].title_set_nr
             img[20*2048+27] = 8'd2;               // TT_SRP[1].vts_ttn
+            img[20*2048+38] = 8'd1;               // TT_SRP[2].title_set_nr
+            img[20*2048+39] = 8'd3;               // TT_SRP[2].vts_ttn (frame-field)
 
             // VMGM PGCI_UT @21: PGCN1 entry 0x82, 1 cell (unused here)
             put_ut(21, 16'd1);
@@ -398,11 +416,13 @@ module iso_reader_celldur_tb;
             //   cell 2: pbtime 10s, cmd 2  (0xB2)   elapsed-credit case
             //   cell 3: pbtime  6s, plain  (0xB3)   last cell: PGC-end hold
             //   cmd tbl: post=1 (Nop), cell 1/2 (Nop); pm {1,2,3,4}
-            be16(23*2048+0, 16'd2);
+            be16(23*2048+0, 16'd3);
             img[23*2048+8] = 8'h81;               // SRP[0].entry_id (title 1)
             be32(23*2048+8+4, 32'd16);
             img[23*2048+16] = 8'h82;              // SRP[1].entry_id (title 2)
             be32(23*2048+16+4, 32'd700);
+            img[23*2048+24] = 8'h83;              // SRP[2].entry_id (title 3)
+            be32(23*2048+24+4, 32'd1100);
             put_pgc(23*2048+16, 8'd4, 8'd4, 16'd0, 8'd0, 16'd400, 16'd240, 16'd256);
             img[23*2048+16+240] = 8'd1;           // pm[0] = cell 1
             img[23*2048+16+241] = 8'd2;           // pm[1] = cell 2
@@ -432,6 +452,22 @@ module iso_reader_celldur_tb;
             put_cell(23*2048+700, 16'd256, 1, 8'd0, 8'd0, 32'h095959C0, 32'd5, 32'd5);
             put_cell(23*2048+700, 16'd256, 2, 8'd0, 8'd0, 32'h000002C0, 32'd6, 32'd6);
             put_cmdtbl(23*2048+700, 16'd400, 0, 1, 0,
+                       64'd0, 64'd0, 64'd0);
+
+            // title 3 PGC @1100 - the C_PBTM FRAME-FIELD vectors (T8-T10).
+            // rate|frames byte: 2'b01 = 25 fps, so 0x64 = 24 frames (0.96 s),
+            // 0x42 = 2 frames (0.08 s), 0x63 = 23 frames (0.92 s).
+            //   cell 0: 1 s + 24 f = 1.96 s, cmd 1 -> stored 2 s -> HOLDS 2 s
+            //   cell 1: 1 s +  2 f = 1.08 s, cmd 2 -> stored 1 s -> NO hold
+            //   cell 2: 3 s + 23 f = 3.92 s, last  -> stored 4 s -> PGC-end 4 s
+            put_pgc(23*2048+1100, 8'd3, 8'd3, 16'd0, 8'd0, 16'd400, 16'd236, 16'd256);
+            img[23*2048+1100+236] = 8'd1;         // pm {1,2,3}
+            img[23*2048+1100+237] = 8'd2;
+            img[23*2048+1100+238] = 8'd3;
+            put_cell(23*2048+1100, 16'd256, 0, 8'd0, 8'd1, 32'h00000164, 32'd0, 32'd0);
+            put_cell(23*2048+1100, 16'd256, 1, 8'd0, 8'd2, 32'h00000142, 32'd1, 32'd1);
+            put_cell(23*2048+1100, 16'd256, 2, 8'd0, 8'd0, 32'h00000363, 32'd2, 32'd2);
+            put_cmdtbl(23*2048+1100, 16'd400, 0, 1, 2,
                        64'd0, 64'd0, 64'd0);
 
             // payload sectors
@@ -604,6 +640,49 @@ module iso_reader_celldur_tb;
         while (n_vm_pgc_end < 2 && t < 400000) begin @(posedge clk); t = t + 1; end
         if (n_vm_pgc_end < 2) fail("T7: vm_pgc_end never dispatched after the hold");
         $display("T7 PASS: 16-bit residual machinery end-to-end (600 s hold -> spec-max meta -> PGC end)");
+
+        // ------------- T8-T10: the C_PBTM FRAME FIELD ----------------------
+        // Jump to title 3 (button JumpTT 3 - the VM is idle after T7's POST).
+        @(negedge clk); btn_cmd = 64'h3002000000030000; btn_cmd_valid = 1;
+        @(negedge clk); btn_cmd_valid = 0;
+
+        // T8: the Weakest Link reveal shape - 1 s + 24 f @25 fps = 1.96 s. The
+        // frames must round INTO the stored duration (2 s), or the residual (1)
+        // sits under RESID_MIN and the screen flashes past with no hold at all.
+        t = 0;
+        while (!(still_active && dut.cur_pgcn == 16'd3 && cur_cell == 8'd0) &&
+               t < 4000000) begin @(posedge clk); t = t + 1; end
+        $display("T8 hold: still_active=%b secs=%0d next=%0d dur=%0d",
+                 still_active, dut.still_secs, dut.still_next,
+                 dut.cell_meta_mem[0][31:16]);
+        if (!still_active)                        fail("T8: 1 s + 24 f cell did NOT hold (frames dropped)");
+        if (dut.cell_meta_mem[0][31:16] !== 16'd2) fail("T8: meta duration != 2 s (frames not rounded in)");
+        if (dut.still_secs !== 16'd2)             fail("T8: hold != 2 s");
+        if (dut.still_next !== 2'd1)              fail("T8: hold action != STILL_CMD");
+        $display("T8 PASS: 1 s + 24 f (1.96 s) holds 2 s - the WL answer-reveal shape");
+
+        // T9: 1 s + 2 f = 1.08 s rounds DOWN -> stored 1 s -> no hold (checked
+        // continuously by frac_hold_viol; the meta value is the direct proof).
+        t = 0;
+        while (!(dut.cur_pgcn == 16'd3 && cur_cell == 8'd1) && t < 4000000) begin
+            @(posedge clk); t = t + 1;
+        end
+        if (dut.cell_meta_mem[1][31:16] !== 16'd1) fail("T9: 1 s + 2 f wrongly rounded UP");
+        $display("T9 PASS: 1 s + 2 f stays 1 s (sub-second cells keep no-hold)");
+
+        // T10: 3 s + 23 f = 3.92 s on the LAST cell -> 4 s PGC-end hold.
+        t = 0;
+        while (!(still_active && dut.cur_pgcn == 16'd3 && cur_cell == 8'd2) &&
+               t < 4000000) begin @(posedge clk); t = t + 1; end
+        $display("T10 hold: still_active=%b secs=%0d next=%0d dur=%0d",
+                 still_active, dut.still_secs, dut.still_next,
+                 dut.cell_meta_mem[2][31:16]);
+        if (!still_active)                         fail("T10: last cell did not PGC-end hold");
+        if (dut.cell_meta_mem[2][31:16] !== 16'd4) fail("T10: meta duration != 4 s");
+        if (dut.still_secs !== 16'd4)              fail("T10: PGC-end hold != 4 s");
+        if (dut.still_next !== 2'd2)               fail("T10: hold action != STILL_PGEND");
+        if (frac_hold_viol) fail("T9: title-3 cell 1 (1.08 s) raised a hold");
+        $display("T10 PASS: 3 s + 23 f (3.92 s) holds 4 s at PGC end");
 
         if (errors == 0) $display("ISO_READER_CELLDUR_TB: ALL TESTS PASSED");
         else             $display("ISO_READER_CELLDUR_TB: FAILED with %0d errors", errors);

--- a/docs/disc_sweep.md
+++ b/docs/disc_sweep.md
@@ -884,6 +884,511 @@ just happens to be how you reach them.
 > current no-hold behaviour. Detail + the accepted ±0.5 s quantisation:
 > `docs/dvd_nav.md` "Authored cell duration → Amendment (2026-08-25)".
 
+### Round-8 (2026-08-25) — the "same question every time" is AUTHORED: Menu skips the disc's own RNG seeding
+
+**HW report (same session):** with the hold fixed, Weakest Link asked **the same question
+every time** — and the user then pinned it precisely: *it only happens if you press the
+**Menu button during the boot sequence** to skip to the main menu.* Let the intro play and
+the questions randomise.
+
+**That is the disc's own design, and we reproduce it exactly.** WL seeds its question
+index inside the boot chain:
+
+```
+VTS21 PGC24 PRE : g[12] = 0 ; g[13] rnd 0xffff ; SetMode Counter g[12] = g[13]
+VTS21 PGC28 POST: g[5] = g[12] ; g[4] rnd 0x35f ; (guard g[4] != 0)
+VTS21 PGC30 PRE : g[5] += g[4] ; g[5] %= 0x35f          <- the question index
+VTS02 PGC1381 POST: same advance after every question
+```
+
+and its **Root-menu trampoline bypasses both**:
+
+```
+VTSM(21) PGC1 : g[15] = 2 ; JumpSS VMGM pgc 4
+VMGM   PGC4  : JumpTT 21
+VTS21  PGC1  : if (g[15]==0) LinkPGCN 29   <- the boot intro
+               if (g[15]==1) LinkPGCN 24   <- the RNG seeding
+               if (g[15]==2) LinkPGCN 30   <- the player-select menu   <== Menu lands here
+```
+
+Press Menu before the chain reaches PGC24/PGC28 and the game runs with `g[4] = g[5] = 0`:
+index 0, and `g[5] += g[4]` never moves it — **the same question, for every player,
+forever**. Confirmed three ways: the command dumps above, our golden model
+(`tools/dvd_vm_ref.py menu`) landing on PGC30 with `g4=g5=0`, and **libdvdnav's own
+`trace_menuearly`** taking the identical route (VTSM21 PGC1 → VMGM4 → JumpTT 21 → PGC1 →
+PGC30). A real player does the same thing.
+
+**⚠ UOP enforcement would NOT change this** (asked and answered before writing any code):
+this disc sets **no operation-prohibition bits at all** — 4,257 title PGCs with
+`prohibited_ops == 0`, and all 68 NAV packs across the boot clip with
+`vobu_uop_ctl == 0`. Same finding as the Atmosfear round. There is no flag saying "don't
+call the menu here", so no faithful player can refuse the press.
+
+**The boot-chain menu shortcut (PR #4) is also not involved:** it only retargets when
+`best_menu_vts != cur_vts`, and on WL both are VTS 21, so the shortcut is inert and the
+spec path runs.
+
+**Verdict: authored fragility, faithfully reproduced. No RTL fix shipped.** Workaround:
+let the boot chain play (or press Menu once the disc's own menu is up). The only thing
+that could paper over it is a deviation that *runs* the skipped chain instead of jumping
+(see the options recorded in `docs/dvd_vm.md` "Menu over a boot chain"), which would
+misbehave on ordinary movie discs.
+
+> ⛔ **RETRACTED — the "first-boot entropy hole" diagnosis (written earlier the same day).**
+> Before the user isolated the Menu press, this round argued that the `rnd` LFSR seed was
+> deterministic because the first mount after a core load is machine-timed. The evidence
+> now shows the observation is fully explained by the skipped seeding commands, and
+> nothing supports the mount-timing theory. **The `TIMESTAMP` change shipped for it is
+> KEPT as hardening, not as a fix** — it makes the seed match libdvdnav's
+> `srand(time.tv_usec)` and costs nothing — but it is UNVERIFIED and must not be recorded
+> as the cause of anything. The LFSR **zero-lockup guard** that shipped alongside it
+> stands on its own (provable by inspection: `lfsr ^ entropy_val` can reach 0, and 0 is
+> absorbing). See `docs/dvd_vm.md` "DVD-game entropy".
+
+### Cluster B — game dispatchers take the wrong branch (Weakest Link, Family Feud II, Brain Game) — 3 discs ★ TOP PRIORITY
+
+All three are `HL_BTNN`/GPRM **dispatcher** discs: the button press itself does little, and
+the real routing happens in a PRE/POST chain that reads SPRM8 or a GPRM and jumps. Weakest
+Link reads `HL_BTNN` **1426 times** — by far the most SPRM8-dependent disc we own.
+
+Symptoms: WL cuts to "Round winnings" exactly where the first question should appear; FF
+"How to Play → Start" lands on the end-of-game Fast Money round; BG's buttons return to the
+menu.
+
+We have prior art here — SPRM8 has been wrong twice before, in ways that produce precisely
+"the dispatcher picked the wrong option": PR fj#135 (`sprm8` not latched on `btn_cmd_valid`
+→ menus always picked option 1, memory `sprm8-hlbtnn-latch`) and PR fj#137 (a POST read saw
+the *drifting* live `btn_sel` shadow → `sprm8_frozen`, memory `atmosfear-sprm8-frozen`).
+**PR fj#159 reworked promotion/arming — the layer that feeds `btn_sel` — so an SPRM8-shadow
+regression is a live possibility and should be the first thing checked.**
+
+Brain Game folds in here (see Cluster C's retraction): its buttons must set `g[3]` to
+2/3/4/6 to escape the menu, and "does nothing" is exactly what an unset `g[3]` produces.
+
+> **★ Decisive measurement — see "Round-2 measurements" below for the full version.**
+> Weakest Link is the instrument (1426 `HL_BTNN` reads, and a golden `trace_nav` capture of
+> the screen we never reach). Probe **SPRM8 + g[0], g[4], g[5], g[13]** at the divergence.
+
+### Cluster C — ⛔ **RETRACTED** (counter-inflated dispatcher loop) — hypothesis was WRONG
+
+The original theory: Brain Game's `PGC7` self-loops `LinkPGCN 7` `g[0]` times where
+`g[0] = 6 + seconds-on-menu` (seeded from a counter-mode GPRM), so PR fj#119's 1 Hz tick
+turned a 6-load dispatcher into a 6–50-load one = the black screen.
+
+> **⛔ REFUTED on hardware 2026-08-17.** Pressing Start after **2 s** and after **60 s**
+> produced **identical** behaviour. Dwell time does not change the outcome, so the loop
+> count is not the mechanism. **Do not re-chase this.** The disc's machine as decoded below
+> is still accurate and still useful — only the *inflation* theory is dead.
+
+The IFO decode stands and is worth keeping, because it shows what Brain Game needs in
+order to work at all (`VTSM vts=2`):
+
+```
+FP:    g[2]=1; g[3]=0x63; JumpSS VTSM(vts 2, menu 3)     <- boot landing is authored
+PGC1:  if g[3]==0x63 -> PGC2 ... else -> PGC3            <- dispatcher (g[3]=0x63 at boot)
+PGC2:  HL_BTNN=btn1; g[3]=0x62; SetMode Counter g[1]=6
+       POST: g[2]=HL_BTNN/0x400; LinkPGCN 6
+PGC6:  g[0]=g[1]; if g[0]>0x32 g[0]=0x23; SetMode Register g[1]=0; LinkPGCN 7
+PGC7:  g[1]=0x3e8; g[1] rnd g[1]; g[0]-=1;
+       if (g[0] > 0) LinkPGCN 7
+       if (g[3]==0) LinkPGCN 3;  if (g[3]==0x62) LinkPGCN 3;  else LinkPGCN 8
+PGC8:  dispatch g[3] -> JumpVTS_TT 1/2/3
+```
+
+**The surviving reading:** the tail of that chain routes to `PGC3` (the menu) whenever
+`g[3]` is still 0 or 0x62, and only reaches the `JumpVTS_TT` dispatcher (`PGC8`) when
+**`g[3]` has been set to 2/3/4/6 by the pressed button's command**. "The button does
+nothing" is therefore consistent with **`g[3]` never being set** — i.e. the button's
+command not taking effect — which is the same failure shape as Cluster B, so **Brain Game
+is folded into Cluster B** below.
+
+Also verified **not** a bug en route: Brain Game's odd boot landing (dispatcher takes the
+`g[3]==0x63` branch at cold boot) is **authored** — First Play sets `g[3]=0x63` itself.
+
+### Round-2 measurements (2026-08-17) — what the first probes settled
+
+**★ My block-numbering instruction in round 1 was WRONG and is corrected here:**
+blocks **1–4 are the FIRST row** (`blk1` hl_btns_armed, `blk2` video_live, `blk3` sp_seen,
+`blk4` spb_seen) and **5–8 the SECOND row** (`blk5` vbuf_deep, `blk6` still_active,
+`blk7` hl_on_w, `blk8` hlvis_seen). I asked for "blocks 3,4,7,8 (second row)" — those are
+not the same row, and the reported second row is therefore **blk5–blk8**.
+
+Reported second row (`blk5 blk6 blk7 blk8`):
+
+| Disc | vbuf_deep | still_active | **hl_on_w** | hlvis_seen |
+|---|---|---|---|---|
+| Harry Potter (Player Mode screen) | red | red | **GREEN** | green |
+| Speed Racer (first-loop main menu) | GREEN | red | **GREEN** | green |
+
+**What this proves:**
+- **`blk7` GREEN on both = `hl_on_w` (nav_pci `armed` AND `fetched`) is true.** Promotion
+  *and* the button-record fetch complete. **Cluster A is definitively not a promotion or
+  fetch fault** — that half of the round-1 reasoning is confirmed, and PR fj#159's promotion
+  model v2 is exonerated for these two discs.
+- **`blk6` red on both = the reader is NOT parked on a still**, so both are *motion/looping*
+  menus. `menu_settled` cannot fire on either (it requires `still_active`), so promotion here
+  came from the 1 s timer — the documented behaviour for looping menus, working as designed.
+- **`blk8` GREEN is NOT trustworthy as reported.** ⚠️ The probe watched `sp_force_q`, which
+  is `hud_on_w | bar_on_w | hl_use` — it reads green whenever the **transport HUD or seek bar**
+  draws any pixel, regardless of the highlight. A HUD auto-popup alone turns it green.
+  **Fixed in this change** ([emu.sv](../dvd/emu.sv), `hl_use_q`): blk8 now watches the
+  highlight term only. The green readings above must be re-taken on the next build.
+  *(Same lesson as the stale `straddle_check` model earlier in this sweep: our own probes go
+  stale and lie. A probe that can be green for two different reasons answers no question.)*
+
+**Still needed for Cluster A — the FIRST row, blocks 3 and 4** (`sp_seen`, `spb_seen`), plus
+the corrected blk8:
+- **blk4 red** → no SPU bytes reached the decoder → demux/substream routing.
+- **blk4 green, blk3 red** → bytes arrived, no subpicture pixel displayed → `spu_decode`
+  commit (the menu re-send guard, or the show window).
+- **blk3 green, corrected blk8 red** → subpicture displays but the recolour never fires →
+  rect/coli/`hl_use` path (PR fj#83 family).
+- **blk3 green AND corrected blk8 green** → the recolour genuinely fires and is still
+  invisible → the failure is downstream: the **PGC palette** lookup or the blend output.
+  (Both discs recover after a PGC re-load — Harry Potter when a skip forces one, Speed Racer
+  on the next loop — which fits a palette that is stale or unloaded for the new menu; see
+  memory `pgc-palette-seek-reset-bug`.)
+
+### Cluster B measurements — what came back
+
+- **Weakest Link: "ALL menu options that start the game land on the same Round Winnings
+  screen."** A dispatcher receiving a *constant* regardless of which button was pressed is
+  the signature of an SPRM8/GPRM that is not tracking the activation (`sprm8` resets to
+  `0x0400` = button 1). This strengthens Cluster B considerably.
+- **Family Feud II: the same question no matter how long you wait** — so dwell time is not
+  the entropy on this disc, and cluster F does not close for free.
+- Brain Game's dwell test (above) also showed no time dependence.
+
+Together those say **the GPRM/entropy state these discs read is not varying with time**, and
+Weakest Link's says **it does not vary with the button either**. Both point at the same
+place: the register state the dispatchers read.
+
+**Ruled out by direct comparison against libdvdnav (do not re-chase):**
+- **The ALU.** `tools/dvd_vm_ref.py set_op` matches `libdvdnav decoder.c eval_set_op`
+  case-for-case for ops 1–7 and 9–11 (including `/=` and `%=`, and ÷0 → 0xFFFF). Weakest
+  Link's engine leans on `g[5] %= 0x35f` and `g[13] = g[0] / 0x10`, and both are correct.
+- **`Goto` indexing.** DVD command numbers are 1-based and the RTL does
+  `pc <= blk_base + ins[7:0] - 1` ([dvd_vm.sv:1027](../dvd/dvd_vm.sv#L1027)); the python
+  model matches. A jump-table off-by-one would have explained "everything lands in one
+  place", but it is not present.
+- **The entropy machinery is wired**: free-running `entropy_ctr`, 1 Hz `sec_tick`,
+  mount-latched `rnd_seed`, gamepad `entropy_stir` ([emu.sv](../dvd/emu.sv) ~L1223).
+  Whether the *tick reaches counter-mode GPRMs in practice* is still unmeasured — the tick
+  is applied only in `V_IDLE` ([dvd_vm.sv:678](../dvd/dvd_vm.sv#L678)).
+
+**Weakest Link golden-oracle reference (captured for the next round).** `tools/bin/trace_nav`
+drives libdvdnav interactively, and on this disc it reaches the real game:
+
+```
+tools/bin/trace_nav WEAKEST_LINK_DES.iso "1 1"
+  PARK #1  title=21 part=1  buttons=1   -> btn1 cmd 71 04 00 0e 00 00 00 19  = g[14]=0, LinkPGCN 25
+  PARK #2  TT vts=21 PGC:30  buttons=12  GPRM[4]=708 GPRM[5]=118   <- the QUESTION screen
+     btn1-4,7-9: HL_BTNN = 0x2c00 (button 11), LinkCN <n>
+     btn5:       g[0] = 0x11, LinkPGCN 31
+     btn6:       HL_BTNN = 0x1800 (button 6), LinkPGCN 42
+  PGC30 PRE: g[5] += g[4]; g[5] %= 0x35f; g[13] = g[0]; g[13] /= 0x10; if (g[13]==N) Goto ...
+  PGC30 POST: LinkPGCN 30 (loop)
+```
+
+So **libdvdnav reaches the 12-button question screen where our hardware shows Round
+Winnings** — a confirmed divergence with a golden trace to diff against. `g[5]` (question
+index, mod 863) and `g[0] >> 4` (screen dispatch) are the two values to probe.
+
+> **★ Decisive measurement for Cluster B:** put **SPRM8 and GPRM g[0], g[4], g[5], g[13]**
+> on the debug overlay, then walk Weakest Link to the failure with `trace_nav` open beside
+> it and diff the registers at the divergence point. Cheap pre-check needing no build:
+> on the Weakest Link player-select menu pick the **second** option rather than the first —
+> if the failure is identical, a stuck SPRM8 is near-certain.
+
+### Round-3 (2026-08-17) — ★ WEAKEST LINK ROOT CAUSE FOUND: PGCN is 8 bits, the disc needs 11
+
+**This one is solved, offline, with high confidence.**
+
+`tools/bin/trace_nav WEAKEST_LINK_DES.iso "1 5"` (boot → the player-select screen → SINGLE
+PLAYER) shows libdvdnav walking to the question bank at **VTS 2, PGC 1381**. Our hardware
+shows a "Round winnings" screen instead, for *every* option on that menu.
+
+**Why every option:** the disc's question PGCs live in a huge PGCIT, and
+
+| Disc | VTS_PGCIT `nr_of_srp` |
+|---|---|
+| **WEAKEST_LINK_DES** | **TT_02 = 1394**, TT_23 = 1021, TT_22 = 355 |
+| tomb_raider_pal | TT_04 = 256 (exactly at the edge) |
+| *every other disc in the library* | < 256 |
+
+…while **our PGCN is 8 bits everywhere**:
+`jump_pgcn [7:0]`, `cur_pgcn [7:0]`, `next/prev/goup_pgcn [7:0]`, `want_pgcn [7:0]`,
+`link_pgcn_u/c [7:0]`, `ptt_pgcn_c [7:0]`, `rsm_pgcn [7:0]`, `deadend_pgcn [7:0]`
+([dvd_iso_reader.sv](../dvd/dvd_iso_reader.sv), [dvd_vm.sv](../dvd/dvd_vm.sv)) — and the
+link operand is taken as **`jump_pgcn <= ins[7:0]`**
+([dvd_vm.sv:1302](../dvd/dvd_vm.sv#L1302)) when **the DVD `LinkPGCN` field is 15 bits**.
+
+So `LinkPGCN 1381` (0x565) becomes `0x65` = **101**. The alias is *deterministic*, which is
+exactly why **all** paths land on the same wrong screen rather than behaving randomly. The
+intro plays normally first because PGC31's PRE/POST are reached correctly (its own PGCNs are
+small) — only the jump into the question bank aliases.
+
+Ruled out en route, by direct comparison against the golden trace (do not re-chase):
+- **The ALU is exact.** Replaying PGC31's whole POST block through `dvd_vm_ref` from
+  libdvdnav's entry registers reproduces `g[2]=1, g[3]=25, g[8]=2800 (the winnings!),
+  g[9]=4096, g[13]=1, g[6]=0` — every value matches, including the saturating `*=`, the
+  register-source `|=` bitfield pack and `/=`.
+- **`Goto` indexing** (1-based, correct in both RTL and model) and the **PTT tables**
+  (WL's VTS 2 title has `nr_of_ptts = 1`; max 29 across the disc — the `ptt_mem` 256 bound
+  is nowhere near).
+
+**✅ FIXED (2026-08-17, `feature/pgcn-16bit`) — see the fix note at the end of this
+section.** Original fix shape: widen the PGCN path from 8 to 16 bits end-to-end — the reader's
+jump/current/next/prev/goup/want/link/rsm/deadend registers and the VM's `jump_pgcn` plus
+`ins[14:0]` extraction for `LinkPGCN` — and raise the PGCIT SRP walk beyond 255. Note the
+golden models share the ceiling: `dvd_vm_ref.pgcit()` caps at `min(nr_srp, 99)`, so widen
+that too or the model can't validate the fix.
+
+> **⚠️ Audit gap worth remembering:** the prework capacity audit (max commands / programs /
+> cells per PGC) *missed this* because it walked PGCs through `pgcit()`, which silently caps
+> at 99 SRPs — the audit never saw a PGC count. **A capacity audit must measure the table
+> the code indexes, not the table the tool happens to enumerate.**
+
+#### ✅ The fix (2026-08-17) — 15-bit PGCN end-to-end
+
+**Root of the root cause:** the DVD `LinkPGCN` operand is a **15-bit** field
+(`libdvdnav decoder.c eval_link_instruction`: `getbits(14, 15)`), and
+`JumpSS_VMGM_PGC`'s `pgcN` is `getbits(46, 15)`. We extracted `ins[7:0]` and
+`ins[39:32]` respectively. Everything downstream was 8 bits to match.
+
+Changed (`dvd/dvd_vm.sv`, `dvd/dvd_iso_reader.sv`, `dvd/emu.sv` wiring):
+
+| Site | Was | Now |
+|---|---|---|
+| `LinkPGCN` operand | `ins[7:0]` | **`ins[14:0]`** |
+| `JumpSS_VMGM_PGC` pgcN | `ins[39:32]` | **`ins[46:32]`** |
+| `jump_pgcn`, `cur_pgcn`, `next/prev/goup_pgcn`, `want_pgcn`, `link_pgcn_u/c`, `jpgcn_l`, `rsm_pgcn`, `deadend_pgcn`, `srp_i` | `[7:0]` | `[15:0]` |
+| PGC header `next/prev/goup` capture | low byte only (@157/159/161) | **full u16** (@156–161) |
+| PRE-scan `LinkPGCN` target | byte 7 only | **`{byte6[6:0], byte7}`** |
+| `ptt_mem` entry | `{pgcn_lo, pgn_lo}` (16 b) | **`{pgcn u16, pgn_lo}` (24 b)** |
+| PTT resolve | `nr_pgci_srp > 255 → "garbage" → PGCN 1` | full u16 (that guard *was* the clamp) |
+| SRP fetch address | 17-bit `pit_off + 8 + srp_i*8` | **21-bit** (`srp_i*8` needs 19) |
+
+**Regression test — `dvd_vm_tb` S13**, which reproduces the bug exactly when the fix is
+reverted: `LinkPGCN 1381` → **`got pgcn=101`**, the precise `1381 & 0xFF` alias predicted
+from the disc analysis. S13 covers a large `LinkPGCN`, a small one (no regression on normal
+discs), and a large `JumpSS_VMGM_PGC`.
+
+**Golden model:** `IsoNav.pgcit()` capped enumeration at `min(nr_srp, 99)`, which is why the
+prework capacity audit never saw a PGC count. Raised to the spec bound; it now enumerates all
+1394 of Weakest Link's VTS_02 PGCs.
+
+**Regression status:** `dvd_vm_tb`, `dvd_vm_atmos_tb`, `iso_reader_tb`, `iso_reader_menu_tb`,
+`iso_reader_seek_tb`, `iso_reader_chapter_tb`, `iso_reader_real_tb`, `iso_reader_vm_tb` — all
+green.
+
+> **HW gate:** Weakest Link → pick any number of players + LET'S PLAY (or SINGLE PLAYER) →
+> the **first question** should appear instead of the Round Winnings screen. The golden path
+> to diff against is `tools/bin/trace_nav WEAKEST_LINK_DES.iso "1 5"` → VTS 2, PGC 1381.
+> Also re-check a normal disc (MiB/Matrix) for no menu regression, and Tomb Raider, whose
+> TT_04 PGCIT sits at exactly 256.
+
+### Round-4 (2026-08-18) — Weakest Link plays, but the answer window is cut: DRAIN_WD < an authored cell
+
+**HW after the PGCN fix:** the game now reaches the real questions ✅. New symptom: *"there is
+a timer for answering (not visible on screen) and it expires as soon as the highlight appears,
+showing 'Too Late!' and moving to the next player."*
+
+**Decoded from the disc.** The answer screen is **VTS 8 PGC 51**, and its cell table is the
+whole story:
+
+| cell | sectors | size | authored pbtime |
+|---|---|---|---|
+| **0 (the answer window)** | 32961–33271 = **311** | **0.6 MB** | **17 s** |
+| 1–6 (the "time's up" branches) | ~69 each | 0.14 MB | 1 s |
+
+`cell[0].cmd_nr = 1` → `cellc[0] = LinkCN 2`, i.e. when cell 0 ends the disc jumps into the
+timeout branch. Its POST reads the answer out of `HL_BTNN`
+(`g[14] = HL_BTNN; if (g[14]==0x1400) …` — button 5 = 0x1400 is the neutral/no-answer
+position that `fosl` selects, and the answer buttons 1/2/4 are `auto_action`).
+
+**The mechanism:** 0.6 MB **fits entirely inside the 2 MB VBUF**. So the reader parses the
+whole 17-second cell in a fraction of a second, hits the cell end, and the cell command's
+verdict is produced at the **parse front** while the display is still at the start of the
+question. The Phase-B tail drain (PR fj#150) is exactly the guard for this — a natural
+cell-command verdict waits for `vbuf_empty` — and it *does* engage here (`ev_cellcmd` →
+`nat_src` → `vm_from_wait` → `snat_l`). But it is bounded by **`DRAIN_WD`, which was 5.0 s**,
+and `vbuf_empty` cannot arrive until the decoder has displayed all 17 s. **The watchdog fired
+first and truncated a 17-second answer window to 5 seconds.**
+
+**Fix:** `DRAIN_WD` 5 s → **60 s**, sized from the thing that actually bounds the wait: the
+time for the decoder to *display* a full VBUF. 2 MB at the ~300 kbit/s these screens are
+authored at is ~56 s. Normal transitions are unaffected — they exit early on `vbuf_empty`;
+the bound only ever fires when `vbuf_empty` never arrives (a wedged decoder), which is
+already a failure state. `drain_tmr` widened 28 → 31 bits.
+
+> **⚠️ This fix may be necessary but not sufficient — flagged before testing.** The same
+> parse-vs-display skew applies to the *button* timeline: because the entire cell buffers at
+> once, every PCI/HLI packet in those 17 seconds is parsed within a fraction of a second, so
+> nav_pci sees the whole arm/disarm schedule up front and only the (parse-anchored) STC paces
+> it. If the highlight still appears at the wrong moment after this fix, that is the next
+> thread — and it is the same family as Cluster A. Watch specifically whether the answer
+> buttons are *responsive* before they are *visible*.
+
+### Round-5 (2026-08-18) — the DRAIN_WD fix did NOT change it; the symptom is re-framed
+
+**HW report:** *"still too fast, seems the same speed as before. The buttons are responsive
+before the highlight — it turns out the highlight is a different colour depending on whether
+you got the answer right or wrong, and the highlight I was seeing was revealing the correct
+answer, not a highlight for selection."*
+
+Two things follow, and they matter more than the timing question:
+
+1. **The answer buttons ARE armed and responsive during the window** — so nav_pci's HLI
+   handling on this screen is working. This confirms the caveat filed with the DRAIN_WD fix:
+   the button timeline runs at the parse front.
+2. **There is no visible SELECTION highlight at all.** The only thing that ever becomes
+   visible is the disc's answer *reveal*. So Weakest Link is unplayable for the same reason as
+   Speed Racer and Harry Potter — **Cluster A, the highlight render** — not (or not only) a
+   timer bug. You cannot answer a question when you cannot see which answer is selected.
+
+**Offline finding that gives Cluster A a WL-specific lead.** Scanning the answer cell's
+sectors (VTS_08 title VOB, RBN 32961+) shows what is multiplexed there:
+
+```
+stream 0xE0 (video) 33   substream 0x80 (audio) 55
+substream 0x20 0x21 0x22 0x23 0x24 0x25 0x26 0x27 0x28 0x29   <- TEN subpicture streams
+```
+
+The screen carries **ten subpicture substreams**, each sent as a small one-shot SPU — and
+`ps_demux` filters to **exactly one** substream. If the selection graphic lives on a stream we
+are not routing, no amount of correct HLI handling will make it appear. The disc also uses
+`SPSTN` (SPRM2, the *subpicture stream number*) as a **game variable** — VTS2 PGC1381's POST
+does `g[13] = SPSTN; g[13] %= 0x40;` and scores the answer from it (`g[7] += 0/2/5/10/20/30/45`),
+and the disc issues `SetSTN` 9 times across VTS2/VTS8. So on this disc the subpicture stream
+selection is *gameplay state*, not a user preference.
+
+**On the timing half:** the gate chain was traced and is correct in principle —
+`ev_cellcmd` → `blk=BLK_CELL` + `nat_src=1` ([dvd_vm.sv:827](../dvd/dvd_vm.sv#L827)) →
+`vm_from_wait` → `seek_natural_mux` ([emu.sv:1322](../dvd/emu.sv#L1322)) → `snat_l` → the seek
+waits on `vbuf_empty`. Since the observed speed did not change, either the build under test
+predates the fix, or the display is not in fact being cut and the "fast" impression comes
+entirely from the invisible selection highlight. **Not chasing it further until that is
+measured** — two hypotheses on this symptom have already died (`foac`, which is 0 on every
+HLI this disc authors, and `auto_action`-on-arm, which cannot fire because `moved` is set only
+by D-pad navigation).
+
+> **★ Two measurements needed (both cheap):**
+> 1. **Which `.rbf` was under test** — `DVD_pgcn16_drain_20260818_1149.rbf` carries the
+>    DRAIN_WD fix; `DVD_pgcn16_MARGINAL_*` does not.
+> 2. **Roughly how many seconds the question stays up before the reveal.** ~17 s ⇒ the cell
+>    plays correctly and this is purely a render bug (fold into Cluster A). ~1–5 s ⇒ the cell
+>    IS being cut and the drain gate is not doing its job.
+> 3. Optional but decisive for the render half: the O[2] **first-row** blocks (blk3 `sp_seen`,
+>    blk4 `spb_seen`) on the answer screen — with ten substreams multiplexed, blk4 red would
+>    mean we are routing a substream that carries nothing on this screen.
+
+### Round-6 (2026-08-18) — ★ ROOT CAUSE: the answer cell is ONE I-FRAME held for 17 s
+
+Measurements: the **drain build was under test**, the question holds **~1.5 s**, and the O[2]
+first row on the question screen reads **green green green green** (armed, video_live,
+sp_seen, spb_seen) before flipping to red at the transition.
+
+**Decoding the cell's actual content settles it.** Extracting the video ES from all 311
+sectors of VTS 8 PGC 51 cell 0:
+
+```
+video ES bytes = 64837   picture headers = 1   GOP headers = 1
+```
+
+**One picture.** The 17-second answer window is a **single I-frame that the disc expects the
+player to HOLD for the cell's authored playback time** (`pbtime = 17 s`, with
+`still_time = 0` — the hold is expressed by the cell's *duration*, not by a still flag).
+
+That explains every observation at once, including the two failed fixes:
+
+- **~1.5 s, not 5 s and not 60 s.** The tail-drain gate is not timing out — it is **passing
+  immediately**, because `vbuf_empty` is *true*: there is only one frame to decode, 64 KB
+  drains instantly, and the compressed buffer really is empty while the frame is still meant
+  to be on screen for another 16.5 s. **Raising `DRAIN_WD` could never have helped**, which is
+  exactly what the hardware said.
+- **The buttons are responsive** — the NAV packs across all 311 sectors are parsed within that
+  same fraction of a second, so the HLI arms correctly and early.
+- **`spb_seen` red at the transition** — the cell command's seek executes with a flush.
+- **All four first-row probes green on the question screen** — the subpicture *does* arrive and
+  display here, so Weakest Link is **not** blocked on the Cluster-A render bug after all. Its
+  selection highlight is invisible for a different reason (or is simply not authored as a
+  recoloured subpicture on this screen); the window closing in 1.5 s is the whole problem.
+
+**Why our model of "cell end" is wrong.** The reader ends a cell when its **sectors are
+delivered**. For ordinary cells that is close enough (the display trails by the VBUF depth,
+and `vbuf_empty` bridges the gap). For a **still-image cell** the two diverge completely:
+the data is exhausted in ~0.2 s while the authored presentation time is 17 s. A real player
+ends a cell when its **authored playback time has elapsed on the display timeline**.
+
+**Fix direction (next change).** This is the sibling of PR fj#144, which honoured an explicit
+`still_time` on title-domain cells; here the hold is authored as `pbtime` with
+`still_time = 0`. Hold such a cell for its authored duration before running the cell command:
+reuse the existing `still_secs`/`still_timed`/`STILL_CMD` machinery (the freeze path is already
+HW-proven for Thayer's Quest timed choices), sourcing the duration from the cell playback time
+the reader already reads for the HUD (`cell_start_mem` prefix sums). Scope it the same way
+PR fj#144 was — title domain + `vm_mode` + the cell carries a cell command — so ordinary movie
+playback is untouched. The natural trigger is "content exhausted (`vbuf_empty`) but the cell's
+authored time has not elapsed".
+
+⛔ **Retracted by this finding:** the `DRAIN_WD` 5 s → 60 s change (previous round) was
+predicated on the wait timing out. It does not, so the raise is inert for this disc. It is
+harmless and arguably still correct as a deadlock bound, but it is **not** the fix and must not
+be recorded as one.
+
+> **✅ FIXED + HW-CONFIRMED 2026-08-18 (PR fj#165):** the general real-player model — a
+> title-domain (vm_mode) cell end that dispatches to the VM (cell command / PGC end) with
+> ≥2 s of its authored `C_PBTM` unspent on the DISPLAY clock serves the residual as a
+> timed still first, so the cell command evaluates at the cell's authored end. Design +
+> implementation detail: `docs/dvd_nav.md` "Authored cell duration". HW verdict: WL
+> questions hold for the correct time and are answerable; no regressions on the other
+> menu discs. **New finding from the same HW round: WL's questions are NOT random** —
+> the same question sequence every run. That is a separate issue: WL joins the
+> **Cluster-B entropy family** below (Brain Game / Family Feud II — dispatcher registers
+> not varying), it is NOT part of the cell-timing fix.
+
+### Round-7 (2026-08-25) — ★ the OTHER half of the authored duration: the C_PBTM FRAME FIELD
+
+**HW report:** gameplay works, but the **correct/wrong answer reveal** shown after choosing
+an answer and the **"money banked"** screen shown after pressing Bank both flash past in
+**under a second**; a real player (checked against gameplay footage) holds each for about
+**two**. Questions themselves hold for the right time — i.e. the Round-6 fix is working.
+
+**Decoded from the disc — the screens are 1.96-second cells stored as 1 second.** The
+gameplay loop was traced with `tools/bin/trace_nav WEAKEST_LINK_DES.iso "1 5 1 1 1 …"`:
+answering a question runs the button's auto-action → POST → `LinkCN 5`, so the reveal is
+**VTS 18 PGC 29 cell 5**; banking lands on **VTS 02 PGC 248 cell 0**. Dumping their cell
+records and demuxing their video:
+
+| screen | cell | C_PBTM | pictures in the cell | real length |
+|---|---|---|---|---|
+| answer reveal | VTS18 PGC29 cells 1–6 | `0:00:01` + **24 f** @25 fps | **1** | **1.96 s** |
+| money banked | VTS02 PGC248 cell 0 | `0:00:01` + **24 f** | **1** | **1.96 s** |
+| chain/bank status | VTS02 PGC1381 cells 0–6 | `0:00:03` + 23 f | 1 | 3.92 s |
+| question (works) | VTS18 PGC29 cell 0 | `0:00:17` + 23 f | 1 | 17.92 s |
+
+`C_PBTM` is `{hh, mm, ss, rate|frames}` and the reader summed **hh:mm:ss only**, dropping
+the frame field. This disc (PAL, 25 fps) authors its short screens as *N seconds +
+(fps−1) frames* = N+1 seconds minus a frame, so 1.96 s stored as **1 s** — and 1 s is
+**below `RESID_MIN` (2 s)**, so the Round-6 hold was never armed and the single I-frame
+flashed by in decode time. The 17 s question cleared the threshold, which is precisely why
+one screen worked and the other did not. Same authoring style is everywhere on this disc:
+**5,279 cells at exactly `1 s + 24 f`**.
+
+⛔ **Ruled out before the disc was decoded** (worth recording — both fit the symptom):
+the mid-PGC plain-advance path (which by design serves no hold) is not involved — every
+gameplay cell on this disc carries a cell command; and the user-button provenance
+(`nat_src`, PR fj#150) is not involved either — these cells flash on any path, the press
+just happens to be how you reach them.
+
+> **✅ FIXED + HW-CONFIRMED 2026-08-25 (user report, `DVD_celldurfrm_MARGINAL` build):**
+> the stored per-cell duration now rounds the frame field to the nearest second
+> (`pb_dur_w`), so the reveal and banked screens hold 2 s and the status screens 4 s. `pb_c` stays truncated
+> where the libdvdnav still HEURISTIC reads it (lockstep with `vm.c`), and `RESID_MIN`
+> stays 2 s so sub-second cells — Deal or No Deal authors ~1,800 of them — keep their
+> current no-hold behaviour. Detail + the accepted ±0.5 s quantisation:
+> `docs/dvd_nav.md` "Authored cell duration → Amendment (2026-08-25)".
+
 ### Round-8 (2026-08-25) — ★ Cluster B's last piece: the first-boot entropy hole
 
 **HW report (same session):** with the hold fixed, Weakest Link asks **the same question

--- a/docs/disc_sweep.md
+++ b/docs/disc_sweep.md
@@ -842,6 +842,48 @@ be recorded as one.
 > **Cluster-B entropy family** below (Brain Game / Family Feud II — dispatcher registers
 > not varying), it is NOT part of the cell-timing fix.
 
+### Round-7 (2026-08-25) — ★ the OTHER half of the authored duration: the C_PBTM FRAME FIELD
+
+**HW report:** gameplay works, but the **correct/wrong answer reveal** shown after choosing
+an answer and the **"money banked"** screen shown after pressing Bank both flash past in
+**under a second**; a real player (checked against gameplay footage) holds each for about
+**two**. Questions themselves hold for the right time — i.e. the Round-6 fix is working.
+
+**Decoded from the disc — the screens are 1.96-second cells stored as 1 second.** The
+gameplay loop was traced with `tools/bin/trace_nav WEAKEST_LINK_DES.iso "1 5 1 1 1 …"`:
+answering a question runs the button's auto-action → POST → `LinkCN 5`, so the reveal is
+**VTS 18 PGC 29 cell 5**; banking lands on **VTS 02 PGC 248 cell 0**. Dumping their cell
+records and demuxing their video:
+
+| screen | cell | C_PBTM | pictures in the cell | real length |
+|---|---|---|---|---|
+| answer reveal | VTS18 PGC29 cells 1–6 | `0:00:01` + **24 f** @25 fps | **1** | **1.96 s** |
+| money banked | VTS02 PGC248 cell 0 | `0:00:01` + **24 f** | **1** | **1.96 s** |
+| chain/bank status | VTS02 PGC1381 cells 0–6 | `0:00:03` + 23 f | 1 | 3.92 s |
+| question (works) | VTS18 PGC29 cell 0 | `0:00:17` + 23 f | 1 | 17.92 s |
+
+`C_PBTM` is `{hh, mm, ss, rate|frames}` and the reader summed **hh:mm:ss only**, dropping
+the frame field. This disc (PAL, 25 fps) authors its short screens as *N seconds +
+(fps−1) frames* = N+1 seconds minus a frame, so 1.96 s stored as **1 s** — and 1 s is
+**below `RESID_MIN` (2 s)**, so the Round-6 hold was never armed and the single I-frame
+flashed by in decode time. The 17 s question cleared the threshold, which is precisely why
+one screen worked and the other did not. Same authoring style is everywhere on this disc:
+**5,279 cells at exactly `1 s + 24 f`**.
+
+⛔ **Ruled out before the disc was decoded** (worth recording — both fit the symptom):
+the mid-PGC plain-advance path (which by design serves no hold) is not involved — every
+gameplay cell on this disc carries a cell command; and the user-button provenance
+(`nat_src`, PR fj#150) is not involved either — these cells flash on any path, the press
+just happens to be how you reach them.
+
+> **🔧 FIXED, ⏳ HW-confirm pending (branch `fix/cell-duration-frames`):** the stored
+> per-cell duration now rounds the frame field to the nearest second (`pb_dur_w`), so the
+> reveal and banked screens hold 2 s and the status screens 4 s. `pb_c` stays truncated
+> where the libdvdnav still HEURISTIC reads it (lockstep with `vm.c`), and `RESID_MIN`
+> stays 2 s so sub-second cells — Deal or No Deal authors ~1,800 of them — keep their
+> current no-hold behaviour. Detail + the accepted ±0.5 s quantisation:
+> `docs/dvd_nav.md` "Authored cell duration → Amendment (2026-08-25)".
+
 ### Round-3 — Cluster A SPLITS: the two highlight bugs have DIFFERENT roots
 
 First-row probes (`blk1` hl_btns_armed, `blk2` video_live, `blk3` sp_seen, `blk4` spb_seen):

--- a/docs/disc_sweep.md
+++ b/docs/disc_sweep.md
@@ -876,13 +876,39 @@ gameplay cell on this disc carries a cell command; and the user-button provenanc
 (`nat_src`, PR fj#150) is not involved either — these cells flash on any path, the press
 just happens to be how you reach them.
 
-> **🔧 FIXED, ⏳ HW-confirm pending (branch `fix/cell-duration-frames`):** the stored
-> per-cell duration now rounds the frame field to the nearest second (`pb_dur_w`), so the
-> reveal and banked screens hold 2 s and the status screens 4 s. `pb_c` stays truncated
+> **✅ FIXED + HW-CONFIRMED 2026-08-25 (user report, `DVD_celldurfrm_MARGINAL` build):**
+> the stored per-cell duration now rounds the frame field to the nearest second
+> (`pb_dur_w`), so the reveal and banked screens hold 2 s and the status screens 4 s. `pb_c` stays truncated
 > where the libdvdnav still HEURISTIC reads it (lockstep with `vm.c`), and `RESID_MIN`
 > stays 2 s so sub-second cells — Deal or No Deal authors ~1,800 of them — keep their
 > current no-hold behaviour. Detail + the accepted ±0.5 s quantisation:
 > `docs/dvd_nav.md` "Authored cell duration → Amendment (2026-08-25)".
+
+### Round-8 (2026-08-25) — ★ Cluster B's last piece: the first-boot entropy hole
+
+**HW report (same session):** with the hold fixed, Weakest Link asks **the same question
+every time from a cold core load** — and **reloading the disc without reloading the core
+randomises it** from then on.
+
+That asymmetry is the whole diagnosis. The `rnd` LFSR was seeded from `entropy_ctr` at the
+**mount instant**, which is entropy only if the mount is user-timed. The FIRST mount after
+a core load need not be (MiSTer can mount from the core-launch path), and from there the
+chain to the disc's first `rnd` is machine-timed — so the seed, and every `rnd` off it,
+repeated exactly. The second mount is user-timed, hence randomised.
+
+WL hangs its entire question order on two `rnd` calls inside that window (VTS21 PGC24's
+`g[13] rnd 0xffff` → `SetMode Counter g[12]`, and PGC28's `g[5] = g[12]` + `g[4] rnd
+0x35f`, advanced by `g[5] += g[4]` after every question), which is why it shows the fault
+so starkly. Verified by running the golden model (`tools/dvd_vm_ref.py`) over the real ISO:
+the chain executes correctly, so the VM logic was never the problem — only the seed.
+
+> **🔧 FIXED, ⏳ HW-confirm pending:** `hps_io`'s **`TIMESTAMP`** (wall clock, sent by Main
+> at core load before any mount) is XORed into the seed — the same source libdvdnav uses
+> (`srand(time.tv_usec)`). Also fixed en route: an LFSR **zero-lockup** in the stir path
+> (`lfsr ^ entropy_val` can hit 0, and 0 is absorbing → every later `rnd` returns 1).
+> Detail: `docs/dvd_vm.md` "First-boot hole". **This closes the WL half of Cluster B's
+> entropy family** — Brain Game / Family Feud II are untested against it and may be the
+> same root cause.
 
 ### Round-3 — Cluster A SPLITS: the two highlight bugs have DIFFERENT roots
 

--- a/docs/disc_sweep_testing.md
+++ b/docs/disc_sweep_testing.md
@@ -5,6 +5,11 @@ Harry Potter Interactive DVD Game testing:
 - On several occasions, skipping menus transitions lead to the correct screen screen (static image) being pixelated but it looked normal after a few seconds.
 - There is a score card screen you can access during the game that flashes on screen for about 2 seconds before returning and I think this is supposed to last longer.
 
+WEAKEST_LINK_DES testing (2026-08-25 round — the answer-reveal / banked-money flash is
+diagnosed and fixed on branch `fix/cell-duration-frames`; see docs/disc_sweep.md Round-7):
+- Selecting an answer flashes the correct/wrong reveal in <1 s (should be ~2 s), and the
+  banked-money screen after Bank does the same; questions hold correctly.
+
 WEAKEST_LINK_DES testing:
 - Game loads to menu fine
 - Selecting single player plays a long intro to the game then when it lookslike it's about to ask a question, it cuts to a screen that displays 'Round winnings' of 7500 GBP but select or direction buttons do not work on this screen. Menu button does return to the player selection menu.

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -1685,8 +1685,11 @@ residual is served through the existing HW-proven timed-still machinery (PR fj#9
   paths the same lead means the countdown runs concurrently with the decoder playing out
   its buffered tail (the still freeze is watchdog-suppression only), so a normal video
   cell's hold converges on the same wait the `vbuf_empty` tail-drain already imposes.
-- **`RESID_MIN = 2 s`** absorbs load→display latency and sub-second truncation; WL's
-  1-second answer-branch cells (cells 1–3 of PGC 51, `pbtime=1s` + cmd) stay instant.
+- **`RESID_MIN = 2 s`** absorbs load→display latency and sub-second truncation; cells
+  whose rounded authored duration leaves under 2 s unspent stay instant.
+  ⚠️ *This bullet used to read "WL's 1-second answer-branch cells … stay instant" as if
+  that were correct. It was the bug fixed on 2026-08-25 — see the amendment below: those
+  cells are not 1-second cells.*
 - **Known limitations:** durations clamp at 255 s (`pb_c`) and `cell_secs` saturates to
   match, so a >4 min still-shaped cell holds at most ~4 min (no real disc authors this);
   the elapsed clock keeps counting through a user pause (raster keeps ticking — parity
@@ -1698,3 +1701,62 @@ residual is served through the existing HW-proven timed-still machinery (PR fj#9
   display-seconds tick → hold is the residual 4 s only; T4 PGC-end hold then POST.
   Cross-checked against the real disc: WL VTS 8 PGC 51 cell 0 reads
   `pbtm 0:00:17, still=0, cmd=1, 311 sectors` (matches Round-6 exactly).
+
+### Amendment (2026-08-25) — the C_PBTM FRAME FIELD: short screens flashed by
+
+**Status: 🔧 fixed, ⏳ HW-confirm pending** (branch `fix/cell-duration-frames`).
+
+**Symptom.** On Weakest Link the questions held for the authored time (the fix above
+works), but the **correct/wrong answer reveal** after choosing an answer, and the
+**"money banked"** screen after pressing Bank, both flashed past in well under a second
+where a real player shows them for about two.
+
+**Root cause — half of the authored duration was never read.** `C_PBTM` is a BCD
+`dvd_time {hh, mm, ss, rate|frames}`, and `pb_c` (the value stored per cell and used as
+the hold source) summed **hh:mm:ss only**, discarding the frame field. Interactive discs
+author their short screens as *"N seconds + (fps−1) frames"* — i.e. N+1 seconds minus one
+frame:
+
+| screen | disc location | C_PBTM | real length | stored (before) |
+|---|---|---|---|---|
+| answer reveal | VTS 18 PGC 29 cells 1–6 | `0:00:01` + **24 f** @25 fps | **1.96 s** | 1 s |
+| money banked | VTS 02 PGC 248 cell 0 | `0:00:01` + **24 f** | **1.96 s** | 1 s |
+| chain/bank status | VTS 02 PGC 1381 cells 0–6 | `0:00:03` + 23 f | 3.92 s | 3 s |
+| question (works) | VTS 18 PGC 29 cell 0 | `0:00:17` + 23 f | 17.92 s | 17 s |
+
+Every one of these cells is **a single I-frame** (`pics=1 gops=1` over the whole cell —
+same shape as the Round-6 question cell), so the authored duration is the *only* thing
+holding them on screen. With 1.96 s stored as 1 s the residual was 1 s, which is **under
+`RESID_MIN` (2 s)** — so no hold was served at all and the frame flashed by in the time
+the pipeline needed to decode it (~0.2 s). The 17 s question cleared `RESID_MIN` easily,
+which is exactly why one worked and the other did not. Both this disc's screens are also
+reached by a **user button press**, which is what made them look like a provenance /
+tail-drain problem; they are not — the same cells flash on any path.
+
+**Fix.** The frame field is rounded into the stored duration (`pb_dur_w` at the cell-meta
+write): 1 s + 24 f → 2, 3 s + 23 f → 4, 17 s + 23 f → 18. Rate bits pick the threshold
+(2'b01 = 25 fps → ≥13 frames rounds up, otherwise ≥15).
+
+Deliberate scope limits, both load-bearing:
+
+- **`pb_c` stays truncated for the libdvdnav still HEURISTIC** (`heur_hit_w`, the
+  `size/time > 30` test) — that code is a port of `vm.c get_current_position`, which
+  truncates, and `tools/iso_nav_check.py` mirrors it. Only the *hold* uses the rounded
+  value.
+- **`RESID_MIN` stays 2 s.** With rounding a genuine 2 s screen now qualifies, while
+  sub-second cells (`0 s + n f`) round to 1 and still take no hold — Deal or No Deal
+  alone authors ~1,800 half-second cells, and lowering the threshold would give every one
+  of them a ~0.4 s freeze they do not have today.
+
+**Residual imprecision (accepted, documented):** the hold countdown is 1 Hz, so a hold is
+quantised to whole seconds — ±0.5 s worst case, +40 ms on the "N s + (fps−1) f" shape
+that dominates real discs. Frame-granular holding would need a sub-second countdown in
+`S_STILL` and a wider `cell_meta_mem`; not worth it until a disc shows a symptom.
+
+**Tests:** `bench/dvd/iso_reader_celldur_tb.sv` T8 (1 s + 24 f holds 2 s — the reveal
+shape), T9 (1 s + 2 f stays 1 s, monitored so it never holds), T10 (3 s + 23 f → 4 s
+PGC-end hold). T1–T7 unchanged and green.
+
+**HW gate:** Weakest Link — answer reveal and the banked-money screen each stay up ~2 s;
+questions still hold ~18 s and stay answerable; MiB/Matrix/T2 menus, Thayer's timed
+choices and a normal movie unchanged.

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -1704,7 +1704,8 @@ residual is served through the existing HW-proven timed-still machinery (PR fj#9
 
 ### Amendment (2026-08-25) — the C_PBTM FRAME FIELD: short screens flashed by
 
-**Status: 🔧 fixed, ⏳ HW-confirm pending** (branch `fix/cell-duration-frames`).
+**Status: ✅ HW-CONFIRMED 2026-08-25** (user report: "the hold durations are correct now",
+`DVD_celldurfrm_MARGINAL` build; branch `fix/cell-duration-frames`).
 
 **Symptom.** On Weakest Link the questions held for the authored time (the fix above
 works), but the **correct/wrong answer reveal** after choosing an answer, and the

--- a/docs/dvd_vm.md
+++ b/docs/dvd_vm.md
@@ -225,60 +225,60 @@ Bit-exactness: the golden model and `dvd_vm_tb` PART 1/2 drive the fixed 0xACE1 
 no ticks/stir, so all existing vectors are unchanged. `dvd_vm_tb` PART 3 + `dvd_vm_ref.py
 Regs.tick()` cover the tick, seed variation, stir, and the zero-seed guard.
 
-### ★ First-boot hole — the seed needs a WALL CLOCK, not just the mount instant (2026-08-25)
+### Seed hardening — the wall clock (2026-08-25), and what it is NOT
 
-**Status: 🔧 fixed, ⏳ HW-confirm pending** (branch `fix/cell-duration-frames`).
+**Status: 🔧 shipped as HARDENING, unverified. It fixes no known symptom.**
 
-**Symptom (user report, Weakest Link).** From a cold core load the game asked **the same
-question every time** (the Scotland-flag one), for every player. Reloading the disc
-*without* reloading the core fixed it — from then on the questions were properly
-randomised.
-
-**Why.** The seed above was `entropy_ctr[15:0]` alone, sampled when `dvd_vm` sees `start`
-(the mount). That is only entropy if the mount instant is **user-timed**. On the first
-mount after a core load it need not be — MiSTer can mount an image from the core-launch
-path, and from there the whole chain to the disc's first `rnd` is machine-timed, so the
-sample (and every `rnd` derived from it) repeated exactly. The second mount *is* user-timed,
-which is precisely the asymmetry the user saw.
-
-Weakest Link makes the consequence total, because its whole question order hangs off two
-`rnd` calls made during that machine-timed window:
-
-```
-VTS21 PGC24 PRE : g[13] rnd 0xffff ; SetMode Counter g[12] = g[13]  <- seed a wall counter
-VTS21 PGC28 POST: g[5] = g[12]     ; g[4] rnd 0x35f                 <- harvest + step
-VTS21 PGC30 PRE : g[5] += g[4] ; g[5] %= 0x35f                      <- the question index
-       (and VTS02 PGC1381's POST repeats that advance after every question)
-```
-
-**Fix — take the source a real player uses.** libdvdnav seeds with `srand(time.tv_usec)`;
-the MiSTer framework hands every core the same wall clock. `hps_io`'s **`TIMESTAMP`**
-(seconds since the epoch, sent by Main once at core load, *before* any mount —
-`user_io.cpp` `send_rtc(3)` just before reset release) is now XORed into the seed in
-`emu.sv`:
+`rnd_seed` was `entropy_ctr[15:0]` alone, sampled when `dvd_vm` sees `start` (the mount) —
+entropy only if that instant is user-timed. `hps_io`'s **`TIMESTAMP`** (seconds since the
+epoch, sent by Main once at core load, before any mount — `user_io.cpp` `send_rtc(3)` just
+before reset release) is now XORed in, both halves so a 16-bit seed still moves with the
+high word:
 
 ```verilog
 wire [15:0] vm_rnd_seed = entropy_ctr[15:0] ^ hps_timestamp[15:0] ^ hps_timestamp[31:16];
 ```
 
-Both halves of the timestamp fold in so a 16-bit seed still moves with the high word. If
-the framework never sends it (`TIMESTAMP` stays 0) the seed degrades to the old
-counter-only behaviour, so nothing depends on it being present. Note the timestamp is
-constant for the session — it fixes *cold-load* determinism; the counter keeps supplying
-per-mount variation, and `entropy_stir` keeps supplying per-play variation from gamepad
-timing.
+That is the source libdvdnav uses (`srand(time.tv_usec)`), it costs nothing, and it
+degrades to the old counter-only value if a framework never sends it. **But it was
+written for a diagnosis that turned out to be wrong** — see the retraction in
+`docs/disc_sweep.md` "Round-8": Weakest Link's repeated question came from the disc's own
+seeding commands being SKIPPED, not from a stale seed. Do not cite this as the fix for
+anything until some symptom actually confirms it.
 
-**Also fixed here: an LFSR zero-lockup.** `entropy_stir` did `lfsr <= lfsr ^ entropy_val`
-unguarded, and `entropy_val` is a free-running counter — it lands on the LFSR's own value
-roughly once in 65,536 stirs. An all-zero LFSR never leaves zero (`lfsr_next` of 0 is 0),
-so every later `rnd` would return 1 forever. The stir now falls back to `0xACE1`, the same
-guard `lfsr_seed` already had. Test: `dvd_vm_tb` PART 3 **T5**.
+**Also shipped, and this one stands on its own: an LFSR zero-lockup guard.**
+`entropy_stir` did `lfsr <= lfsr ^ entropy_val` unguarded, and `entropy_val` is a
+free-running counter — it lands on the LFSR's own value roughly once in 65,536 stirs. Zero
+is absorbing for this LFSR (`lfsr_next` of 0 is 0), so every later `rnd` would return 1
+forever. The stir now falls back to `0xACE1`, the same guard `lfsr_seed` already had.
+Test: `dvd_vm_tb` PART 3 **T5**.
 
-**HW gate:** Weakest Link asks a *different* first question on each cold core load (not
-just after a disc reload); Scene It's per-load variation (PR fj#119) still works.
+### Menu over a boot chain — why a skipped intro can break a game disc
 
-Deferred (still): **NVTMR fire (SPRM9)** — libdvdnav doesn't fire it either (stores only;
-`decoder.c:527`), and the census found 1/7 discs set it at 999 s (never fires in practice).
+Game discs put **setup** in their boot chain, and their Root-menu trampoline jumps past
+it. Weakest Link is the worked example (full command dumps in `docs/disc_sweep.md`
+"Round-8"): `rnd`-seeded question state is written by VTS21 PGC24/PGC28, while
+`VTSM(21) Root → VMGM 4 → JumpTT 21 → PGC1 dispatcher` lands straight on the menu (PGC30).
+Press Menu during the intro and the game plays unseeded — the same question for every
+player. **libdvdnav does the identical jump** (`tools/bin/trace_menuearly`), so this is
+what a real player does too.
+
+Two things were checked before considering any change, and both are worth remembering:
+
+- **UOPs cannot help here.** WL sets **no** prohibition bits: 4,257 title PGCs with
+  `prohibited_ops == 0`, and every NAV pack in the boot clip with `vobu_uop_ctl == 0`
+  (`tools/` scan, 2026-08-25). Same as Atmosfear. Enforcing UOPs is still a legitimate
+  spec feature we have punted, but it would be a no-op on these discs — do not adopt it
+  expecting to fix them.
+- **The boot-chain menu shortcut is inert on WL**, because it only retargets when
+  `best_menu_vts != cur_vts` and both are VTS 21 here.
+
+Deviations that WOULD change it, all rejected so far as worse than the problem: ignoring
+Menu until the disc reaches a menu (breaks Atmosfear, which needs Menu during the boot
+chain), or "skip the clip, keep the VM" — ending the playing PGC and letting the authored
+chain run at speed instead of jumping (on a movie disc that runs the FP chain straight
+into the feature instead of showing a menu). Current answer: stay faithful, document the
+workaround (let the intro play).
 
 ## Execution model
 

--- a/docs/dvd_vm.md
+++ b/docs/dvd_vm.md
@@ -225,6 +225,58 @@ Bit-exactness: the golden model and `dvd_vm_tb` PART 1/2 drive the fixed 0xACE1 
 no ticks/stir, so all existing vectors are unchanged. `dvd_vm_tb` PART 3 + `dvd_vm_ref.py
 Regs.tick()` cover the tick, seed variation, stir, and the zero-seed guard.
 
+### ★ First-boot hole — the seed needs a WALL CLOCK, not just the mount instant (2026-08-25)
+
+**Status: 🔧 fixed, ⏳ HW-confirm pending** (branch `fix/cell-duration-frames`).
+
+**Symptom (user report, Weakest Link).** From a cold core load the game asked **the same
+question every time** (the Scotland-flag one), for every player. Reloading the disc
+*without* reloading the core fixed it — from then on the questions were properly
+randomised.
+
+**Why.** The seed above was `entropy_ctr[15:0]` alone, sampled when `dvd_vm` sees `start`
+(the mount). That is only entropy if the mount instant is **user-timed**. On the first
+mount after a core load it need not be — MiSTer can mount an image from the core-launch
+path, and from there the whole chain to the disc's first `rnd` is machine-timed, so the
+sample (and every `rnd` derived from it) repeated exactly. The second mount *is* user-timed,
+which is precisely the asymmetry the user saw.
+
+Weakest Link makes the consequence total, because its whole question order hangs off two
+`rnd` calls made during that machine-timed window:
+
+```
+VTS21 PGC24 PRE : g[13] rnd 0xffff ; SetMode Counter g[12] = g[13]  <- seed a wall counter
+VTS21 PGC28 POST: g[5] = g[12]     ; g[4] rnd 0x35f                 <- harvest + step
+VTS21 PGC30 PRE : g[5] += g[4] ; g[5] %= 0x35f                      <- the question index
+       (and VTS02 PGC1381's POST repeats that advance after every question)
+```
+
+**Fix — take the source a real player uses.** libdvdnav seeds with `srand(time.tv_usec)`;
+the MiSTer framework hands every core the same wall clock. `hps_io`'s **`TIMESTAMP`**
+(seconds since the epoch, sent by Main once at core load, *before* any mount —
+`user_io.cpp` `send_rtc(3)` just before reset release) is now XORed into the seed in
+`emu.sv`:
+
+```verilog
+wire [15:0] vm_rnd_seed = entropy_ctr[15:0] ^ hps_timestamp[15:0] ^ hps_timestamp[31:16];
+```
+
+Both halves of the timestamp fold in so a 16-bit seed still moves with the high word. If
+the framework never sends it (`TIMESTAMP` stays 0) the seed degrades to the old
+counter-only behaviour, so nothing depends on it being present. Note the timestamp is
+constant for the session — it fixes *cold-load* determinism; the counter keeps supplying
+per-mount variation, and `entropy_stir` keeps supplying per-play variation from gamepad
+timing.
+
+**Also fixed here: an LFSR zero-lockup.** `entropy_stir` did `lfsr <= lfsr ^ entropy_val`
+unguarded, and `entropy_val` is a free-running counter — it lands on the LFSR's own value
+roughly once in 65,536 stirs. An all-zero LFSR never leaves zero (`lfsr_next` of 0 is 0),
+so every later `rnd` would return 1 forever. The stir now falls back to `0xACE1`, the same
+guard `lfsr_seed` already had. Test: `dvd_vm_tb` PART 3 **T5**.
+
+**HW gate:** Weakest Link asks a *different* first question on each cold core load (not
+just after a disc reload); Scene It's per-load variation (PR fj#119) still works.
+
 Deferred (still): **NVTMR fire (SPRM9)** — libdvdnav doesn't fire it either (stores only;
 `decoder.c:527`), and the census found 1/7 discs set it at 999 s (never fires in practice).
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1768,6 +1768,13 @@ every one of them — the trail is worth more than the clone size. Note the larg
 > Design + status: `docs/dvd_nav.md` "authored cell duration". (WL questions not random =
 > separate open issue, Cluster B in `docs/disc_sweep.md`.)
 >
+> **🔧 2026-08-25, ⏳ HW-confirm pending — the C_PBTM FRAME FIELD (branch
+> `fix/cell-duration-frames`).** The duration above was read as hh:mm:ss only, dropping
+> the frame field: WL's answer-reveal and money-banked screens are `1 s + 24 f` = 1.96 s
+> single-I-frame cells, stored as 1 s, which fell under `RESID_MIN` and so got no hold at
+> all — they flashed by in ~0.2 s. The stored duration now rounds the frames in. See
+> `docs/disc_sweep.md` "Round-7" + `docs/dvd_nav.md` "Amendment (2026-08-25)".
+>
 > **★ NEW TRACK (2026-08-18): SPEC HARDENING — design to the DVD spec maximum, phased
 > plan in `docs/spec_hardening.md`.** The PGCN and cell-duration bugs were both
 > "designed to the test shelf, not the spec". Phase 1 (next session) =

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1775,13 +1775,14 @@ every one of them — the trail is worth more than the clone size. Note the larg
 > all — they flashed by in ~0.2 s. The stored duration now rounds the frames in. See
 > `docs/disc_sweep.md` "Round-7" + `docs/dvd_nav.md` "Amendment (2026-08-25)".
 >
-> **🔧 2026-08-25, ⏳ HW-confirm pending — FIRST-BOOT ENTROPY (same branch).** The rnd
-> LFSR was seeded only from the mount instant, which is not entropy when the first mount
-> after a core load is machine-timed: Weakest Link asked the same question on every cold
-> load (a disc reload fixed it, since that mount IS user-timed). `hps_io`'s `TIMESTAMP`
-> (wall clock) is now XORed into the seed — libdvdnav's `srand(time)` parity — plus a
-> zero-lockup guard on the stir path. See `docs/disc_sweep.md` "Round-8" +
-> `docs/dvd_vm.md` "First-boot hole".
+> **2026-08-25 — WL "same question every time" = AUTHORED, no fix shipped.** It happens
+> only when Menu is pressed during the boot sequence: the disc seeds its question index in
+> the boot chain (VTS21 PGC24/PGC28) and its own Root trampoline jumps past it, so the game
+> runs with `g[4]=g[5]=0`. libdvdnav does the identical jump and the disc sets NO UOP bits
+> (4,257 PGCs, all zero), so no faithful player can refuse the press. Workaround: let the
+> intro play. Shipped alongside as unverified HARDENING (not a fix): `TIMESTAMP` XORed into
+> the rnd seed, plus a real LFSR zero-lockup guard on the stir path. See
+> `docs/disc_sweep.md` "Round-8" + `docs/dvd_vm.md` "Menu over a boot chain".
 >
 > **★ NEW TRACK (2026-08-18): SPEC HARDENING — design to the DVD spec maximum, phased
 > plan in `docs/spec_hardening.md`.** The PGCN and cell-duration bugs were both

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1768,12 +1768,20 @@ every one of them — the trail is worth more than the clone size. Note the larg
 > Design + status: `docs/dvd_nav.md` "authored cell duration". (WL questions not random =
 > separate open issue, Cluster B in `docs/disc_sweep.md`.)
 >
-> **🔧 2026-08-25, ⏳ HW-confirm pending — the C_PBTM FRAME FIELD (branch
+> **✅ HW-CONFIRMED 2026-08-25 — the C_PBTM FRAME FIELD (branch
 > `fix/cell-duration-frames`).** The duration above was read as hh:mm:ss only, dropping
 > the frame field: WL's answer-reveal and money-banked screens are `1 s + 24 f` = 1.96 s
 > single-I-frame cells, stored as 1 s, which fell under `RESID_MIN` and so got no hold at
 > all — they flashed by in ~0.2 s. The stored duration now rounds the frames in. See
 > `docs/disc_sweep.md` "Round-7" + `docs/dvd_nav.md` "Amendment (2026-08-25)".
+>
+> **🔧 2026-08-25, ⏳ HW-confirm pending — FIRST-BOOT ENTROPY (same branch).** The rnd
+> LFSR was seeded only from the mount instant, which is not entropy when the first mount
+> after a core load is machine-timed: Weakest Link asked the same question on every cold
+> load (a disc reload fixed it, since that mount IS user-timed). `hps_io`'s `TIMESTAMP`
+> (wall clock) is now XORed into the seed — libdvdnav's `srand(time)` parity — plus a
+> zero-lockup guard on the stir path. See `docs/disc_sweep.md` "Round-8" +
+> `docs/dvd_vm.md` "First-boot hole".
 >
 > **★ NEW TRACK (2026-08-18): SPEC HARDENING — design to the DVD spec maximum, phased
 > plan in `docs/spec_hardening.md`.** The PGCN and cell-duration bugs were both

--- a/dvd/dvd_iso_reader.sv
+++ b/dvd/dvd_iso_reader.sv
@@ -600,9 +600,11 @@ localparam MAXCELL = 255;             // max cells parsed (DVD nr_of_cells is 1 
 reg [31:0] cell_first_mem [0:MAXCELL-1];  // cell first_sector (2048-sector RBN)
 reg [31:0] cell_last_mem  [0:MAXCELL-1];  // cell last_sector  (2048-sector RBN, incl)
 reg [31:0] cell_start_mem [0:MAXCELL-1];  // Phase 11: BCD start time (prefix sum)
-reg [32:0] cell_meta_mem  [0:MAXCELL-1];  // {heur, pb_secs[15:0]@4-6, still_time@2,
+reg [32:0] cell_meta_mem  [0:MAXCELL-1];  // {heur, pb_secs[15:0]@4-7, still_time@2,
                                           //  cell_cmd_nr@3}. pb_secs = authored
                                           // playback time (C_PBTM) in binary seconds,
+                                          // the FRAME field rounded in (pb_dur_w:
+                                          // "1 s + 24 f" = 1.96 s stores as 2, not 1),
                                           // clamped at the SPEC MAX 9:59:59 = 35,999 s
                                           // (spec-hardening Phase 6; was 255) - the
                                           // authored-cell-duration hold source. heur =
@@ -895,6 +897,15 @@ reg        still_last;                // the still cell was the PGC's last cell
 // cell_secs saturates at 16'hFFFF, above the 35,999 s C_PBTM spec max (the
 // Phase-6 clamp widening), so a long cell stops qualifying once its full
 // authored duration has displayed - never a spurious hold.
+//
+// The authored duration read here (cell_dur_w) is the FRAME-ROUNDED C_PBTM
+// (see pb_dur_w at the cell-meta write): before that rounding a "1 s + 24 f"
+// = 1.96 s screen stored as 1 s, and 1 < RESID_MIN meant it got NO hold at
+// all - the Weakest Link answer-reveal / money-banked flash (2026-08-25).
+// RESID_MIN stays at 2 deliberately: with the rounding in place a genuine
+// 2 s screen qualifies, while sub-second cells (0 s + n f, e.g. Deal or No
+// Deal's ~1800 half-second cells) round to 1 and still take no hold - the
+// same behaviour they have today, so no disc gains a new hitch.
 localparam RESID_MIN = 16'd2;         // min unspent seconds worth holding for
 reg [15:0] cell_secs;                 // display seconds since this cell loaded
 reg [5:0]  cell_refr;                 // sub-second display-refresh counter
@@ -1476,6 +1487,30 @@ reg  [31:0] pt_c;                     // this cell's playback_time (BCD)
 reg  [31:0] run_eltm;                 // running duration sum (BCD)
 wire [31:0] run_sum_w;
 bcd_time_add run_eltm_add (.a(run_eltm), .b(pt_c), .sum(run_sum_w));
+// ---- AUTHORED DURATION: ROUND THE C_PBTM FRAME FIELD (2026-08-25) ---------
+// C_PBTM is a BCD dvd_time {hh, mm, ss, rate|frames}; pb_c above keeps only
+// hh:mm:ss because that is what libdvdnav's still HEURISTIC uses (vm.c
+// get_current_position - keep pb_c truncated so detection stays in lockstep
+// with tools/iso_nav_check.py). The HOLD, though, must serve the cell's REAL
+// authored length, and interactive discs author their short screens as
+// "N seconds + (fps-1) frames" = N+1 seconds minus one frame:
+//
+//   Weakest Link (PAL, 25 fps): the correct/wrong answer reveal and the
+//   "money banked" screen are single I-frame cells with pbtime = 1 s + 24 f
+//   = 1.96 s. Truncating to 1 s put the residual (1 s) UNDER RESID_MIN, so
+//   no hold was served at all and the screen flashed by in ~0.2 s - while
+//   the 17 s + 23 f question cell held fine. See docs/disc_sweep.md
+//   "Round-7" and docs/dvd_nav.md "Authored cell duration".
+//
+// So the STORED duration rounds the frame field to the nearest second (the
+// hold countdown is 1 Hz - docs record the +-0.5 s quantisation). Rate bits:
+// 2'b01 = 25 fps, 2'b11 = 30 fps (dvd/bcd_time_add.sv); anything else is
+// malformed and takes the 30 fps threshold (rounds up less eagerly).
+wire [5:0]  pb_frames_w = {2'b0, pt_c[5:4]} * 6'd10 + {2'b0, pt_c[3:0]};
+wire        pb_rndup_w  = (pt_c[7:6] == 2'b01) ? (pb_frames_w >= 6'd13)
+                                               : (pb_frames_w >= 6'd15);
+wire [15:0] pb_dur_w    = (pb_c >= 16'd35999) ? 16'd35999      // spec-max clamp
+                                              : (pb_c + {15'd0, pb_rndup_w});
 always @(posedge clk)
     if (!rst_n) begin
         // title span is captured only in this block (sole driver of the outputs)
@@ -1522,7 +1557,10 @@ always @(posedge clk)
             // Store the EFFECTIVE hold (explicit still_time OR the heuristic),
             // so downstream sees a nonzero still for authored menu/ad/copyright
             // stills that carry still_time==0.
-            cell_meta_mem[cell_wi] <= {heur_flag_w, pb_c, eff_still_w, cm_cmd_c};
+            // pb_dur_w (not pb_c): the frame-rounded authored duration - the
+            // hold must serve the cell's real length, while the heuristic
+            // DETECTION above stays on the truncated libdvdnav value.
+            cell_meta_mem[cell_wi] <= {heur_flag_w, pb_dur_w, eff_still_w, cm_cmd_c};
             cell_cat_mem [cell_wi] <= cm_cat_c;      // Phase 9 angle-block flags
         end
         end
@@ -1588,7 +1626,8 @@ always @(posedge clk)
 // The hold decision, evaluated at CELL FINISHED (cm_rd tracks cell_raddr =
 // this cell, same as the existing still branch). dur_resid is only meaningful
 // under dur_hold's cell_secs < dur guard.
-wire [15:0] cell_dur_w  = cm_rd[31:16];              // authored secs (spec-max clamp)
+wire [15:0] cell_dur_w  = cm_rd[31:16];              // authored secs, frames rounded in
+                                                     // (pb_dur_w; spec-max clamp)
 wire [15:0] dur_resid_w = cell_dur_w - cell_secs;    // unspent authored seconds
 wire        dur_hold_w  = vm_mode && !menu_dom &&
                           !angle_active && !seamless_active && !cell_partial &&

--- a/dvd/dvd_vm.sv
+++ b/dvd/dvd_vm.sv
@@ -740,7 +740,13 @@ always @(posedge clk or negedge rst_n) begin
                         if (gprm_mode[gi]) gprm[gi] <= gprm[gi] + 16'd1;
                     tick_pending <= 1'b0;
                 end
-                if (entropy_stir) lfsr <= lfsr ^ entropy_val;
+                // Zero-guard: an all-zero LFSR is a LOCKUP (lfsr_next of 0 is
+                // 0, so every later rnd returns 1 forever). The XOR can land
+                // there whenever entropy_val happens to equal lfsr, so fold in
+                // the fixed seed instead - same guard as lfsr_seed's.
+                if (entropy_stir)
+                    lfsr <= (|(lfsr ^ entropy_val)) ? (lfsr ^ entropy_val)
+                                                    : 16'hACE1;
                 if (!enable) begin
                     ev_boot <= 1'b0; ev_loaded <= 1'b0; ev_error <= 1'b0;
                     ev_btn  <= 1'b0; ev_menu <= 1'b0; ev_resume <= 1'b0;

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -696,7 +696,11 @@ hps_io #(.CONF_STR(CONF_STR), .BLKSZ(4)) hps_io_inst (
     // Image mount detection
     .img_mounted    (img_mounted),
     .img_readonly   (img_readonly),
-    .img_size       (img_size)
+    .img_size       (img_size),
+
+    // Wall clock (seconds since the epoch), sent by Main once at core load.
+    // The DVD-game entropy seed - see the entropy source below.
+    .TIMESTAMP      (hps_timestamp)
 );
 
 // =========================================================================
@@ -1371,6 +1375,21 @@ wire pause_aud = pause_q | hold_freeze;
 // counter latched by dvd_vm at mount; (2) sec_tick - a 1 Hz pulse that ticks
 // counter-mode GPRMs; (3) entropy_stir - user-input timing folded into the rnd
 // LFSR (so rnd varies per play even when the mount instant is similar).
+// ★ FIRST-BOOT ENTROPY (2026-08-25). The counter below is sampled at the MOUNT
+// instant, which is only entropy if that instant is user-timed. On the FIRST
+// mount after a core load it need not be: MiSTer can mount an image from the
+// core-launch path (and the whole boot chain to the disc's first `rnd` is
+// machine-timed), so the sample - and every `rnd` derived from it - came out
+// IDENTICAL on every first play. HW symptom (Weakest Link, user report): the
+// same question every time from a cold core load, correctly randomised from the
+// second disc load on (that mount IS user-timed). A real player has no such
+// hole because it seeds from a WALL CLOCK - libdvdnav literally does
+// srand(time.tv_usec) at init - so take the same source: hps_io hands us
+// TIMESTAMP (seconds since the epoch), sent by Main at core load, before any
+// mount. XORed into the seed it varies every core load even when the mount
+// instant does not. Falls back to the counter alone if the framework never
+// sends it (TIMESTAMP stays 0). See docs/dvd_vm.md "DVD-game entropy".
+wire [32:0] hps_timestamp;
 reg  [31:0] entropy_ctr = 32'd0;
 reg  [24:0] sec_div     = 25'd0;
 reg         sec_tick    = 1'b0;
@@ -1385,11 +1404,15 @@ always @(posedge clk_sys) begin
     end
 end
 wire vm_entropy_stir = |(joystick_0 ^ joy_prev);   // any gamepad edge = user timing
+// Seed = mount-instant counter XOR the wall clock (both halves of it, so a
+// 16-bit seed still moves with the high word). srand(time()) parity.
+wire [15:0] vm_rnd_seed = entropy_ctr[15:0] ^
+                          hps_timestamp[15:0] ^ hps_timestamp[31:16];
 
 dvd_vm dvd_vm_inst (
     .clk           (clk_sys),
     .rst_n         (reset_n),
-    .rnd_seed      (entropy_ctr[15:0]),
+    .rnd_seed      (vm_rnd_seed),
     .sec_tick      (sec_tick),
     .entropy_stir  (vm_entropy_stir),
     .entropy_val   (entropy_ctr[15:0]),


### PR DESCRIPTION
## Summary

Weakest Link's **correct/wrong answer reveal** and its **"money banked"** screen flashed
past in ~0.2 s where a real player holds each ~2 s, while the 17 s questions (PR fj#165's
authored-cell-duration hold) held correctly.

**Root cause:** `C_PBTM` is a BCD `dvd_time {hh, mm, ss, rate|frames}` and the reader
summed **hh:mm:ss only**, discarding the frame field. Interactive discs author their short
screens as *"N seconds + (fps−1) frames"* — N+1 seconds minus one frame — so those screens
(single-I-frame cells: VTS18 PGC29 cells 1–6 and VTS02 PGC248 cell 0, both `1 s + 24 f`
@25 fps = **1.96 s**) stored as **1 s**. That residual sits *under* `RESID_MIN` (2 s), so
no hold was armed at all. The 17 s question cleared the threshold, which is exactly why one
worked and the other did not.

The stored duration now rounds the frame field to the nearest second: `1 s + 24 f` → 2,
`3 s + 23 f` → 4, `17 s + 23 f` → 18. Scope held tight on purpose:

- `pb_c` stays **truncated** where the libdvdnav still heuristic reads it (a port of
  `vm.c get_current_position`, which truncates; `tools/iso_nav_check.py` mirrors it).
- `RESID_MIN` stays 2 s, so sub-second cells (`0 s + n f`) still take no hold — Deal or No
  Deal alone authors ~1,800 of them and would otherwise gain a ~0.4 s freeze each.

### Also in this branch

- **Entropy hardening (unverified, not a fix):** `hps_io`'s `TIMESTAMP` (wall clock) XORed
  into the `rnd` seed — libdvdnav's `srand(time)` parity. It was written for a diagnosis
  that the next HW round disproved; the docs carry an explicit retraction.
- **LFSR zero-lockup guard** (stands on its own): `lfsr ^ entropy_val` can reach 0, and 0
  is absorbing for this LFSR, so every later `rnd` would return 1 forever.
- **Docs:** Weakest Link's "same question every time" is **authored** — pressing Menu
  during the boot sequence skips the disc's own RNG seeding (VTS21 PGC24/PGC28) because its
  Root trampoline jumps straight to the menu PGC. libdvdnav does the identical jump, and
  the disc sets **no** UOP bits (4,257 title PGCs, 68 boot NAV packs, all zero), so no
  faithful player can refuse the press. No RTL change; README notes the workaround.
- **SEED 8 pinned** for the final netlist.

## Test plan

- [x] `iso_reader_celldur_tb` T8 (1 s + 24 f holds 2 s — the reveal shape), T9 (1 s + 2 f
      stays 1 s, monitored so it never holds), T10 (3 s + 23 f → 4 s PGC-end hold)
- [x] `iso_reader_celldur_tb` T1–T7 unchanged and green
- [x] `dvd_vm_tb` PART 3 T5 — stir zero-lock guard
- [x] Reader/VM suite green (`iso_reader_*`, `dvd_vm_tb`, `dvd_vm_atmos_tb`); `atmos`,
      `attr` and `tpsw_boot` fail identically on `main` (pre-existing)
- [x] Golden-model + libdvdnav cross-checks on the real ISO (`dvd_vm_ref.py`,
      `trace_nav`, `trace_menuearly`)
- [x] Timing gate: SEED 8, clk_dec **90.56 MHz @100C / 90.56 MHz @−40C** (gate 86.0) →
      `releases/DVD_wlentropy_20260825_2010.rbf`
- [x] **HW-CONFIRMED (user, 2026-08-25):** hold durations correct on Weakest Link
- [ ] HW: entropy hardening (no known symptom to confirm it against)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
