### PR TITLE
version: open 0.1d

### DIFF
--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -486,7 +486,7 @@ assign CE_PIXEL = 1'b1;
 // builds: it is part of CONF_STR = part of the netlist, so every compile would
 // become a new netlist and re-roll the fitter seed lottery (DVD.qsf's ledger).
 // Same-day dev builds are identified by their build_release.sh --name filename.
-`define CORE_VERSION "0.1c"
+`define CORE_VERSION "0.1d"
 
 parameter CONF_STR = {
     "DVD;;",


### PR DESCRIPTION
Opens the 0.1d series after publishing v0.1c-20260826, per the version-bump-at-publish rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
