### PR TITLE
mem_shim_burst: cache tag/LRU store to M10K — the ALM congestion reclaim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,26 @@ worse maintenance burden than targeted in-place edits. So:
 
 ## Hardware status (THIS fork, verified 2026-06-21)
 
+- 🔧 **MEM_SHIM_BURST TAG/LRU STORE → M10K — the ALM congestion reclaim (2026-08-27,
+  branch `feature/mem-shim-tag-bram`); sim-complete, ⏳ HW SOAK REQUIRED before merge.**
+  The designated congestion-relief project: post-PR#17 the design sat at 98% ALM and
+  the last two branches each needed fit-rescue work. `dvd/mem_shim_burst.sv` (4,899
+  ALMs — the tag/valid/LRU flop store + per-set 128:1 async muxes, the recurring
+  LUT-RAM pattern) now keeps tags + LRU ranks in two sync-read M10Ks (by-set words);
+  valid bits stay flops. The hit loop grew to 3 overlapped stages (still 1 word/cycle);
+  misses/writes issue from the verdict cycle (fast entry — miss timing matches the flop
+  version; TB pure-miss meter improved 26→25 cyc/resp). **Replacement policy is
+  BIT-EXACT true LRU**, gated by the new A/B TB `bench/dvd/mem_shim_ab_tb.sv` (live
+  module vs a FROZEN flop-tag copy on one trace, independently-stalled rigs, accepted-
+  burst sequences must be identical — 4/4 combos, 1,351 identical misses). Suite:
+  `bench/dvd/run_mem_shim.sh` (all green). Fit: module 4,899→~1,406 ALMs (regs
+  6,546→1,028, +3 M10K), **design 41,202 ALMs (98%) → 36,341 (87%)**; pinned SEED 5
+  held FIRST roll, clk_dec 93.73/90.33 (gate 86.0) — soak build
+  `releases/DVD_shimreclaim_20260828_0259.rbf`. ⚠ This is the
+  shear-fix module — sim cannot prove hit-rate-under-real-traffic, so the HW gate is a
+  long-title soak (MiB full length), seek/chapter/menu stress, VCD raw mode, and an
+  explicit shear/artifact watch. Detail: `docs/history.md` §11.
+
 - 🔧 **PIXELATED MENU STILLS — root-caused + fixed in fabric (2026-08-26, branch
   `fix/picbuf-display-slot-alias`); ✅ HW-CONFIRMED 2026-08-27 (user report: Harry Potter
   artifacting GONE, no regressions on other discs; build `DVD_picbufalias`).** A menu/game still could come up

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,8 +158,9 @@ worse maintenance burden than targeted in-place edits. So:
 
 ## Hardware status (THIS fork, verified 2026-06-21)
 
-- 🔧 **MEM_SHIM_BURST TAG/LRU STORE → M10K — the ALM congestion reclaim (2026-08-27,
-  branch `feature/mem-shim-tag-bram`); sim-complete, ⏳ HW SOAK REQUIRED before merge.**
+- ✅ **MEM_SHIM_BURST TAG/LRU STORE → M10K — the ALM congestion reclaim (2026-08-27,
+  PR #18) — ✅ HW-CONFIRMED 2026-08-28 (user soak: full-length MiB + menu/seek stress,
+  no shear/artifacting; build `DVD_shimreclaim_20260828_0259.rbf`).**
   The designated congestion-relief project: post-PR#17 the design sat at 98% ALM and
   the last two branches each needed fit-rescue work. `dvd/mem_shim_burst.sv` (4,899
   ALMs — the tag/valid/LRU flop store + per-set 128:1 async muxes, the recurring
@@ -172,11 +173,10 @@ worse maintenance burden than targeted in-place edits. So:
   burst sequences must be identical — 4/4 combos, 1,351 identical misses). Suite:
   `bench/dvd/run_mem_shim.sh` (all green). Fit: module 4,899→~1,406 ALMs (regs
   6,546→1,028, +3 M10K), **design 41,202 ALMs (98%) → 36,341 (87%)**; pinned SEED 5
-  held FIRST roll, clk_dec 93.73/90.33 (gate 86.0) — soak build
-  `releases/DVD_shimreclaim_20260828_0259.rbf`. ⚠ This is the
-  shear-fix module — sim cannot prove hit-rate-under-real-traffic, so the HW gate is a
-  long-title soak (MiB full length), seek/chapter/menu stress, VCD raw mode, and an
-  explicit shear/artifact watch. Detail: `docs/history.md` §11.
+  held FIRST roll, clk_dec 93.73/90.33 (gate 86.0). The HW soak mattered because this
+  is the shear-fix module (sim cannot prove hit-rate-under-real-traffic) — it PASSED:
+  entire MiB movie + menu/seek actions, no video issues, no shearing, no artifacting.
+  Detail: `docs/history.md` §11.
 
 - 🔧 **PIXELATED MENU STILLS — root-caused + fixed in fabric (2026-08-26, branch
   `fix/picbuf-display-slot-alias`); ✅ HW-CONFIRMED 2026-08-27 (user report: Harry Potter

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -657,4 +657,14 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # the same worst-roll seed 73.5 -> 83.1 and SEED 5 to 94.5. Lesson re-proven:
 # at 98% ALM, retime the measured limiter; do not re-roll seeds or reach for
 # the physical-synthesis switch (PR fj#92 retired it deliberately).
+#
+# 2026-08-28 (feature/mem-shim-tag-bram netlist — the ALM RECLAIM): SEED 5 held
+# FIRST ROLL, clk_dec 93.73 @100C / 90.33 @-40C, PASS with margin. This is the
+# congestion-relief project the two entries above motivated: mem_shim_burst's
+# tag/LRU flop store (4,899 ALMs / 6,546 regs, per-set 128:1 async muxes) moved
+# to M10K -> module now ~1,406 ALMs / 1,028 regs / 16 M10K, DESIGN 41,202 (98%)
+# -> 36,341 (87%) ALMs, RAM 503 -> 506 M10K. With ~5k ALMs of placement slack
+# back, seed sweeps should again be rarely needed (the sub-86 rule stands: a
+# failing fit on THIS netlist family means the netlist degraded -- measure with
+# tools/timing_paths.sh, don't re-roll).
 set_global_assignment -name SEED 5

--- a/bench/dvd/cache_missrate_tb.sv
+++ b/bench/dvd/cache_missrate_tb.sv
@@ -77,8 +77,13 @@ module cache_missrate_tb;
     wire        dbg_busy, dbg_ack;
     wire [15:0] dbg_rd, dbg_wr, dbg_rsp, dbg_pend, dbg_missrate;
 
+    // cwf_en/dual_en tied OFF: these ports postdate this TB and were left
+    // unconnected (= X) — the flop-tag FSM happened to resolve the X to the
+    // same "cwf off, dual off" config, the BRAM-tag FSM's reordered state
+    // ternary does not. emu.sv always drives both pins on hardware.
     mem_shim_burst #(.ASSOC(4), .NSETS(64)) dut (
         .clk(clk), .rst_n(rst_n), .hard_rst_n(rst_n),
+        .cwf_en(1'b0), .dual_en(1'b0),
         .mem_req_rd_cmd(req_cmd), .mem_req_rd_addr(req_addr), .mem_req_rd_dta(req_dta),
         .mem_req_rd_en(req_en), .mem_req_rd_valid(req_valid),
         .mem_res_wr_dta(res_dta), .mem_res_wr_en(res_en), .mem_res_wr_almost_full(res_almost_full),

--- a/bench/dvd/mem_shim_ab_tb.sv
+++ b/bench/dvd/mem_shim_ab_tb.sv
@@ -86,7 +86,13 @@ module mem_shim_ab_tb;
     generate
     for (g = 0; g < 2; g = g + 1) begin : rig
         // ---- FIFO model (standard mode: valid the cycle after rd_en) ----
+        // With random SUPPLY GAPS (per-rig seed): a pop can find the FIFO
+        // "empty" even when trace commands remain — models the real decoder's
+        // bursty request stream. Exercises the stream's drain/refetch paths and
+        // the dual S_PEEK (FIFO-pop) candidate path, and widens the invariance
+        // proof: supply timing must not change decisions either.
         integer     q_head = 0;
+        integer     gseed = (g == 0) ? 32'h6A9_0001 : 32'h6A9_0002;
         reg  [1:0]  req_cmd;
         reg  [21:0] req_addr;
         reg  [63:0] req_dta;
@@ -99,7 +105,7 @@ module mem_shim_ab_tb;
                 req_valid <= 1'b0; q_head <= 0;
                 req_cmd <= 0; req_addr <= 0; req_dta <= 0;
             end else if (req_en) begin
-                if (!q_empty) begin
+                if (!q_empty && (($random(gseed) % 8) != 0)) begin
                     req_cmd   <= q_cmd[q_head];
                     req_addr  <= q_addr[q_head];
                     req_dta   <= q_dta[q_head];
@@ -253,6 +259,20 @@ module mem_shim_ab_tb;
         .debug_cache_missrate(rig[1].dbg_mr)
     );
 
+    // ---- pairing-alive tripwire (hierarchical, sim-only) ----
+    // The A/B burst-sequence compare is blind to PAIRING (it changes only
+    // timing, never decisions) — so a rework that silently kills the dual
+    // overlap would still "pass". Count S_ISSUE2 entries in both DUTs and
+    // require NEW to pair when REF does.
+    localparam [3:0] ST_ISSUE2 = 4'd13;
+    reg [3:0] pst_r = 4'd0, pst_n = 4'd0;
+    integer   pairs_r = 0, pairs_n = 0;
+    always @(posedge clk) if (rst_n) begin
+        pst_r <= dut_ref.state; pst_n <= dut_new.state;
+        if ((dut_ref.state == ST_ISSUE2) && (pst_r != ST_ISSUE2)) pairs_r = pairs_r + 1;
+        if ((dut_new.state == ST_ISSUE2) && (pst_n != ST_ISSUE2)) pairs_n = pairs_n + 1;
+    end
+
     // ---- stimulus ----
     integer j, k, base, ra;
     integer tseed = 32'h7EA_C0DE;
@@ -340,8 +360,12 @@ module mem_shim_ab_tb;
         $display("=================================================");
         $display("mem_shim_ab_tb (cwf=%0d dual=%0d): %0d cmds, %0d reads",
                  `MSAB_CWF, `MSAB_DUAL, q_count, exp_count);
-        $display("  REF: bursts=%0d resp=%0d writes=%0d | NEW: bursts=%0d resp=%0d writes=%0d",
-                 cap_bn[0], cap_rn[0], cap_wn[0], cap_bn[1], cap_rn[1], cap_wn[1]);
+        $display("  REF: bursts=%0d resp=%0d writes=%0d pairs=%0d | NEW: bursts=%0d resp=%0d writes=%0d pairs=%0d",
+                 cap_bn[0], cap_rn[0], cap_wn[0], pairs_r, cap_bn[1], cap_rn[1], cap_wn[1], pairs_n);
+        if (`MSAB_DUAL && (pairs_r > 0) && (pairs_n == 0)) begin
+            $display("  ERROR: dual pairing is DEAD in NEW (REF paired %0d times)", pairs_r);
+            errors = errors + 1;
+        end
 
         if (cap_rn[0] !== exp_count || cap_rn[1] !== exp_count) begin
             $display("  ERROR: response counts (exp %0d)", exp_count);

--- a/bench/dvd/mem_shim_ab_tb.sv
+++ b/bench/dvd/mem_shim_ab_tb.sv
@@ -1,0 +1,390 @@
+// =============================================================================
+// bench/dvd/mem_shim_ab_tb.sv — A/B gate: BRAM-tag mem_shim_burst vs the frozen
+// flop-tag reference (mem_shim_burst_ref.sv)
+// =============================================================================
+// The tag/LRU-to-M10K rework (feature/mem-shim-tag-bram) must be DECISION-EXACT:
+// same replacement policy, same victim choices, same hit/miss verdict for every
+// read — "hit rate must be identical" means bit-exact LRU behaviour, not close.
+//
+// Both DUTs (REF = frozen pre-BRAM copy, NEW = dvd/mem_shim_burst.sv) run the
+// SAME command trace at shipping geometry (NSETS=128, ASSOC=4), each through its
+// own FIFO model and its own behavioral DDR model with INDEPENDENT random
+// waitrequest + response-backpressure seeds. Decisions must be timing-invariant
+// (strict in-order processing + deterministic LRU), so the two runs must agree
+// even though every stall lands differently. Compared, element by element:
+//   - the SEQUENCE of accepted read-burst addresses (one burst = one read miss:
+//     equal sequences <=> identical miss decisions <=> identical LRU state), and
+//   - the SEQUENCE of read-response data (both also checked against a reference
+//     memory, so "equal" can't mean "equally wrong").
+// The trace leans on the policy: same-set tag competition (6+ streams offset by
+// NSETS*LINEW), write-hit LRU touches, random aliasing mixes, ADDR_ERR
+// sprinkles, and dual-pairable / non-pairable miss runs.
+// Combos: rerun with -DMSAB_CWF=0/1 x -DMSAB_DUAL=0/1 (see run_mem_shim.sh).
+// =============================================================================
+`timescale 1ns/1ps
+module mem_shim_ab_tb;
+    localparam CMD_NOOP  = 2'd0;
+    localparam CMD_READ  = 2'd2;
+    localparam CMD_WRITE = 2'd3;
+    localparam [21:0] ADDR_ERR = 22'h077FFF;
+    localparam NSETS = 128;
+    localparam LINEW = 8;
+
+`ifndef MSAB_CWF
+ `define MSAB_CWF 1
+`endif
+`ifndef MSAB_DUAL
+ `define MSAB_DUAL 1
+`endif
+
+    reg clk = 0, rst_n = 0;
+    always #5 clk = ~clk;   // 100 MHz
+
+    // ---- shared command trace ----
+    localparam MAXCMD = 8192;
+    reg  [1:0]  q_cmd  [0:MAXCMD-1];
+    reg  [21:0] q_addr [0:MAXCMD-1];
+    reg  [63:0] q_dta  [0:MAXCMD-1];
+    integer     q_count = 0;
+
+    // reference memory (stream-order semantics; both DUTs are in-order)
+    localparam MEMW = 22'h080000;
+    reg [63:0] ref_mem [0:MEMW-1];
+    reg [63:0] exp_dta [0:MAXCMD-1];
+    integer    exp_count = 0;
+
+    task enqueue_write(input [21:0] a, input [63:0] d);
+        begin
+            q_cmd[q_count] = CMD_WRITE; q_addr[q_count] = a; q_dta[q_count] = d;
+            q_count = q_count + 1;
+            if (a != ADDR_ERR) ref_mem[a] = d;
+        end
+    endtask
+    task enqueue_read(input [21:0] a);
+        begin
+            q_cmd[q_count] = CMD_READ; q_addr[q_count] = a; q_dta[q_count] = 64'd0;
+            q_count = q_count + 1;
+            exp_dta[exp_count] = (a == ADDR_ERR) ? 64'd0 : ref_mem[a];
+            exp_count = exp_count + 1;
+        end
+    endtask
+
+    integer errors = 0;
+
+    // =========================================================================
+    // one complete harness per DUT: FIFO model + DDR model + capture arrays
+    // (generate keeps the two rigs identical except for the random seeds)
+    // =========================================================================
+    // capture arrays, indexed [dut]: 0 = REF, 1 = NEW
+    reg [21:0] cap_burst [0:1][0:MAXCMD-1];   // accepted read-burst word addrs, in order
+    integer    cap_bn    [0:1];
+    reg [63:0] cap_resp  [0:1][0:MAXCMD-1];   // read-response data, in order
+    integer    cap_rn    [0:1];
+    integer    cap_wn    [0:1];               // accepted write count
+
+    genvar g;
+    generate
+    for (g = 0; g < 2; g = g + 1) begin : rig
+        // ---- FIFO model (standard mode: valid the cycle after rd_en) ----
+        integer     q_head = 0;
+        reg  [1:0]  req_cmd;
+        reg  [21:0] req_addr;
+        reg  [63:0] req_dta;
+        reg         req_valid;
+        wire        req_en;
+        wire        q_empty = (q_head >= q_count);
+
+        always @(posedge clk) begin
+            if (!rst_n) begin
+                req_valid <= 1'b0; q_head <= 0;
+                req_cmd <= 0; req_addr <= 0; req_dta <= 0;
+            end else if (req_en) begin
+                if (!q_empty) begin
+                    req_cmd   <= q_cmd[q_head];
+                    req_addr  <= q_addr[q_head];
+                    req_dta   <= q_dta[q_head];
+                    req_valid <= 1'b1;
+                    q_head    <= q_head + 1;
+                end else begin
+                    req_valid <= 1'b0;
+                end
+            end else begin
+                req_valid <= 1'b0;
+            end
+        end
+
+        // ---- DUT wires ----
+        wire [63:0] res_dta;
+        wire        res_en;
+        reg         res_almost_full = 1'b0;
+        wire [28:0] ddr_addr;
+        wire [7:0]  ddr_burstcnt;
+        wire        ddr_read, ddr_write;
+        wire [63:0] ddr_writedata;
+        wire [7:0]  ddr_byteenable;
+        reg  [63:0] ddr_readdata = 0;
+        reg         ddr_readdatavalid = 0;
+        reg         ddr_waitrequest = 0;
+        wire [3:0]  dbg_state;
+        wire [1:0]  dbg_saved_cmd;
+        wire        dbg_busy, dbg_ack;
+        wire [15:0] dbg_rd, dbg_wr, dbg_rsp, dbg_pend, dbg_mr;
+
+        // ---- behavioral pipelined DDR model (as mem_shim_burst_tb) ----
+        reg [63:0] ddr_mem [0:MEMW-1];
+        localparam RD_LATENCY = 12;
+        localparam BQD = 8;
+        reg [21:0] bq_addr [0:BQD-1];
+        integer    bq_cnt  [0:BQD-1];
+        integer    bq_wr = 0, bq_rd = 0, bq_n = 0;
+        integer    rd_lat = 0, rd_beats = 0;
+        reg [21:0] rd_ptr = 0;
+        integer    seed = (g == 0) ? 32'h0AB0_5EED : 32'h1CEB_00DA;  // per-rig seeds
+        reg        stall_en = 1'b0;
+        reg        pop;
+
+        wire acc_rd = ddr_read  && !ddr_waitrequest;
+        wire acc_wr = ddr_write && !ddr_waitrequest;
+
+        always @(posedge clk) begin
+            if (!rst_n) res_almost_full <= 1'b0;
+            else if (stall_en) res_almost_full <= (($random(seed) % 4) == 0);
+            else res_almost_full <= 1'b0;
+        end
+
+        always @(posedge clk) begin
+            if (!rst_n) begin
+                ddr_readdatavalid <= 0; ddr_readdata <= 0; ddr_waitrequest <= 0;
+                rd_lat <= 0; rd_beats <= 0; rd_ptr <= 0;
+                bq_wr <= 0; bq_rd <= 0; bq_n <= 0;
+            end else begin
+                pop = 1'b0;
+                ddr_waitrequest <= stall_en ? (($random(seed) % 4) == 0) : 1'b0;
+                if (!ddr_waitrequest) begin
+                    if (ddr_write) ddr_mem[ddr_addr[21:0]] <= ddr_writedata;
+                    if (ddr_read) begin
+                        bq_addr[bq_wr] <= ddr_addr[21:0];
+                        bq_cnt [bq_wr] <= ddr_burstcnt;
+                        bq_wr <= (bq_wr + 1) % BQD;
+                    end
+                end
+                if (rd_beats == 0) begin
+                    ddr_readdatavalid <= 1'b0;
+                    if (bq_n > 0) begin
+                        rd_ptr   <= bq_addr[bq_rd];
+                        rd_beats <= bq_cnt [bq_rd];
+                        rd_lat   <= RD_LATENCY;
+                        bq_rd    <= (bq_rd + 1) % BQD;
+                        pop = 1'b1;
+                    end
+                end else if (rd_lat > 0) begin
+                    rd_lat <= rd_lat - 1; ddr_readdatavalid <= 1'b0;
+                end else begin
+                    ddr_readdatavalid <= 1'b1;
+                    ddr_readdata      <= ddr_mem[rd_ptr];
+                    rd_ptr            <= rd_ptr + 1;
+                    rd_beats          <= rd_beats - 1;
+                    if (rd_beats == 1) begin
+                        if (bq_n > 0) begin
+                            rd_ptr   <= bq_addr[bq_rd];
+                            rd_beats <= bq_cnt [bq_rd];
+                            rd_lat   <= 0;
+                            bq_rd    <= (bq_rd + 1) % BQD;
+                            pop = 1'b1;
+                        end
+                    end
+                end
+                bq_n <= bq_n + (acc_rd ? 1 : 0) - (pop ? 1 : 0);
+            end
+        end
+
+        // ---- capture: burst sequence, write count, response sequence ----
+        always @(posedge clk) if (rst_n) begin
+            if (acc_rd) begin
+                cap_burst[g][cap_bn[g]] <= ddr_addr[21:0];
+                cap_bn[g] <= cap_bn[g] + 1;
+            end
+            if (acc_wr) cap_wn[g] <= cap_wn[g] + 1;
+            if (res_en) begin
+                cap_resp[g][cap_rn[g]] <= res_dta;
+                cap_rn[g] <= cap_rn[g] + 1;
+            end
+        end
+    end
+    endgenerate
+
+    // ---- the two DUTs (shipping geometry) ----
+    mem_shim_burst_ref #(.NSETS(NSETS), .ASSOC(4), .LINEW(LINEW)) dut_ref (
+        .clk(clk), .rst_n(rst_n), .hard_rst_n(rst_n),
+        .cwf_en(1'b`MSAB_CWF), .dual_en(1'b`MSAB_DUAL),
+        .mem_req_rd_cmd(rig[0].req_cmd), .mem_req_rd_addr(rig[0].req_addr),
+        .mem_req_rd_dta(rig[0].req_dta),
+        .mem_req_rd_en(rig[0].req_en), .mem_req_rd_valid(rig[0].req_valid),
+        .mem_res_wr_dta(rig[0].res_dta), .mem_res_wr_en(rig[0].res_en),
+        .mem_res_wr_almost_full(rig[0].res_almost_full),
+        .ddr3_addr(rig[0].ddr_addr), .ddr3_burstcnt(rig[0].ddr_burstcnt),
+        .ddr3_read(rig[0].ddr_read), .ddr3_write(rig[0].ddr_write),
+        .ddr3_writedata(rig[0].ddr_writedata), .ddr3_byteenable(rig[0].ddr_byteenable),
+        .ddr3_readdata(rig[0].ddr_readdata), .ddr3_readdatavalid(rig[0].ddr_readdatavalid),
+        .ddr3_waitrequest(rig[0].ddr_waitrequest),
+        .debug_state(rig[0].dbg_state), .debug_saved_cmd(rig[0].dbg_saved_cmd),
+        .debug_sdram_busy(rig[0].dbg_busy), .debug_sdram_ack(rig[0].dbg_ack),
+        .debug_rd_count(rig[0].dbg_rd), .debug_wr_count(rig[0].dbg_wr),
+        .debug_rsp_count(rig[0].dbg_rsp), .debug_read_pend_cycles(rig[0].dbg_pend),
+        .debug_cache_missrate(rig[0].dbg_mr)
+    );
+    mem_shim_burst #(.NSETS(NSETS), .ASSOC(4), .LINEW(LINEW)) dut_new (
+        .clk(clk), .rst_n(rst_n), .hard_rst_n(rst_n),
+        .cwf_en(1'b`MSAB_CWF), .dual_en(1'b`MSAB_DUAL),
+        .mem_req_rd_cmd(rig[1].req_cmd), .mem_req_rd_addr(rig[1].req_addr),
+        .mem_req_rd_dta(rig[1].req_dta),
+        .mem_req_rd_en(rig[1].req_en), .mem_req_rd_valid(rig[1].req_valid),
+        .mem_res_wr_dta(rig[1].res_dta), .mem_res_wr_en(rig[1].res_en),
+        .mem_res_wr_almost_full(rig[1].res_almost_full),
+        .ddr3_addr(rig[1].ddr_addr), .ddr3_burstcnt(rig[1].ddr_burstcnt),
+        .ddr3_read(rig[1].ddr_read), .ddr3_write(rig[1].ddr_write),
+        .ddr3_writedata(rig[1].ddr_writedata), .ddr3_byteenable(rig[1].ddr_byteenable),
+        .ddr3_readdata(rig[1].ddr_readdata), .ddr3_readdatavalid(rig[1].ddr_readdatavalid),
+        .ddr3_waitrequest(rig[1].ddr_waitrequest),
+        .debug_state(rig[1].dbg_state), .debug_saved_cmd(rig[1].dbg_saved_cmd),
+        .debug_sdram_busy(rig[1].dbg_busy), .debug_sdram_ack(rig[1].dbg_ack),
+        .debug_rd_count(rig[1].dbg_rd), .debug_wr_count(rig[1].dbg_wr),
+        .debug_rsp_count(rig[1].dbg_rsp), .debug_read_pend_cycles(rig[1].dbg_pend),
+        .debug_cache_missrate(rig[1].dbg_mr)
+    );
+
+    // ---- stimulus ----
+    integer j, k, base, ra;
+    integer tseed = 32'h7EA_C0DE;
+    initial begin
+        cap_bn[0] = 0; cap_bn[1] = 0;
+        cap_rn[0] = 0; cap_rn[1] = 0;
+        cap_wn[0] = 0; cap_wn[1] = 0;
+        for (k = 0; k < MEMW; k = k + 1) begin
+            ref_mem[k] = 64'd0;
+            rig[0].ddr_mem[k] = 64'd0;
+            rig[1].ddr_mem[k] = 64'd0;
+        end
+
+        // Phase 1: warm + re-read (hit streaming with stage-B touches)
+        base = 22'h001000;
+        for (j = 0; j < 64; j = j + 1) enqueue_write(base + j, {32'hA100_0000 + j, j[31:0]});
+        for (j = 0; j < 64; j = j + 1) enqueue_read (base + j);
+        for (j = 0; j < 64; j = j + 1) enqueue_read (base + j);
+
+        // Phase 2: 6-stream same-set interleave (the LRU stress: 6 tags compete
+        // for 4 ways of the same sets, victim choice decides every future miss)
+        for (j = 0; j < 6; j = j + 1)
+            for (k = 0; k < 64; k = k + 1)
+                enqueue_write(22'h010000 + j*(NSETS*LINEW) + k, {32'h5200_0000 + j, k[31:0]});
+        for (k = 0; k < 64; k = k + 1)
+            for (j = 0; j < 6; j = j + 1)
+                enqueue_read(22'h010000 + j*(NSETS*LINEW) + k);
+
+        // Phase 3: random aliasing mix — reads/writes confined to 8 tag-aliases
+        // of a 2-set window so victim selection churns constantly; write hits
+        // exercise the S_WR_CMD touch path.
+        for (j = 0; j < 1200; j = j + 1) begin
+            ra = 22'h020000 + ($random(tseed) % (2*LINEW))            // 2 sets
+                           + (($random(tseed) % 8) * (NSETS*LINEW));  // 8 aliases
+            if (($random(tseed) % 3) == 0) enqueue_write(ra, {$random(tseed), $random(tseed)});
+            else                           enqueue_read (ra);
+        end
+
+        // Phase 4: ADDR_ERR sprinkled into a hit/miss mix
+        enqueue_read(ADDR_ERR);
+        for (j = 0; j < 8; j = j + 1) begin
+            enqueue_read (base + j);
+            enqueue_read (ADDR_ERR);
+            enqueue_write(ADDR_ERR, 64'hFFFF_FFFF_FFFF_FFFF);
+            enqueue_read (22'h030000 + j*LINEW);
+            enqueue_write(22'h030000 + j*LINEW, {32'h4400_0000 + j, j[31:0]});
+            enqueue_read (22'h030000 + j*LINEW);
+        end
+
+        // Phase 5: dual-outstanding shapes — pairable (different-set) miss runs,
+        // then same-set miss runs (never pairable), then miss->hit->miss->write.
+        base = 22'h040000;
+        for (j = 0; j < 48*LINEW; j = j + 1) enqueue_write(base + j, {32'h6600_0000 + j, j[31:0]});
+        for (j = 0; j < 48; j = j + 1) enqueue_read(base + j*LINEW);
+        for (j = 0; j < 12; j = j + 1)
+            enqueue_write(22'h050000 + j*(NSETS*LINEW), {32'h5A00_0000 + j, j[31:0]});
+        for (j = 0; j < 12; j = j + 1) enqueue_read(22'h050000 + j*(NSETS*LINEW));
+        for (j = 0; j < 8; j = j + 1) begin
+            enqueue_read (base + j*LINEW);        // hit (warmed above)
+            enqueue_read (22'h060000 + j*LINEW);  // fresh miss
+            enqueue_write(22'h060000 + j*LINEW, {32'h7700_0000 + j, j[31:0]});
+            enqueue_read (22'h060000 + j*LINEW);  // read-after-write
+        end
+
+        // Phase 6: broad random mix (final policy soak)
+        for (j = 0; j < 2000; j = j + 1) begin
+            ra = ($random(tseed) % 4000) & 22'h3FFFF;
+            if (($random(tseed) % 4) == 0) enqueue_write(ra, {$random(tseed), $random(tseed)});
+            else                           enqueue_read (ra);
+        end
+
+        // go (random stalls active from the start on BOTH rigs, different seeds)
+        rig[0].stall_en = 1'b1;
+        rig[1].stall_en = 1'b1;
+        rst_n = 0; repeat (5) @(posedge clk); rst_n = 1;
+
+        // wait until both rigs have consumed + answered everything
+        for (j = 0; j < 400000; j = j + 1) begin
+            @(posedge clk);
+            if ((cap_rn[0] >= exp_count) && (cap_rn[1] >= exp_count)) j = 400000;
+        end
+        repeat (50) @(posedge clk);
+
+        // ---- compare ----
+        $display("=================================================");
+        $display("mem_shim_ab_tb (cwf=%0d dual=%0d): %0d cmds, %0d reads",
+                 `MSAB_CWF, `MSAB_DUAL, q_count, exp_count);
+        $display("  REF: bursts=%0d resp=%0d writes=%0d | NEW: bursts=%0d resp=%0d writes=%0d",
+                 cap_bn[0], cap_rn[0], cap_wn[0], cap_bn[1], cap_rn[1], cap_wn[1]);
+
+        if (cap_rn[0] !== exp_count || cap_rn[1] !== exp_count) begin
+            $display("  ERROR: response counts (exp %0d)", exp_count);
+            errors = errors + 1;
+        end
+        if (cap_bn[0] !== cap_bn[1]) begin
+            $display("  ERROR: miss counts differ (REF %0d vs NEW %0d)", cap_bn[0], cap_bn[1]);
+            errors = errors + 1;
+        end
+        if (cap_wn[0] !== cap_wn[1]) begin
+            $display("  ERROR: write counts differ (REF %0d vs NEW %0d)", cap_wn[0], cap_wn[1]);
+            errors = errors + 1;
+        end
+        for (j = 0; j < ((cap_bn[0] < cap_bn[1]) ? cap_bn[0] : cap_bn[1]); j = j + 1)
+            if (cap_burst[0][j] !== cap_burst[1][j]) begin
+                if (errors < 12)
+                    $display("  ERROR burst#%0d: REF %h vs NEW %h", j, cap_burst[0][j], cap_burst[1][j]);
+                errors = errors + 1;
+            end
+        for (j = 0; j < exp_count; j = j + 1) begin
+            if (j < cap_rn[0] && cap_resp[0][j] !== exp_dta[j]) begin
+                if (errors < 12)
+                    $display("  ERROR REF resp#%0d: got %h exp %h", j, cap_resp[0][j], exp_dta[j]);
+                errors = errors + 1;
+            end
+            if (j < cap_rn[1] && cap_resp[1][j] !== exp_dta[j]) begin
+                if (errors < 12)
+                    $display("  ERROR NEW resp#%0d: got %h exp %h", j, cap_resp[1][j], exp_dta[j]);
+                errors = errors + 1;
+            end
+        end
+
+        if (errors == 0)
+            $display("  RESULT: PASS — burst sequences identical (%0d misses), all responses correct", cap_bn[0]);
+        else
+            $display("  RESULT: FAIL (%0d errors)", errors);
+        $finish;
+    end
+
+    initial begin
+        #40_000_000;
+        $display("  RESULT: FAIL — global timeout. REF state=%0d %0d/%0d, NEW state=%0d %0d/%0d",
+                 rig[0].dbg_state, cap_rn[0], exp_count, rig[1].dbg_state, cap_rn[1], exp_count);
+        $finish;
+    end
+endmodule

--- a/bench/dvd/mem_shim_burst_ref.sv
+++ b/bench/dvd/mem_shim_burst_ref.sv
@@ -1,6 +1,9 @@
 // =============================================================================
-// dvd/mem_shim_burst.sv — burst f2sdram (DDRAM) bridge with a SET-ASSOCIATIVE
-// read cache (ao486 L2-style)
+// bench/dvd/mem_shim_burst_ref.sv — FROZEN pre-BRAM-tag reference copy of
+// dvd/mem_shim_burst.sv (main @ c223041), renamed mem_shim_burst_ref.
+// Used ONLY by mem_shim_ab_tb.sv as the bit-exact LRU/miss-decision golden.
+// Do NOT edit: its whole value is being byte-identical in behaviour to the
+// flop-tag implementation that shipped through PR #17.
 // =============================================================================
 // Drop-in replacement for dvd/mem_shim.sv (identical port list). Read throughput
 // is dominated by CACHE HIT RATE, not burst size or clock — proven by the ao486
@@ -22,35 +25,17 @@
 //   defaults: LINEW=8 (burst beats), NSETS=128, ASSOC=4  => 32 KB (ao486-exact)
 // Address[21:0] (64-bit word address):  [21:10] tag | [9:3] set | [2:0] off
 //
-// STORAGE (reworked 2026-08-27, feature/mem-shim-tag-bram — the ALM reclaim):
-//   - DATA (32 KB): M10K BRAM since the first burst bridge (it won't fit in
-//     flops — an earlier version that read the array straight into the shared
-//     mem_res_wr_dta register failed Quartus inference, error 276003). Clean
-//     SIMPLE-DUAL-PORT RAM: one registered read port, one FSM-muxed write port.
-//   - TAGS + LRU: now ALSO M10K (this module's recurring-LUT-RAM-pattern
-//     paydown, cf. M19/parse_buf). Before: 12b x 128 sets x 4 ways of tag flops
-//     + 2b x 512 LRU flops read through per-set 128:1 async muxes ~= 4.9k ALMs
-//     — the third-largest block in the design. Now: tag_ram = NSETS x
-//     (ASSOC*TAG_W) and lru_ram = NSETS x (ASSOC*ASW), each sync-read (one set
-//     = all ways per read), written whole-word via captured set snapshots so no
-//     byte-enables are needed. The 1-cycle read latency is absorbed by a third
-//     pipeline stage in the hit loop (see PIPELINE below) — still 1 word/cycle,
-//     and the miss/write paths enter their slow states in the SAME cycle count
-//     as the flop-tag version (fast-path entry from the stream stage).
-//   - VALID: stays in flops (ASSOC x NSETS = 512 FFs, cheap) so S_INIT
-//     invalidation and the victim-invalidate-before-fill rule keep their
-//     simple, reset-friendly semantics — BRAM has no reset.
+// STORAGE: the 32 KB data array MUST be M10K BRAM (it won't fit in flops — an
+// earlier version that read the array straight into the shared mem_res_wr_dta
+// register failed Quartus inference, error 276003). So cache_data is a clean
+// SIMPLE-DUAL-PORT RAM: a dedicated registered read port (cache_rdata, async read
+// address) and a write port driven from the FSM. The 1-cycle BRAM read latency
+// adds one state on the hit path (S_PROC -> S_HIT) and a short drain on the miss
+// serve path. Tags/valid/LRU stay in flops so all ways are compared in one cycle.
 //
 // REPLACEMENT: true LRU via per-set rank counters (0 = MRU .. ASSOC-1 = LRU),
-// exactly ao486's scheme, BIT-EXACT vs the flop implementation (gated by
-// bench/dvd/mem_shim_ab_tb.sv against the frozen pre-BRAM copy). A sync-read
-// rank store needs read-after-write consistency for back-to-back same-set hits:
-// a 2-deep bypass (the stage-B touch being written THIS cycle + a last-write
-// register lw_*) forwards ranks the RAM can't return yet. Mixed-port
-// read-during-write on M10K is undefined => any same-cycle same-set write is
-// bypassed by construction, so the undefined value is never consumed.
-// A wrong victim only lowers hit rate, never returns wrong data — correctness
-// rests entirely on the tag/valid check + fill.
+// exactly ao486's scheme. A wrong victim only lowers hit rate, never returns wrong
+// data — correctness rests entirely on the tag/valid check + fill.
 //
 // COHERENCE: write-through to DDR (single beat) + UPDATE the cached word on a
 // write hit (ao486-style: a write hit doesn't cost a later miss). On a read miss
@@ -63,7 +48,7 @@
 // {7'b0011000, word_addr[21:0]} puts window 3 (HPS byte 0x30000000) in bits[28:25]
 // with no left-shift. Burst base = the line-aligned word address.
 // =============================================================================
-module mem_shim_burst #(
+module mem_shim_burst_ref #(
     parameter [21:0]  ADDR_ERR = 22'h077FFF, // MP@ML sentinel (dvd/mem_override/mem_codes.v)
     // cache geometry (defaults = ao486 L2: 4-way, 128 sets, 8-word lines = 32 KB).
     // LINEW = burst beats (hardware-proven at 8). ASSOC>=2.
@@ -129,27 +114,21 @@ module mem_shim_burst #(
     localparam integer ASW    = $clog2(ASSOC);   // way index                 (ASSOC=4 -> 2)
     localparam integer TAG_W  = 22 - LOFF_W - SET_W;          // addr[21:10] -> 12 bits
     localparam integer DIDX_W = SET_W + ASW + LOFF_W;         // cache_data index -> 12 bits
-    localparam integer TAGV_W = ASSOC * TAG_W;                // one set's tag word -> 48 bits
-    localparam integer LRUV_W = ASSOC * ASW;                  // one set's rank word -> 8 bits
 
     assign ddr3_byteenable = 8'hFF;
 
     // ---- cache storage ----
-    // DATA: simple-dual-port BRAM (M10K). Written ONLY via the single muxed write
-    // port below, read ONLY via the dedicated registered port — this clean
-    // separation is what makes it infer as M10K. Index = {set, way, off}.
+    // DATA: simple-dual-port BRAM (M10K). Written ONLY in the FSM block (single
+    // muxed write port), read ONLY via the dedicated registered port below — this
+    // clean separation is what makes it infer as M10K. Index = {set, way, off}.
     reg [63:0]       cache_data [0:NSETS*ASSOC*LINEW-1];
-    // TAGS + LRU: simple-dual-port BRAM too (the ALM reclaim). One address = one
-    // SET; the word carries all ASSOC ways so a single sync read gives the full
-    // compare/victim context. Whole-word writes only (set snapshots captured at
-    // lookup time make the read-modify-write free — see fill validate below).
-    (* ramstyle = "M10K" *) reg [TAGV_W-1:0] tag_ram [0:NSETS-1];
-    (* ramstyle = "M10K" *) reg [LRUV_W-1:0] lru_ram [0:NSETS-1];
-    // valid: one bit per way, in flops (cheap; keeps S_INIT + victim-invalidate
-    // semantics — BRAM has no reset).
-    reg [ASSOC-1:0]  cache_valid[0:NSETS-1];
+    // tags / valid / LRU rank: small, flop-based so all ways of a set are read in
+    // parallel for single-cycle hit detection.
+    reg [TAG_W-1:0]  cache_tag  [0:NSETS-1][0:ASSOC-1];
+    reg [ASSOC-1:0]  cache_valid[0:NSETS-1];                  // one valid bit per way
+    reg [ASW-1:0]    lru_rank   [0:NSETS-1][0:ASSOC-1];       // 0 = MRU .. ASSOC-1 = LRU
 
-    // ---- current command (latched when the stream hands off to a slow path) ----
+    // ---- current command (latched in S_RX) ----
     reg  [1:0] cur_cmd;
     reg [21:0] cur_addr;
     reg [63:0] cur_dta;
@@ -158,25 +137,19 @@ module mem_shim_burst #(
     wire [SET_W-1:0]  cur_set  = cur_addr[LOFF_W +: SET_W];          // [9:3]
     wire [TAG_W-1:0]  cur_tag  = cur_addr[LOFF_W+SET_W +: TAG_W];    // [21:10]
     wire              cur_aerr = (cur_addr == ADDR_ERR);
+    wire [21:0] cur_line_base  = {cur_addr[21:LOFF_W], {LOFF_W{1'b0}}};
 
-    // ---- FSM state ----
-    // PIPELINED 1-word/cycle hit loop, now THREE overlapped stages (the tag RAM
-    // is sync-read):
-    //   Stage T: select the live source (pk > sk > FIFO) and present its SET to
-    //            the tag/LRU RAM;
-    //   Stage A: the RAM word for the pA_* command is out — compare tags, pick
-    //            hit way / victim, present the hit word's data-RAM address;
-    //   Stage B: cache_rdata is out — emit + LRU-touch (write port).
-    // S_PROC is the RARE slow path only (ADDR_ERR / NOOP): a read MISS issues its
-    // burst and a WRITE issues its beat DIRECTLY from the stage-A verdict cycle
-    // (fast-path entry), so miss/write timing matches the flop-tag version.
-    // S_RX/S_HIT (4'd2/4'd4) are the RETIRED 2-cycle loop — kept as reserved
-    // encodings so debug_state numbering for the slow-path states is unchanged.
+    // ---- FSM state (declared early: the lookup mux below references `state`) ----
+    // PIPELINED 1-word/cycle hit loop: S_STREAM overlaps Stage A (look up the LIVE
+    // command, present its BRAM address) with Stage B (emit the hit looked up last
+    // cycle). S_PROC is the SLOW path only (miss fill / write / ADDR_ERR / NOOP).
+    // S_RX/S_HIT (4'd2/4'd4) are the RETIRED 2-cycle loop — kept as reserved encodings
+    // so debug_state numbering for the slow-path states is unchanged.
     localparam [3:0] S_INIT      = 4'd0,    // clear valid bits + seed LRU after reset
                      S_REQ       = 4'd1,    // pulse rd_en (refetch after slow path / drain)
-                     S_RX        = 4'd2,    // (retired encoding)
-                     S_PROC      = 4'd3,    // slow path: ADDR_ERR / NOOP (rare)
-                     S_HIT       = 4'd4,    // (retired encoding)
+                     S_RX        = 4'd2,    // LOOKUP: hit? -> S_HIT, else latch + S_PROC
+                     S_PROC      = 4'd3,    // slow path: miss fill / write / aerr / noop
+                     S_HIT       = 4'd4,    // emit the hit word + prefetch next command
                      S_FILL_CMD  = 4'd5,    // drive burst read, wait acceptance
                      S_FILL_DAT  = 4'd6,    // collect LINEW beats into the victim way
                      S_FILL_DRN  = 4'd7,    // 1-cycle drain so the last beat write commits
@@ -184,42 +157,28 @@ module mem_shim_burst #(
                      S_SERVE     = 4'd9,    // emit the miss's requested word
                      S_WR_CMD    = 4'd10,   // drive single write, wait acceptance
                      S_STREAM    = 4'd11,   // PIPELINED hit loop: 1 word/cycle
-                     S_PEEK      = 4'd12,   // DUAL: latch the next command, present its set
-                     S_ISSUE2    = 4'd13,   // DUAL: drive burst B, wait acceptance
-                     S_PEEK2     = 4'd14;   // DUAL: tag word out — pair decision
+                     S_PEEK      = 4'd12,   // DUAL: 1-cycle look at the next command (pair B?)
+                     S_ISSUE2    = 4'd13;   // DUAL: drive burst B, wait acceptance
     reg [3:0] state;
 
     // ---- PIPELINED HIT path (1 word/cycle) ----
-    // Stage A register: the command whose tag/LRU RAM word is on tag_rd/lru_rd
-    // this cycle.
-    reg             pA_valid;
-    reg  [1:0]      pA_cmd;
-    reg [21:0]      pA_addr;
-    reg [63:0]      pA_dta;
-    wire [LOFF_W-1:0] pA_off  = pA_addr[LOFF_W-1:0];
-    wire [SET_W-1:0]  pA_set  = pA_addr[LOFF_W +: SET_W];
-    wire [TAG_W-1:0]  pA_tag  = pA_addr[LOFF_W+SET_W +: TAG_W];
-    wire              pA_aerr = (pA_addr == ADDR_ERR);
-    wire [21:0] pA_line_base  = {pA_addr[21:LOFF_W], {LOFF_W{1'b0}}};
-    // Stage B register (emit): the hit looked up LAST cycle; cache_rdata is valid
-    // now. pB_* holds set/way/off (to re-read on backpressure + LRU-touch on
-    // emit) and the command's bypassed rank word (pB_lru) for the touch.
+    // Stage B (emit): the hit looked up LAST cycle; cache_rdata is valid now, so we
+    // emit it while Stage A looks up the NEXT command. pB_* holds Stage B's
+    // set/way/off (to re-read on backpressure + LRU-touch on emit).
     reg             pB_valid;
     reg [SET_W-1:0] pB_set;
     reg [ASW-1:0]   pB_way;
     reg [LOFF_W-1:0]pB_off;
-    reg [LRUV_W-1:0]pB_lru;
     // Skid register: the FIFO holds `valid` for only one cycle, so when a command
-    // arrives during a backpressure stall — or on the cycle stage A exits to a
-    // slow path (the pop was speculative) — we capture it here so it is never
-    // lost. Drained at stage T (after pk) before the live FIFO output.
+    // arrives during a backpressure stall (can't process it yet) we capture it here
+    // so it is never lost. Drained before the live FIFO output when present.
     reg             sk_valid;
     reg  [1:0]      sk_cmd;
     reg [21:0]      sk_addr;
     reg [63:0]      sk_dta;
 
     // ---- PAIRED DUAL-OUTSTANDING miss fills (dual_en) — declared early because the
-    // stage-T mux and rd_en assign below reference pk_valid/dual_en_q ----
+    // lookup mux and rd_en assign below reference pk_valid/dual_en_q ----
     // On a read miss (slot A) we peek the next command; if it is ALSO a read miss to
     // a DIFFERENT set (so no victim-way collision with A), we issue burst B as well,
     // overlapping the two DDR command latencies. Beats return in order (all of A then
@@ -228,11 +187,6 @@ module mem_shim_burst #(
     // line + queues a fallback serve. The case statement only ISSUES bursts and
     // sequences A->peek->B. Responses stay strictly in order. A non-pairable peek is
     // stashed in pk_* and processed by S_STREAM after the fill, so no command is lost.
-    // NOTE (BRAM-tag rework): the peek costs 2 cycles now (present set / decide),
-    // and pairing is SUPPRESSED when the skid holds a command at fill entry — the
-    // skid command is OLDER than the FIFO head, so peeking the FIFO there would
-    // reorder. Decisions are unaffected: the un-paired B misses later through the
-    // stream with an identical LRU view (A and B are different sets by rule).
     reg        dual_en_q;
     reg [SET_W-1:0]  ifb_set;    // slot B (2nd burst) line set
     reg [ASW-1:0]    ifb_way;    // slot B victim way (chosen from B's set; set != A's)
@@ -247,105 +201,39 @@ module mem_shim_burst #(
     reg  [1:0] pk_cmd;
     reg [21:0] pk_addr;
     reg [63:0] pk_dta;
-    wire [LOFF_W-1:0] pk_off  = pk_addr[LOFF_W-1:0];
-    wire [SET_W-1:0]  pk_set  = pk_addr[LOFF_W +: SET_W];
-    wire [TAG_W-1:0]  pk_tag  = pk_addr[LOFF_W+SET_W +: TAG_W];
-    wire              pk_aerr = (pk_addr == ADDR_ERR);
-    wire [21:0] pk_line_base  = {pk_addr[21:LOFF_W], {LOFF_W{1'b0}}};
     // fallback serve queue (depth 2): words whose cwf early-serve didn't fire.
     reg [SET_W-1:0]  sv_set [0:1];
     reg [ASW-1:0]    sv_way [0:1];
     reg [LOFF_W-1:0] sv_off [0:1];
     reg              sv_fail[0:1];   // that fill timed out => serve zero
-    reg        sv_wr, sv_rd;   // 1-bit ring pointers (depth 2)
+    reg              sv_wr, sv_rd;   // 1-bit ring pointers (depth 2)
     reg [1:0]        sv_n;           // queued count (0..2)
 
-    // ---- Stage T source mux ----
-    // Priority: the peeked-non-pairable hold (pk_*, drained first so order is
-    // preserved), then the backpressure/exit skid, then the live FIFO output.
-    // (pk and sk can never BOTH be valid: pairing peeks are suppressed while the
-    // skid holds, and the skid only loads while streaming — the rd_en guard is
-    // defensive.)
+    // ---- 2-cycle hit pipeline: look up on the LIVE FIFO output ----
+    // To serve a hit in 2 cycles (lookup -> emit) the tag compare and BRAM read
+    // address must use the command the cycle it arrives (state S_RX), not the
+    // latched copy. Everywhere else (miss fill / write in S_PROC) the latched
+    // cur_addr is the right source. lu_* is that mux; the FSM prefetches the next
+    // command during S_HIT so S_RX almost always has a valid word waiting.
+    // Streaming lookup source: prefer the skid register, else the LIVE FIFO output.
+    // In slow-path states (not S_STREAM) the latched cur_* is the right source.
+    // Lookup is live in S_STREAM (hit pipeline) and S_PEEK (dual pair decision).
+    // Source priority: the peeked-non-pairable hold (pk_*, drained first so order is
+    // preserved), then the backpressure skid, then the live FIFO output. pk_* and
+    // sk_* are both 0 while in S_PEEK, so the peek there always sees the FIFO command.
+    wire        lu_live   = (state == S_STREAM) || (state == S_PEEK);
     wire        lu_src_v  = pk_valid ? 1'b1    : sk_valid ? 1'b1    : mem_req_rd_valid;
     wire [1:0]  lu_src_c  = pk_valid ? pk_cmd  : sk_valid ? sk_cmd  : mem_req_rd_cmd;
     wire [21:0] lu_src_a  = pk_valid ? pk_addr : sk_valid ? sk_addr : mem_req_rd_addr;
     wire [63:0] lu_src_d  = pk_valid ? pk_dta  : sk_valid ? sk_dta  : mem_req_rd_dta;
+    wire [21:0] lu_addr = lu_live ? lu_src_a : cur_addr;
+    wire [LOFF_W-1:0] lu_off  = lu_addr[LOFF_W-1:0];
+    wire [SET_W-1:0]  lu_set  = lu_addr[LOFF_W +: SET_W];
+    wire [TAG_W-1:0]  lu_tag  = lu_addr[LOFF_W+SET_W +: TAG_W];
+    wire              lu_aerr = (lu_addr == ADDR_ERR);
+    wire [21:0] lu_line_base  = {lu_addr[21:LOFF_W], {LOFF_W{1'b0}}};   // B's burst base
 
-    // ---- tag/LRU RAM read port (shared address; registered outputs) ----
-    // Streaming presents the LIVE stage-T source's set (so the word is out when
-    // that command sits in stage A); a stall re-presents stage A's set so the
-    // word HOLDS across the stall; S_PEEK/S_PEEK2 present the peeked command's
-    // set through the same stage-T mux (pk latches at the S_PEEK edge and takes
-    // mux priority in S_PEEK2). In the remaining (slow-path) states the read is
-    // don't-care: every consumer there uses the snap_* / fillB_* snapshots.
-    reg  [TAGV_W-1:0] tag_rd;
-    reg  [LRUV_W-1:0] lru_rd;
-    wire [SET_W-1:0]  tl_raddr = ((state == S_STREAM) && mem_res_wr_almost_full)
-                               ? pA_set
-                               : lu_src_a[LOFF_W +: SET_W];
-    always @(posedge clk) begin
-        tag_rd <= tag_ram[tl_raddr];
-        lru_rd <= lru_ram[tl_raddr];
-    end
-
-    // ---- LRU touch (pure function of a rank word) ----
-    // Make way `way` MRU (rank 0), age the ways younger than its old rank.
-    // Same policy, bit for bit, as the flop version's lru_touch task.
-    function automatic [LRUV_W-1:0] lru_touch_f(input [LRUV_W-1:0] ranks,
-                                                input [ASW-1:0]    way);
-        integer ti;
-        reg [ASW-1:0] old;
-        begin
-            old = {ASW{1'b0}};
-            for (ti = 0; ti < ASSOC; ti = ti + 1)
-                if (ti[ASW-1:0] == way) old = ranks[ti*ASW +: ASW];
-            for (ti = 0; ti < ASSOC; ti = ti + 1) begin
-                if (ti[ASW-1:0] == way)
-                    lru_touch_f[ti*ASW +: ASW] = {ASW{1'b0}};
-                else if (ranks[ti*ASW +: ASW] < old)
-                    lru_touch_f[ti*ASW +: ASW] = ranks[ti*ASW +: ASW] + 1'b1;
-                else
-                    lru_touch_f[ti*ASW +: ASW] = ranks[ti*ASW +: ASW];
-            end
-        end
-    endfunction
-
-    // S_INIT seed: way i gets rank i (0 = MRU .. ASSOC-1 = LRU)
-    wire [LRUV_W-1:0] lru_seed;
-    genvar gs;
-    generate
-        for (gs = 0; gs < ASSOC; gs = gs + 1) begin : g_seed
-            assign lru_seed[gs*ASW +: ASW] = gs[ASW-1:0];
-        end
-    endgenerate
-
-    // ---- LRU read-after-write bypass (streaming) ----
-    // The rank word a stage-A command reads from the RAM can be stale by up to
-    // two writes: the touch being WRITTEN this cycle (stage B, same set) and the
-    // touch written LAST cycle (mixed-port read-during-write at the capture edge
-    // is undefined on M10K). Forward both; newest wins. Chained same-set touches
-    // stay consistent because each bypassed value feeds the next touch.
-    // Gated to S_STREAM: outside the stream the RAM is always up to date w.r.t.
-    // its readers (snapshots are captured before any conflicting write), and lw_*
-    // could be stale vs a later fill-validate touch.
-    reg              lw_valid;
-    reg [SET_W-1:0]  lw_set;
-    reg [LRUV_W-1:0] lw_ranks;
-    wire stream_touch = (state == S_STREAM) && !mem_res_wr_almost_full && pB_valid;
-    wire [LRUV_W-1:0] pB_touched = lru_touch_f(pB_lru, pB_way);
-    wire [LRUV_W-1:0] lru_eff =
-        (stream_touch && (pB_set == pA_set)) ? pB_touched :
-        (lw_valid     && (lw_set == pA_set)) ? lw_ranks   : lru_rd;
-
-    // ---- combinational hit / victim select over the looked-up set word ----
-    // Inputs: stage A's command while streaming, the peeked command in S_PEEK2.
-    // (S_PROC never uses this block — it runs on the snap_* snapshot registers.)
-    wire              peek_cmp  = (state == S_PEEK2);
-    wire [TAG_W-1:0]  cmp_tag   = peek_cmp ? pk_tag : pA_tag;
-    wire [SET_W-1:0]  cmp_set   = peek_cmp ? pk_set : pA_set;
-    wire [LRUV_W-1:0] cmp_lru   = peek_cmp ? lru_rd : lru_eff;
-    wire [ASSOC-1:0]  cmp_valid = cache_valid[cmp_set];
-
+    // ---- combinational hit / victim select over the LOOKUP set ----
     integer wi;
     reg                hit_c;
     reg  [ASW-1:0]     hit_way_c;
@@ -355,7 +243,7 @@ module mem_shim_burst #(
         hit_c     = 1'b0;
         hit_way_c = {ASW{1'b0}};
         for (wi = 0; wi < ASSOC; wi = wi + 1)
-            if (cmp_valid[wi] && (tag_rd[wi*TAG_W +: TAG_W] == cmp_tag)) begin
+            if (cache_valid[lu_set][wi[ASW-1:0]] && cache_tag[lu_set][wi[ASW-1:0]] == lu_tag) begin
                 hit_c     = 1'b1;
                 hit_way_c = wi[ASW-1:0];
             end
@@ -363,62 +251,62 @@ module mem_shim_burst #(
         victim_c = {ASW{1'b0}};
         vic_done = 1'b0;
         for (wi = ASSOC-1; wi >= 0; wi = wi - 1)
-            if (!cmp_valid[wi]) begin victim_c = wi[ASW-1:0]; vic_done = 1'b1; end
+            if (!cache_valid[lu_set][wi[ASW-1:0]]) begin victim_c = wi[ASW-1:0]; vic_done = 1'b1; end
         if (!vic_done)
             for (wi = 0; wi < ASSOC; wi = wi + 1)
-                if (cmp_lru[wi*ASW +: ASW] == (ASSOC-1)) victim_c = wi[ASW-1:0];
+                if (lru_rank[lu_set][wi[ASW-1:0]] == (ASSOC-1)) victim_c = wi[ASW-1:0];
     end
 
-    // ---- streaming stage-A verdict ----
-    wire sA_hit  = pA_valid && (pA_cmd == CMD_READ) && hit_c && !pA_aerr;
-    wire sA_slow = pA_valid && !sA_hit;              // miss / write / aerr / noop
-    wire pA_rd_miss = (pA_cmd == CMD_READ)  && !pA_aerr && !hit_c;
-    wire pA_wr_fast = (pA_cmd == CMD_WRITE) && !pA_aerr;
+    // streaming-pipeline helper signals (need hit_c above)
+    wire lu_valid     = lu_live && lu_src_v;                 // a streamable cmd is live
+    wire stream_hit   = lu_valid && (lu_src_c == CMD_READ) && hit_c && !lu_aerr;
     wire stream_stall = (state == S_STREAM) && mem_res_wr_almost_full;
 
-    // ---- slow-path lookup snapshots ----
-    // Captured on the stage-A exit cycle; consumed by S_PROC (decisions), the
-    // fast-path write (wr_is_hit/wr_way latch directly), and slot A's fill
-    // validate (whole-word tag/LRU read-modify-write). Valid from capture until
-    // the fill/write completes: nothing else writes that set in between (the
-    // stream is drained; a paired slot B is a DIFFERENT set by rule).
-    reg [TAGV_W-1:0] snap_tags;
-    reg [LRUV_W-1:0] snap_lru;
-    reg              snap_hit;
-    reg [ASW-1:0]    snap_hit_way;
-    reg [ASW-1:0]    snap_victim;
-    // slot B's set snapshot (captured in S_PEEK2 for B's validate RMW)
-    reg [TAGV_W-1:0] fillB_tags;
-    reg [LRUV_W-1:0] fillB_lru;
+    // LRU "touch": make way `a` of set `s` MRU (rank 0), age the younger ways.
+    task automatic lru_touch(input [SET_W-1:0] s, input [ASW-1:0] a);
+        integer ti;
+        reg [ASW-1:0] old;
+        begin
+            old = lru_rank[s][a];
+            for (ti = 0; ti < ASSOC; ti = ti + 1) begin
+                if (ti[ASW-1:0] == a)               lru_rank[s][ti[ASW-1:0]] <= {ASW{1'b0}};
+                else if (lru_rank[s][ti[ASW-1:0]] < old)
+                                                    lru_rank[s][ti[ASW-1:0]] <= lru_rank[s][ti[ASW-1:0]] + 1'b1;
+            end
+        end
+    endtask
 
-    // rd_en pulses in S_REQ (cold refetch) and EVERY streaming cycle the pipeline
-    // advances — the pop is SPECULATIVE (the popped command's verdict is only
-    // known one cycle later at stage A), so a slow-path exit parks the in-flight
-    // command in the skid. It stays low on a stall (almost_full), on the exit
-    // cycle itself, when both hold registers are full (defensive), and on the
-    // empty-drain cycle (a pop there would land in S_REQ unconsumed and be lost).
+    // rd_en pulses in S_REQ (cold refetch) and EVERY cycle the pipeline advances a
+    // hit — including a skid-drain hit (the skid command was popped pre-stall; the
+    // FIFO's NEXT command still needs a pop) — so a fresh command lands next cycle
+    // => continuous 1 word/cycle. It stays low on a stall (almost_full) and on a
+    // miss (don't over-fetch past the command handed to the slow path).
     assign mem_req_rd_en = (state == S_REQ)
-                        || ((state == S_STREAM) && !mem_res_wr_almost_full && !sA_slow
-                            && !(pk_valid && sk_valid) && (lu_src_v || pA_valid))
+                        || (state == S_STREAM && !mem_res_wr_almost_full && stream_hit)
                         // DUAL: on burst-A acceptance, pop the next command so it is
-                        // live in S_PEEK for the pair decision (unless the skid holds
-                        // an older command — peeking would reorder).
-                        || ((state == S_FILL_CMD) && dual_en_q && !ddr3_waitrequest && !sk_valid);
+                        // live in S_PEEK for the pair decision.
+                        || (state == S_FILL_CMD && dual_en_q && !ddr3_waitrequest);
 
     reg [LOFF_W:0]  beat;        // 0..LINEW beat counter (one extra bit)
     reg [ASW-1:0]   sel_way;     // victim way being filled / served on a miss
+    reg [ASW-1:0]   hit_way_r;   // hit way latched in S_RX, used for LRU in S_HIT
     reg [ASW-1:0]   wr_way;      // way to update on a write hit
     reg             wr_is_hit;   // the in-flight write hit a cached line
     reg [SET_W-1:0] init_idx;    // S_INIT walk index
 
     // ---- cache_data read port (combinational address, registered output) ----
-    // Serve states read the HEAD of the fallback serve queue (sv_rd); a streaming
-    // stall re-reads Stage B's word (so cache_rdata holds across the stall); else
-    // present stage A's hit word, which becomes Stage B next cycle.
+    // Serve states read the just-filled victim way; the lookup (S_RX) reads the hit
+    // way of the LIVE command (lu_*); S_HIT just re-reads the same hit word (cur_*
+    // == the latched command, hit_way_c stable) so it survives a backpressure hold.
+    // serve states read the just-filled victim word; a streaming stall RE-READS the
+    // Stage-B word (so cache_rdata holds across the stall); otherwise we present the
+    // looked-up command's hit word (Stage A), which becomes Stage B next cycle.
+    // serve states read the HEAD of the fallback serve queue (sv_rd); a streaming
+    // stall re-reads Stage-B; else present the looked-up command's hit word (Stage A).
     wire serve_rd = (state == S_SERVE_ADR) || (state == S_SERVE);
     wire [DIDX_W-1:0] raddr_comb = serve_rd     ? {sv_set[sv_rd], sv_way[sv_rd], sv_off[sv_rd]}
                                  : stream_stall ? {pB_set,  pB_way,   pB_off}
-                                 :                {pA_set,  hit_way_c, pA_off};
+                                 :                {lu_set,  hit_way_c, lu_off};
     reg [63:0] cache_rdata;
     always @(posedge clk) cache_rdata <= cache_data[raddr_comb];
 
@@ -433,7 +321,7 @@ module mem_shim_burst #(
     // S_SERVE_ADR + S_SERVE to read it back from BRAM, emit ddr3_readdata straight
     // to the response FIFO the cycle that beat lands, then keep filling the rest of
     // the line in the background. `served` records that the word was emitted (so the
-    // end-of-fill path skips the serve states and goes directly to refetch). Best-
+    // end-of-fill path skips the serve states and goes directly to S_REQ). Best-
     // effort: if the response FIFO is full at that beat, served stays 0 and the
     // legacy serve-at-end path runs. NEVER early-serves on a timed-out fill.
     reg        cwf_en_q;        // registered enable (no combinational fanout from the pin)
@@ -448,10 +336,9 @@ module mem_shim_burst #(
     wire              c_served = c2 ? served_b : served;
 
     // A burst beat is landing this cycle (any fill-region state — collection is
-    // centralized so a beat is never dropped while we are peeking/issuing B):
+    // centralized so a beat is never dropped while we are issuing B):
     wire in_fill   = (state == S_FILL_CMD) || (state == S_FILL_DAT)
-                  || (state == S_PEEK)     || (state == S_PEEK2)
-                  || (state == S_ISSUE2);
+                  || (state == S_PEEK)     || (state == S_ISSUE2);
     wire fill_beat = in_fill && ddr3_readdatavalid;
     // ...and it is the active slot's requested word, the FIFO can take it, CWF on.
     // ORDER GUARD: slot B may early-serve only once slot A has been served (`served`)
@@ -460,7 +347,6 @@ module mem_shim_burst #(
     wire cwf_fire  = cwf_en_q && fill_beat && !c_served && !c_aerr
                   && (beat[LOFF_W-1:0] == c_off) && !mem_res_wr_almost_full
                   && (!c2 || served);
-    wire fill_last = fill_beat && (beat == LINEW-1);
 
     // ---- cache_data SINGLE WRITE PORT (combinational decode -> one clocked write) ----
     // ALL writes to cache_data go through this one port so the 2048x64b array infers
@@ -485,51 +371,6 @@ module mem_shim_burst #(
     end
     always @(posedge clk) if (cache_we) cache_data[cache_waddr] <= cache_wdata;
 
-    // ---- tag_ram SINGLE WRITE PORT ----
-    // Only writer: the fill validate (last beat of the active slot). Whole-word
-    // write: the set's snapshot (captured at the miss lookup) with the victim
-    // way's slice replaced — legal because nothing else writes that set between
-    // capture and validate.
-    reg [TAGV_W-1:0] tag_wr_word;
-    integer twi;
-    always @* begin
-        tag_wr_word = c2 ? fillB_tags : snap_tags;
-        for (twi = 0; twi < ASSOC; twi = twi + 1)
-            if (twi[ASW-1:0] == c_way)
-                tag_wr_word[twi*TAG_W +: TAG_W] = c_tag;
-    end
-    always @(posedge clk) if (fill_last) tag_ram[c_set] <= tag_wr_word;
-
-    // ---- lru_ram SINGLE WRITE PORT ----
-    // Writers (mutually exclusive by state): S_INIT seed walk, fill validate
-    // touch, streaming stage-B touch, write-hit touch.
-    reg              lru_we;
-    reg [SET_W-1:0]  lru_waddr;
-    reg [LRUV_W-1:0] lru_wdata;
-    always @* begin
-        lru_we    = 1'b0;
-        lru_waddr = {SET_W{1'b0}};
-        lru_wdata = {LRUV_W{1'b0}};
-        if (state == S_INIT) begin
-            lru_we    = 1'b1;
-            lru_waddr = init_idx;
-            lru_wdata = lru_seed;
-        end else if (fill_last) begin
-            lru_we    = 1'b1;
-            lru_waddr = c_set;
-            lru_wdata = lru_touch_f(c2 ? fillB_lru : snap_lru, c_way);
-        end else if (stream_touch) begin
-            lru_we    = 1'b1;
-            lru_waddr = pB_set;
-            lru_wdata = pB_touched;
-        end else if ((state == S_WR_CMD) && !ddr3_waitrequest && wr_is_hit) begin
-            lru_we    = 1'b1;
-            lru_waddr = cur_set;
-            lru_wdata = lru_touch_f(snap_lru, wr_way);
-        end
-    end
-    always @(posedge clk) if (lru_we) lru_ram[lru_waddr] <= lru_wdata;
-
     always @(posedge clk) begin
         if (!rst_n) begin
             state          <= S_INIT;
@@ -546,29 +387,15 @@ module mem_shim_burst #(
             cur_dta        <= 64'd0;
             beat           <= 0;
             sel_way        <= 0;
-            pA_valid       <= 1'b0;
-            pA_cmd         <= 2'd0;
-            pA_addr        <= 22'd0;
-            pA_dta         <= 64'd0;
+            hit_way_r      <= 0;
             pB_valid       <= 1'b0;
             pB_set         <= 0;
             pB_way         <= 0;
             pB_off         <= 0;
-            pB_lru         <= 0;
             sk_valid       <= 1'b0;
             sk_cmd         <= 2'd0;
             sk_addr        <= 22'd0;
             sk_dta         <= 64'd0;
-            lw_valid       <= 1'b0;
-            lw_set         <= 0;
-            lw_ranks       <= 0;
-            snap_tags      <= 0;
-            snap_lru       <= 0;
-            snap_hit       <= 1'b0;
-            snap_hit_way   <= 0;
-            snap_victim    <= 0;
-            fillB_tags     <= 0;
-            fillB_lru      <= 0;
             wr_way         <= 0;
             wr_is_hit      <= 1'b0;
             fill_to        <= 0;
@@ -604,10 +431,9 @@ module mem_shim_burst #(
             // CENTRALIZED COLLECT (runs in ALL fill-region states so a returning
             // beat is never dropped while we are peeking/issuing burst B).
             // Routes the beat to the ACTIVE slot (c2 ? B : A), critical-word early-
-            // serves its requested word, and on the LAST beat validates the line
-            // (valid bit here; the tag/LRU words commit through their write ports
-            // this same cycle), queues a fallback serve if it wasn't early-served,
-            // then advances to slot B (pair) or finishes.
+            // serves its requested word, and on the LAST beat validates the line,
+            // queues a fallback serve if it wasn't early-served, then advances to
+            // slot B (pair) or finishes.
             // =================================================================
             // CWF early-serve for the active slot:
             if (cwf_fire) begin
@@ -618,8 +444,10 @@ module mem_shim_burst #(
             if (fill_beat) begin
                 // (the beat itself is written via the single cache_data write port)
                 if (beat == LINEW-1) begin
-                    // validate the active line (tag + LRU via their write ports)
+                    // validate the active line
+                    cache_tag[c_set][c_way]   <= c_tag;
                     cache_valid[c_set][c_way] <= 1'b1;
+                    lru_touch(c_set, c_way);
                     // queue a fallback serve unless the word was/is early-served
                     if (!(c_served || cwf_fire)) begin
                         sv_set[sv_wr] <= c_set; sv_way[sv_wr] <= c_way;
@@ -634,11 +462,11 @@ module mem_shim_burst #(
                     end else begin
                         // single A, or B just finished: drain/serve. Preserve the
                         // cwf fast-path (nothing queued AND this word served). If a
-                        // held command exists (pk/sk), go to S_STREAM DIRECTLY
+                        // peeked command is held (pk_valid), go to S_STREAM DIRECTLY
                         // (not S_REQ — S_REQ pops the FIFO and would skip a command
-                        // while S_STREAM consumes the hold first).
+                        // while S_STREAM consumes pk first).
                         if ((sv_n == 2'd0) && (c_served || cwf_fire))
-                            state <= (pk_valid || sk_valid) ? S_STREAM : S_REQ;
+                            state <= pk_valid ? S_STREAM : S_REQ;
                         else
                             state <= S_FILL_DRN;
                     end
@@ -666,40 +494,37 @@ module mem_shim_burst #(
 
             case (state)
             // =================================================================
-            // Walk every set: invalidate all ways, seed LRU ranks (0,1,2,3 — via
-            // the lru_ram write port). Avoids a huge async-reset fanout.
+            // Walk every set: invalidate all ways, seed LRU ranks (0,1,2,3).
+            // Avoids a huge async-reset fanout on the tag/valid/LRU arrays.
             S_INIT: begin
                 cache_valid[init_idx] <= {ASSOC{1'b0}};
+                for (wi = 0; wi < ASSOC; wi = wi + 1)
+                    lru_rank[init_idx][wi[ASW-1:0]] <= wi[ASW-1:0];
                 if (init_idx == NSETS-1) state <= S_REQ;
                 else                     init_idx <= init_idx + 1'b1;
             end
 
             // =================================================================
             S_REQ: begin                 // rd_en is combinationally high here
-                pA_valid <= 1'b0;         // enter streaming with an empty pipeline
-                pB_valid <= 1'b0;
+                pB_valid <= 1'b0;         // enter streaming with an empty pipeline
                 sk_valid <= 1'b0;
-                lw_valid <= 1'b0;
                 state    <= S_STREAM;
             end
 
             // =================================================================
-            // PIPELINED HIT LOOP (1 word/cycle). Three overlapped stages:
-            //   Stage T: present the live source's SET to the tag/LRU RAM and
-            //            register the command into pA_* (rd_en fetched ahead).
-            //   Stage A: the set word is on tag_rd/lru_rd — verdict. A clean READ
-            //            hit presents its data-RAM address and moves to pB_*; a
-            //            miss ISSUES ITS BURST NOW (fast entry), a write issues
-            //            its beat now; ADDR_ERR/NOOP go to S_PROC.
-            //   Stage B: cache_rdata is out — emit + LRU touch (write port).
-            // Backpressure stalls all three stages without losing a command (the
-            // skid); the speculative in-flight pop on a slow exit parks there too.
+            // PIPELINED HIT LOOP (1 word/cycle). Two overlapped stages:
+            //   Stage A: look up the LIVE command (skid-or-FIFO), present its hit
+            //            word's BRAM address (raddr_comb), and latch pB_* for emit.
+            //   Stage B: the hit looked up LAST cycle — cache_rdata is valid now —
+            //            is emitted while Stage A runs. => one response per cycle.
+            // A clean READ hit advances and fetches the next command (rd_en high). A
+            // miss/write/ADDR_ERR is latched into cur_* and handed to the slow path
+            // S_PROC. Backpressure stalls without losing a command (the skid).
             S_STREAM: begin
                 if (mem_res_wr_almost_full) begin
                     // STALL: can't emit Stage B. Capture a just-arrived FIFO command
                     // into the skid (its `valid` is 1 cycle only) so it survives;
-                    // tl_raddr re-reads Stage A's set and raddr_comb Stage B's word
-                    // so tag_rd/lru_rd/cache_rdata hold. No emit/consume/fetch.
+                    // raddr_comb re-reads Stage B so cache_rdata holds. No emit/fetch.
                     if (!sk_valid && !pk_valid && mem_req_rd_valid) begin
                         sk_cmd   <= mem_req_rd_cmd;
                         sk_addr  <= mem_req_rd_addr;
@@ -707,100 +532,44 @@ module mem_shim_burst #(
                         sk_valid <= 1'b1;
                     end
                 end else begin
-                    // Stage B: emit the hit looked up two cycles ago. Its LRU
-                    // touch commits through the write port this cycle; lw_* keeps
-                    // the written word for next cycle's read bypass.
+                    // Stage B: emit the hit looked up last cycle.
                     if (pB_valid) begin
                         mem_res_wr_dta <= cache_rdata;
                         mem_res_wr_en  <= 1'b1;
-                        lw_valid <= 1'b1;
-                        lw_set   <= pB_set;
-                        lw_ranks <= pB_touched;
+                        lru_touch(pB_set, pB_way);
                     end
-                    if (sA_slow) begin
-                        // Stage A holds a non-streamable command: capture its
-                        // lookup and hand off. The stage-T source is left in
-                        // place (younger commands, served after); a live FIFO
-                        // word — the speculative pop — parks in the skid.
-                        cur_cmd      <= pA_cmd;
-                        cur_addr     <= pA_addr;
-                        cur_dta      <= pA_dta;
-                        snap_tags    <= tag_rd;
-                        snap_lru     <= lru_eff;
-                        snap_hit     <= hit_c;
-                        snap_hit_way <= hit_way_c;
-                        snap_victim  <= victim_c;
-                        pA_valid     <= 1'b0;
-                        pB_valid     <= 1'b0;
-                        lw_valid     <= 1'b0;
-                        if (!sk_valid && !pk_valid && mem_req_rd_valid) begin
-                            sk_cmd   <= mem_req_rd_cmd;
-                            sk_addr  <= mem_req_rd_addr;
-                            sk_dta   <= mem_req_rd_dta;
-                            sk_valid <= 1'b1;
-                        end
-                        if (pA_rd_miss) begin
-                            // FAST miss entry (timing parity with the flop-tag
-                            // version: verdict -> S_FILL_CMD in one cycle).
-                            // Invalidate the victim now (so a fill timeout can't
-                            // leave a stale valid line), issue one burst line-fill.
-                            sel_way                        <= victim_c;
-                            cache_valid[pA_set][victim_c]  <= 1'b0;
-                            ddr3_addr                      <= {7'b0011000, pA_line_base};
-                            ddr3_burstcnt                  <= LINEW[7:0];
-                            ddr3_read                      <= 1'b1;
-                            beat                           <= 0;
-                            fill_to                        <= 0;
-                            fill_failed                    <= 1'b0;
-                            served                         <= 1'b0;   // CWF: not yet emitted
-                            // DUAL bookkeeping: fresh fill, empty serve queue, slot A.
-                            pairing    <= 1'b0;  ifb_active <= 1'b0;
-                            c2         <= 1'b0;  a_done     <= 1'b0;  served_b <= 1'b0;
-                            sv_wr      <= 1'b0;  sv_rd      <= 1'b0;  sv_n     <= 2'd0;
-                            state                          <= S_FILL_CMD;
-                        end else if (pA_wr_fast) begin
-                            // FAST write entry (single-beat write-through)
-                            wr_is_hit      <= hit_c;       // update cached word on accept
-                            wr_way         <= hit_way_c;
-                            ddr3_addr      <= {7'b0011000, pA_addr};
-                            ddr3_burstcnt  <= 8'd1;
-                            ddr3_writedata <= pA_dta;
-                            ddr3_write     <= 1'b1;
-                            state          <= S_WR_CMD;
-                        end else begin
-                            state <= S_PROC;               // ADDR_ERR / NOOP / REFRESH
+                    // Stage A: process the live command (pk hold first, then skid,
+                    // then FIFO — pk_* is a dual-peeked non-pairable command held in
+                    // order). Consuming it clears whichever source supplied lu_*.
+                    if (lu_src_v) begin
+                        if (stream_hit) begin            // clean READ hit -> stream on
+                            pB_valid <= 1'b1;            // (its addr is on raddr_comb)
+                            pB_set   <= lu_set;
+                            pB_way   <= hit_way_c;
+                            pB_off   <= lu_off;
+                            sk_valid <= 1'b0;            // consumed the skid/pk if used
+                            pk_valid <= 1'b0;
+                        end else begin                  // miss / write / aerr
+                            cur_cmd  <= lu_src_c;
+                            cur_addr <= lu_src_a;
+                            cur_dta  <= lu_src_d;
+                            pB_valid <= 1'b0;
+                            sk_valid <= 1'b0;
+                            pk_valid <= 1'b0;
+                            state    <= S_PROC;          // slow path (drains pipeline)
                         end
                     end else begin
-                        // Stage A -> B advance (or bubble): stage A's hit word
-                        // address is on raddr_comb; its bypassed rank word rides
-                        // along for the stage-B touch.
-                        pB_valid <= sA_hit;
-                        pB_set   <= pA_set;
-                        pB_way   <= hit_way_c;
-                        pB_off   <= pA_off;
-                        pB_lru   <= lru_eff;
-                        // Stage T -> A: consume the live source (pk first, then
-                        // skid, then FIFO — order is preserved by the priority).
-                        pA_cmd   <= lu_src_c;
-                        pA_addr  <= lu_src_a;
-                        pA_dta   <= lu_src_d;
-                        pA_valid <= lu_src_v;
-                        if (lu_src_v) begin
-                            if (pk_valid)      pk_valid <= 1'b0;
-                            else if (sk_valid) sk_valid <= 1'b0;
-                        end else if (!pA_valid) begin
-                            state <= S_REQ;   // T and A empty: drain (pB emitted above), refetch
-                        end
+                        pB_valid <= 1'b0;                // FIFO empty: drain, refetch
+                        state    <= S_REQ;
                     end
                 end
             end
 
             // =================================================================
-            // SLOW PATH on the LATCHED command + its snap_* lookup snapshot.
-            // Reachable only for the RARE cases (ADDR_ERR read/write, NOOP,
-            // REFRESH) — read misses and normal writes fast-path from S_STREAM.
-            // The miss/write arms are kept intact (they run correctly off the
-            // snapshots) as belt-and-suspenders.
+            // SLOW PATH (miss fill / write / ADDR_ERR / NOOP) on the LATCHED command.
+            // hit_c/victim_c are combinational over cur_set here (lu_* == cur_* when
+            // state != S_RX). Returns to S_REQ which refetches with a 2-cycle bubble
+            // (acceptable: the slow path already costs 10s of cycles).
             S_PROC: begin
                 case (cur_cmd)
                 CMD_READ: begin
@@ -808,33 +577,34 @@ module mem_shim_burst #(
                         if (!mem_res_wr_almost_full) begin
                             mem_res_wr_dta <= 64'd0;   // sentinel: synthetic zero
                             mem_res_wr_en  <= 1'b1;
-                            state          <= (pk_valid || sk_valid) ? S_STREAM : S_REQ;
+                            state          <= S_REQ;
                         end
                     end
                     else begin
-                        // miss (defensive; normally fast-pathed): invalidate the
-                        // victim, then issue one burst line-fill.
-                        sel_way                          <= snap_victim;
-                        cache_valid[cur_set][snap_victim] <= 1'b0;
-                        ddr3_addr                        <= {7'b0011000, {cur_addr[21:LOFF_W], {LOFF_W{1'b0}}}};
-                        ddr3_burstcnt                    <= LINEW[7:0];
-                        ddr3_read                        <= 1'b1;
-                        beat                             <= 0;
-                        fill_to                          <= 0;
-                        fill_failed                      <= 1'b0;
-                        served                           <= 1'b0;
+                        // miss: invalidate the victim now (so a fill timeout can't
+                        // leave a stale valid line), then issue one burst line-fill.
+                        sel_way                        <= victim_c;
+                        cache_valid[cur_set][victim_c] <= 1'b0;
+                        ddr3_addr                      <= {7'b0011000, cur_line_base};
+                        ddr3_burstcnt                  <= LINEW[7:0];
+                        ddr3_read                      <= 1'b1;
+                        beat                           <= 0;
+                        fill_to                        <= 0;
+                        fill_failed                    <= 1'b0;
+                        served                         <= 1'b0;   // CWF: not yet emitted
+                        // DUAL bookkeeping: fresh fill, empty serve queue, slot A.
                         pairing    <= 1'b0;  ifb_active <= 1'b0;
                         c2         <= 1'b0;  a_done     <= 1'b0;  served_b <= 1'b0;
                         sv_wr      <= 1'b0;  sv_rd      <= 1'b0;  sv_n     <= 2'd0;
-                        state                            <= S_FILL_CMD;
+                        state                          <= S_FILL_CMD;
                     end
                 end
                 CMD_WRITE: begin
                     if (cur_aerr) begin
-                        state <= (pk_valid || sk_valid) ? S_STREAM : S_REQ;  // drop sentinel write
+                        state <= S_REQ;                // drop sentinel write
                     end else begin
-                        wr_is_hit      <= snap_hit;    // update cached word on accept
-                        wr_way         <= snap_hit_way;
+                        wr_is_hit      <= hit_c;       // update cached word on accept
+                        wr_way         <= hit_way_c;
                         ddr3_addr      <= {7'b0011000, cur_addr};
                         ddr3_burstcnt  <= 8'd1;
                         ddr3_writedata <= cur_dta;
@@ -842,66 +612,53 @@ module mem_shim_burst #(
                         state          <= S_WR_CMD;
                     end
                 end
-                default: state <= (pk_valid || sk_valid) ? S_STREAM : S_REQ;  // NOOP / REFRESH
+                default: state <= S_REQ;               // NOOP / REFRESH
                 endcase
             end
+
+            // =================================================================
+            // (The old 2-cycle S_RX/S_HIT hit loop is replaced by the pipelined
+            // S_STREAM above — 1 word/cycle.)
 
             // =================================================================
             // Burst read (slot A): wait for command acceptance. Beats (incl. a same-
             // cycle accept+data) are collected by the centralized COLLECT block above.
             // On accept: in DUAL mode go peek the next command for a pair (rd_en was
-            // pulsed combinationally this cycle — suppressed if the skid holds an
-            // older command); else collect normally.
+            // pulsed combinationally this cycle); else collect normally.
             S_FILL_CMD: begin
                 if (!ddr3_waitrequest) begin
                     ddr3_read <= 1'b0;
-                    state     <= (dual_en_q && !sk_valid) ? S_PEEK : S_FILL_DAT;
+                    state     <= dual_en_q ? S_PEEK : S_FILL_DAT;
                 end
             end
 
             // =================================================================
             // DUAL: the next command is live this cycle (popped on A's acceptance).
-            // Latch it into pk_* (its FIFO valid is 1 cycle only) and present its
-            // set to the tag/LRU RAM (via the stage-T mux — pk takes priority next
-            // cycle so the address holds); decide in S_PEEK2.
+            // Pair it as burst B iff it is a READ MISS to a DIFFERENT set (so its
+            // victim can't collide with A's in-flight way). Otherwise hold it in pk_*
+            // for S_STREAM to process in order and fall back to a single A fill.
             S_PEEK: begin
-                if (mem_req_rd_valid) begin
-                    pk_cmd   <= mem_req_rd_cmd;
-                    pk_addr  <= mem_req_rd_addr;
-                    pk_dta   <= mem_req_rd_dta;
-                    pk_valid <= 1'b1;
-                    state    <= S_PEEK2;
+                if (lu_src_v) begin
+                    if ((lu_src_c == CMD_READ) && !hit_c && !lu_aerr && (lu_set != cur_set)) begin
+                        ifb_set  <= lu_set;
+                        ifb_way  <= victim_c;
+                        ifb_off  <= lu_off;
+                        ifb_tag  <= lu_tag;
+                        cache_valid[lu_set][victim_c] <= 1'b0;     // invalidate B's victim
+                        served_b <= 1'b0;
+                        pairing  <= 1'b1;
+                        // issue burst B now (A is already accepted / in flight)
+                        ddr3_addr     <= {7'b0011000, lu_line_base};
+                        ddr3_burstcnt <= LINEW[7:0];
+                        ddr3_read     <= 1'b1;
+                        state         <= S_ISSUE2;
+                    end else begin
+                        pk_cmd <= lu_src_c; pk_addr <= lu_src_a; pk_dta <= lu_src_d;
+                        pk_valid <= 1'b1;
+                        state    <= S_FILL_DAT;                    // single A
+                    end
                 end else begin
                     state <= S_FILL_DAT;                           // FIFO empty: single A
-                end
-            end
-
-            // =================================================================
-            // DUAL: the peeked command's set word is on tag_rd/lru_rd. Pair it as
-            // burst B iff it is a READ MISS to a DIFFERENT set (so its victim
-            // can't collide with A's in-flight way; also guarantees A's validate
-            // never writes B's set word between B's snapshot and B's validate).
-            // Otherwise keep it held in pk_* for S_STREAM to process in order and
-            // fall back to a single A fill.
-            S_PEEK2: begin
-                if ((pk_cmd == CMD_READ) && !hit_c && !pk_aerr && (pk_set != cur_set)) begin
-                    ifb_set    <= pk_set;
-                    ifb_way    <= victim_c;
-                    ifb_off    <= pk_off;
-                    ifb_tag    <= pk_tag;
-                    cache_valid[pk_set][victim_c] <= 1'b0;     // invalidate B's victim
-                    fillB_tags <= tag_rd;                      // B's validate RMW base
-                    fillB_lru  <= lru_rd;
-                    served_b   <= 1'b0;
-                    pairing    <= 1'b1;
-                    pk_valid   <= 1'b0;
-                    // issue burst B now (A is already accepted / in flight)
-                    ddr3_addr     <= {7'b0011000, pk_line_base};
-                    ddr3_burstcnt <= LINEW[7:0];
-                    ddr3_read     <= 1'b1;
-                    state         <= S_ISSUE2;
-                end else begin
-                    state <= S_FILL_DAT;                       // pk stays held, single A
                 end
             end
 
@@ -928,7 +685,7 @@ module mem_shim_burst #(
             // served). raddr_comb presents the queue head; cache_rdata is valid in
             // S_SERVE one cycle later.
             S_FILL_DRN:  state <= (sv_n != 2'd0) ? S_SERVE_ADR
-                                                 : ((pk_valid || sk_valid) ? S_STREAM : S_REQ);
+                                                 : (pk_valid ? S_STREAM : S_REQ);
             S_SERVE_ADR: state <= S_SERVE;
 
             S_SERVE: begin
@@ -937,21 +694,24 @@ module mem_shim_burst #(
                     mem_res_wr_en  <= 1'b1;
                     sv_rd          <= sv_rd + 1'b1;
                     sv_n           <= sv_n - 1'b1;
-                    // more queued -> next serve; else hand off (S_STREAM if a held
-                    // command exists, else S_REQ).
+                    // more queued -> next serve; else hand off (S_STREAM if a peeked
+                    // command is held, else S_REQ).
                     state          <= (sv_n > 2'd1) ? S_SERVE_ADR
-                                                    : ((pk_valid || sk_valid) ? S_STREAM : S_REQ);
+                                                    : (pk_valid ? S_STREAM : S_REQ);
                 end
             end
 
             // =================================================================
-            // Single-beat write: wait for acceptance. On a write hit the cached
-            // word updates via the cache_data write port and the LRU touch
-            // commits via the lru_ram write port (both decoded on this accept).
+            // Single-beat write: wait for acceptance, then update the cached word
+            // on a write hit (write-through already sent the data to DDR).
             S_WR_CMD: begin
                 if (!ddr3_waitrequest) begin
                     ddr3_write <= 1'b0;
-                    state <= (pk_valid || sk_valid) ? S_STREAM : S_REQ;
+                    if (wr_is_hit) begin
+                        // (cached word updated via the single cache_data write port)
+                        lru_touch(cur_set, wr_way);
+                    end
+                    state <= S_REQ;
                 end
             end
             endcase
@@ -980,8 +740,8 @@ module mem_shim_burst #(
     // =========================================================================
     // Over each fixed 65536-cycle window (~0.73 ms @90 MHz) accumulate:
     //   tele_idle = cycles BLOCKED BY THE DECODER: the request FIFO is empty when
-    //               we want a command (S_REQ / streaming with no live source), OR
-    //               the response FIFO is full when we want to emit.
+    //               we want a command (S_REQ / S_RX-with-no-valid), OR the response
+    //               FIFO is full when we want to emit (S_HIT/S_SERVE & almost_full).
     //   tele_fill = cycles actively servicing a read MISS (burst fill + serve).
     // Latched at window end as 8-bit fractions (count>>8), packed {idle, fill}:
     //   high byte ~FF  => bridge is STARVED / back-pressured by the decoder
@@ -1024,9 +784,9 @@ module mem_shim_burst #(
     // = ambiguous. THIS row settles it. Per 65536-cycle window, classify every
     // READ access by outcome and report the MISS RATE:
     //   cm_hit  = a streamed read served straight from cache (S_STREAM Stage-B emit)
-    //   cm_miss = a read that had to launch a burst line-fill (the stage-A miss
-    //             verdict / fast fill entry, non-ADDR_ERR). ADDR_ERR sentinel
-    //             reads are excluded (not a real cache access).
+    //   cm_miss = a read that had to launch a burst line-fill (S_PROC CMD_READ,
+    //             non-ADDR_ERR). ADDR_ERR sentinel reads are excluded (not a real
+    //             cache access).
     // At window close, miss_pct = cm_miss*256/(cm_hit+cm_miss) via a small
     // restoring divider (runs in ~26 of the window's 65536 cycles), 8-bit
     // (0xFF ~= 100% miss). reads_hi = saturating top byte of (cm_hit+cm_miss) =
@@ -1039,8 +799,7 @@ module mem_shim_burst #(
     //                              => COMPUTE-bound; lever = decoder datapath.
     // See memory clock-lever-exhausted-matrix / current-clocks-levers-spent.
     wire cm_hit  = (state == S_STREAM) && !mem_res_wr_almost_full && pB_valid;
-    wire cm_miss = (state == S_STREAM) && !mem_res_wr_almost_full
-                 && sA_slow && pA_rd_miss;
+    wire cm_miss = (state == S_PROC)   && (cur_cmd == CMD_READ)    && !cur_aerr;
 
     reg [15:0] cm_win;
     reg [16:0] cm_hit_acc, cm_miss_acc;        // per-window counts (17b, saturating)
@@ -1103,7 +862,7 @@ module mem_shim_burst #(
         end
     end
 
-    assign debug_state            = state;           // 0..14 (2/4 retired)
+    assign debug_state            = state;           // 0..10
     assign debug_saved_cmd        = cur_cmd;
     assign debug_sdram_busy       = ddr3_waitrequest;
     assign debug_sdram_ack        = rd_accepted | wr_accepted;

--- a/bench/dvd/run_mem_shim.sh
+++ b/bench/dvd/run_mem_shim.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# run_mem_shim.sh — mem_shim_burst (DDR burst bridge + set-associative cache)
+# regression suite. One command for the whole verification ladder of the
+# tag/LRU-to-M10K rework (feature/mem-shim-tag-bram) and any later change to
+# the bridge:
+#   1. mem_shim_burst_tb   — functional chain test (in-order response checking,
+#                            coherence, ADDR_ERR, backpressure) across the four
+#                            {cwf,dual} toggle combos + off-default geometries.
+#   2. mem_shim_ab_tb      — the BIT-EXACT LRU gate: the live module vs the
+#                            frozen flop-tag reference (mem_shim_burst_ref.sv)
+#                            on one trace through independently-stalled rigs;
+#                            the accepted-burst sequences must be IDENTICAL
+#                            (same misses <=> same victims <=> same LRU state).
+#   3. cache_missrate_tb   — the {miss%, intensity} telemetry row.
+#   4. mem_shim_serialize_tb — the old mem_shim read-serializer guard (kept as
+#                            the ordering canary; unchanged by cache work).
+#   5. mem_addr_recon_vs_disp_tb — recon-write vs display-read address identity.
+#
+# Every result line is gated on "RESULT: PASS" (vvp exits 0 even on FAIL — the
+# M19 lesson), so a FAIL anywhere fails the script.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+rc=0
+run() {
+    local name=$1; shift
+    local defines=$1; shift
+    echo "== $name $defines =="
+    # shellcheck disable=SC2086
+    iverilog -g2012 $defines -o "bench/dvd/${name}_sim" "$@" "bench/dvd/${name}.sv"
+    local out
+    out="$(vvp "bench/dvd/${name}_sim")"
+    echo "$out" | tail -4
+    if ! echo "$out" | grep -q "RESULT: PASS\|RESULT: decode WRITE addr == display READ addr"; then
+        rc=1
+    fi
+}
+
+# 1. functional: default (cwf on, single-outstanding), dual, cwf-off, geometries
+run mem_shim_burst_tb ""                              dvd/mem_shim_burst.sv
+run mem_shim_burst_tb "-DMSB_DUAL=1"                  dvd/mem_shim_burst.sv
+run mem_shim_burst_tb "-DMSB_CWF=0 -DMSB_DUAL=1"      dvd/mem_shim_burst.sv
+run mem_shim_burst_tb "-DMSB_ASSOC=2"                 dvd/mem_shim_burst.sv
+run mem_shim_burst_tb "-DMSB_NSETS=128 -DMSB_DUAL=1"  dvd/mem_shim_burst.sv
+
+# 2. A/B decision-exactness vs the frozen flop-tag reference (all 4 combos)
+for d in "-DMSAB_CWF=1 -DMSAB_DUAL=1" "-DMSAB_CWF=1 -DMSAB_DUAL=0" \
+         "-DMSAB_CWF=0 -DMSAB_DUAL=1" "-DMSAB_CWF=0 -DMSAB_DUAL=0"; do
+    run mem_shim_ab_tb "$d" dvd/mem_shim_burst.sv bench/dvd/mem_shim_burst_ref.sv
+done
+
+# 3. telemetry
+run cache_missrate_tb "" dvd/mem_shim_burst.sv
+
+# 4./5. ordering canaries (unchanged modules)
+run mem_shim_serialize_tb "" dvd/mem_shim.sv
+run mem_addr_recon_vs_disp_tb "-D__IVERILOG__ -I rtl/mpeg2" rtl/mpeg2/mem_addr.v
+
+if [ $rc -eq 0 ]; then echo "RUN_MEM_SHIM: ALL SUITES PASSED";
+else echo "RUN_MEM_SHIM: FAILURES"; fi
+exit $rc

--- a/docs/history.md
+++ b/docs/history.md
@@ -321,7 +321,7 @@ escalation ladder stays documented for a future netlist that outgrows this margi
 2026-08-01 (PR fj#156, user report: "looks great")** — fringe gone, playback clean, S/PDIF
 unaffected (the pll_audio crossing false-pathed = stock framework semantics, as audited).
 
-## 11. mem_shim_burst tag/LRU store to M10K — the ALM congestion reclaim (2026-08-27, `feature/mem-shim-tag-bram`)
+## 11. mem_shim_burst tag/LRU store to M10K — the ALM congestion reclaim (MERGED, PR #18; ✅ HW-CONFIRMED 2026-08-28)
 
 **The motive.** After PR #17 the design sat at **98% ALM (41,202/41,910)** and the fit
 lottery was back despite §10's SDC fix: the D-pad branch needed a seed re-sweep, and the
@@ -382,8 +382,8 @@ ladder, PASS-grepped (the M19 vvp-exit-0 lesson).
   ledger entry (94.5/91.5) despite the whole-module rework. The reclaim's point —
   seed sweeps become rare again — holds on its first data point.
 
-**HW soak.** Required before merge — this is the shear-fix module and sim cannot prove
-hit-rate-under-real-traffic: long title playback (MiB full length), seek/chapter
-stress, menu stress, VCD raw mode, an explicit shear/artifact watch. Status: ⏳ soak
-pending as of 2026-08-28 (`releases/DVD_shimreclaim_20260828_0259.rbf` is the soak
-build); branch unmerged until it passes.
+**HW soak — ✅ PASSED 2026-08-28 (user report), merge gate cleared.** Required because
+this is the shear-fix module and sim cannot prove hit-rate-under-real-traffic. Soak on
+`releases/DVD_shimreclaim_20260828_0259.rbf`: the entire MiB movie played through plus
+menu/seek actions — no video issues, no shearing, no artifacting. Merged as PR #18
+(no release cut yet — rides with the next one; `` `CORE_VERSION `` 0.1e stays open).

--- a/docs/history.md
+++ b/docs/history.md
@@ -320,3 +320,70 @@ escalation ladder stays documented for a future netlist that outgrows this margi
 `releases/DVD_sdcgroups_sweep_20260801_1449.rbf` = the SEED-29 build. ✅ **HW-CONFIRMED
 2026-08-01 (PR fj#156, user report: "looks great")** — fringe gone, playback clean, S/PDIF
 unaffected (the pll_audio crossing false-pathed = stock framework semantics, as audited).
+
+## 11. mem_shim_burst tag/LRU store to M10K — the ALM congestion reclaim (2026-08-27, `feature/mem-shim-tag-bram`)
+
+**The motive.** After PR #17 the design sat at **98% ALM (41,202/41,910)** and the fit
+lottery was back despite §10's SDC fix: the D-pad branch needed a seed re-sweep, and the
+menu-link branch burned eleven failed seeds before a measured retime of framestore's
+mem_request_fifo write closed it (see the DVD.qsf seed ledger). The 2026-08-27
+per-entity fit report named the fish: `dvd/mem_shim_burst.sv` = **4,899 ALMs / 6,546
+registers**, third-largest block in the design, bigger than all of dvd_vm. The 32 KB
+cache DATA array was already M10K, but the tag/valid/LRU store was not: 12b × 128 sets ×
+4 ways of tag flops read through four parallel 128:1 async muxes, plus 2b × 512 LRU
+rank flops — the project's recurring LUT-RAM pattern (M19, parse_buf, iso-navigator)
+one more time. RAM headroom existed (503/553 M10K), and the whole tag+LRU store is
+under 8 kbit.
+
+**The design.** Tags and LRU ranks moved to two sync-read simple-dual-port M10Ks
+addressed BY SET (one read = all four ways' context); the valid bits stayed in flops
+(512 FFs — S_INIT invalidation and victim-invalidate-before-fill keep their
+reset-friendly semantics, since BRAM has no reset). The 1-cycle RAM latency is absorbed
+by growing the `S_STREAM` hit loop from two to **three overlapped stages** (present
+set → compare + present data address → emit): still 1 word/cycle, with command N+1's
+tag read overlapping command N's data read. Misses and writes issue their DDR
+transaction **directly from the compare-stage verdict cycle** (fast entry), so the
+miss/write path costs the same cycle count as the flop version (the TB's pure-miss
+meter actually improved, 26.0 → 25.0 cyc/resp). Geometry and policy untouched:
+NSETS=128 / ASSOC=4 / LINEW=8, true LRU.
+
+**Why it stays bit-exact** (the §-level invariant: hit rate IS the product — the
+direct-mapped predecessor sheared on real hardware):
+- Back-to-back same-set hits see current ranks through a **2-deep bypass** — the
+  stage-B touch being written that cycle, plus a last-write register covering the
+  M10K's undefined mixed-port read-during-write edge. Any colliding write is bypassed
+  by construction, so the undefined RAM value is never consumed.
+- Fills **read-modify-write whole set words from snapshots** captured at the miss
+  lookup — legal because nothing else writes that set in between (the stream is
+  drained; a paired slot B is a different set by rule). No byte-enables needed.
+- The dual peek costs 2 cycles now (`S_PEEK` latches + presents, new `S_PEEK2`
+  decides), and pairing is suppressed when the skid holds a command at fill entry (the
+  stream's pops are speculative now, and peeking the FIFO past a parked older command
+  would reorder). The un-paired miss lands later with an identical LRU view.
+
+**The gate.** New `bench/dvd/mem_shim_ab_tb.sv` runs the live module against a FROZEN
+copy of the flop-tag implementation (`bench/dvd/mem_shim_burst_ref.sv`, main @c223041)
+on one trace through two independently-random-stalled rigs, and requires the
+accepted-burst-address sequences to be **identical** (same misses ⇔ same victims ⇔ same
+LRU state). All four {cwf,dual} combos: 1,351 identical misses, every response checked
+against a reference memory. `mem_shim_burst_tb` unchanged across five config sweeps
+(pure-hit throughput still 1.0 cyc/resp). `bench/dvd/run_mem_shim.sh` bundles the
+ladder, PASS-grepped (the M19 vvp-exit-0 lesson).
+
+**Numbers** (build `DVD_shimreclaim_20260828_0259.rbf`, pinned SEED 5, FIRST roll):
+- Module: 4,899 ALMs / 6,546 registers → **~1,406 ALMs / 1,028 registers** (−3.5k
+  ALMs, −5.5k FFs in-module); +3 M10K (2× tag 128×48, 1× LRU 128×8), all three
+  stores altsyncram-inferred (checked in the fit report — the resurrected-RAM
+  lesson from D-pad seek cuts both ways).
+- Design: **41,202 ALMs (98%) → 36,341 (87%)** = −4,861 ALMs of placement pressure
+  (beats the −3–4k target); RAM 503 → 506 / 553 M10K; DSPs unchanged.
+- Timing: clk_dec **93.73 MHz @100C / 90.33 @−40C** (gate 86.0) — the pinned SEED 5
+  passed on the first roll, no sweep needed, margin comparable to the menu-link
+  ledger entry (94.5/91.5) despite the whole-module rework. The reclaim's point —
+  seed sweeps become rare again — holds on its first data point.
+
+**HW soak.** Required before merge — this is the shear-fix module and sim cannot prove
+hit-rate-under-real-traffic: long title playback (MiB full length), seek/chapter
+stress, menu stress, VCD raw mode, an explicit shear/artifact watch. Status: ⏳ soak
+pending as of 2026-08-28 (`releases/DVD_shimreclaim_20260828_0259.rbf` is the soak
+build); branch unmerged until it passes.

--- a/dvd/mem_shim_burst.sv
+++ b/dvd/mem_shim_burst.sv
@@ -228,11 +228,14 @@ module mem_shim_burst #(
     // line + queues a fallback serve. The case statement only ISSUES bursts and
     // sequences A->peek->B. Responses stay strictly in order. A non-pairable peek is
     // stashed in pk_* and processed by S_STREAM after the fill, so no command is lost.
-    // NOTE (BRAM-tag rework): the peek costs 2 cycles now (present set / decide),
-    // and pairing is SUPPRESSED when the skid holds a command at fill entry — the
-    // skid command is OLDER than the FIFO head, so peeking the FIFO there would
-    // reorder. Decisions are unaffected: the un-paired B misses later through the
-    // stream with an identical LRU view (A and B are different sets by rule).
+    // NOTE (BRAM-tag rework): the stream's pops are SPECULATIVE, so at fill entry
+    // the next command usually sits in the SKID already (parked on the miss-exit
+    // cycle) — that skid command IS the peek candidate then (its set has been on
+    // the tag-RAM address since the exit cycle, so S_FILL_CMD goes straight to
+    // S_PEEK2); only an empty skid pops the FIFO for a candidate (S_PEEK latches
+    // it into pk_*). sk and pk are therefore mutually exclusive. A non-pairable
+    // candidate simply STAYS in its hold register for S_STREAM to process in
+    // order — no command is ever lost or reordered.
     reg        dual_en_q;
     reg [SET_W-1:0]  ifb_set;    // slot B (2nd burst) line set
     reg [ASW-1:0]    ifb_way;    // slot B victim way (chosen from B's set; set != A's)
@@ -247,11 +250,19 @@ module mem_shim_burst #(
     reg  [1:0] pk_cmd;
     reg [21:0] pk_addr;
     reg [63:0] pk_dta;
-    wire [LOFF_W-1:0] pk_off  = pk_addr[LOFF_W-1:0];
-    wire [SET_W-1:0]  pk_set  = pk_addr[LOFF_W +: SET_W];
-    wire [TAG_W-1:0]  pk_tag  = pk_addr[LOFF_W+SET_W +: TAG_W];
-    wire              pk_aerr = (pk_addr == ADDR_ERR);
-    wire [21:0] pk_line_base  = {pk_addr[21:LOFF_W], {LOFF_W{1'b0}}};
+    // Pair-candidate mux for S_PEEK2: the skid command when it holds one (the
+    // common case — the speculative pop parked the next command there on the
+    // miss-exit cycle), else the S_PEEK-latched pk. Mutually exclusive by
+    // construction (S_PEEK is only entered with an empty skid; the skid only
+    // loads while streaming).
+    wire        cand_is_sk = sk_valid;
+    wire [1:0]  cand_cmd  = sk_valid ? sk_cmd  : pk_cmd;
+    wire [21:0] cand_addr = sk_valid ? sk_addr : pk_addr;
+    wire [LOFF_W-1:0] cand_off  = cand_addr[LOFF_W-1:0];
+    wire [SET_W-1:0]  cand_set  = cand_addr[LOFF_W +: SET_W];
+    wire [TAG_W-1:0]  cand_tag  = cand_addr[LOFF_W+SET_W +: TAG_W];
+    wire              cand_aerr = (cand_addr == ADDR_ERR);
+    wire [21:0] cand_line_base  = {cand_addr[21:LOFF_W], {LOFF_W{1'b0}}};
     // fallback serve queue (depth 2): words whose cwf early-serve didn't fire.
     reg [SET_W-1:0]  sv_set [0:1];
     reg [ASW-1:0]    sv_way [0:1];
@@ -341,8 +352,8 @@ module mem_shim_burst #(
     // Inputs: stage A's command while streaming, the peeked command in S_PEEK2.
     // (S_PROC never uses this block — it runs on the snap_* snapshot registers.)
     wire              peek_cmp  = (state == S_PEEK2);
-    wire [TAG_W-1:0]  cmp_tag   = peek_cmp ? pk_tag : pA_tag;
-    wire [SET_W-1:0]  cmp_set   = peek_cmp ? pk_set : pA_set;
+    wire [TAG_W-1:0]  cmp_tag   = peek_cmp ? cand_tag : pA_tag;
+    wire [SET_W-1:0]  cmp_set   = peek_cmp ? cand_set : pA_set;
     wire [LRUV_W-1:0] cmp_lru   = peek_cmp ? lru_rd : lru_eff;
     wire [ASSOC-1:0]  cmp_valid = cache_valid[cmp_set];
 
@@ -849,13 +860,17 @@ module mem_shim_burst #(
             // =================================================================
             // Burst read (slot A): wait for command acceptance. Beats (incl. a same-
             // cycle accept+data) are collected by the centralized COLLECT block above.
-            // On accept: in DUAL mode go peek the next command for a pair (rd_en was
-            // pulsed combinationally this cycle — suppressed if the skid holds an
-            // older command); else collect normally.
+            // On accept, in DUAL mode: if the skid already holds the next command
+            // (the speculative pop parked it on the miss-exit cycle) its set word
+            // has been on the tag-RAM address since the exit — decide DIRECTLY in
+            // S_PEEK2; else pop the FIFO for a candidate (rd_en was pulsed
+            // combinationally this cycle) and latch it in S_PEEK first.
             S_FILL_CMD: begin
                 if (!ddr3_waitrequest) begin
                     ddr3_read <= 1'b0;
-                    state     <= (dual_en_q && !sk_valid) ? S_PEEK : S_FILL_DAT;
+                    state     <= !dual_en_q ? S_FILL_DAT
+                               : sk_valid   ? S_PEEK2
+                               :              S_PEEK;
                 end
             end
 
@@ -877,31 +892,32 @@ module mem_shim_burst #(
             end
 
             // =================================================================
-            // DUAL: the peeked command's set word is on tag_rd/lru_rd. Pair it as
-            // burst B iff it is a READ MISS to a DIFFERENT set (so its victim
-            // can't collide with A's in-flight way; also guarantees A's validate
-            // never writes B's set word between B's snapshot and B's validate).
-            // Otherwise keep it held in pk_* for S_STREAM to process in order and
-            // fall back to a single A fill.
+            // DUAL: the candidate's (skid- or pk-held) set word is on
+            // tag_rd/lru_rd. Pair it as burst B iff it is a READ MISS to a
+            // DIFFERENT set (so its victim can't collide with A's in-flight way;
+            // also guarantees A's validate never writes B's set word between B's
+            // snapshot and B's validate). Otherwise it stays in its hold register
+            // for S_STREAM to process in order; single A fill.
             S_PEEK2: begin
-                if ((pk_cmd == CMD_READ) && !hit_c && !pk_aerr && (pk_set != cur_set)) begin
-                    ifb_set    <= pk_set;
+                if ((cand_cmd == CMD_READ) && !hit_c && !cand_aerr && (cand_set != cur_set)) begin
+                    ifb_set    <= cand_set;
                     ifb_way    <= victim_c;
-                    ifb_off    <= pk_off;
-                    ifb_tag    <= pk_tag;
-                    cache_valid[pk_set][victim_c] <= 1'b0;     // invalidate B's victim
+                    ifb_off    <= cand_off;
+                    ifb_tag    <= cand_tag;
+                    cache_valid[cand_set][victim_c] <= 1'b0;   // invalidate B's victim
                     fillB_tags <= tag_rd;                      // B's validate RMW base
                     fillB_lru  <= lru_rd;
                     served_b   <= 1'b0;
                     pairing    <= 1'b1;
-                    pk_valid   <= 1'b0;
+                    if (cand_is_sk) sk_valid <= 1'b0;          // candidate consumed
+                    else            pk_valid <= 1'b0;
                     // issue burst B now (A is already accepted / in flight)
-                    ddr3_addr     <= {7'b0011000, pk_line_base};
+                    ddr3_addr     <= {7'b0011000, cand_line_base};
                     ddr3_burstcnt <= LINEW[7:0];
                     ddr3_read     <= 1'b1;
                     state         <= S_ISSUE2;
                 end else begin
-                    state <= S_FILL_DAT;                       // pk stays held, single A
+                    state <= S_FILL_DAT;                       // candidate stays held
                 end
             end
 


### PR DESCRIPTION
## Summary

The designated congestion-relief project: `dvd/mem_shim_burst.sv`'s tag/valid/LRU store
(12b × 128 sets × 4 ways of tag flops + 2b × 512 LRU rank flops behind per-set 128:1
async muxes — 4,899 ALMs, the third-largest block in the design) moves into two
sync-read M10Ks. Valid bits stay in flops so S_INIT invalidation and
victim-invalidate-before-fill keep their reset-friendly semantics.

- The `S_STREAM` hit loop grows to three overlapped stages (present set → compare +
  present data address → emit): still **1 word/cycle**, tag read of command N+1
  overlapped with data read of command N.
- Misses and writes issue their DDR transaction directly from the verdict cycle (fast
  entry) — miss/write cycle counts match the flop version (TB pure-miss meter improved
  26.0 → 25.0 cyc/resp).
- **Replacement stays true LRU, bit-exact**: 2-deep rank bypass for same-set
  back-to-back hits (M10K mixed-port read-during-write is undefined → any colliding
  write is bypassed by construction); fills RMW whole set-words from snapshots captured
  at the miss lookup.
- Dual pairing preserved under the new speculative-pop skid: the skid command is the
  pairing candidate (a first cut silently killed pairing — caught by a coverage probe,
  fixed, and now tripwired in the A/B TB).

**Fit** (build `DVD_shimreclaim_20260828_0259.rbf`, pinned SEED 5, first roll):
module 4,899 → ~1,406 ALMs (6,546 → 1,028 regs, +3 M10K, all altsyncram-inferred);
**design 41,202 ALMs (98%) → 36,341 (87%)**; clk_dec 93.73 @100C / 90.33 @−40C
(gate 86.0). The point of the reclaim — seed sweeps become rare again — holds on its
first data point.

Detail: `docs/history.md` §11.

## Test plan

- [x] `bench/dvd/mem_shim_ab_tb.sv` (new): live module vs FROZEN flop-tag reference on
      one trace, independently-stalled + supply-gapped rigs — accepted-burst sequences
      IDENTICAL (1,351 misses) in all four {cwf,dual} combos; pairing-alive tripwire
      (NEW 207 vs REF 194 pairs); every response checked against a reference memory
- [x] `mem_shim_burst_tb` unchanged across five config sweeps (default, dual, cwf-off,
      ASSOC=2, NSETS=128) — pure-hit throughput still 1.0 cyc/resp
- [x] `cache_missrate_tb` (cwf/dual ports now tied off — latent X-resolution luck),
      `mem_shim_serialize_tb`, `mem_addr_recon_vs_disp_tb` green
- [x] `bench/dvd/run_mem_shim.sh` bundles the ladder, PASS-grepped
- [x] Fit gate: clk_dec ≥ 86 MHz both slow corners, ALM back to 87%
- [x] **HW soak** (shear-fix module — sim cannot prove hit-rate-under-real-traffic):
      full-length MiB playback + menu/seek stress, VCD raw mode — no video issues, no
      shearing, no artifacting (user-confirmed 2026-08-28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
