### PR TITLE
emu: bump CORE_VERSION to 0.1e after publishing 0.1d

### DIFF
--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -486,7 +486,7 @@ assign CE_PIXEL = 1'b1;
 // builds: it is part of CONF_STR = part of the netlist, so every compile would
 // become a new netlist and re-roll the fitter seed lottery (DVD.qsf's ledger).
 // Same-day dev builds are identified by their build_release.sh --name filename.
-`define CORE_VERSION "0.1d"
+`define CORE_VERSION "0.1e"
 
 parameter CONF_STR = {
     "DVD;;",


### PR DESCRIPTION
Routine post-release bump, per the CLAUDE.md rule that `CORE_VERSION` moves the moment a release is published so no dev build advertises a version that already exists on the releases page.

0.1d shipped as [v0.1d-20260827](https://github.com/owenb321/MiSTer_DVD/releases/tag/v0.1d-20260827).

🤖 Generated with [Claude Code](https://claude.com/claude-code)