### PR TITLE
version: open 0.1b for development + write down the release convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1055,6 +1055,28 @@ told apart on the SD card. The date/time suffix is appended automatically.
 The script always passes `-o bitstream_compression=on` and warns if the output
 exceeds ~4 MB. Copy the resulting `releases/*.rbf` to the SD card to load it.
 
+### Versioning and publishing releases
+
+Two identifiers, deliberately at different granularities:
+
+- **`` `CORE_VERSION `` in `dvd/emu.sv`** — the series (`0.1b`), shown in the OSD as
+  ``v`CORE_VERSION` `BUILD_DATE` `` (e.g. `v0.1b 260825`). **Bump it the moment a release
+  is PUBLISHED, not when the next one is cut**, so no dev build ever advertises a version
+  that already exists on the releases page — that line is the only thing a bug report can
+  quote. Keeping the next version open also means the latest `.rbf` already matches the
+  tag when you decide to release, instead of forcing a rebuild (and a possible fitter
+  re-sweep) at release time.
+- **`BUILD_DATE`** — `yymmdd`, regenerated per compile by `sys/build_id.tcl`. ⚠ Do NOT
+  extend it with a time or a git SHA to separate same-day builds: it is part of
+  `CONF_STR`, hence part of the netlist, so every compile would become a new netlist and
+  re-roll the fitter seed lottery (see `DVD.qsf`'s seed ledger). Same-day dev builds are
+  told apart by their `build_release.sh --name` filename, which already carries
+  `<date>_<time>`.
+
+Publishing (GitHub, `gh`): tag `v<version>-<yyyymmdd>` (the first release was
+`v0.1a-20260825`), title `<version> (<date>) — <headline>`, attach the **timing-clean**
+`.rbf` only — never a `_MARGINAL_` one. Then bump `` `CORE_VERSION `` in the same session.
+
 > **Always build after completing a requested feature.** When an RTL/feature change is
 > finished (committed, PR opened), run `./build_release.sh --compile` to produce a fresh
 > loadable `.rbf` so it's ready to flash and HW-test — don't leave the user to trigger the

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -437,7 +437,18 @@ assign CE_PIXEL = 1'b1;
 // date matters for a public release: it is the only way a bug report can identify
 // WHICH build the reporter is running.
 `include "build_id.v"
-`define CORE_VERSION "0.1a"
+// VERSIONING (2026-08-25): bump this the moment a release is PUBLISHED, not when
+// the next one is cut. `0.1a` shipped as tag v0.1a-20260825, so every build made
+// after that point must advertise 0.1b or it lies about which build it is - and
+// this OSD line is the only thing a bug report can quote. Keeping the next
+// version open also means the latest .rbf already matches the tag when you decide
+// to release, instead of forcing a rebuild (and a fitter re-sweep) at release
+// time. BUILD_DATE below still separates dev builds within the series.
+// ⚠ Do NOT add a time-of-day or git SHA to BUILD_DATE to separate same-day
+// builds: it is part of CONF_STR = part of the netlist, so every compile would
+// become a new netlist and re-roll the fitter seed lottery (DVD.qsf's ledger).
+// Same-day dev builds are identified by their build_release.sh --name filename.
+`define CORE_VERSION "0.1b"
 
 parameter CONF_STR = {
     "DVD;;",


### PR DESCRIPTION
## Summary

Opens **0.1b** for development and writes down the release convention.

Every build made since the `v0.1a-20260825` release still advertised `v0.1a` in the OSD
version line — the one string a bug report can quote — so an interim build claimed to be a
published release. Bumping immediately after publishing (rather than when the next release
is cut) fixes that, and means the latest `.rbf` already matches whatever tag gets cut
instead of forcing a rebuild — and a possible fitter re-sweep — at release time.

`CLAUDE.md` gains a short "Versioning and publishing releases" section recording the
convention and the non-obvious constraint behind it: **`BUILD_DATE` must not gain a
time-of-day or git SHA** to separate same-day builds, because it lives in `CONF_STR` and
therefore in the netlist — every compile would become a new netlist and re-roll the fitter
seed lottery (see `DVD.qsf`'s seed ledger). Same-day dev builds are identified by their
`build_release.sh --name` filename, which already carries `<date>_<time>`.

## Notes

- The define is part of `CONF_STR`, so this perturbs the fit. No build or sweep was run:
  the next feature branch needs a fresh fit anyway, so the cost belongs there rather than
  in a standalone sweep now.
- Consequence: `releases/DVD_wlentropy_20260825_2010.rbf` (SEED 8, timing-clean) still
  reads `v0.1a 260825` — it is the right build to flash today, it just predates the bump.

## Test plan

- [x] `` `CORE_VERSION `` is the only functional change; OSD line renders as
      ``v`CORE_VERSION` `BUILD_DATE` `` = `v0.1b <yymmdd>`
- [ ] Fit/timing: deferred to the next feature build (no release pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
