### PR TITLE
picbuf: don't let the decoder write into the frame slot being displayed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,8 @@ worse maintenance burden than targeted in-place edits. So:
 ## Hardware status (THIS fork, verified 2026-06-21)
 
 - 🔧 **PIXELATED MENU STILLS — root-caused + fixed in fabric (2026-08-26, branch
-  `fix/picbuf-display-slot-alias`); ⏳ HW-CONFIRM PENDING.** A menu/game still could come up
+  `fix/picbuf-display-slot-alias`); ✅ HW-CONFIRMED 2026-08-27 (user report: Harry Potter
+  artifacting GONE, no regressions on other discs; build `DVD_picbufalias`).** A menu/game still could come up
   **blocky, "like it hasn't finished loading"** because the decoder was writing the new picture
   **into the frame slot the display was scanning out**. `rtl/mpeg2/motcomp_picbuf.v` guards its
   `current_frame` (:268/:278) and `prev_i_p_frame` (:355) updates with `~vld_last_frame`, but the
@@ -179,8 +180,8 @@ worse maintenance burden than targeted in-place edits. So:
   Potter Interactive disc, every `still_time=255` still is `SEQ GOP PIC:I SEQ_END` (so a still
   arms the collision for whatever decodes next ⇒ still→still navigation collided every time)
   while every video/transition cell ends on a coded B (⇒ never armed). So this does **not**
-  explain the reported jump-vs-natural asymmetry, nor a multi-second artifact — expect it to fix
-  a blocky flash. Also learned: that disc's stills are **title-domain**, and the menu-still cold
+  explain the reported jump-vs-natural asymmetry, nor a multi-second artifact — yet on HW the fix
+  cleared ALL observed artifacting on the disc, so those observation-level discrepancies closed with it. Also learned: that disc's stills are **title-domain**, and the menu-still cold
   re-decode (`dvd_iso_reader.sv:4017`) is `menu_dom`-gated, so it never ran there at all — a
   separate, deliberately deferred item. Detail: `docs/dvd_menu_refinements.md` §5.
   A follow-up **audit of the rest of the upstream decoder found no further fix-now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,8 @@ worse maintenance burden than targeted in-place edits. So:
   a blocky flash. Also learned: that disc's stills are **title-domain**, and the menu-still cold
   re-decode (`dvd_iso_reader.sv:4017`) is `menu_dom`-gated, so it never ran there at all — a
   separate, deliberately deferred item. Detail: `docs/dvd_menu_refinements.md` §5.
+  A follow-up **audit of the rest of the upstream decoder found no further fix-now
+  defects** — findings + the audited-clean list: `docs/decoder_audit.md`.
 
 - ✅ **LAUNCH FEEDBACK TRIO — HW-CONFIRMED 2026-08-26 (5 HW rounds; PR #9 +
   the follow-up rounds PR); design + full history: `docs/idle_screen.md`.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,32 @@ worse maintenance burden than targeted in-place edits. So:
 
 ## Hardware status (THIS fork, verified 2026-06-21)
 
+- 🔧 **PIXELATED MENU STILLS — root-caused + fixed in fabric (2026-08-26, branch
+  `fix/picbuf-display-slot-alias`); ⏳ HW-CONFIRM PENDING.** A menu/game still could come up
+  **blocky, "like it hasn't finished loading"** because the decoder was writing the new picture
+  **into the frame slot the display was scanning out**. `rtl/mpeg2/motcomp_picbuf.v` guards its
+  `current_frame` (:268/:278) and `prev_i_p_frame` (:355) updates with `~vld_last_frame`, but the
+  **fwd/bwd reference swap (:322/:327) was not guarded** — so at every `sequence_end_code` the
+  slot pointers rotated one extra step, `STATE_LAST_FRAME` put that slot on screen while clearing
+  `prev_i_p_frame_valid`, and the next sequence's first I both targeted the displayed slot AND
+  took `STATE_IP_FRAME_0`'s `~output_frame_valid` shortcut (:164) past the anti-overwrite
+  handshake. **Fix = add `~vld_last_frame` to the swap** (the alias becomes structurally
+  impossible: `fwd`/`bwd` are always a distinct {0,1} pair and `output_frame == prev_i_p_frame
+  == bwd` at a sequence end). This is an **upstream mpeg2fpga bug** — the file was untouched
+  since import. Sim: new `bench/dvd/motcomp_picbuf_tb.sv` ([A] still→still fails pre-fix, passes
+  post-fix; [B] video→still control; [C] boot-deadlock guard) + a `` `ifdef CHECK `` assertion now
+  live in the module. ⛔ **Do NOT instead gate the `STATE_IP_FRAME_0` shortcut on slot
+  inequality — it DEADLOCKS the core** (`dvd/resample_addrgen.v:543` gates pickup on
+  `output_frame_valid`, which is 0 in exactly that scenario, so `output_frame_rd` never arrives).
+  ⚠ **Scope is honest and narrower than the symptom:** measured over 70 real cells of the Harry
+  Potter Interactive disc, every `still_time=255` still is `SEQ GOP PIC:I SEQ_END` (so a still
+  arms the collision for whatever decodes next ⇒ still→still navigation collided every time)
+  while every video/transition cell ends on a coded B (⇒ never armed). So this does **not**
+  explain the reported jump-vs-natural asymmetry, nor a multi-second artifact — expect it to fix
+  a blocky flash. Also learned: that disc's stills are **title-domain**, and the menu-still cold
+  re-decode (`dvd_iso_reader.sv:4017`) is `menu_dom`-gated, so it never ran there at all — a
+  separate, deliberately deferred item. Detail: `docs/dvd_menu_refinements.md` §5.
+
 - ✅ **LAUNCH FEEDBACK TRIO — HW-CONFIRMED 2026-08-26 (5 HW rounds; PR #9 +
   the follow-up rounds PR); design + full history: `docs/idle_screen.md`.**
   Shipped as release v0.1c. HW rounds delivered on top of the original trio:

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -626,4 +626,8 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # Round-6 netlist (Line-21 CC toggle moved to the debug page, CONF_STR only):
 # SEED 9 held first roll, BETTER margin -- clk_dec 93.0 @100C / 88.6 @-40C
 # -> releases/DVD_cc21r5_20260827_0032.rbf. This is the merge candidate.
+# picbufalias netlist (fix/picbuf-display-slot-alias: two ~vld_last_frame guard
+# terms in motcomp_picbuf's reference swap -- a tiny logic delta): SEED 9 held
+# first roll, clk_dec 87.54 @100C / 90.91 @-40C (gate 86.0 PASS both corners)
+# -> releases/DVD_picbufalias_20260827_0158.rbf.
 set_global_assignment -name SEED 9

--- a/bench/dvd/motcomp_picbuf_tb.sv
+++ b/bench/dvd/motcomp_picbuf_tb.sv
@@ -1,0 +1,263 @@
+`timescale 1ns/1ps
+/*
+ * motcomp_picbuf_tb.sv — does the decoder ever write into the frame slot the
+ * DISPLAY is currently scanning out?
+ *
+ * The pixelated-menu-still bug. motcomp_picbuf hands the VLD a decode target
+ * (current_frame) and tells resample which slot to show (output_frame). A
+ * handshake in STATE_IP_FRAME_0 exists precisely to stop those aliasing —
+ * its own comment says "don't overwrite a picture which still needs to be
+ * displayed". At a sequence_end_code that handshake is bypassed:
+ *
+ *   1. STATE_UPDATE with vld_last_frame=1 guards current_frame and
+ *      prev_i_p_frame, but NOT the fwd/bwd reference swap (:322/:327), so the
+ *      slot pointers rotate one extra step.
+ *   2. STATE_LAST_FRAME emits prev_i_p_frame for display and clears
+ *      prev_i_p_frame_valid.
+ *   3. The next sequence's first I gets current_frame <= forward_reference_frame
+ *      — which the extra swap has just made equal to the displayed slot.
+ *   4. The I/P emit branch sets output_frame_valid <= prev_i_p_frame_valid = 0,
+ *      so STATE_IP_FRAME_0's `~output_frame_valid` shortcut releases the VLD
+ *      immediately, and the new picture paints into the slot on screen.
+ *
+ * MEASURED on the real Harry Potter Interactive DVD (HOGWARTS CHALLENGE):
+ * every still cell is `SEQ GOP PIC:I SEQ_END` with the B7 ending a video PES
+ * (so ps_demux's S_VID_FLUSH filler fires and the VLD really does reach
+ * STATE_SEQUENCE_END), while every video/transition cell ends on a coded B.
+ * So a STILL arms the collision for whatever decodes next -> still->still menu
+ * navigation collides every time; video->still does not. Scenarios A and B
+ * below are exactly those two measured shapes.
+ *
+ * The first link of that chain was verified against the REAL disc bytes rather
+ * than by reading the demux source. bench/dvd/test_vobs/ is gitignored, so
+ * regenerate the fixture locally from the Harry Potter Interactive DVD image in
+ * your own disc library: demux stream_id 0xE0 out of the 9 sectors at
+ * VTS_04_1.VOB RBN 319831..319839 (the still_time=255 cell), append the 24 filler
+ * bytes dvd/ps_demux.sv's S_VID_FLUSH emits after a 000001B7 at a PES end, and
+ * write it as 64-bit big-endian $readmemh words. Then:
+ *   vvp bench/dvd/vld_drop_rff_sim +ES=bench/dvd/test_vobs/hp_still_i.hex
+ * emits exactly one frame at picture 0 -- i.e. STATE_SEQUENCE_END really is
+ * reached and last_frame really does fire on this disc's stills. (Observed
+ * 2026-08-26: "EMIT n=1 at_pic=0".)
+ *
+ * Build:
+ *   iverilog -g2012 -D__IVERILOG__ -I rtl/mpeg2 -o bench/dvd/motcomp_picbuf_sim \
+ *       rtl/mpeg2/motcomp_picbuf.v bench/dvd/motcomp_picbuf_tb.sv
+ *   vvp bench/dvd/motcomp_picbuf_sim [+SCAN=n] [+VERBOSE=1]
+ */
+
+module motcomp_picbuf_tb;
+
+  reg clk = 0; always #5 clk = ~clk;
+  reg rst = 0;                       // synchronous, ACTIVE LOW
+
+`include "vld_codes.v"
+
+  // picbuf's own state encoding (parameters are not visible through the
+  // hierarchical reference, so mirror the ones the checker needs)
+  localparam [3:0] ST_IP_FRAME_1 = 4'h3,
+                   ST_B_FRAME_0  = 4'h4,
+                   ST_LAST_FRAME = 4'h6;
+
+  integer SCAN    = 40;              // display scan-out length, in clocks
+  integer VERBOSE = 0;
+
+  // ---------------- DUT ----------------
+  reg  [2:0] picture_coding_type = I_TYPE;
+  reg        last_frame = 1'b0;
+  reg        update_picture_buffers = 1'b0;
+  reg        output_frame_rd = 1'b0;
+
+  wire [2:0] fwd, bwd, current_frame, output_frame;
+  wire       output_frame_valid, picbuf_busy;
+
+  motcomp_picbuf dut (
+    .clk(clk), .clk_en(1'b1), .rst(rst),
+    .source_select(3'd0),
+    .progressive_sequence(1'b1), .progressive_frame(1'b1),
+    .top_field_first(1'b1), .repeat_first_field(1'b0),
+    .last_frame(last_frame),
+    .picture_coding_type(picture_coding_type),
+    .forward_reference_frame(fwd), .backward_reference_frame(bwd),
+    .current_frame(current_frame),
+    .output_frame(output_frame), .output_frame_valid(output_frame_valid),
+    .output_frame_rd(output_frame_rd),
+    .output_progressive_sequence(), .output_progressive_frame(),
+    .output_top_field_first(), .output_repeat_first_field(),
+    .update_picture_buffers(update_picture_buffers),
+    .picbuf_busy(picbuf_busy),
+    .flags_commit(1'b0)
+    );
+
+  // ---------------- display model ----------------
+  // Mirrors dvd/resample_addrgen.v: pickup is gated on output_frame_valid
+  // (:543 ofv_pickup, :598), the picked-up slot is latched (:1065
+  // output_frame_sav) and then PERSISTENCE-re-scanned every refresh while
+  // nothing new decodes — so disp_held never drops once set.
+  reg  [2:0] disp_slot = 3'd0;
+  reg        disp_held = 1'b0;
+  integer    scan_cnt  = 0;
+  integer    pickups   = 0;
+  reg        gov_ack   = 1'b0;
+
+  always @(posedge clk)
+    if (~rst) begin
+      output_frame_rd <= 1'b0; gov_ack <= 1'b0; scan_cnt <= 0; disp_held <= 1'b0;
+    end else begin
+      output_frame_rd <= 1'b0;
+      if (~gov_ack && output_frame_valid) begin
+        if (scan_cnt < SCAN) scan_cnt <= scan_cnt + 1;
+        else begin
+          scan_cnt        <= 0;
+          disp_slot       <= output_frame;
+          disp_held       <= 1'b1;
+          pickups         <= pickups + 1;
+          output_frame_rd <= 1'b1;
+          gov_ack         <= 1'b1;
+        end
+      end else if (gov_ack && ~output_frame_valid) gov_ack <= 1'b0;
+    end
+
+  // ---------------- the invariant ----------------
+  // Checked on the cycles picbuf releases the VLD to write macroblocks.
+  // STATE_LAST_FRAME also drops picbuf_busy, but no macroblocks can follow it
+  // before the next update_picture_buffers, so it is deliberately excluded —
+  // without that mask the bench false-fails on every sequence end.
+  integer fails = 0;
+  integer checks = 0;
+
+  always @(posedge clk)
+    if (rst && ((dut.state == ST_IP_FRAME_1) || (dut.state == ST_B_FRAME_0))) begin
+      checks = checks + 1;
+      if (disp_held && (current_frame == disp_slot)) begin
+        fails = fails + 1;
+        $display("  FAIL t=%0t: VLD released to decode into slot %0d while the display is scanning slot %0d  (fwd=%0d bwd=%0d ofv=%0d)",
+                 $time, current_frame, disp_slot, fwd, bwd, output_frame_valid);
+      end
+    end
+
+  always @(posedge clk)
+    if (rst && (fwd == bwd)) begin
+      fails = fails + 1;
+      $display("  FAIL t=%0t: forward_reference_frame == backward_reference_frame == %0d", $time, fwd);
+    end
+
+  // ---------------- VLD model ----------------
+  // motcomp.v:265-268 freezes the VLD while picbuf_busy, so a picture is never
+  // announced while the previous one is still being placed.
+  task push(input [2:0] ptype, input lastf);
+    begin
+      wait (picbuf_busy == 1'b0); @(posedge clk);
+      picture_coding_type    <= ptype;
+      last_frame             <= lastf;
+      update_picture_buffers <= 1'b1;
+      @(posedge clk);
+      update_picture_buffers <= 1'b0;
+      wait (picbuf_busy == 1'b0);           // released -> "decoding macroblocks"
+      repeat (20) @(posedge clk);
+      if (VERBOSE)
+        $display("    push %s%s -> current=%0d fwd=%0d bwd=%0d out=%0d disp=%0d",
+                 (ptype==I_TYPE)?"I":(ptype==P_TYPE)?"P":"B", lastf?" +SEQ_END":"",
+                 current_frame, fwd, bwd, output_frame, disp_slot);
+    end
+  endtask
+
+  task wait_pickup(input integer n);       // let the display latch what was emitted
+    begin : wp
+      integer target; target = pickups + n;
+      fork
+        begin wait (pickups >= target); end
+        begin repeat (20*SCAN + 2000) @(posedge clk); end
+      join_any
+      disable fork;
+    end
+  endtask
+
+  task reset_dut;
+    begin
+      rst = 1'b0; disp_held = 1'b0; disp_slot = 3'd0;
+      repeat (4) @(posedge clk);
+      rst = 1'b1; @(posedge clk);
+    end
+  endtask
+
+  integer f0;
+  integer sc;
+  initial begin
+    if (!$value$plusargs("SCAN=%d", SCAN))       SCAN = 40;
+    if (!$value$plusargs("VERBOSE=%d", VERBOSE)) VERBOSE = 0;
+
+    // ---- A: still -> still (the MEASURED Harry Potter shape) ----------------
+    // Each still cell is SEQ GOP PIC:I SEQ_END. The seq_end update pulse carries
+    // the retained coding type of the last coded picture, which for a still is I.
+    reset_dut; f0 = fails;
+    $display("[A] still -> still   (SEQ,I,SEQ_END then SEQ,I,SEQ_END)");
+    push(I_TYPE, 1'b0);          // the still's single I picture
+    push(I_TYPE, 1'b1);          // sequence_end_code
+    wait_pickup(1);              // the still is now on screen, reader parked
+    push(I_TYPE, 1'b0);          // the NEXT still's I  <-- collides pre-fix
+    wait_pickup(1);
+    $display("[A] %s  (%0d new failures)", (fails==f0)?"pass":"FAIL", fails-f0);
+
+    // ---- B: video -> still (control; measured transition cells end on a B) ---
+    reset_dut; f0 = fails;
+    $display("[B] video -> still   (I,B,B,P,B,B,SEQ_END-carrying-B then still I)");
+    push(I_TYPE, 1'b0);
+    push(B_TYPE, 1'b0); push(B_TYPE, 1'b0);
+    push(P_TYPE, 1'b0);
+    push(B_TYPE, 1'b0); push(B_TYPE, 1'b0);
+    push(B_TYPE, 1'b1);          // seq_end, retained type = B -> swap must NOT fire
+    wait_pickup(1);
+    push(I_TYPE, 1'b0);
+    wait_pickup(1);
+    $display("[B] %s  (%0d new failures)", (fails==f0)?"pass":"FAIL", fails-f0);
+
+    // ---- C: cold boot must not stall (guards the rejected IP_FRAME_0 change) --
+    reset_dut; f0 = fails;
+    $display("[C] cold boot        (first I after reset must release the VLD)");
+    fork
+      begin push(I_TYPE, 1'b0); end
+      begin
+        repeat (500) @(posedge clk);
+        fails = fails + 1;
+        $display("  FAIL: picbuf_busy never dropped for the first picture — DEADLOCK");
+      end
+    join_any
+    disable fork;
+    $display("[C] %s  (%0d new failures)", (fails==f0)?"pass":"FAIL", fails-f0);
+
+    // ---- D: two back-to-back sequence ends -----------------------------------
+    reset_dut; f0 = fails;
+    $display("[D] double seq_end   (I,SEQ_END,SEQ_END then I)");
+    push(I_TYPE, 1'b0);
+    push(I_TYPE, 1'b1);
+    wait_pickup(1);
+    push(I_TYPE, 1'b1);
+    wait_pickup(1);
+    push(I_TYPE, 1'b0);
+    wait_pickup(1);
+    $display("[D] %s  (%0d new failures)", (fails==f0)?"pass":"FAIL", fails-f0);
+
+    // ---- E: steady-state playback, no sequence ends ---------------------------
+    reset_dut; f0 = fails;
+    $display("[E] steady state     (40 pictures, I B B P B B ...)");
+    push(I_TYPE, 1'b0);
+    for (sc = 0; sc < 13; sc = sc + 1) begin
+      push(B_TYPE, 1'b0); push(B_TYPE, 1'b0); push(P_TYPE, 1'b0);
+    end
+    wait_pickup(1);
+    $display("[E] %s  (%0d new failures)", (fails==f0)?"pass":"FAIL", fails-f0);
+
+    $display("\nSUMMARY: release-point checks=%0d pickups=%0d fails=%0d", checks, pickups, fails);
+    if (fails == 0) $display("RESULT: PASS"); else $display("RESULT: FAIL");
+    $finish;
+  end
+
+  initial begin
+    #20_000_000;
+    $display("\nSUMMARY: TIMEOUT — the FSM stalled (fails=%0d)", fails);
+    $display("RESULT: FAIL");
+    $finish;
+  end
+
+endmodule

--- a/bench/dvd/run_prefetch_chain.sh
+++ b/bench/dvd/run_prefetch_chain.sh
@@ -17,7 +17,7 @@
 set -e
 cd "$(dirname "$0")/../.."
 
-SRC="rtl/mpeg2/resample.v rtl/mpeg2/resample_addrgen.v rtl/mpeg2/resample_dta.v \
+SRC="rtl/mpeg2/resample.v dvd/resample_addrgen.v rtl/mpeg2/resample_dta.v \
 rtl/mpeg2/resample_bilinear.v rtl/mpeg2/mem_addr.v rtl/mpeg2/mixer.v \
 rtl/mpeg2/pixel_queue.v rtl/mpeg2/syncgen.v rtl/mpeg2/read_write.v \
 rtl/mpeg2/wrappers.v rtl/mpeg2/fwft.v rtl/mpeg2/xilinx_fifo_dc.v rtl/mpeg2/xfifo_sc.v \

--- a/bench/dvd/vld_drop_rff_tb.sv
+++ b/bench/dvd/vld_drop_rff_tb.sv
@@ -21,7 +21,8 @@
  *
  * Build:
  *   iverilog -g2012 -D__IVERILOG__ -I rtl/mpeg2 -o bench/dvd/vld_drop_rff_sim \
- *       rtl/mpeg2/vld.v rtl/mpeg2/getbits.v bench/dvd/vld_drop_rff_tb.sv
+ *       rtl/mpeg2/vld.v rtl/mpeg2/getbits.v rtl/mpeg2/motcomp_picbuf.v \
+ *       bench/dvd/vld_drop_rff_tb.sv
  *   vvp bench/dvd/vld_drop_rff_sim +ES=<stream.hex> [+MAXPIC=N] [+REQ=0]
  *
  * +ES    : $readmemh file of the ES as 64-bit big-endian words (first stream

--- a/docs/decoder_audit.md
+++ b/docs/decoder_audit.md
@@ -1,0 +1,94 @@
+# mpeg2fpga Decoder Audit — 2026-08-26
+
+**Trigger.** The pixelated-menu-still fix (branch `fix/picbuf-display-slot-alias`) found a
+genuine upstream bug in `rtl/mpeg2/motcomp_picbuf.v` — a missing `~vld_last_frame` guard that
+let the decoder write into the frame slot being displayed. This audit swept the rest of the
+upstream decoder for more of the same, plus the other defect classes this fork has actually
+hit on hardware (CE-domain mismatches, FIFO margins, counter wraps, netlist-semantics traps).
+
+**Scope.** The `rtl/mpeg2/*.v` files in the active build (per `DVD.qsf`), plus the
+fork-owned memory shims where the decoder's correctness depends on them. Display-side
+(`dvd/resample_addrgen.v`, mixer/syncgen) and the drop/A-V machinery were NOT re-audited —
+they have had dedicated multi-round HW sagas with their own TBs (see `docs/history.md`,
+`docs/lipsync_pickup.md`, `docs/crt_480i.md`).
+
+## Verdict
+
+One real bug was found and fixed (the picbuf slot alias — see
+`docs/dvd_menu_refinements.md` §5). The remaining sweep found **no further fix-now defects**:
+the upstream design is defensively built in exactly the places that looked most dangerous.
+Findings below are ranked; F1–F3 are robustness/cosmetic corners, F4–F6 hygiene.
+
+## Audited and CLEAN (with the evidence that closed each)
+
+- **Memory-address bounds (`mem_addr.v`).** The scariest class — a corrupt slice scribbling
+  across frame slots — is already contained: macroblock x/y only ever advance by 0/+1 from a
+  known origin (`:132-174`, anything else raises `error`), and every computed address is
+  bounds-checked against `end_address` with errors redirected to the parked `ADDR_ERR` word
+  (`:1176-1273`, `mem_codes.v:235`). Cross-slot writes are impossible even on garbage input.
+- **getbits/vld advance interlock (`getbits.v:106`, `vld.v:1184-1191`).** `cursor` adds
+  `advance` unconditionally in `STATE_READY`, which is only safe because the VLD's `clk_en`
+  IS `vld_en` and its `advance`/`align` registers fall to 0 when frozen. Verified both halves.
+- **VBUF ring + flush (`framestore_request.v:463-501`).** `vb_flush` outranks the increment
+  paths; the whole chain (byte packer alignment, write fifo, pointers, read fifo) resets via
+  `vbuf_rst`, so no stale beat survives a flush. Wrap arithmetic (incl. the `VBUF_END`/`VBUF`
+  corner in `next_vbuf_full`) is correct. The no-back-to-back-writes holdoff's bitrate
+  assumption is covered by the reader's designed backpressure (STD model).
+- **FIFO overflow margins (`fifo_size.v`).** RLD prog_full leaves 2 free slots vs ≤1
+  write/cycle and a ~1-cycle stop latency; MVEC likewise. An MVEC overflow would lose an
+  `update_picture_buffers` (display pointer wedge → watchdog), so this margin matters — it
+  holds. Years of upstream use + this fork's full-stream cosims agree.
+- **FWFT skid buffers (`fwft.v`).** 3-slot capacity vs exactly 3 possible in-flight reads
+  (traced cycle-by-cycle). The pixel_queue-class CE hazard is moot in the decode domain:
+  `mpeg2video.v` wires `clk_en(1'b1)` everywhere except the VLD's `vld_en` (producer flow
+  control, not a CE domain). The only real CE domain is dot_clk — where that bug already
+  happened and was fixed (PR fj#65's CE-stretch).
+- **framestore_response routing.** Lock-step tag+data fifos; desync impossible while the
+  memory shim honours 1:1 request:response, which `mem_shim_burst` guarantees (BIST + TB).
+- **Watchdog (`watchdog.v`).** Sound; the active-low `watchdog_rst` reading gotcha is already
+  documented in CLAUDE.md.
+- **`sync_reg` multi-bit 2FF.** Used only on quasi-static config (sizes, matrix
+  coefficients); a torn word during a seq-header change is transient. Acceptable by design.
+- **`second_field` recovery (`vld.v:2222-2226`)** — frame pictures force-reset it, so an
+  illegal field count self-heals. Dimension changes mid-stream recompute `mb_width/height`
+  continuously; oversized streams fall into the `ADDR_ERR` clamp above.
+- **Double-`sequence_end` corner** — covered by `bench/dvd/motcomp_picbuf_tb.sv` scenario
+  [D], passes with the fix in.
+
+## Findings (ranked, none fix-now)
+
+- **F1 — Partial pictures display on parse errors (upstream design, corrupt streams only).**
+  `vld.v` error recovery (`STATE_ERROR`/`dct_error` → `STATE_NEXT_START_CODE`, `:930/:979`)
+  abandons the rest of the slice/picture; the frame slot keeps stale content there and the
+  picture is emitted normally at the next header — there is no picture-complete gate anywhere.
+  Inherent to the architecture, self-repairing, and only reachable on nonconformant/corrupt
+  input. Documented so nobody hunts a "half-decoded frame" as a fork regression.
+- **F2 — The aux_frame swap shares the fixed bug's shape (`motcomp_picbuf.v:350-356`)** —
+  unguarded by `~vld_last_frame`, so a seq_end whose retained coding type is B rotates the
+  aux pair one extra step. Traced for a displayable alias: it requires the display to be
+  persisting on an AUX slot across the seq_end, which `STATE_LAST_FRAME` prevents whenever
+  any I/P ever existed (it moves display to `prev_i_p_frame`) — the residual case is a
+  stream with B pictures and no reference frame at all, which is undecodable garbage anyway.
+  Optional same-shape guard if the file is ever touched again; deliberately NOT bundled into
+  the slot-alias fix.
+- **F3 — End-of-stream tail stranding (cosmetic, linear files only).** `vbuf_write` emits
+  64-bit words only when full (≤7 bytes strand), and getbits needs a further full word to
+  slide its window — so a stream that just STOPS (raw `.m2v` EOF; anything not ending in
+  B7-at-PES-end) never decodes its last slices and never flushes the reorder hold: the final
+  picture is not shown. DVD stills are covered by `ps_demux`'s `S_VID_FLUSH` filler; a
+  general end-of-stream filler (e.g. on reader `strm_done`+drain) would close this for
+  linear playback. Small, optional follow-up.
+- **F4 — ~15 `N'(expr)` size casts survive the project ban** (`dvd/av_sync.sv`,
+  `dvd/dvd_audio_decode.sv`, `dvd/iec61937_wrap.sv`, `dvd/ac3/pcm_out.sv`,
+  `dvd/ac3/mantissa_dequant.sv`; `grep -nE "[0-9]+'\("`). The ban exists because Quartus 17
+  mangled `signed'(27'(x >>> 16))` as a multiply operand (memory
+  `quartus-sizecast-netlist-cosim`). Every survivor sits in a HW-proven path (A/V sync
+  verified to the LSB; AC-3 byte-exact PCMDUMP gates), so they are grandfathered-safe under
+  THIS Quartus — but convert them opportunistically whenever those files are next edited,
+  and keep running the grep on new RTL.
+- **F5 — Hygiene:** `dvd/mem_shim.sv` (the retired non-burst shim, whose read-retry
+  gives up by synthesizing a zero beat) is still listed in `DVD.qsf` but uninstantiated;
+  drop it from the file list on some future netlist-changing branch.
+- **F6 — Noted, deliberate:** `mem_shim_burst.sv`'s fill timeout serves zeroes without
+  validating the cache line — belt-and-suspenders for a path BIST showed never times out.
+

--- a/docs/disc_sweep.md
+++ b/docs/disc_sweep.md
@@ -989,10 +989,20 @@ wrong; the measurement split them.
 - **Speed Racer:** ~0.5 s hitch at the race's correct/incorrect **video branches**. That is
   the seamless-branch/ILVU path (PR fj#112, memory `seamless-branch-ilvu-navigation`) — either
   the branch is not being followed via `next_vobu` or it is taking a flushing jump.
-- **Harry Potter:** skipping a transition leaves the static image **pixelated for a few
-  seconds**. The menu still cold re-decode (PR fj#116) is supposed to give a clean image; a
-  few seconds of macroblocking says the re-decode started mid-GOP rather than on the still's
-  I-frame.
+- **Harry Potter:** the static image comes up **pixelated**. ⛔ The "re-decode started mid-GOP"
+  guess below was **WRONG** — root-caused 2026-08-26 to an upstream `motcomp_picbuf.v` defect:
+  the fwd/bwd reference swap was missing the `~vld_last_frame` guard its two sibling blocks
+  have, so at every `sequence_end_code` the decode target could alias the slot the display was
+  scanning out, and the new picture painted in on screen. Fixed by adding the guard; see
+  `docs/dvd_menu_refinements.md` §5 and `bench/dvd/motcomp_picbuf_tb.sv`.
+  ⚠ Note this also proved the disc's stills get **no** cold re-decode at all: they are
+  *title-domain* (`VTS_PGCIT`) `still_time=255` cells, and `dvd_iso_reader.sv:4017` gates the
+  re-decode on `menu_dom`. Measured: every still cell is `SEQ GOP PIC:I SEQ_END`, every
+  video/transition cell ends on a coded B — so still→still navigation collided every time,
+  video→still never did.
+  *(Original wording, kept for the record: "The menu still cold re-decode (PR fj#116) is
+  supposed to give a clean image; a few seconds of macroblocking says the re-decode started
+  mid-GOP rather than on the still's I-frame.")*
 
 Both are quality-of-transition, not navigation — genuinely lower priority than A/B/C, but
 they share the "what happens at a cell boundary" surface, so triage them together.

--- a/docs/disc_sweep.md
+++ b/docs/disc_sweep.md
@@ -993,7 +993,8 @@ wrong; the measurement split them.
   guess below was **WRONG** — root-caused 2026-08-26 to an upstream `motcomp_picbuf.v` defect:
   the fwd/bwd reference swap was missing the `~vld_last_frame` guard its two sibling blocks
   have, so at every `sequence_end_code` the decode target could alias the slot the display was
-  scanning out, and the new picture painted in on screen. Fixed by adding the guard; see
+  scanning out, and the new picture painted in on screen. Fixed by adding the guard —
+  **✅ HW-CONFIRMED 2026-08-27 (user report): HP artifacting gone, no regressions**; see
   `docs/dvd_menu_refinements.md` §5 and `bench/dvd/motcomp_picbuf_tb.sv`.
   ⚠ Note this also proved the disc's stills get **no** cold re-decode at all: they are
   *title-domain* (`VTS_PGCIT`) `still_time=255` cells, and `dvd_iso_reader.sv:4017` gates the

--- a/docs/dvd_menu_refinements.md
+++ b/docs/dvd_menu_refinements.md
@@ -330,6 +330,40 @@ Matrix submenus similarly; MiB/BBB menus unchanged; normal playback (O[1] Off) u
 
 ## 5. Menu stills don't reach their final frame — cold re-decode (clean), with a FAST trigger
 
+> **★ 2026-08-26 — SEPARATE ROOT CAUSE FOUND for the PIXELATED half: the decoder was
+> writing the new picture INTO the frame slot the display was scanning out.**
+> `rtl/mpeg2/motcomp_picbuf.v`'s `STATE_UPDATE` guards `current_frame` (:268/:278) and
+> `prev_i_p_frame` (:355) with `~vld_last_frame`, but the **forward/backward reference swap
+> (:322/:327) was NOT guarded**, so at every `sequence_end_code` the slot pointers rotated one
+> extra step. `STATE_LAST_FRAME` then emits `prev_i_p_frame` for display *and* clears
+> `prev_i_p_frame_valid`; the next sequence's first I therefore took
+> `current_frame <= forward_reference_frame` — which the extra swap had just made equal to the
+> displayed slot — while `output_frame_valid == 0` let `STATE_IP_FRAME_0`'s `~output_frame_valid`
+> shortcut (:164) release the VLD with no display handshake. The picture then painted into the
+> slot `dvd/resample_addrgen.v` was persistence-re-scanning (`output_frame_sav`, :1065) =
+> "blocky, like it hasn't finished loading". **Fix: add `~vld_last_frame` to the swap** —
+> the alias becomes structurally impossible (`fwd`/`bwd` are always a distinct {0,1} pair, and
+> at a sequence end `output_frame == prev_i_p_frame == bwd`). Sim:
+> `bench/dvd/motcomp_picbuf_tb.sv` scenario [A] fails pre-fix, passes post-fix; a new
+> `` `ifdef CHECK `` assertion in the module catches any recurrence in every picbuf bench.
+>
+> ⛔ **Do NOT "harden" the `STATE_IP_FRAME_0` shortcut instead** — gating it on slot inequality
+> DEADLOCKS the core: `dvd/resample_addrgen.v:543` gates pickup on `output_frame_valid`, which
+> is 0 in exactly the scenario such a gate would try to catch, so `output_frame_rd` can never
+> arrive. (It also aliases legitimately at video start, where all the slot regs reset to 0.)
+>
+> **What this does and does not explain.** MEASURED over 70 real cells of
+> `Harry Potter Interactive DVD Game (HOGWARTS CHALLENGE)`: every `still_time=255` still cell is
+> `SEQ GOP PIC:I SEQ_END` with the `B7` ending a video PES (so `ps_demux`'s `S_VID_FLUSH` filler
+> fires and the VLD really does reach `STATE_SEQUENCE_END`), while every video/transition cell
+> ends on a coded **B**. Since the swap is `!= B_TYPE`-gated, **a still arms the collision for
+> whatever decodes next** — so still→still menu navigation collided every time, and video→still
+> did not. It therefore does **not** explain the reported "clean when jumped to, pixelated when
+> landing naturally" asymmetry (video transitions never armed it), nor the "pixelated for a few
+> seconds" duration (the filler fires, so the still's I-frame does fully decode — this predicts
+> a blocky flash of a frame or two). Any residual after the fix has a second cause.
+
+
 > **Status (2026-07-12): the PR fj#85 cold re-decode is the CORRECT mechanism and is KEPT.**
 > The §5b trailing-byte flush primer that briefly replaced it was **HW-reverted** — it made
 > the still appear fast but **PIXELATED** (see §5b), because it shoves out the *mid-stream*
@@ -419,7 +453,11 @@ diagnostic at the stuck blank-cubes frame.
 backward reference and only pushed to the screen when the **next** I/P frame arrives *or* the VLD
 hits the `sequence_end_code` (`STATE_LAST_FRAME` flush). At the still-park the reader stops, and
 **ps_demux drops the trailing padding stream**, so the VLD starves right at the `seq_end` and
-never reaches `STATE_SEQUENCE_END`. cell 0's frame stays in the reorder hold → the screen keeps
+never reaches `STATE_SEQUENCE_END`. ⚠ **STALE as written (corrected 2026-08-26):** `ps_demux`
+now synthesizes 24 filler bytes after a `000001B7` at a PES end (`S_VID_FLUSH`, `ps_demux.sv:187-203`),
+so the VLD *does* reach `STATE_SEQUENCE_END` on real still cells — verified on the Harry Potter
+disc. The surviving lag mechanism is the buffered-depth lead plus the reorder hold, not seq_end
+starvation. cell 0's frame stays in the reorder hold → the screen keeps
 the forward reference = **cell 5's blank last frame**. keep_vbuf (continuous decode, no flush)
 is what exposes it; re-entry from a range only *looks* right because that source transition's
 last frame already carries numbers (cell 0's frame isn't displayed there either — it's masked).

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -504,7 +504,7 @@ and its jump's flush hits an empty buffer (A/V re-anchor semantics preserved). D
   `S_STREAM`, so a VM jump (Menu key, button) hits `jump_go` at once and clears
   `vmw_pgc_pend`; a transport seek likewise. Menu-domain PGC ends bypass the wait
   entirely (their tail rides `keep_vbuf`; menus stay snappy).
-- **`DRAIN_WD` watchdog (~5 s, module parameter).** A wedged/never-draining decoder
+- **`DRAIN_WD` watchdog (60 s, module parameter — `dvd_iso_reader.sv:78`; was ~5 s, widened for Weakest Link's 17 s answer cell).** A wedged/never-draining decoder
   degrades to the old dispatch-with-flush behaviour instead of parking the transition.
   Very-low-bitrate tails > 5 s truncate at the bound — still strictly better than before.
 - **No decoder-watchdog suppression needed — and it must NOT be added.** The decoder
@@ -642,7 +642,11 @@ the cell command on timeout). **✅ HW-CONFIRMED (2026-07-29, PR fj#144).** Watc
 heuristic (`vm.c` playback-time rule) can now mark a *heuristic* (implicit) still on a short
 single-VOBU title cell under `vm_mode` — matches libdvdnav, but verify normal FMV clips don't
 falsely freeze; (b) the frozen choice frame is decoded warm (just-played), so no menu-style
-cold re-decode is applied — confirm it isn't pixelated.
+cold re-decode is applied — confirm it isn't pixelated. **✅ ANSWERED 2026-08-26: it WAS
+pixelated, but the cause was not the warm decode** — it was the `motcomp_picbuf.v` sequence-end
+slot alias (the decoder writing into the slot being scanned out). Fixed in
+`rtl/mpeg2/motcomp_picbuf.v`; see `docs/dvd_menu_refinements.md` §5. The `menu_dom`-only gate on
+the cold re-decode remains a separate, deliberate open item.
 
 ### Proto-nav glue (emu.sv, replaced by the VM in Phase 4)
 

--- a/rtl/mpeg2/motcomp_picbuf.v
+++ b/rtl/mpeg2/motcomp_picbuf.v
@@ -317,14 +317,32 @@ module motcomp_picbuf(
    and subsequent B pictures will use the I or P picture being decoded as backward reference frame.
    */
 
+  /* DVD-FORK FIX (pixelated menu stills): the sequence-end STATE_UPDATE must
+   * NOT rotate the reference slots. The current_frame (above) and prev_i_p_frame
+   * (below) updates are already guarded with ~vld_last_frame because no picture
+   * is being decoded at a sequence end -- this swap was not, so the pointers
+   * rotated one extra step. STATE_LAST_FRAME then emits prev_i_p_frame (== the
+   * old backward_reference_frame) for display AND clears prev_i_p_frame_valid,
+   * so the next sequence's first I picture took current_frame <=
+   * forward_reference_frame -- which the extra swap had just made equal to the
+   * slot now on screen -- while output_frame_valid == 0 let STATE_IP_FRAME_0's
+   * shortcut release the VLD without waiting for the display handshake. The
+   * picture then painted into the slot resample was persistence-re-scanning:
+   * the "menu still comes up blocky, like it hasn't finished loading" bug.
+   * Measured on Harry Potter Interactive DVD: every still cell is
+   * SEQ GOP PIC:I SEQ_END, so a still arms this for whatever decodes next and
+   * still->still menu navigation collided every time.
+   * Safe: the picture after a sequence end is necessarily an I, which predicts
+   * from nothing, so only slot ALLOCATION matters here, never slot contents.
+   * See bench/dvd/motcomp_picbuf_tb.sv scenario [A]. */
   always @(posedge clk)
     if (~rst) forward_reference_frame <= 3'd0;
-    else if (clk_en && (state == STATE_UPDATE) && (vld_picture_coding_type != B_TYPE)) forward_reference_frame <= backward_reference_frame;
+    else if (clk_en && (state == STATE_UPDATE) && (vld_picture_coding_type != B_TYPE) && ~vld_last_frame) forward_reference_frame <= backward_reference_frame;
     else forward_reference_frame <= forward_reference_frame;
 
   always @(posedge clk)
     if (~rst) backward_reference_frame <= 3'd1;
-    else if (clk_en && (state == STATE_UPDATE) && (vld_picture_coding_type != B_TYPE)) backward_reference_frame <= forward_reference_frame;
+    else if (clk_en && (state == STATE_UPDATE) && (vld_picture_coding_type != B_TYPE) && ~vld_last_frame) backward_reference_frame <= forward_reference_frame;
     else backward_reference_frame <= backward_reference_frame;
 
   always @(posedge clk)
@@ -493,6 +511,32 @@ module motcomp_picbuf(
         output_repeat_first_field     <= output_repeat_first_field;
         prev_output_frame_valid       <= prev_output_frame_valid;
       end
+
+`ifdef CHECK
+  /* DVD-FORK: the decode target must never be the slot the display is scanning
+   * out (see the sequence-end fix above). Checked on the two states that release
+   * the VLD to write macroblocks -- STATE_LAST_FRAME also drops picbuf_busy, but
+   * no macroblocks can follow it before the next update_picture_buffers.
+   * chk_shown suppresses it before the very first emission (video start), where
+   * output_frame is still its reset value and nothing is on screen. Note the
+   * existing prev_output_frame_valid reg canNOT be used here: the same I/P emit
+   * branch that zeroes output_frame_valid also zeroes it, so it reads 0 at
+   * exactly the moment of interest. Everything here is inside `ifdef CHECK, so
+   * synthesis sees none of it.
+   * NOTE this is deliberately an assertion and NOT an FSM change -- gating
+   * STATE_IP_FRAME_0's shortcut on slot inequality DEADLOCKS the core, because
+   * dvd/resample_addrgen.v:543 gates pickup on output_frame_valid, which is 0
+   * in exactly the scenario such a gate would be trying to catch. */
+  reg chk_shown;
+  always @(posedge clk)
+    if (~rst) chk_shown <= 1'b0;
+    else if (clk_en && output_frame_valid) chk_shown <= 1'b1;
+
+  always @(posedge clk)
+    if (rst && clk_en && ((state == STATE_IP_FRAME_1) || (state == STATE_B_FRAME_0))
+        && chk_shown && (current_frame == output_frame))
+      $display("%m\t*** Error: releasing decode into displayed slot %0d", current_frame);
+`endif
 
 `ifdef DEBUG
 


### PR DESCRIPTION
## Summary

A menu/game still could come up **blocky, "like it hasn't finished loading"** — most visibly on the
Harry Potter Interactive DVD Game (HOGWARTS CHALLENGE), whose screens are chained single-I-frame
still cells. Root cause is an **upstream mpeg2fpga bug** in `rtl/mpeg2/motcomp_picbuf.v` (untouched
since import): at every `sequence_end_code`, the forward/backward reference swap is missing the
`~vld_last_frame` guard its two sibling blocks have, so the slot pointers rotate one extra step.
`STATE_LAST_FRAME` then puts that slot on screen while clearing `prev_i_p_frame_valid`, and the next
sequence's first I-frame both targets the displayed slot AND skips the anti-overwrite handshake via
`STATE_IP_FRAME_0`'s `~output_frame_valid` shortcut — the picture paints into the slot the display is
persistence-re-scanning, macroblock by macroblock, in full view.

Measured on the real disc (70 cells): every `still_time=255` still is `SEQ GOP PIC:I SEQ_END` (arms
the collision for whatever decodes next ⇒ still→still navigation collided every time); every
video/transition cell ends on a coded B (never arms).

**Fix: two `&& ~vld_last_frame` terms** on the swap. The alias becomes structurally impossible
(`fwd`/`bwd` are always a distinct {0,1} pair; at a sequence end `output_frame == prev_i_p_frame ==
bwd`). ⛔ Deliberately NOT done by hardening the `STATE_IP_FRAME_0` shortcut — that deadlocks the
core (`resample_addrgen` gates pickup on `output_frame_valid`, which is 0 in exactly that scenario);
recorded in the RTL comment and a sim-only `` `ifdef CHECK `` assertion instead.

Also in this PR: new `bench/dvd/motcomp_picbuf_tb.sv` (fails pre-fix, passes post-fix), a follow-up
audit of the rest of the upstream decoder (`docs/decoder_audit.md` — no further fix-now defects),
doc corrections (Cluster D's wrong "mid-GOP re-decode" guess, the stale §5 seq_end-starvation claim,
the stale `DRAIN_WD` figure), two stale bench build lines, and the seed-ledger entry.

## Test plan

- [x] `motcomp_picbuf_tb` scenario [A] (still→still, the measured disc shape) FAILS on unmodified RTL, PASSES with the fix; [B] video→still control, [C] cold-boot deadlock guard, [D] double seq_end, [E] 40-picture steady state all pass
- [x] In-module `CHECK` assertion verified to fire on reverted RTL, silent on fixed
- [x] `vld_mpeg1_tb` (3 modes) pass; `vld_mpeg1` + `vld_drop_rff` output **byte-identical** pre- vs post-fix on the committed real streams (no-collateral-change check)
- [x] Real HP still-cell ES + demux filler drives the real VLD to `STATE_SEQUENCE_END` (one emit at picture 0)
- [x] Timing: clk_dec 87.54 @100C / 90.91 @-40C, gate 86.0 PASS both corners (SEED 9 held first roll)
- [x] **HW-CONFIRMED** (`DVD_picbufalias_20260827_0158.rbf`): Harry Potter artifacting GONE; no regressions on other discs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
