### PR TITLE
Fix mid-play file-load A/V desync: mount flush trio + decoder soft reset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,8 +158,10 @@ worse maintenance burden than targeted in-place edits. So:
 
 ## Hardware status (THIS fork, verified 2026-06-21)
 
-- 🔧 **MID-PLAY LOAD A/V DESYNC — FIXED IN FABRIC (2026-08-28, branch
-  `fix/mount-avsync-flush`); ⏳ HW-confirm pending. The companion FILM-ENGAGE flush was
+- ✅ **MID-PLAY LOAD A/V DESYNC — FIXED IN FABRIC; ✅ HW-CONFIRMED 2026-08-28 (user
+  report: mid-play loads across VOB/mpg/ISO/VCD cut to black, start clean, hold sync;
+  T2 logo chain clean; seeks/menus/cold mount unregressed; build
+  `DVD_mountflush2_20260828_1537.rbf`). The companion FILM-ENGAGE flush was
   attempted and ⛔ REVERTED after a T2 HW regression — that skew stays OPEN, owned by
   the planned early-film-detect feature.** The rule both bugs share: a playback
   discontinuity needs the FULL FLUSH TRIO (seek/vbuf + load + aud) or audio phases

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,27 +158,31 @@ worse maintenance burden than targeted in-place edits. So:
 
 ## Hardware status (THIS fork, verified 2026-06-21)
 
-- 🔧 **MID-PLAY LOAD + FILM-ENGAGE A/V DESYNC — FIXED IN FABRIC (2026-08-28, branch
-  `fix/mount-avsync-flush`); ⏳ HW-confirm pending.** Two same-family bugs, one rule:
-  a playback discontinuity needs the FULL FLUSH TRIO (seek/vbuf + load + aud) or audio
-  phases against the wrong video timeline. (1) **Mount:** loading a new file mid-play
+- 🔧 **MID-PLAY LOAD A/V DESYNC — FIXED IN FABRIC (2026-08-28, branch
+  `fix/mount-avsync-flush`); ⏳ HW-confirm pending. The companion FILM-ENGAGE flush was
+  attempted and ⛔ REVERTED after a T2 HW regression — that skew stays OPEN, owned by
+  the planned early-film-detect feature.** The rule both bugs share: a playback
+  discontinuity needs the FULL FLUSH TRIO (seek/vbuf + load + aud) or audio phases
+  against the wrong video timeline. **Mount fix (kept):** loading a new file mid-play
   fired load_flush + aud_flush but NOT the VBUF flush — the old "Seek-only; clip-load
   path untouched" exclusion predated the lip-sync v5 video_live re-arm, which turned
   the surviving 0.5–2 MB old-file VBUF into a PERMANENT audio lead (STC anchors on the
   new file, governor displays old frames; forward skew < 15 s never re-anchors; only a
   core reload avoided it). `start_streaming` now fires the trio, keep_vbuf-ungated.
-  (2) **Film switch:** `Film 24p Out = Auto` engaging ~2 s into a menu→feature entry
-  switched raster + STC rate with NO flush (`il_switch` watches only il_eff) — the
-  user-reported "skew entering the film, chapter-skip fixes it". New `film_switch`
-  (filmp_eff XOR edge, both directions, `~menu_active`-gated) ORs with il_switch into
-  `mode_switch` → the trio; trade = a brief seek-like re-lock at engage (README now
-  says it's normal; discs flipping film↔video constantly may prefer Off). Also:
-  flush glue EXTRACTED to `dvd/flush_ctl.sv` + `bench/dvd/flush_ctl_tb.sv` locks the
-  11-row trigger matrix (proven RED against the pre-fix logic); `frame_drop_ctl` debt
-  now clears on `flush_vbuf_eff` (carried-in stale debt could fire spurious B-drops
-  post-seek/mount). Post-mortem + deferred items (detector re-arm, vidfeed_cdc):
-  `docs/av_sync.md` "Mid-play mount desync post-mortem"; film side:
-  `docs/film_24p_plan.md` §13.
+  **Film-switch attempt (reverted):** a bare `filmp_eff` XOR edge into `mode_switch`
+  broke T2's menu→Play Dolby/THX logo chain — the logos flap the detector, each flap
+  flushed at an arbitrary mid-stream position (no reader jump = no VOBU re-alignment),
+  garbage seq headers (186-wide popups) flipped pal_eff (25 Hz) which feeds back into
+  film_want = a self-feeding corruption/strobe loop. ⚠ il_switch's fire-on-edge
+  pattern is only safe for ~once/title signals; a filmp edge oscillates and the flush
+  perturbs the parse the detector feeds on. Full post-mortem + the reintroduction
+  requirements (hold-suppression + holdoff, T2 logo chain as HW gate):
+  `docs/film_24p_plan.md` §13. Also shipped: flush glue EXTRACTED to
+  `dvd/flush_ctl.sv` + `bench/dvd/flush_ctl_tb.sv` locks the 11-row trigger matrix
+  (proven RED against the pre-fix logic); `frame_drop_ctl` debt now clears on
+  `flush_vbuf_eff` (carried-in stale debt could fire spurious B-drops post-seek/mount).
+  Post-mortem + deferred items (detector re-arm, vidfeed_cdc): `docs/av_sync.md`
+  "Mid-play mount desync post-mortem".
 - ✅ **MEM_SHIM_BURST TAG/LRU STORE → M10K — the ALM congestion reclaim (2026-08-27,
   PR #18) — ✅ HW-CONFIRMED 2026-08-28 (user soak: full-length MiB + menu/seek stress,
   no shear/artifacting; build `DVD_shimreclaim_20260828_0259.rbf`).**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,27 @@ worse maintenance burden than targeted in-place edits. So:
 
 ## Hardware status (THIS fork, verified 2026-06-21)
 
+- 🔧 **MID-PLAY LOAD + FILM-ENGAGE A/V DESYNC — FIXED IN FABRIC (2026-08-28, branch
+  `fix/mount-avsync-flush`); ⏳ HW-confirm pending.** Two same-family bugs, one rule:
+  a playback discontinuity needs the FULL FLUSH TRIO (seek/vbuf + load + aud) or audio
+  phases against the wrong video timeline. (1) **Mount:** loading a new file mid-play
+  fired load_flush + aud_flush but NOT the VBUF flush — the old "Seek-only; clip-load
+  path untouched" exclusion predated the lip-sync v5 video_live re-arm, which turned
+  the surviving 0.5–2 MB old-file VBUF into a PERMANENT audio lead (STC anchors on the
+  new file, governor displays old frames; forward skew < 15 s never re-anchors; only a
+  core reload avoided it). `start_streaming` now fires the trio, keep_vbuf-ungated.
+  (2) **Film switch:** `Film 24p Out = Auto` engaging ~2 s into a menu→feature entry
+  switched raster + STC rate with NO flush (`il_switch` watches only il_eff) — the
+  user-reported "skew entering the film, chapter-skip fixes it". New `film_switch`
+  (filmp_eff XOR edge, both directions, `~menu_active`-gated) ORs with il_switch into
+  `mode_switch` → the trio; trade = a brief seek-like re-lock at engage (README now
+  says it's normal; discs flipping film↔video constantly may prefer Off). Also:
+  flush glue EXTRACTED to `dvd/flush_ctl.sv` + `bench/dvd/flush_ctl_tb.sv` locks the
+  11-row trigger matrix (proven RED against the pre-fix logic); `frame_drop_ctl` debt
+  now clears on `flush_vbuf_eff` (carried-in stale debt could fire spurious B-drops
+  post-seek/mount). Post-mortem + deferred items (detector re-arm, vidfeed_cdc):
+  `docs/av_sync.md` "Mid-play mount desync post-mortem"; film side:
+  `docs/film_24p_plan.md` §13.
 - ✅ **MEM_SHIM_BURST TAG/LRU STORE → M10K — the ALM congestion reclaim (2026-08-27,
   PR #18) — ✅ HW-CONFIRMED 2026-08-28 (user soak: full-length MiB + menu/seek stress,
   no shear/artifacting; build `DVD_shimreclaim_20260828_0259.rbf`).**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,15 @@ worse maintenance burden than targeted in-place edits. So:
   `dvd/flush_ctl.sv` + `bench/dvd/flush_ctl_tb.sv` locks the 11-row trigger matrix
   (proven RED against the pre-fix logic); `frame_drop_ctl` debt now clears on
   `flush_vbuf_eff` (carried-in stale debt could fire spurious B-drops post-seek/mount).
+  **Mount decoder SOFT RESET (same branch, follow-up HW round):** the trio flushes
+  BUFFERS only — the decode pipeline (vld in-flight picture, reference frames, picbuf)
+  survives on sync_rst by upstream design, so a flat-file load showed MACROBLOCK
+  GARBAGE (truncated picture + new file's open-GOP B-frames motion-compensated against
+  the OLD file's references; DVD first cells are closed-GOP which is why ISOs looked
+  better). Fix: `flush_ctl.mount_flush` (mount ONLY, never seeks — those need display
+  continuity) → `mpeg2video.soft_flush` → new `reset.soft_rst_n` leg = the exact
+  watchdog-expiry soft reset (regfile/modeline on hard_rst SURVIVE — the HW-proven
+  recovery path); a warm load now cuts to black and starts as cold as a core reload.
   Post-mortem + deferred items (detector re-arm, vidfeed_cdc): `docs/av_sync.md`
   "Mid-play mount desync post-mortem".
 - ✅ **MEM_SHIM_BURST TAG/LRU STORE → M10K — the ALM congestion reclaim (2026-08-27,

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -70,6 +70,9 @@ set_global_assignment -name SYSTEMVERILOG_FILE dvd/lpcm_unpack.sv
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/spdif_pass.sv
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/iec61937_wrap.sv
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/av_sync.sv
+# Flush/reset trigger matrix (extracted from emu.sv 2026-08-28 for TB coverage of
+# the mount/seek/jump/mode_switch flush trio). See bench/dvd/flush_ctl_tb.sv.
+set_global_assignment -name SYSTEMVERILOG_FILE dvd/flush_ctl.sv
 # Reference-read run-ahead prefetch (O[18]): single-bitstream A/B gate for the deepened
 # fwd/bwd motion-comp reference data fifos. See dvd/ref_dta_gate.sv / docs/motcomp_throughput.md.
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/ref_dta_gate.sv

--- a/README.md
+++ b/README.md
@@ -220,6 +220,13 @@ Notes:
   and does nothing without it.
 - **`A/V Offset` defaults to +100 ms**, which is the correct null for NTSC film and also
   measures correctly on PAL. There should be no need to change it.
+- **A brief re-lock hiccup when the film mode engages or disengages is normal.** When
+  Auto detects film a couple of seconds into a title (or drops back at a film→video
+  content change), the core performs a seek-equivalent re-sync so audio and video stay
+  locked through the raster switch — the picture skips forward for a moment, exactly
+  like a chapter jump. On discs that switch between film and video content frequently
+  (some episodic or extras-heavy discs), the repeated re-locks can be more distracting
+  than the cadence win — set `Film 24p Out` to **Off** for those.
 - If the analog CRT raster is active, the film raster is suppressed — the re-interlacer
   needs the standard progressive raster to work from.
 

--- a/README.md
+++ b/README.md
@@ -220,13 +220,9 @@ Notes:
   and does nothing without it.
 - **`A/V Offset` defaults to +100 ms**, which is the correct null for NTSC film and also
   measures correctly on PAL. There should be no need to change it.
-- **A brief re-lock hiccup when the film mode engages or disengages is normal.** When
-  Auto detects film a couple of seconds into a title (or drops back at a film→video
-  content change), the core performs a seek-equivalent re-sync so audio and video stay
-  locked through the raster switch — the picture skips forward for a moment, exactly
-  like a chapter jump. On discs that switch between film and video content frequently
-  (some episodic or extras-heavy discs), the repeated re-locks can be more distracting
-  than the cadence win — set `Film 24p Out` to **Off** for those.
+- When Auto engages a couple of seconds into a title, the audio can end up slightly
+  offset until the next seek re-syncs it — a chapter jump (or a D-pad seek) clears it.
+  A proper fix (detecting film before the first frame is shown) is planned.
 - If the analog CRT raster is active, the film raster is suppressed — the re-interlacer
   needs the standard progressive raster to work from.
 

--- a/bench/dvd/cadence_phase_tb.sv
+++ b/bench/dvd/cadence_phase_tb.sv
@@ -79,7 +79,7 @@ module cadence_phase_tb;
   wire [4:0]  debt;
   frame_drop_ctl #(.DROP_THRESHOLD(2), .DEBT_MAX(15)) dut (
     .clk(clk), .clk_en(1'b1), .rst(rst_n),
-    .enable(1'b1), .bitstream_ok(1'b1),
+    .enable(1'b1), .bitstream_ok(1'b1), .flush(1'b0),
     .frame_late(frame_late), .drop_ack(drop_ack), .drop_cost(drop_cost),
     .drop_req(drop_req),
     .frames_late_cnt(flate_cnt), .frames_dropped_cnt(fdrop_cnt), .debt_out(debt)

--- a/bench/dvd/film_drift_tb.sv
+++ b/bench/dvd/film_drift_tb.sv
@@ -89,7 +89,7 @@ module film_drift_tb;
   wire [4:0]  debt;
   frame_drop_ctl #(.DROP_THRESHOLD(2), .DEBT_MAX(15)) dut (
     .clk(clk), .clk_en(1'b1), .rst(rst_n),
-    .enable(enable), .bitstream_ok(1'b1),
+    .enable(enable), .bitstream_ok(1'b1), .flush(1'b0),
     .frame_late(frame_late), .drop_ack(drop_ack), .drop_cost(drop_cost),
     .drop_req(drop_req),
     .frames_late_cnt(flate_cnt), .frames_dropped_cnt(fdrop_cnt), .debt_out(debt)

--- a/bench/dvd/flush_ctl_tb.sv
+++ b/bench/dvd/flush_ctl_tb.sv
@@ -163,14 +163,14 @@ module flush_ctl_tb;
     check_row(1, 0, 0, 0, "[6] keep_vbuf seek must fire load only");
     keep_vbuf = 0;
 
-    // [7] raster-regime switch (il_switch engage OR film_switch engage) -> all
+    // [7] raster-regime switch (mode_switch, today il_switch) -> all
     //     three (the il_switch full re-sync rule)
     mode_switch = 1;
     fork pulse_and_measure; begin @(posedge clk); mode_switch <= 0; end join
     check_row(1, 1, 1, 0, "[7] mode_switch engage must fire load+aud+seek");
 
-    // [8] raster-regime switch, other direction (film DISENGAGE mid-title,
-    //     film->video content — same XOR edge, same trio; user-asked 2026-08-28)
+    // [8] a second mode_switch pulse (e.g. the opposite-direction edge) fires
+    //     the same trio again — the counters re-arm cleanly back-to-back
     mode_switch = 1;
     fork pulse_and_measure; begin @(posedge clk); mode_switch <= 0; end join
     check_row(1, 1, 1, 0, "[8] mode_switch disengage must fire load+aud+seek");

--- a/bench/dvd/flush_ctl_tb.sv
+++ b/bench/dvd/flush_ctl_tb.sv
@@ -1,0 +1,211 @@
+`timescale 1ns/1ps
+//
+// flush_ctl_tb.sv — trigger-matrix testbench for dvd/flush_ctl.sv.
+//
+// The flush glue decides which of the three pipeline resets fire on each
+// playback event. It lived inline in emu.sv with NO sim coverage, and the
+// mid-play mount A/V-desync bug (2026-08-28) lived exactly there: a mount
+// fired load_flush + aud_flush but NOT seek_flush, so the decoder played the
+// OLD file's buffered VBUF tail against the NEW file's STC anchor — a
+// permanent audio lead only a core reload avoided. This TB locks the matrix:
+//
+//   event                                  load  aud   seek  aud_resync
+//   start_streaming (mount)                 x     x     x        -
+//   start_streaming with keep_vbuf=1        x     x     x        -   (ungated!)
+//   seek_ack / jump_ack, keep_vbuf=0        x     x     x        -
+//   seek_ack / jump_ack, keep_vbuf=1        x     -     -        -   (menu hop)
+//   mode_switch (interlace/film raster)     x     x     x        -
+//   aud_switch (audio track)                -     -     -        x
+//
+// Plus: reset clears everything; every flush level is exactly 64 cycles;
+// pipe_rst_n = rst_n & ~load_flush; aud_rst_n = rst_n & ~aud_flush & ~aud_resync.
+//
+// Build:
+//   iverilog -g2012 -o bench/dvd/flush_ctl_sim \
+//       dvd/flush_ctl.sv bench/dvd/flush_ctl_tb.sv
+//   vvp bench/dvd/flush_ctl_sim
+//
+module flush_ctl_tb;
+
+  reg  clk = 0;
+  reg  rst_n = 0;
+  reg  start_streaming = 0, seek_ack = 0, jump_ack = 0;
+  reg  mode_switch = 0, aud_switch = 0, keep_vbuf = 0;
+  wire load_flush, aud_flush, aud_resync, seek_flush;
+  wire pipe_rst_n, aud_rst_n;
+
+  flush_ctl dut (
+    .clk             (clk),
+    .rst_n           (rst_n),
+    .start_streaming (start_streaming),
+    .seek_ack        (seek_ack),
+    .jump_ack        (jump_ack),
+    .mode_switch     (mode_switch),
+    .aud_switch      (aud_switch),
+    .keep_vbuf       (keep_vbuf),
+    .load_flush      (load_flush),
+    .aud_flush       (aud_flush),
+    .aud_resync      (aud_resync),
+    .seek_flush      (seek_flush),
+    .pipe_rst_n      (pipe_rst_n),
+    .aud_rst_n       (aud_rst_n)
+  );
+
+  always #10 clk = ~clk;             // 50 MHz-ish; frequency is irrelevant
+
+  integer errors = 0;
+  integer n_load, n_aud, n_seek, n_resync;
+
+  task fail(input [8*64-1:0] msg);
+    begin
+      errors = errors + 1;
+      $display("FAIL: %0s (t=%0t)", msg, $time);
+    end
+  endtask
+
+  // Expect all four outputs idle.
+  task expect_idle(input [8*64-1:0] ctx);
+    begin
+      if (load_flush || aud_flush || seek_flush || aud_resync) begin
+        $display("  state: load=%b aud=%b seek=%b resync=%b", load_flush, aud_flush, seek_flush, aud_resync);
+        fail(ctx);
+      end
+      if (!pipe_rst_n || !aud_rst_n) fail("rst_n outputs not idle-high");
+    end
+  endtask
+
+  // Pulse one event for exactly one cycle, then measure how many cycles each
+  // flush output stays high (counted until all four are low again).
+  task pulse_and_measure;
+    begin
+      n_load = 0; n_aud = 0; n_seek = 0; n_resync = 0;
+      @(posedge clk);   // event registered here
+      // event inputs are cleared by the caller right after this task starts;
+      // count the level durations
+      begin : count
+        integer guard;
+        guard = 0;
+        forever begin
+          @(posedge clk);
+          if (load_flush)  n_load   = n_load   + 1;
+          if (aud_flush)   n_aud    = n_aud    + 1;
+          if (seek_flush)  n_seek   = n_seek   + 1;
+          if (aud_resync)  n_resync = n_resync + 1;
+          // reset-derivation invariants hold on every cycle
+          if (pipe_rst_n !== (rst_n & ~load_flush))               fail("pipe_rst_n derivation");
+          if (aud_rst_n  !== (rst_n & ~aud_flush & ~aud_resync))  fail("aud_rst_n derivation");
+          if (!load_flush && !aud_flush && !seek_flush && !aud_resync) disable count;
+          guard = guard + 1;
+          if (guard > 300) begin fail("flush level never released"); disable count; end
+        end
+      end
+    end
+  endtask
+
+  // One matrix row: fire the event, check which outputs pulsed and that every
+  // active output held exactly 64 cycles.
+  task check_row(input integer e_load, input integer e_aud,
+                 input integer e_seek, input integer e_resync,
+                 input [8*64-1:0] ctx);
+    begin
+      if ((e_load   ? n_load   != 64 : n_load   != 0) ||
+          (e_aud    ? n_aud    != 64 : n_aud    != 0) ||
+          (e_seek   ? n_seek   != 64 : n_seek   != 0) ||
+          (e_resync ? n_resync != 64 : n_resync != 0)) begin
+        $display("  got load=%0d aud=%0d seek=%0d resync=%0d, want %0d/%0d/%0d/%0d x64",
+                 n_load, n_aud, n_seek, n_resync, e_load, e_aud, e_seek, e_resync);
+        fail(ctx);
+      end
+    end
+  endtask
+
+  initial begin
+    // ---- reset ----
+    repeat (4) @(posedge clk);
+    rst_n = 1;
+    repeat (2) @(posedge clk);
+    expect_idle("outputs not idle after reset release");
+
+    // [1] mount -> ALL THREE flushes (THE 2026-08-28 BUG: pre-fix, seek_flush
+    //     stayed 0 here and the old file's VBUF survived into the new file)
+    start_streaming = 1;
+    fork pulse_and_measure; begin @(posedge clk); start_streaming <= 0; end join
+    check_row(1, 1, 1, 0, "[1] mount must fire load+aud+seek");
+
+    // [2] mount with keep_vbuf=1 held (stale level from a previous menu hop)
+    //     -> STILL all three (the mount terms are ungated by keep_vbuf)
+    keep_vbuf = 1;
+    start_streaming = 1;
+    fork pulse_and_measure; begin @(posedge clk); start_streaming <= 0; end join
+    check_row(1, 1, 1, 0, "[2] mount under keep_vbuf must fire load+aud+seek");
+    keep_vbuf = 0;
+
+    // [3] title seek (keep_vbuf=0) -> all three
+    seek_ack = 1;
+    fork pulse_and_measure; begin @(posedge clk); seek_ack <= 0; end join
+    check_row(1, 1, 1, 0, "[3] title seek must fire load+aud+seek");
+
+    // [4] VM jump (keep_vbuf=0, e.g. menu->title Play) -> all three
+    jump_ack = 1;
+    fork pulse_and_measure; begin @(posedge clk); jump_ack <= 0; end join
+    check_row(1, 1, 1, 0, "[4] ~keep_vbuf jump must fire load+aud+seek");
+
+    // [5] menu->menu jump (keep_vbuf=1) -> load_flush ONLY (video tail plays
+    //     out, audio rides through: docs/dvd_menu_refinements.md sec.2/5d)
+    keep_vbuf = 1;
+    jump_ack = 1;
+    fork pulse_and_measure; begin @(posedge clk); jump_ack <= 0; end join
+    check_row(1, 0, 0, 0, "[5] keep_vbuf jump must fire load only");
+
+    // [6] menu-internal seek (keep_vbuf=1) -> load_flush only
+    seek_ack = 1;
+    fork pulse_and_measure; begin @(posedge clk); seek_ack <= 0; end join
+    check_row(1, 0, 0, 0, "[6] keep_vbuf seek must fire load only");
+    keep_vbuf = 0;
+
+    // [7] raster-regime switch (il_switch engage OR film_switch engage) -> all
+    //     three (the il_switch full re-sync rule)
+    mode_switch = 1;
+    fork pulse_and_measure; begin @(posedge clk); mode_switch <= 0; end join
+    check_row(1, 1, 1, 0, "[7] mode_switch engage must fire load+aud+seek");
+
+    // [8] raster-regime switch, other direction (film DISENGAGE mid-title,
+    //     film->video content — same XOR edge, same trio; user-asked 2026-08-28)
+    mode_switch = 1;
+    fork pulse_and_measure; begin @(posedge clk); mode_switch <= 0; end join
+    check_row(1, 1, 1, 0, "[8] mode_switch disengage must fire load+aud+seek");
+
+    // [9] mode_switch under keep_vbuf=1 (detector flip while a stale menu level
+    //     lingers) -> still all three (mode_switch terms ungated by keep_vbuf)
+    keep_vbuf = 1;
+    mode_switch = 1;
+    fork pulse_and_measure; begin @(posedge clk); mode_switch <= 0; end join
+    check_row(1, 1, 1, 0, "[9] mode_switch under keep_vbuf must fire all three");
+    keep_vbuf = 0;
+
+    // [10] audio track switch -> aud_resync ONLY (minimal scope: ring + decoder)
+    aud_switch = 1;
+    fork pulse_and_measure; begin @(posedge clk); aud_switch <= 0; end join
+    check_row(0, 0, 0, 1, "[10] aud_switch must fire aud_resync only");
+
+    // [11] core reset mid-flush clears every counter
+    start_streaming = 1;
+    @(posedge clk);
+    start_streaming <= 0;   // NBA: the DUT must still sample the pulse at this edge
+    repeat (5) @(posedge clk);
+    if (!load_flush || !seek_flush) fail("[11] setup: flushes not running");
+    rst_n = 0;
+    @(posedge clk); @(posedge clk);
+    #1;
+    if (load_flush || aud_flush || seek_flush || aud_resync) fail("[11] reset must clear all counters");
+    if (pipe_rst_n || aud_rst_n) fail("[11] rst_n low must drive both rst outputs low");
+    rst_n = 1;
+    repeat (2) @(posedge clk);
+    expect_idle("[11] outputs not idle after reset");
+
+    if (errors == 0) $display("flush_ctl_tb: ALL TESTS PASSED (11 scenarios)");
+    else             $fatal(1, "flush_ctl_tb: %0d FAILURE(S)", errors);
+    $finish;
+  end
+
+endmodule

--- a/bench/dvd/flush_ctl_tb.sv
+++ b/bench/dvd/flush_ctl_tb.sv
@@ -9,13 +9,16 @@
 // OLD file's buffered VBUF tail against the NEW file's STC anchor — a
 // permanent audio lead only a core reload avoided. This TB locks the matrix:
 //
-//   event                                  load  aud   seek  aud_resync
-//   start_streaming (mount)                 x     x     x        -
-//   start_streaming with keep_vbuf=1        x     x     x        -   (ungated!)
-//   seek_ack / jump_ack, keep_vbuf=0        x     x     x        -
-//   seek_ack / jump_ack, keep_vbuf=1        x     -     -        -   (menu hop)
-//   mode_switch (interlace/film raster)     x     x     x        -
-//   aud_switch (audio track)                -     -     -        x
+//   event                                  load  aud   seek  mount  aud_resync
+//   start_streaming (mount)                 x     x     x     x        -
+//   start_streaming with keep_vbuf=1        x     x     x     x        -   (ungated!)
+//   seek_ack / jump_ack, keep_vbuf=0        x     x     x     -        -
+//   seek_ack / jump_ack, keep_vbuf=1        x     -     -     -        -   (menu hop)
+//   mode_switch (interlace/film raster)     x     x     x     -        -
+//   aud_switch (audio track)                -     -     -     -        x
+//
+// mount_flush = the decoder soft-reset request (mpeg2video.soft_flush): fires on a
+// MOUNT ONLY, never on seeks/jumps/mode switches (those need display continuity).
 //
 // Plus: reset clears everything; every flush level is exactly 64 cycles;
 // pipe_rst_n = rst_n & ~load_flush; aud_rst_n = rst_n & ~aud_flush & ~aud_resync.
@@ -31,7 +34,7 @@ module flush_ctl_tb;
   reg  rst_n = 0;
   reg  start_streaming = 0, seek_ack = 0, jump_ack = 0;
   reg  mode_switch = 0, aud_switch = 0, keep_vbuf = 0;
-  wire load_flush, aud_flush, aud_resync, seek_flush;
+  wire load_flush, aud_flush, aud_resync, seek_flush, mount_flush;
   wire pipe_rst_n, aud_rst_n;
 
   flush_ctl dut (
@@ -47,6 +50,7 @@ module flush_ctl_tb;
     .aud_flush       (aud_flush),
     .aud_resync      (aud_resync),
     .seek_flush      (seek_flush),
+    .mount_flush     (mount_flush),
     .pipe_rst_n      (pipe_rst_n),
     .aud_rst_n       (aud_rst_n)
   );
@@ -54,7 +58,7 @@ module flush_ctl_tb;
   always #10 clk = ~clk;             // 50 MHz-ish; frequency is irrelevant
 
   integer errors = 0;
-  integer n_load, n_aud, n_seek, n_resync;
+  integer n_load, n_aud, n_seek, n_resync, n_mount;
 
   task fail(input [8*64-1:0] msg);
     begin
@@ -66,8 +70,8 @@ module flush_ctl_tb;
   // Expect all four outputs idle.
   task expect_idle(input [8*64-1:0] ctx);
     begin
-      if (load_flush || aud_flush || seek_flush || aud_resync) begin
-        $display("  state: load=%b aud=%b seek=%b resync=%b", load_flush, aud_flush, seek_flush, aud_resync);
+      if (load_flush || aud_flush || seek_flush || aud_resync || mount_flush) begin
+        $display("  state: load=%b aud=%b seek=%b resync=%b mount=%b", load_flush, aud_flush, seek_flush, aud_resync, mount_flush);
         fail(ctx);
       end
       if (!pipe_rst_n || !aud_rst_n) fail("rst_n outputs not idle-high");
@@ -78,7 +82,7 @@ module flush_ctl_tb;
   // flush output stays high (counted until all four are low again).
   task pulse_and_measure;
     begin
-      n_load = 0; n_aud = 0; n_seek = 0; n_resync = 0;
+      n_load = 0; n_aud = 0; n_seek = 0; n_resync = 0; n_mount = 0;
       @(posedge clk);   // event registered here
       // event inputs are cleared by the caller right after this task starts;
       // count the level durations
@@ -91,10 +95,11 @@ module flush_ctl_tb;
           if (aud_flush)   n_aud    = n_aud    + 1;
           if (seek_flush)  n_seek   = n_seek   + 1;
           if (aud_resync)  n_resync = n_resync + 1;
+          if (mount_flush) n_mount  = n_mount  + 1;
           // reset-derivation invariants hold on every cycle
           if (pipe_rst_n !== (rst_n & ~load_flush))               fail("pipe_rst_n derivation");
           if (aud_rst_n  !== (rst_n & ~aud_flush & ~aud_resync))  fail("aud_rst_n derivation");
-          if (!load_flush && !aud_flush && !seek_flush && !aud_resync) disable count;
+          if (!load_flush && !aud_flush && !seek_flush && !aud_resync && !mount_flush) disable count;
           guard = guard + 1;
           if (guard > 300) begin fail("flush level never released"); disable count; end
         end
@@ -106,14 +111,16 @@ module flush_ctl_tb;
   // active output held exactly 64 cycles.
   task check_row(input integer e_load, input integer e_aud,
                  input integer e_seek, input integer e_resync,
+                 input integer e_mount,
                  input [8*64-1:0] ctx);
     begin
       if ((e_load   ? n_load   != 64 : n_load   != 0) ||
           (e_aud    ? n_aud    != 64 : n_aud    != 0) ||
           (e_seek   ? n_seek   != 64 : n_seek   != 0) ||
-          (e_resync ? n_resync != 64 : n_resync != 0)) begin
-        $display("  got load=%0d aud=%0d seek=%0d resync=%0d, want %0d/%0d/%0d/%0d x64",
-                 n_load, n_aud, n_seek, n_resync, e_load, e_aud, e_seek, e_resync);
+          (e_resync ? n_resync != 64 : n_resync != 0) ||
+          (e_mount  ? n_mount  != 64 : n_mount  != 0)) begin
+        $display("  got load=%0d aud=%0d seek=%0d resync=%0d mount=%0d, want %0d/%0d/%0d/%0d/%0d x64",
+                 n_load, n_aud, n_seek, n_resync, n_mount, e_load, e_aud, e_seek, e_resync, e_mount);
         fail(ctx);
       end
     end
@@ -130,63 +137,63 @@ module flush_ctl_tb;
     //     stayed 0 here and the old file's VBUF survived into the new file)
     start_streaming = 1;
     fork pulse_and_measure; begin @(posedge clk); start_streaming <= 0; end join
-    check_row(1, 1, 1, 0, "[1] mount must fire load+aud+seek");
+    check_row(1, 1, 1, 0, 1, "[1] mount must fire load+aud+seek+mountrst");
 
     // [2] mount with keep_vbuf=1 held (stale level from a previous menu hop)
     //     -> STILL all three (the mount terms are ungated by keep_vbuf)
     keep_vbuf = 1;
     start_streaming = 1;
     fork pulse_and_measure; begin @(posedge clk); start_streaming <= 0; end join
-    check_row(1, 1, 1, 0, "[2] mount under keep_vbuf must fire load+aud+seek");
+    check_row(1, 1, 1, 0, 1, "[2] mount under keep_vbuf must fire all four");
     keep_vbuf = 0;
 
     // [3] title seek (keep_vbuf=0) -> all three
     seek_ack = 1;
     fork pulse_and_measure; begin @(posedge clk); seek_ack <= 0; end join
-    check_row(1, 1, 1, 0, "[3] title seek must fire load+aud+seek");
+    check_row(1, 1, 1, 0, 0, "[3] title seek: trio, NO mount reset");
 
     // [4] VM jump (keep_vbuf=0, e.g. menu->title Play) -> all three
     jump_ack = 1;
     fork pulse_and_measure; begin @(posedge clk); jump_ack <= 0; end join
-    check_row(1, 1, 1, 0, "[4] ~keep_vbuf jump must fire load+aud+seek");
+    check_row(1, 1, 1, 0, 0, "[4] ~keep_vbuf jump: trio, NO mount reset");
 
     // [5] menu->menu jump (keep_vbuf=1) -> load_flush ONLY (video tail plays
     //     out, audio rides through: docs/dvd_menu_refinements.md sec.2/5d)
     keep_vbuf = 1;
     jump_ack = 1;
     fork pulse_and_measure; begin @(posedge clk); jump_ack <= 0; end join
-    check_row(1, 0, 0, 0, "[5] keep_vbuf jump must fire load only");
+    check_row(1, 0, 0, 0, 0, "[5] keep_vbuf jump must fire load only");
 
     // [6] menu-internal seek (keep_vbuf=1) -> load_flush only
     seek_ack = 1;
     fork pulse_and_measure; begin @(posedge clk); seek_ack <= 0; end join
-    check_row(1, 0, 0, 0, "[6] keep_vbuf seek must fire load only");
+    check_row(1, 0, 0, 0, 0, "[6] keep_vbuf seek must fire load only");
     keep_vbuf = 0;
 
     // [7] raster-regime switch (mode_switch, today il_switch) -> all
     //     three (the il_switch full re-sync rule)
     mode_switch = 1;
     fork pulse_and_measure; begin @(posedge clk); mode_switch <= 0; end join
-    check_row(1, 1, 1, 0, "[7] mode_switch engage must fire load+aud+seek");
+    check_row(1, 1, 1, 0, 0, "[7] mode_switch: trio, NO mount reset");
 
     // [8] a second mode_switch pulse (e.g. the opposite-direction edge) fires
     //     the same trio again — the counters re-arm cleanly back-to-back
     mode_switch = 1;
     fork pulse_and_measure; begin @(posedge clk); mode_switch <= 0; end join
-    check_row(1, 1, 1, 0, "[8] mode_switch disengage must fire load+aud+seek");
+    check_row(1, 1, 1, 0, 0, "[8] repeat mode_switch: trio, NO mount reset");
 
     // [9] mode_switch under keep_vbuf=1 (detector flip while a stale menu level
     //     lingers) -> still all three (mode_switch terms ungated by keep_vbuf)
     keep_vbuf = 1;
     mode_switch = 1;
     fork pulse_and_measure; begin @(posedge clk); mode_switch <= 0; end join
-    check_row(1, 1, 1, 0, "[9] mode_switch under keep_vbuf must fire all three");
+    check_row(1, 1, 1, 0, 0, "[9] mode_switch under keep_vbuf: trio only");
     keep_vbuf = 0;
 
     // [10] audio track switch -> aud_resync ONLY (minimal scope: ring + decoder)
     aud_switch = 1;
     fork pulse_and_measure; begin @(posedge clk); aud_switch <= 0; end join
-    check_row(0, 0, 0, 1, "[10] aud_switch must fire aud_resync only");
+    check_row(0, 0, 0, 1, 0, "[10] aud_switch must fire aud_resync only");
 
     // [11] core reset mid-flush clears every counter
     start_streaming = 1;
@@ -197,7 +204,7 @@ module flush_ctl_tb;
     rst_n = 0;
     @(posedge clk); @(posedge clk);
     #1;
-    if (load_flush || aud_flush || seek_flush || aud_resync) fail("[11] reset must clear all counters");
+    if (load_flush || aud_flush || seek_flush || aud_resync || mount_flush) fail("[11] reset must clear all counters");
     if (pipe_rst_n || aud_rst_n) fail("[11] rst_n low must drive both rst outputs low");
     rst_n = 1;
     repeat (2) @(posedge clk);

--- a/bench/dvd/frame_drop_ctl_tb.sv
+++ b/bench/dvd/frame_drop_ctl_tb.sv
@@ -38,11 +38,12 @@ module frame_drop_ctl_tb;
   integer errors = 0;
 
   reg bitstream_ok = 1'b1;   // healthy by default; the guard case toggles it
+  reg flush = 1'b0;          // VBUF-flush level; case [9] drives it
   reg [3:0] drop_cost = 4'd2; // flat SHOW_N by default; the film case drives 3
 
   frame_drop_ctl #(.DROP_THRESHOLD(DROP_THRESHOLD), .DEBT_MAX(DEBT_MAX)) dut (
     .clk(clk), .clk_en(clk_en), .rst(rst),
-    .enable(enable), .bitstream_ok(bitstream_ok),
+    .enable(enable), .bitstream_ok(bitstream_ok), .flush(flush),
     .frame_late(frame_late), .drop_ack(drop_ack), .drop_cost(drop_cost),
     .drop_req(drop_req),
     .frames_late_cnt(frames_late_cnt),
@@ -210,9 +211,36 @@ module frame_drop_ctl_tb;
     check("film: long-run neutral (req off)", drop_req == 1'b0);
     drop_cost = 4'd2;
 
+    // ---- 9. VBUF flush clears carried debt (2026-08-28 mount/seek fix) ----
+    // Debt used to survive every discontinuity (reset only by sync_rst), so a
+    // warm mount/seek carried stale lateness into the new position and fired
+    // spurious B-drops the moment vbuf_healthy re-armed.
+    $display("[9] flush clears carried debt");
+    enable = 1'b0; @(negedge clk); enable = 1'b1; @(negedge clk);  // debt = 0
+    for (i = 0; i < 5; i = i + 1) pulse_late;    // bank 5 refreshes of "old title" debt
+    @(negedge clk);
+    check("flush: debt banked pre", debt_out == 5'd5);
+    check("flush: req armed pre",   drop_req == 1'b1);
+    flush = 1'b1;                                 // the seek/mount VBUF flush level
+    @(negedge clk); @(negedge clk);
+    check("flush: debt cleared",    debt_out == 5'd0);
+    check("flush: req off",         drop_req == 1'b0);
+    pulse_late;                                   // a late DURING the flush window
+    @(negedge clk);
+    check("flush: holds debt at 0 while asserted", debt_out == 5'd0);
+    flush = 1'b0;
+    @(negedge clk);
+    pulse_late; pulse_late;                       // normal accounting resumes
+    @(negedge clk);
+    check("flush: accounting resumes (debt 2)", debt_out == 5'd2);
+    check("flush: req resumes",                 drop_req == 1'b1);
+    pulse_ack; @(negedge clk);                    // leave the ledger clean
+    // telemetry must NOT have been cleared by the flush (free-running totals)
+    check("flush: late counter untouched", frames_late_cnt > 16'd0);
+
     $display("");
     if (errors == 0) $display("PASS: frame_drop_ctl_tb (all checks)");
-    else             $display("FAIL: frame_drop_ctl_tb (%0d errors)", errors);
+    else             $fatal(1, "FAIL: frame_drop_ctl_tb (%0d errors)", errors);
     $finish;
   end
 

--- a/bench/dvd/frame_drop_sys_tb.sv
+++ b/bench/dvd/frame_drop_sys_tb.sv
@@ -94,7 +94,7 @@ module frame_drop_sys_tb;
 
   frame_drop_ctl #(.DROP_THRESHOLD(SHOW_N), .DEBT_MAX(15)) dut (
     .clk(clk), .clk_en(1'b1), .rst(rst_n),
-    .enable(enable), .frame_late(frame_late), .drop_ack(drop_ack), .drop_cost(4'd2),
+    .enable(enable), .bitstream_ok(1'b1), .flush(1'b0), .frame_late(frame_late), .drop_ack(drop_ack), .drop_cost(4'd2),
     .drop_req(drop_req),
     .frames_late_cnt(flate_cnt), .frames_dropped_cnt(fdrop_cnt), .debt_out(debt)
   );

--- a/bench/dvd/run_prefetch_chain.sh
+++ b/bench/dvd/run_prefetch_chain.sh
@@ -21,6 +21,7 @@ SRC="rtl/mpeg2/resample.v dvd/resample_addrgen.v rtl/mpeg2/resample_dta.v \
 rtl/mpeg2/resample_bilinear.v rtl/mpeg2/mem_addr.v rtl/mpeg2/mixer.v \
 rtl/mpeg2/pixel_queue.v rtl/mpeg2/syncgen.v rtl/mpeg2/read_write.v \
 rtl/mpeg2/wrappers.v rtl/mpeg2/fwft.v rtl/mpeg2/xilinx_fifo_dc.v rtl/mpeg2/xfifo_sc.v \
+dvd/disp_hstretch.sv dvd/disp_vscale.sv \
 bench/dvd/resample_chain_tb.sv"
 
 echo "### building SHALLOW (upstream 256) ..."

--- a/docs/av_sync.md
+++ b/docs/av_sync.md
@@ -630,6 +630,23 @@ holdoff, TB'd in flush_ctl_tb, with the T2 logo chain as an explicit HW gate). S
 carried-in stale lateness at the new position). `vbuf_healthy` needs no change — the
 VBUF flush zeroes the fill, so the hysteresis drops it to the cold-boot state by itself.
 
+**Mount decoder soft reset (2026-08-28, follow-up HW round — macroblocks at flat-file
+load):** the flush trio discards BUFFERED data but the decode pipeline's state survives
+by upstream design (the "trick play" flush resets only the VBUF FIFOs; vld/getbits/
+motcomp/picbuf are on `sync_rst`). Right for seeks — wrong for a NEW FILE: the in-flight
+picture "completes" on the new file's first start code (one truncated garbage frame),
+and the old file's reference frames stay flagged valid, so an open-GOP-leading new file
+(common for flat `.mpg`/`.VOB` clips cut from longer streams; DVD first cells are
+usually closed-GOP, MPEG-1/VCD equally exposed) motion-compensates its first B-frames
+against the PREVIOUS file — HW symptom: macroblock garbage at load instead of a clean
+black cut. Fix: `flush_ctl.mount_flush` (mount ONLY, never seeks) →
+`mpeg2video.soft_flush` → a new `reset.soft_rst_n` leg that requests exactly the
+watchdog-expiry soft reset: everything on `sync_rst`/`mem_rst`/`dot_rst` clears while
+the **regfile/modeline survive** (they are on `hard_rst` — the HW-proven watchdog
+recovery path exercises this routinely). A warm load now starts the decoder as cold as
+a core reload: black until the new file's first frame. Matrix TB extended (mount rows
+fire all four; seek/jump/mode rows prove mount_flush stays 0).
+
 **Considered and DEFERRED (recorded so they aren't re-derived):**
 - *Cadence/film/PAL detector confidence re-arm on mount* (`resample_addrgen.v` conf_*
   accumulators, reset by `rst` only): a `pickup_hold`-edge reset would drop film lock on

--- a/docs/av_sync.md
+++ b/docs/av_sync.md
@@ -605,17 +605,25 @@ title seek/jump, raster-regime switch — needs ALL THREE of `seek_flush` (VBUF 
 deliberate keep_vbuf menu-transition and aud_resync carve-outs. The trigger matrix now
 lives in `dvd/flush_ctl.sv` with `bench/dvd/flush_ctl_tb.sv` locking every row.
 
-**Film-switch skew (same fix, same day):** with `Film 24p Out = Auto` (default), the
-cadence detector engages the 23.976/25 Hz film raster ~2 s AFTER a menu→feature jump
-established sync at 59.94/50 Hz. The modeline re-walks and `TPR_Q16` muxes to the film
-rate, but no flush fired on that edge (`il_switch` watches only `il_eff`) — the raster
-hand-off left a constant phase error; HW workaround was a chapter skip (= the missing
-trio). Now `film_switch = (filmp_eff ^ filmp_eff_q) & ~menu_active`, ORed with
-`il_switch` into `mode_switch`, fires the trio on BOTH edges (engage and mid-title
-film→video disengage). The `~menu_active` gate keeps a detector decay during a menu from
-glitching the keep_vbuf machinery (menus aren't lip-sync-scheduled; the next menu→title
-jump flushes anyway). Trade, same as Interlaced Auto: a brief seek-like re-lock at the
-switch instead of a permanent skew.
+**Film-switch skew — ⛔ ATTEMPTED AND REVERTED (same day; the skew remains a known
+issue).** With `Film 24p Out = Auto` (default), the cadence detector engages the
+23.976/25 Hz film raster ~2 s AFTER a menu→feature jump established sync at
+59.94/50 Hz. The modeline re-walks and `TPR_Q16` muxes to the film rate, but no flush
+fires on that edge (`il_switch` watches only `il_eff`) — the raster hand-off leaves a
+constant phase error; HW workaround is a chapter skip (= the trio). The obvious fix — a
+`filmp_eff` XOR edge ORed into `mode_switch` — **shipped briefly and BROKE T2's
+menu→Play logo chain on HW**: Dolby/THX logos flap the detector, each flap fired the
+trio at an arbitrary mid-stream byte position (no reader jump ⇒ no VOBU re-alignment,
+unlike every other trio consumer), repeated mid-parse flushes produced garbage sequence
+headers (186-wide resolution popups), a garbage 576-line parse flipped `pal_eff`
+(25 Hz), and `pal_eff` feeds back into `film_want` → another `filmp_eff` edge → a
+self-feeding corruption/strobe loop. `il_switch` is only safe because `il_eff` changes
+~once/title — **do not re-add a bare filmp edge**. The proper fix is the planned
+early-film-detect feature (a parse-front sniffer seeds the detector during the load
+hold, so the raster is right BEFORE the first frame and each jump's own trio covers the
+transition; a mid-title film_switch then needs hold-suppression + a post-discontinuity
+holdoff, TB'd in flush_ctl_tb, with the T2 logo chain as an explicit HW gate). See
+`docs/film_24p_plan.md` §13.
 
 **Also fixed in the same pass:** `frame_drop_ctl`'s debt ledger now clears on
 `flush_vbuf_eff` (it survived every discontinuity and could fire spurious B-drops from

--- a/docs/av_sync.md
+++ b/docs/av_sync.md
@@ -576,12 +576,65 @@ compounding flaws in the original anchor logic:
   buffering; VBUF 2 MB at a low 2 Mb/s ≈ 8 s worst case). Real seeks (Phase 8) will
   flush + force a re-anchor explicitly anyway.
 
-**Known limitations:** `video_live` is cleared only by core reset, not by the clip-load
-flush (the decoder isn't reset on reload), so a reloaded clip's STC starts advancing at
-anchor parse time again — a small, bounded offset; acceptable until flush-on-seek lands.
-A pathological video-less program stream never sets `video_live`, so scheduled audio
-would wait — covered by the existing ring drain-watchdog (degrades to drop-on-full,
-video-side unaffected).
+**Known limitations:** ~~`video_live` is cleared only by core reset~~ — OUTDATED TWICE
+OVER: the v5 `pickup_hold` rising edge re-arms `video_live` on every load (a reload
+behaves like a cold start), and since 2026-08-28 a file mount also fires the full flush
+trio (see "Mid-play mount desync post-mortem" below). A pathological video-less program
+stream never sets `video_live`, so scheduled audio would wait — covered by the existing
+ring drain-watchdog (degrades to drop-on-full, video-side unaffected).
+
+## Mid-play mount desync post-mortem (2026-08-28, `fix/mount-avsync-flush`)
+
+**Symptom:** loading a new file while another played left audio permanently out of sync;
+only a core reload between loads avoided it. **Root cause — a half-flushed pipeline:**
+`start_streaming` fired `load_flush` (fresh STC anchor + `av_vid_hold`/`video_live`
+re-arm) and `aud_flush` (audio cold start) but NOT the seek/VBUF flush, so 0.5–2 MB of
+the OLD file's bitstream survived in the decoder. The STC anchored on the NEW file's
+first `vid_pts`; the STD hold released on the new file's audio (`aud_caught`); the
+governor's first pickup displayed an OLD-file frame → `video_live=1` → STC advanced →
+the drain gate released NEW-file audio against a display a whole VBUF depth stale. The
+skew is forward and < 15 s, so the one-sided re-anchor (by design, above) never corrects
+it; the rate is locked (NCO trim retired), so it never grinds out either. A cold boot
+starts with an empty VBUF — hence "fine after a core reload". This is the exact mirror
+of the `il_switch` v1 lesson (VBUF-flush-only ⇒ audio ~1 s LATE; load+aud-only ⇒ audio
+EARLY by the residual depth).
+
+**THE FLUSH TRIO RULE (write it on the wall):** any playback discontinuity — mount,
+title seek/jump, raster-regime switch — needs ALL THREE of `seek_flush` (VBUF discard) +
+`load_flush` (demux/av_sync re-anchor) + `aud_flush` (audio cold start), except the
+deliberate keep_vbuf menu-transition and aud_resync carve-outs. The trigger matrix now
+lives in `dvd/flush_ctl.sv` with `bench/dvd/flush_ctl_tb.sv` locking every row.
+
+**Film-switch skew (same fix, same day):** with `Film 24p Out = Auto` (default), the
+cadence detector engages the 23.976/25 Hz film raster ~2 s AFTER a menu→feature jump
+established sync at 59.94/50 Hz. The modeline re-walks and `TPR_Q16` muxes to the film
+rate, but no flush fired on that edge (`il_switch` watches only `il_eff`) — the raster
+hand-off left a constant phase error; HW workaround was a chapter skip (= the missing
+trio). Now `film_switch = (filmp_eff ^ filmp_eff_q) & ~menu_active`, ORed with
+`il_switch` into `mode_switch`, fires the trio on BOTH edges (engage and mid-title
+film→video disengage). The `~menu_active` gate keeps a detector decay during a menu from
+glitching the keep_vbuf machinery (menus aren't lip-sync-scheduled; the next menu→title
+jump flushes anyway). Trade, same as Interlaced Auto: a brief seek-like re-lock at the
+switch instead of a permanent skew.
+
+**Also fixed in the same pass:** `frame_drop_ctl`'s debt ledger now clears on
+`flush_vbuf_eff` (it survived every discontinuity and could fire spurious B-drops from
+carried-in stale lateness at the new position). `vbuf_healthy` needs no change — the
+VBUF flush zeroes the fill, so the hysteresis drops it to the cold-boot state by itself.
+
+**Considered and DEFERRED (recorded so they aren't re-derived):**
+- *Cadence/film/PAL detector confidence re-arm on mount* (`resample_addrgen.v` conf_*
+  accumulators, reset by `rst` only): a `pickup_hold`-edge reset would drop film lock on
+  EVERY seek (~1.7 s re-lock ⇒ raster churn, and a det-driven mode_switch could re-fire
+  the flush). A mount-only reset needs new plumbing CDC'd through
+  mpeg2video→resample→addrgen for a bounded, self-correcting ~2 s wrong-cadence window
+  on cross-cadence warm mounts. Revisit only if post-fix HW shows a residual constant
+  offset there.
+- *`vidfeed_cdc` reset on `pipe_rst_n`* (stale clk_sys→clk_dec ES bytes splice ahead of
+  the new stream): seeks/jumps have the identical exposure today and are HW-clean (the
+  decoder's start-code hunt absorbs the residue); resetting a dual-clock FIFO from a
+  clk_sys-timed level adds CDC risk, and widening a flush-reset net has twice failed to
+  route in this design (the aud_rst_n Error 11802 note).
 
 **Verification:** `av_sync_tb` check `[0]` (STC frozen through 20 dead refreshes + a 1 s
 parse-lead PTS without re-anchor) and `[4a/4b/4c]` (+2.2 s lead → no re-anchor; −2.2 s →

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -289,7 +289,22 @@ ALSO flushes the decoder's VBUF** (the ~1 s compressed-video cushion in DDR): `s
 separate seek-only `seek_flush` level, 2-FF synced to `clk_dec` as `mpeg2video.vbuf_flush`, ORed
 into the regfile's native `flush_vbuf` (`rtl/mpeg2/mpeg2video.v`). Without it the audio (small
 ring) jumps immediately while the video plays the old buffered ~1 s first — the first HW build's
-exact symptom. Seek-only; the known-good clip-load path is untouched.
+exact symptom.
+
+> **Mount flush (2026-08-28, `fix/mount-avsync-flush`) — the "Seek-only; the known-good
+> clip-load path is untouched" exclusion is RETIRED.** That wording dated from when the
+> seek flush was introduced: the clip-load path had just been stabilized and, crucially,
+> `video_live` was then cleared only by core reset, so a warm reload kept the old STC
+> advancing and the un-flushed VBUF cost only a small bounded offset. The lip-sync v5
+> `pickup_hold`→`video_live` re-arm (PR fj#60) changed that — a reload re-anchors the STC
+> on the NEW file's first `vid_pts` like a cold start — which turned the surviving
+> 0.5–2 MB of OLD-file VBUF into a *permanent* audio lead of the whole residual depth
+> (the governor's first pickup showed an OLD frame against the NEW anchor; a forward skew
+> < ~15 s never re-anchors). HW symptom: loading a new file mid-play desynced audio until
+> a core reload. `start_streaming` now fires the full flush trio (seek/vbuf + load + aud)
+> exactly like `il_switch` and a chapter seek, ungated by `keep_vbuf` (a stale menu-hop
+> level must not suppress a mount flush). The trigger matrix now lives in
+> `dvd/flush_ctl.sv` and is locked by `bench/dvd/flush_ctl_tb.sv`.
 
 **Pause = freeze video + audio in lock-step.** Video-referenced-STC (master-clock) design; pause
 holds *everything* frozen rather than gating the sector feed (the multi-MB VBUF would keep

--- a/docs/film_24p_plan.md
+++ b/docs/film_24p_plan.md
@@ -631,23 +631,37 @@ be counted via `refresh_tick_dbg`.
 
 ---
 
-## 13. Engage/disengage now fires the full seek-equivalent flush (2026-08-28, `fix/mount-avsync-flush`)
+## 13. ⛔ Engage/disengage flush — ATTEMPTED AND REVERTED (2026-08-28, `fix/mount-avsync-flush`); the engage skew remains OPEN, owned by the early-film-detect feature
 
 **Symptom (user report, 2026-08-27):** entering the main film from a menu introduced a
 small constant A/V skew once Auto engaged the 24p raster; a chapter skip fixed it. The
 menu→title jump establishes audio sync at 59.94/50 Hz, then ~2 s later the detector
 locks and the raster + `TPR_Q16` switch — with **no flush on that edge** (`il_switch`
-watches only `il_eff`), so the raster hand-off left a constant phase error the one-sided
-re-anchor can never catch (forward, < 15 s) and the locked rate never grinds out. The
-chapter-skip workaround was exactly the missing flush trio.
+watches only `il_eff`), so the raster hand-off leaves a constant phase error the
+one-sided re-anchor can never catch (forward, < 15 s) and the locked rate never grinds
+out. The chapter-skip workaround is exactly the missing flush trio.
 
-**Fix (emu.sv):** `film_switch = (filmp_eff ^ filmp_eff_q) & ~menu_active`, ORed with
-`il_switch` into `mode_switch`, which drives all three flush triggers (load + aud +
-seek/vbuf) in `dvd/flush_ctl.sv`. Both edges covered (engage AND a mid-title film→video
-disengage — the mirror skew). The `~menu_active` gate keeps a detector-confidence decay
-during a menu from glitching the keep_vbuf menu machinery; the next menu→title jump
-flushes anyway. Trade (same as Interlaced Auto): a brief seek-like re-lock at the
-switch, ~once per title entry — README's Film 24p section now tells users the hiccup is
-normal and that discs which flip content types constantly may prefer `Off`. Trigger
-matrix locked by `bench/dvd/flush_ctl_tb.sv`; post-mortem in `docs/av_sync.md`.
-⏳ HW-confirm pending.
+**The attempted fix and why it was REVERTED:** `film_switch = (filmp_eff ^ filmp_eff_q)
+& ~menu_active`, ORed with `il_switch` into `mode_switch` → the full trio on both
+edges. **HW verdict (same day, T2): catastrophic on the menu→Play logo chain.** The
+Dolby/THX logos flap the cadence detector (mixed film/video/still content in quick
+succession); each flap fired the trio at an ARBITRARY mid-stream byte position — unlike
+a chapter seek there is no reader jump, so nothing re-aligns delivery to a VOBU
+boundary — and repeated mid-parse flushes produced garbage sequence headers (resolution
+popups, 186-wide), a garbage 576-line parse flipped `pal_eff` (25 Hz raster), and
+`pal_eff` feeds back into `film_want` (`film_det = pal_eff ? det_pal : det_ntsc`) →
+another `filmp_eff` edge → another flush: a self-feeding corruption loop ending in a
+green/white strobe. Not always the same failure point (detector state is
+content/history dependent). ⚠ Lesson: `il_switch`'s "fire the trio on a live mode
+edge" pattern is only safe for a signal that changes ~once/title — a bare `filmp_eff`
+edge can OSCILLATE, and the flush itself perturbs the very parse the detector feeds on.
+
+**Disposition:** reverted to `mode_switch = il_switch` (emu.sv carries a ⛔ comment at
+the edge-detect). The engage skew is back to pre-branch behavior (constant offset until
+the next seek; chapter skip clears it — README notes this). **The proper fix is the
+early-film-detect feature** (`feature/film-early-detect` plan): a parse-front sniffer
+classifies cadence during the load hold and seeds the detector, so the raster is
+correct BEFORE the first frame and every title/logo entry is covered by its jump's own
+trio — no mid-play engage at all on the common path. If a mid-title film_switch flush
+is reintroduced there it MUST have hold-suppression + a post-discontinuity holdoff,
+TB'd in `flush_ctl_tb`, **with the T2 menu→Play logo chain as an explicit HW gate**.

--- a/docs/film_24p_plan.md
+++ b/docs/film_24p_plan.md
@@ -628,3 +628,26 @@ be counted via `refresh_tick_dbg`.
 - [ ] A second NTSC film disc (different mastering = different cadence-break rate)
       stays locked too.
 - [ ] 60 Hz / PAL / analog / menus unchanged (corrector inert outside NTSC film24).
+
+---
+
+## 13. Engage/disengage now fires the full seek-equivalent flush (2026-08-28, `fix/mount-avsync-flush`)
+
+**Symptom (user report, 2026-08-27):** entering the main film from a menu introduced a
+small constant A/V skew once Auto engaged the 24p raster; a chapter skip fixed it. The
+menu→title jump establishes audio sync at 59.94/50 Hz, then ~2 s later the detector
+locks and the raster + `TPR_Q16` switch — with **no flush on that edge** (`il_switch`
+watches only `il_eff`), so the raster hand-off left a constant phase error the one-sided
+re-anchor can never catch (forward, < 15 s) and the locked rate never grinds out. The
+chapter-skip workaround was exactly the missing flush trio.
+
+**Fix (emu.sv):** `film_switch = (filmp_eff ^ filmp_eff_q) & ~menu_active`, ORed with
+`il_switch` into `mode_switch`, which drives all three flush triggers (load + aud +
+seek/vbuf) in `dvd/flush_ctl.sv`. Both edges covered (engage AND a mid-title film→video
+disengage — the mirror skew). The `~menu_active` gate keeps a detector-confidence decay
+during a menu from glitching the keep_vbuf menu machinery; the next menu→title jump
+flushes anyway. Trade (same as Interlaced Auto): a brief seek-like re-lock at the
+switch, ~once per title entry — README's Film 24p section now tells users the hiccup is
+normal and that discs which flip content types constantly may prefer `Off`. Trigger
+matrix locked by `bench/dvd/flush_ctl_tb.sv`; post-mortem in `docs/av_sync.md`.
+⏳ HW-confirm pending.

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -2116,11 +2116,26 @@ always @(posedge clk_sys) begin
 end
 wire reader_busy = fifo_almost_full | menu_vbuf_throttle | vbuf_hard_over;
 
-// SEEK VBUF FLUSH: on a transport seek (NOT a clip load), also discard the
+// SEEK VBUF FLUSH: on a transport seek OR a new file mount, also discard the
 // decoder's ~1 s compressed video cushion (VBUF) so the picture jumps with the
-// audio instead of playing the old buffered stream for ~1 s. Seek-only (the
-// known-good clip-load path is left untouched). A ~64-cycle level, 2-FF synced
-// into clk_dec, drives mpeg2video.vbuf_flush.
+// audio instead of playing the old buffered stream for ~1 s. A ~64-cycle level,
+// 2-FF synced into clk_dec, drives mpeg2video.vbuf_flush.
+//
+// MOUNT FLUSH (2026-08-28): start_streaming now fires this too, completing the
+// full flush trio (seek/vbuf + load + aud) for a mid-play file load — the same
+// trio il_switch performs (see the il_switch comment for the HW-proven rule that
+// all three are needed). The original "Seek-only (the known-good clip-load path
+// is left untouched)" exclusion predated the lip-sync v5 pickup_hold->video_live
+// re-arm (PR fj#60): back then a warm reload kept the old STC advancing and the
+// un-flushed VBUF was a small bounded offset. After v5, a reload re-anchors the
+// STC on the NEW file's first vid_pts and re-arms video_live like a cold start —
+// so the surviving 0.5-2 MB of OLD-file VBUF meant the governor's first pickup
+// displayed an OLD frame against the NEW anchor: audio led video by the whole
+// residual VBUF depth, permanently (a forward skew < ~15 s never re-anchors,
+// av_sync FWD_REANCHOR_TICKS). Only a core reload (empty VBUF) avoided it.
+// The mount term is deliberately UNGATED by keep_vbuf: a stale keep_vbuf=1 level
+// from a previous menu hop must not suppress a mount flush (mirrors the ungated
+// start_streaming term in aud_flush_cnt above).
 // PHASE-5 MENU TRANSITION: a menu->menu seek/jump (keep_vbuf) suppresses the
 // VBUF flush so the buffered transition-animation tail plays out (no cold
 // re-lock on a stale/black frame). Title seeks and menu->title jumps still
@@ -2142,7 +2157,8 @@ wire      seek_flush_now = seek_ack && ~keep_vbuf;
 // see that il_switch comment for why the vbuf flush ALONE desynced audio.
 always @(posedge clk_sys) begin
     if (~reset_n)                                          seek_flush_cnt <= 7'd0;
-    else if (seek_flush_now || jump_flush || il_switch)    seek_flush_cnt <= 7'd64;   // seek / menu->title jump / interlace mode switch
+    else if (seek_flush_now || jump_flush || il_switch || start_streaming)
+                                                           seek_flush_cnt <= 7'd64;   // seek / menu->title jump / interlace mode switch / file mount
     else if (seek_flush)                                   seek_flush_cnt <= seek_flush_cnt - 7'd1;
 end
 reg vbuf_flush_s1, vbuf_flush_dec;
@@ -2923,6 +2939,10 @@ always @(posedge clk_sys) begin
     // never picked up) and keeping video_live=0 (which blocks the highlight render
     // gate + nav_pci fallback). Forcing it off for menu_active makes the menu
     // display immediately and video_live stay set. Titles are unaffected.
+    // A file MOUNT cannot be swallowed by this branch even if a menu was up on
+    // the old disc: the reader's `start` clears menu_dom (-> menu_active) on the
+    // first cycle of the mount while pipe_rst_n stays low for ~64 cycles, so the
+    // !pipe_rst_n arm below always latches the hold (verified 2026-08-28).
     if (menu_active) begin
         av_vid_hold     <= 1'b0;
         av_vid_hold_tmr <= '0;

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -1939,33 +1939,26 @@ wire [2:0] sp_track_eff  = (menus_on && menu_active) || sp_menu_early ? 3'd0 :
 // Declared here (above CLIP-LOAD FLUSH) so it precedes its use in load_flush/aud_flush.
 reg       il_eff_q = 1'b0;
 wire      il_switch = il_eff ^ il_eff_q;
-// FILM-RASTER SWITCH (2026-08-28): a LIVE filmp_eff change is the same raster-regime
-// event as il_switch and needs the same full seek-equivalent flush. With Film 24p Out
-// = Auto (the default), the cadence detector engages the 23.976/25 Hz film raster
-// ~2 s AFTER a menu->feature jump established audio sync at 59.94/50 Hz: the modeline
-// re-walks and av_sync's TPR_Q16 muxes to the film rate, but with no flush the raster
-// hand-off leaves a constant phase error between the free-running audio and the video
-// timeline that never re-anchors (forward, < 15 s) - HW symptom: slight skew entering
-// the main film, fixed by a chapter skip (whose seek flush is exactly this trio). The
-// XOR covers BOTH directions: engage (menu->film) and mid-title disengage (film->video
-// content; the detector drops after ~50 non-film pictures and the mirror-image skew
-// would accrue). Gated on ~menu_active: a detector-confidence decay while a MENU is up
-// must not fire a flush into the keep_vbuf menu machinery (visible glitch for nothing -
-// menus aren't lip-sync-scheduled, sched_en=0); the next menu->title jump flushes
-// anyway. Trade (same as Interlaced Auto's il_switch): a brief seek-like re-lock at
-// the switch, ~once per title entry, instead of a permanent skew.
-reg       filmp_eff_q = 1'b0;
-wire      film_switch = (filmp_eff ^ filmp_eff_q) & ~menu_active;
-// mode_switch = any live raster-regime change -> full flush trio (load+aud+seek).
-wire      mode_switch = il_switch | film_switch;
+// ⛔ FILM-RASTER SWITCH — ATTEMPTED AND REVERTED (2026-08-28). A filmp_eff XOR edge
+// briefly drove mode_switch here (full flush trio on a live film engage/disengage, to
+// fix the menu->film constant skew). ON HW IT BROKE T2's menu->Play logo chain: the
+// Dolby/THX logos flap the cadence detector, and each flap fired the trio at an
+// ARBITRARY mid-stream byte position (no reader jump = no VOBU re-alignment, unlike a
+// chapter seek). Repeated mid-parse flushes yielded garbage sequence headers (186-wide
+// resolution popups), a garbage 576-line parse flipped pal_eff (25 Hz), and pal_eff
+// feeds back into film_want -> another filmp_eff edge -> another flush = a self-
+// feeding corruption/strobe loop. il_switch is only safe because il_eff changes
+// ~once/title. Do NOT re-add a bare filmp edge here. The proper fix is the early-
+// film-detect feature (parse-front sniffer seeds the detector during the load hold so
+// the raster is right BEFORE display; a mid-title film_switch then needs hold-
+// suppression + a post-discontinuity holdoff, TB'd in flush_ctl_tb) — see
+// docs/film_24p_plan.md §13.
+// mode_switch = live raster-regime change -> full flush trio (load+aud+seek).
+// Today that is il_switch alone.
+wire      mode_switch = il_switch;
 always @(posedge clk_sys) begin
-    if (~reset_n) begin
-        il_eff_q    <= 1'b0;
-        filmp_eff_q <= 1'b0;
-    end else begin
-        il_eff_q    <= il_eff;
-        filmp_eff_q <= filmp_eff;
-    end
+    if (~reset_n) il_eff_q <= 1'b0;
+    else          il_eff_q <= il_eff;
 end
 
 // =========================================================================

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -1939,9 +1939,33 @@ wire [2:0] sp_track_eff  = (menus_on && menu_active) || sp_menu_early ? 3'd0 :
 // Declared here (above CLIP-LOAD FLUSH) so it precedes its use in load_flush/aud_flush.
 reg       il_eff_q = 1'b0;
 wire      il_switch = il_eff ^ il_eff_q;
+// FILM-RASTER SWITCH (2026-08-28): a LIVE filmp_eff change is the same raster-regime
+// event as il_switch and needs the same full seek-equivalent flush. With Film 24p Out
+// = Auto (the default), the cadence detector engages the 23.976/25 Hz film raster
+// ~2 s AFTER a menu->feature jump established audio sync at 59.94/50 Hz: the modeline
+// re-walks and av_sync's TPR_Q16 muxes to the film rate, but with no flush the raster
+// hand-off leaves a constant phase error between the free-running audio and the video
+// timeline that never re-anchors (forward, < 15 s) - HW symptom: slight skew entering
+// the main film, fixed by a chapter skip (whose seek flush is exactly this trio). The
+// XOR covers BOTH directions: engage (menu->film) and mid-title disengage (film->video
+// content; the detector drops after ~50 non-film pictures and the mirror-image skew
+// would accrue). Gated on ~menu_active: a detector-confidence decay while a MENU is up
+// must not fire a flush into the keep_vbuf menu machinery (visible glitch for nothing -
+// menus aren't lip-sync-scheduled, sched_en=0); the next menu->title jump flushes
+// anyway. Trade (same as Interlaced Auto's il_switch): a brief seek-like re-lock at
+// the switch, ~once per title entry, instead of a permanent skew.
+reg       filmp_eff_q = 1'b0;
+wire      film_switch = (filmp_eff ^ filmp_eff_q) & ~menu_active;
+// mode_switch = any live raster-regime change -> full flush trio (load+aud+seek).
+wire      mode_switch = il_switch | film_switch;
 always @(posedge clk_sys) begin
-    if (~reset_n) il_eff_q <= 1'b0;
-    else          il_eff_q <= il_eff;
+    if (~reset_n) begin
+        il_eff_q    <= 1'b0;
+        filmp_eff_q <= 1'b0;
+    end else begin
+        il_eff_q    <= il_eff;
+        filmp_eff_q <= filmp_eff;
+    end
 end
 
 // =========================================================================
@@ -1961,8 +1985,8 @@ reg [6:0] load_flush_cnt = 7'd0;
 wire      load_flush = load_flush_cnt != 7'd0;
 always @(posedge clk_sys) begin
     if (~reset_n)                          load_flush_cnt <= 7'd0;
-    else if (start_streaming || seek_ack || jump_ack || il_switch)
-                                           load_flush_cnt <= 7'd64;   // load, seek, menu jump OR interlace mode switch
+    else if (start_streaming || seek_ack || jump_ack || mode_switch)
+                                           load_flush_cnt <= 7'd64;   // load, seek, menu jump OR raster-regime (interlace/film) switch
     else if (load_flush)                   load_flush_cnt <= load_flush_cnt - 7'd1;
 end
 wire pipe_rst_n = reset_n & ~load_flush;
@@ -2008,8 +2032,8 @@ reg [6:0] aud_flush_cnt = 7'd0;
 wire      aud_flush = aud_flush_cnt != 7'd0;
 always @(posedge clk_sys) begin
     if (~reset_n)                                          aud_flush_cnt <= 7'd0;
-    else if (start_streaming || ((seek_ack || jump_ack) && ~keep_vbuf) || il_switch)
-                                                           aud_flush_cnt <= 7'd64;   // il_switch: full re-sync (see il_switch comment)
+    else if (start_streaming || ((seek_ack || jump_ack) && ~keep_vbuf) || mode_switch)
+                                                           aud_flush_cnt <= 7'd64;   // mode_switch: full re-sync (see il_switch/film_switch comments)
     else if (aud_flush)                                    aud_flush_cnt <= aud_flush_cnt - 7'd1;
 end
 wire aud_rst_n = reset_n & ~aud_flush & ~aud_resync;
@@ -2157,8 +2181,8 @@ wire      seek_flush_now = seek_ack && ~keep_vbuf;
 // see that il_switch comment for why the vbuf flush ALONE desynced audio.
 always @(posedge clk_sys) begin
     if (~reset_n)                                          seek_flush_cnt <= 7'd0;
-    else if (seek_flush_now || jump_flush || il_switch || start_streaming)
-                                                           seek_flush_cnt <= 7'd64;   // seek / menu->title jump / interlace mode switch / file mount
+    else if (seek_flush_now || jump_flush || mode_switch || start_streaming)
+                                                           seek_flush_cnt <= 7'd64;   // seek / menu->title jump / raster-regime switch / file mount
     else if (seek_flush)                                   seek_flush_cnt <= seek_flush_cnt - 7'd1;
 end
 reg vbuf_flush_s1, vbuf_flush_dec;

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -1969,74 +1969,30 @@ always @(posedge clk_sys) begin
 end
 
 // =========================================================================
-// CLIP-LOAD FLUSH (2026-07-02): pulse a short reset through the DEMUX/AUDIO
-// chain on every file mount, so a new clip never inherits the previous one's
-// state. Without this: the audio_ring is still full of the OLD clip's audio
-// (which would play into the new clip) and, worse, its almost_full backpressure
-// is already engaged at t=0 — strangling the new clip's stream before it can
-// flood-fill VBUF, so the decoder starts bitstream-starved (HW: reload of a
-// clip started as a slideshow; only a core reload played smoothly). Scope:
-// ps_stream_fifo, ps_demux, ac3_reframer, audio_ring, dvd_audio_decode, av_sync
-// (fresh STC anchor). NOT the streamer (it must catch this same mount event)
-// and NOT mpeg2video (a full decoder reset would clear the regfile/modeline;
-// the decoder already re-syncs on the next sequence header). The pulse is 64
-// clk_sys cycles (~2.4 us) — over long before the first sector arrives.
-reg [6:0] load_flush_cnt = 7'd0;
-wire      load_flush = load_flush_cnt != 7'd0;
-always @(posedge clk_sys) begin
-    if (~reset_n)                          load_flush_cnt <= 7'd0;
-    else if (start_streaming || seek_ack || jump_ack || mode_switch)
-                                           load_flush_cnt <= 7'd64;   // load, seek, menu jump OR raster-regime (interlace/film) switch
-    else if (load_flush)                   load_flush_cnt <= load_flush_cnt - 7'd1;
-end
-wire pipe_rst_n = reset_n & ~load_flush;
-
-// AUDIO-ONLY RE-SYNC (Phase-10 round 3): on an audio-track switch, re-phase the
-// audio WITHOUT touching ps_stream_fifo / ps_demux (which carry the video bitstream
-// on the same byte stream; resetting them mid-PES corrupts the picture — the round-1
-// green-frame regression). Scope is DELIBERATELY MINIMAL — just `audio_ring` +
-// `dvd_audio_decode` (via `aud_rst_n` = pipe_rst_n AND NOT aud_resync):
-//   - the ring reset DISCARDS the old track's queued frames, so the first frame the
-//     decoder sees post-switch is a NEW-track frame with the correct PTS (a decoder
-//     reset alone would re-phase to the stale old-track PTS still in the ring = no fix);
-//   - the decoder reset drains the PCM FIFO so its drain-gate re-establishes the
-//     playback phase against the (video-continuous, still-correct) av_sync STC.
-// av_sync is NOT reset — its STC never drifts across the switch (video is continuous)
-// and nco_trim is retired, so it's telemetry-only here. ac3_reframer is NOT reset —
-// it self-heals on the next 0x0B77 AC-3 boundary (the ring discards its transient
-// output during the reset window anyway). Keeping the new high-fanout reset net down
-// to 2 modules matters: this design is fit-congestion-marginal (~87% ALM) and a
-// 4-module aud_rst_n net FAILED to route (Error 11802) twice. load / seek / menu jump
-// still reset both via pipe_rst_n. 64 clk_sys cycles; brief silent gap is expected.
-reg [6:0] aud_resync_cnt = 7'd0;
-wire      aud_resync = aud_resync_cnt != 7'd0;
-always @(posedge clk_sys) begin
-    if (~reset_n)            aud_resync_cnt <= 7'd0;
-    else if (aud_switch)     aud_resync_cnt <= 7'd64;
-    else if (aud_resync)     aud_resync_cnt <= aud_resync_cnt - 7'd1;
-end
-
-// AUDIO-CONTINUITY ACROSS A KEEP_VBUF MENU TRANSITION (docs/dvd_menu_refinements.md §5d).
-// pipe_rst_n resets the whole demux/audio chain on EVERY jump (load_flush). For the VIDEO
-// that's fine - ps_demux re-parses the new stream into the KEPT decoder buffer (keep_vbuf),
-// whose ~1 s of buffered frames bridge the re-parse gap, so video rides smoothly through a
-// menu->menu transition. But audio_ring + dvd_audio_decode were ALSO reset, wiping the
-// queued menu audio - so audio DROPPED OUT at the transition while video played on (the T2
-// "next clip's audio missing at the junction"). Fix: gate the AUDIO reset with keep_vbuf,
-// symmetrically with the video vbuf_flush - on a keep_vbuf menu->menu transition the audio
-// ring is NOT reset, so its queued audio keeps draining while ps_demux/reframer (still reset
-// via pipe_rst_n) re-sync and refill it behind the old audio. A REAL flush (clip load, title
-// seek, menu->title Play, Snappy deep-flush = keep_vbuf 0) still resets audio to stay aligned
-// with the video flush.
-reg [6:0] aud_flush_cnt = 7'd0;
-wire      aud_flush = aud_flush_cnt != 7'd0;
-always @(posedge clk_sys) begin
-    if (~reset_n)                                          aud_flush_cnt <= 7'd0;
-    else if (start_streaming || ((seek_ack || jump_ack) && ~keep_vbuf) || mode_switch)
-                                                           aud_flush_cnt <= 7'd64;   // mode_switch: full re-sync (see il_switch/film_switch comments)
-    else if (aud_flush)                                    aud_flush_cnt <= aud_flush_cnt - 7'd1;
-end
-wire aud_rst_n = reset_n & ~aud_flush & ~aud_resync;
+// FLUSH / RESET TRIGGER MATRIX — dvd/flush_ctl.sv (extracted 2026-08-28 so the
+// trigger matrix is testbenchable: bench/dvd/flush_ctl_tb.sv). The full design
+// rationale moved with the code: CLIP-LOAD FLUSH scope (what pipe_rst_n does and
+// deliberately does NOT reset), AUDIO-ONLY RE-SYNC (aud_resync), keep_vbuf
+// audio-continuity (aud_flush gating), the SEEK VBUF FLUSH + the 2026-08-28
+// mount/mode_switch flush-trio rule. Events in, ~64-cycle flush levels out.
+wire load_flush, aud_flush, aud_resync, seek_flush;
+wire pipe_rst_n, aud_rst_n;
+flush_ctl flush_ctl_i (
+    .clk             (clk_sys),
+    .rst_n           (reset_n),
+    .start_streaming (start_streaming),
+    .seek_ack        (seek_ack),
+    .jump_ack        (jump_ack),
+    .mode_switch     (mode_switch),
+    .aud_switch      (aud_switch),
+    .keep_vbuf       (keep_vbuf),
+    .load_flush      (load_flush),
+    .aud_flush       (aud_flush),
+    .aud_resync      (aud_resync),
+    .seek_flush      (seek_flush),
+    .pipe_rst_n      (pipe_rst_n),
+    .aud_rst_n       (aud_rst_n)
+);
 // On a keep_vbuf menu transition the audio ring is NOT reset (audio-continuity), so tell it
 // to DROP the splice frames (truncated old + ps_demux/reframer re-sync garbage) that would
 // otherwise decode as a pop/blip (MiB/Matrix root-menu transitions). §5d.
@@ -2140,51 +2096,13 @@ always @(posedge clk_sys) begin
 end
 wire reader_busy = fifo_almost_full | menu_vbuf_throttle | vbuf_hard_over;
 
-// SEEK VBUF FLUSH: on a transport seek OR a new file mount, also discard the
-// decoder's ~1 s compressed video cushion (VBUF) so the picture jumps with the
-// audio instead of playing the old buffered stream for ~1 s. A ~64-cycle level,
-// 2-FF synced into clk_dec, drives mpeg2video.vbuf_flush.
-//
-// MOUNT FLUSH (2026-08-28): start_streaming now fires this too, completing the
-// full flush trio (seek/vbuf + load + aud) for a mid-play file load — the same
-// trio il_switch performs (see the il_switch comment for the HW-proven rule that
-// all three are needed). The original "Seek-only (the known-good clip-load path
-// is left untouched)" exclusion predated the lip-sync v5 pickup_hold->video_live
-// re-arm (PR fj#60): back then a warm reload kept the old STC advancing and the
-// un-flushed VBUF was a small bounded offset. After v5, a reload re-anchors the
-// STC on the NEW file's first vid_pts and re-arms video_live like a cold start —
-// so the surviving 0.5-2 MB of OLD-file VBUF meant the governor's first pickup
-// displayed an OLD frame against the NEW anchor: audio led video by the whole
-// residual VBUF depth, permanently (a forward skew < ~15 s never re-anchors,
-// av_sync FWD_REANCHOR_TICKS). Only a core reload (empty VBUF) avoided it.
-// The mount term is deliberately UNGATED by keep_vbuf: a stale keep_vbuf=1 level
-// from a previous menu hop must not suppress a mount flush (mirrors the ungated
-// start_streaming term in aud_flush_cnt above).
-// PHASE-5 MENU TRANSITION: a menu->menu seek/jump (keep_vbuf) suppresses the
-// VBUF flush so the buffered transition-animation tail plays out (no cold
-// re-lock on a stale/black frame). Title seeks and menu->title jumps still
-// flush (A/V-sync critical). See docs/dvd_menu_refinements.md sec.2.
-//
-// UNIVERSAL menu behaviour (§5d, 2026-07-13): the old Snappy/Smooth toggle (P1O[18],
-// which OVERRODE keep_vbuf to flush a deep menu buffer) is REMOVED - HW confirmed the
-// keep_vbuf + menu-VBUF-cap + audio-continuity path works on every disc, so menu->menu
-// transitions now ALWAYS keep the buffer (no flush), and the cap (reader_busy above)
-// handles the lag. So the flush is back to the pure keep_vbuf rule: flush a title
-// transport seek / menu->title Play (keep_vbuf=0), never a menu->menu transition.
-reg [6:0] seek_flush_cnt = 7'd0;
-wire      seek_flush = seek_flush_cnt != 7'd0;
-wire      jump_flush = jump_ack && ~keep_vbuf;
-wire      seek_flush_now = seek_ack && ~keep_vbuf;
-// il_switch (interlace mode change) drives the VBUF flush here too — the decoder discards
-// its buffered bitstream and re-locks in the new raster. It is declared above the CLIP-LOAD
-// FLUSH block (it also fires load_flush + aud_flush for a FULL seek-equivalent re-sync);
-// see that il_switch comment for why the vbuf flush ALONE desynced audio.
-always @(posedge clk_sys) begin
-    if (~reset_n)                                          seek_flush_cnt <= 7'd0;
-    else if (seek_flush_now || jump_flush || mode_switch || start_streaming)
-                                                           seek_flush_cnt <= 7'd64;   // seek / menu->title jump / raster-regime switch / file mount
-    else if (seek_flush)                                   seek_flush_cnt <= seek_flush_cnt - 7'd1;
-end
+// SEEK VBUF FLUSH — now generated inside flush_ctl (see the trigger-matrix
+// instantiation above): a title transport seek / menu->title jump (~keep_vbuf),
+// a raster-regime switch (mode_switch), or a file mount (2026-08-28) discards
+// the decoder's ~1 s compressed cushion so the picture jumps with the audio.
+// Full rationale (incl. the mount flush-trio post-mortem and the keep_vbuf
+// menu-transition suppression) lives in dvd/flush_ctl.sv. Here we only 2-FF the
+// clk_sys level into clk_dec to drive mpeg2video.vbuf_flush.
 reg vbuf_flush_s1, vbuf_flush_dec;
 always @(posedge clk_dec) begin
     vbuf_flush_s1  <= seek_flush;

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -1968,7 +1968,7 @@ end
 // deliberately does NOT reset), AUDIO-ONLY RE-SYNC (aud_resync), keep_vbuf
 // audio-continuity (aud_flush gating), the SEEK VBUF FLUSH + the 2026-08-28
 // mount/mode_switch flush-trio rule. Events in, ~64-cycle flush levels out.
-wire load_flush, aud_flush, aud_resync, seek_flush;
+wire load_flush, aud_flush, aud_resync, seek_flush, mount_flush;
 wire pipe_rst_n, aud_rst_n;
 flush_ctl flush_ctl_i (
     .clk             (clk_sys),
@@ -1983,6 +1983,7 @@ flush_ctl flush_ctl_i (
     .aud_flush       (aud_flush),
     .aud_resync      (aud_resync),
     .seek_flush      (seek_flush),
+    .mount_flush     (mount_flush),
     .pipe_rst_n      (pipe_rst_n),
     .aud_rst_n       (aud_rst_n)
 );
@@ -3332,6 +3333,7 @@ mpeg2video mpeg2video_inst (
     .pause             (pause_dec),                    // DVD-FORK (gamepad transport): freeze frame while paused (clk_dec-synced)
     .freeze_wd         (still_dec),                    // DVD-FORK (disc-menu still): watchdog-suppress only (clk_dec-synced)
     .vbuf_flush        (vbuf_flush_dec),               // DVD-FORK (gamepad transport): discard VBUF on a seek (clk_dec-synced)
+    .soft_flush        (mount_flush),                  // DVD-FORK (mount soft reset): watchdog-equivalent decode reset on a file mount (async, synchronizers inside)
     .disp_vscale_mode  (disp_vscale_mode),             // DVD-FORK (CRT anamorphic vscale): 0 Fit / 2 SIF 2x line repeat
     .disp_vscale_en    (disp_vscale_en),               // DVD-FORK (CRT anamorphic letterbox AA): downstream 2-tap blend enable
     .disp_hcrop_en     (disp_hcrop_en),                // DVD-FORK (CRT anamorphic horizontal crop / pan-scan)

--- a/dvd/flush_ctl.sv
+++ b/dvd/flush_ctl.sv
@@ -7,9 +7,11 @@
  * played the OLD file's 0.5-2 MB buffered tail against the NEW file's STC anchor)
  * lived exactly in this glue, which had no sim coverage while it was inline.
  *
- * One module, four counters, clk_sys only. The event inputs are 1-cycle pulses
+ * One module, five counters, clk_sys only. The event inputs are 1-cycle pulses
  * except keep_vbuf (a reader level, sampled by the same event pulses it qualifies).
  * Each flush output is a ~64-cycle level; the consumers treat it as a reset.
+ * mount_flush (mount ONLY) additionally requests the decoder's watchdog-equivalent
+ * soft reset — see its block comment at the bottom.
  *
  * THE FLUSH TRIO RULE (HW-proven, see the il_switch comment in emu.sv and
  * docs/interlaced_auto.md): a playback discontinuity needs ALL THREE of
@@ -49,6 +51,7 @@ module flush_ctl (
     output wire aud_flush,        // ~64-cycle level -> audio chain reset (with aud_resync)
     output wire aud_resync,       // ~64-cycle level -> audio-only re-phase
     output wire seek_flush,       // ~64-cycle level -> 2-FF into clk_dec = mpeg2video.vbuf_flush
+    output wire mount_flush,      // ~64-cycle level, MOUNT ONLY -> mpeg2video.soft_flush (decoder soft reset)
     output wire pipe_rst_n,       // reset_n & ~load_flush
     output wire aud_rst_n         // reset_n & ~aud_flush & ~aud_resync
 );
@@ -160,6 +163,28 @@ always @(posedge clk) begin
     else if (seek_flush_now || jump_flush || mode_switch || start_streaming)
                                                            seek_flush_cnt <= 7'd64;   // seek / menu->title jump / raster-regime switch / file mount
     else if (seek_flush)                                   seek_flush_cnt <= seek_flush_cnt - 7'd1;
+end
+
+// MOUNT SOFT RESET (2026-08-28): on a file MOUNT ONLY, also request the decoder's
+// watchdog-equivalent soft reset (mpeg2video.soft_flush -> reset.soft_rst_n). The
+// flush trio above discards BUFFERED data but deliberately leaves the decode
+// pipeline's state (the upstream "trick play" flush resets only the VBUF FIFOs;
+// vld/getbits/motcomp/picbuf are all on sync_rst) — right for seeks, where the
+// display must hold the last frame and the reference frames are same-file valid.
+// A NEW FILE must not inherit any of it: the in-flight picture "completes" on the
+// new file's first start code (one truncated garbage frame), and the old file's
+// reference frames stay flagged valid, so an open-GOP-leading new file (common for
+// flat .mpg/.VOB clips; MPEG-1/VCD too) motion-compensates its first B-frames
+// against the PREVIOUS file = macroblock garbage at load. The soft reset clears
+// all of it while the regfile/modeline (hard_rst) survive — the exact recovery
+// path a watchdog expiry exercises routinely on HW — so a warm load starts as
+// black and clean as a core reload. NEVER on seeks/jumps/mode switches.
+reg [6:0] mount_flush_cnt = 7'd0;
+assign    mount_flush = mount_flush_cnt != 7'd0;
+always @(posedge clk) begin
+    if (~rst_n)                  mount_flush_cnt <= 7'd0;
+    else if (start_streaming)    mount_flush_cnt <= 7'd64;   // mount ONLY
+    else if (mount_flush)        mount_flush_cnt <= mount_flush_cnt - 7'd1;
 end
 
 endmodule

--- a/dvd/flush_ctl.sv
+++ b/dvd/flush_ctl.sv
@@ -1,0 +1,166 @@
+/*
+ * flush_ctl.sv — flush/reset trigger matrix for the playback pipeline
+ *
+ * DVD-FORK (2026-08-28). Extracted verbatim from dvd/emu.sv so the trigger matrix
+ * is testbenchable (bench/dvd/flush_ctl_tb.sv): the mid-play mount A/V-desync bug
+ * (mount fired load_flush + aud_flush but NOT the seek/VBUF flush, so the decoder
+ * played the OLD file's 0.5-2 MB buffered tail against the NEW file's STC anchor)
+ * lived exactly in this glue, which had no sim coverage while it was inline.
+ *
+ * One module, four counters, clk_sys only. The event inputs are 1-cycle pulses
+ * except keep_vbuf (a reader level, sampled by the same event pulses it qualifies).
+ * Each flush output is a ~64-cycle level; the consumers treat it as a reset.
+ *
+ * THE FLUSH TRIO RULE (HW-proven, see the il_switch comment in emu.sv and
+ * docs/interlaced_auto.md): a playback discontinuity needs ALL THREE of
+ *   seek_flush (decoder VBUF discard) + load_flush (demux/av_sync/STC re-anchor)
+ *   + aud_flush (audio chain cold start)
+ * or audio ends up phased against the wrong video timeline:
+ *   - vbuf-only  => video jumps ~1 s forward, audio keeps its backlog => audio LATE
+ *     (the il_switch v1 lesson);
+ *   - load+aud only => STC anchors on the new stream while the decoder still plays
+ *     the old buffered tail => audio EARLY by the residual VBUF depth, permanently
+ *     (the mid-play mount bug, fixed 2026-08-28 — a forward skew < ~15 s never
+ *     re-anchors, av_sync FWD_REANCHOR_TICKS).
+ * The deliberate exceptions are keep_vbuf menu->menu transitions (video tail plays
+ * out, audio rides through — docs/dvd_menu_refinements.md §5d) and the audio-only
+ * aud_resync (video is continuous, so only the audio side re-phases).
+ *
+ * Kept in emu.sv (not moved): the il_switch/film_switch edge-detects that produce
+ * mode_switch (they need il_eff/filmp_eff/menu_active), aud_drop_pulse, and the
+ * seek_flush 2-FF CDC into clk_dec (vbuf_flush_dec).
+ */
+
+`default_nettype none
+
+module flush_ctl (
+    input  wire clk,              // clk_sys (27 MHz)
+    input  wire rst_n,            // core reset (emu reset_n)
+
+    input  wire start_streaming,  // 1-cycle pulse: new file mounted
+    input  wire seek_ack,         // 1-cycle pulse: reader executed a transport seek
+    input  wire jump_ack,         // 1-cycle pulse: reader executed a VM jump
+    input  wire mode_switch,      // 1-cycle pulse: live raster-regime change (interlace/film)
+    input  wire aud_switch,       // 1-cycle pulse: audio track switch
+    input  wire keep_vbuf,        // level (reader): menu->menu transition keeps the VBUF
+
+    output wire load_flush,       // ~64-cycle level -> pipe_rst_n scope (demux/av_sync/nav)
+    output wire aud_flush,        // ~64-cycle level -> audio chain reset (with aud_resync)
+    output wire aud_resync,       // ~64-cycle level -> audio-only re-phase
+    output wire seek_flush,       // ~64-cycle level -> 2-FF into clk_dec = mpeg2video.vbuf_flush
+    output wire pipe_rst_n,       // reset_n & ~load_flush
+    output wire aud_rst_n         // reset_n & ~aud_flush & ~aud_resync
+);
+
+// =========================================================================
+// CLIP-LOAD FLUSH (2026-07-02): pulse a short reset through the DEMUX/AUDIO
+// chain on every file mount, so a new clip never inherits the previous one's
+// state. Without this: the audio_ring is still full of the OLD clip's audio
+// (which would play into the new clip) and, worse, its almost_full backpressure
+// is already engaged at t=0 — strangling the new clip's stream before it can
+// flood-fill VBUF, so the decoder starts bitstream-starved (HW: reload of a
+// clip started as a slideshow; only a core reload played smoothly). Scope:
+// ps_stream_fifo, ps_demux, ac3_reframer, audio_ring, dvd_audio_decode, av_sync
+// (fresh STC anchor). NOT the streamer (it must catch this same mount event)
+// and NOT mpeg2video (a full decoder reset would clear the regfile/modeline;
+// the decoder already re-syncs on the next sequence header). The pulse is 64
+// clk_sys cycles (~2.4 us) — over long before the first sector arrives.
+reg [6:0] load_flush_cnt = 7'd0;
+assign    load_flush = load_flush_cnt != 7'd0;
+always @(posedge clk) begin
+    if (~rst_n)                            load_flush_cnt <= 7'd0;
+    else if (start_streaming || seek_ack || jump_ack || mode_switch)
+                                           load_flush_cnt <= 7'd64;   // load, seek, menu jump OR raster-regime (interlace/film) switch
+    else if (load_flush)                   load_flush_cnt <= load_flush_cnt - 7'd1;
+end
+assign pipe_rst_n = rst_n & ~load_flush;
+
+// AUDIO-ONLY RE-SYNC (Phase-10 round 3): on an audio-track switch, re-phase the
+// audio WITHOUT touching ps_stream_fifo / ps_demux (which carry the video bitstream
+// on the same byte stream; resetting them mid-PES corrupts the picture — the round-1
+// green-frame regression). Scope is DELIBERATELY MINIMAL — just `audio_ring` +
+// `dvd_audio_decode` (via `aud_rst_n` = pipe_rst_n AND NOT aud_resync):
+//   - the ring reset DISCARDS the old track's queued frames, so the first frame the
+//     decoder sees post-switch is a NEW-track frame with the correct PTS (a decoder
+//     reset alone would re-phase to the stale old-track PTS still in the ring = no fix);
+//   - the decoder reset drains the PCM FIFO so its drain-gate re-establishes the
+//     playback phase against the (video-continuous, still-correct) av_sync STC.
+// av_sync is NOT reset — its STC never drifts across the switch (video is continuous)
+// and nco_trim is retired, so it's telemetry-only here. ac3_reframer is NOT reset —
+// it self-heals on the next 0x0B77 AC-3 boundary (the ring discards its transient
+// output during the reset window anyway). Keeping the new high-fanout reset net down
+// to 2 modules matters: this design is fit-congestion-marginal (~87% ALM) and a
+// 4-module aud_rst_n net FAILED to route (Error 11802) twice. load / seek / menu jump
+// still reset both via pipe_rst_n. 64 clk_sys cycles; brief silent gap is expected.
+reg [6:0] aud_resync_cnt = 7'd0;
+assign    aud_resync = aud_resync_cnt != 7'd0;
+always @(posedge clk) begin
+    if (~rst_n)              aud_resync_cnt <= 7'd0;
+    else if (aud_switch)     aud_resync_cnt <= 7'd64;
+    else if (aud_resync)     aud_resync_cnt <= aud_resync_cnt - 7'd1;
+end
+
+// AUDIO-CONTINUITY ACROSS A KEEP_VBUF MENU TRANSITION (docs/dvd_menu_refinements.md §5d).
+// pipe_rst_n resets the whole demux/audio chain on EVERY jump (load_flush). For the VIDEO
+// that's fine - ps_demux re-parses the new stream into the KEPT decoder buffer (keep_vbuf),
+// whose ~1 s of buffered frames bridge the re-parse gap, so video rides smoothly through a
+// menu->menu transition. But audio_ring + dvd_audio_decode were ALSO reset, wiping the
+// queued menu audio - so audio DROPPED OUT at the transition while video played on (the T2
+// "next clip's audio missing at the junction"). Fix: gate the AUDIO reset with keep_vbuf,
+// symmetrically with the video vbuf_flush - on a keep_vbuf menu->menu transition the audio
+// ring is NOT reset, so its queued audio keeps draining while ps_demux/reframer (still reset
+// via pipe_rst_n) re-sync and refill it behind the old audio. A REAL flush (clip load, title
+// seek, menu->title Play, Snappy deep-flush = keep_vbuf 0) still resets audio to stay aligned
+// with the video flush.
+reg [6:0] aud_flush_cnt = 7'd0;
+assign    aud_flush = aud_flush_cnt != 7'd0;
+always @(posedge clk) begin
+    if (~rst_n)                                            aud_flush_cnt <= 7'd0;
+    else if (start_streaming || ((seek_ack || jump_ack) && ~keep_vbuf) || mode_switch)
+                                                           aud_flush_cnt <= 7'd64;   // mode_switch: full re-sync (see il_switch/film_switch comments)
+    else if (aud_flush)                                    aud_flush_cnt <= aud_flush_cnt - 7'd1;
+end
+assign aud_rst_n = rst_n & ~aud_flush & ~aud_resync;
+
+// SEEK VBUF FLUSH: on a transport seek, a raster-regime switch, OR a new file
+// mount, also discard the decoder's ~1 s compressed video cushion (VBUF) so the
+// picture jumps with the audio instead of playing the old buffered stream for
+// ~1 s. The level is 2-FF synced into clk_dec (in emu.sv) to drive
+// mpeg2video.vbuf_flush.
+//
+// MOUNT FLUSH (2026-08-28): start_streaming fires this too, completing the full
+// flush trio for a mid-play file load (see the module header). The original
+// "Seek-only (the known-good clip-load path is left untouched)" exclusion
+// predated the lip-sync v5 pickup_hold->video_live re-arm (PR fj#60): back then
+// a warm reload kept the old STC advancing and the un-flushed VBUF was a small
+// bounded offset. After v5, a reload re-anchors like a cold start, so the
+// surviving OLD-file VBUF made audio lead video by the whole residual depth,
+// permanently. The mount term is deliberately UNGATED by keep_vbuf: a stale
+// keep_vbuf=1 level from a previous menu hop must not suppress a mount flush
+// (mirrors the ungated start_streaming term in aud_flush_cnt above).
+//
+// PHASE-5 MENU TRANSITION: a menu->menu seek/jump (keep_vbuf) suppresses the
+// VBUF flush so the buffered transition-animation tail plays out (no cold
+// re-lock on a stale/black frame). Title seeks and menu->title jumps still
+// flush (A/V-sync critical). See docs/dvd_menu_refinements.md sec.2.
+//
+// UNIVERSAL menu behaviour (§5d, 2026-07-13): the old Snappy/Smooth toggle (P1O[18],
+// which OVERRODE keep_vbuf to flush a deep menu buffer) is REMOVED - HW confirmed the
+// keep_vbuf + menu-VBUF-cap + audio-continuity path works on every disc, so menu->menu
+// transitions now ALWAYS keep the buffer (no flush), and the cap handles the lag. So
+// the flush is back to the pure keep_vbuf rule: flush a title transport seek /
+// menu->title Play (keep_vbuf=0), never a menu->menu transition.
+wire jump_flush     = jump_ack && ~keep_vbuf;
+wire seek_flush_now = seek_ack && ~keep_vbuf;
+reg [6:0] seek_flush_cnt = 7'd0;
+assign    seek_flush = seek_flush_cnt != 7'd0;
+always @(posedge clk) begin
+    if (~rst_n)                                            seek_flush_cnt <= 7'd0;
+    else if (seek_flush_now || jump_flush || mode_switch || start_streaming)
+                                                           seek_flush_cnt <= 7'd64;   // seek / menu->title jump / raster-regime switch / file mount
+    else if (seek_flush)                                   seek_flush_cnt <= seek_flush_cnt - 7'd1;
+end
+
+endmodule
+
+`default_nettype wire

--- a/dvd/flush_ctl.sv
+++ b/dvd/flush_ctl.sv
@@ -26,9 +26,10 @@
  * out, audio rides through — docs/dvd_menu_refinements.md §5d) and the audio-only
  * aud_resync (video is continuous, so only the audio side re-phases).
  *
- * Kept in emu.sv (not moved): the il_switch/film_switch edge-detects that produce
- * mode_switch (they need il_eff/filmp_eff/menu_active), aud_drop_pulse, and the
- * seek_flush 2-FF CDC into clk_dec (vbuf_flush_dec).
+ * Kept in emu.sv (not moved): the edge-detect that produces mode_switch (today
+ * il_switch only — a filmp_eff edge was attempted and REVERTED 2026-08-28, see the
+ * mode_switch comment in emu.sv for the T2 logo-chain post-mortem), aud_drop_pulse,
+ * and the seek_flush 2-FF CDC into clk_dec (vbuf_flush_dec).
  */
 
 `default_nettype none
@@ -117,7 +118,7 @@ assign    aud_flush = aud_flush_cnt != 7'd0;
 always @(posedge clk) begin
     if (~rst_n)                                            aud_flush_cnt <= 7'd0;
     else if (start_streaming || ((seek_ack || jump_ack) && ~keep_vbuf) || mode_switch)
-                                                           aud_flush_cnt <= 7'd64;   // mode_switch: full re-sync (see il_switch/film_switch comments)
+                                                           aud_flush_cnt <= 7'd64;   // mode_switch: full re-sync (see the mode_switch comment in emu.sv)
     else if (aud_flush)                                    aud_flush_cnt <= aud_flush_cnt - 7'd1;
 end
 assign aud_rst_n = rst_n & ~aud_flush & ~aud_resync;

--- a/dvd/frame_drop_ctl.sv
+++ b/dvd/frame_drop_ctl.sv
@@ -81,6 +81,15 @@ module frame_drop_ctl #(
   // governor just holds (brief slow-motion), consumption falls below delivery, and the
   // cushion refills — self-healing.
   input  wire        bitstream_ok, // level: VBUF cushion healthy (hysteretic, clk-domain)
+  // DVD-FORK FIX (2026-08-28, mid-play load/seek debt carry-over): clear the ledger
+  // whenever the decoder's VBUF is flushed (flush_vbuf_eff level, same clk domain).
+  // The debt survived every discontinuity — reset only by sync_rst — so a warm file
+  // mount or a seek carried up to DEBT_MAX (15) refreshes of stale lateness into the
+  // new position and could fire spurious B-drops (~0.25 s of stutter) the moment
+  // vbuf_healthy re-armed. Post-flush the governor's timeline restarts anyway, so the
+  // old debt refers to display history that no longer exists. Telemetry counters are
+  // deliberately NOT cleared (free-running totals).
+  input  wire        flush,      // level: VBUF flushed (seek/jump/mount/mode switch)
   input  wire        frame_late, // 1-cycle pulse: governor held a late refresh (+1 debt)
   input  wire        drop_ack,   // 1-cycle pulse: VLD dropped a B-frame (-drop_cost debt)
   // FILM-AWARE RECLAIM (2026-07-03): display duration (refreshes) of the frame
@@ -135,7 +144,7 @@ module frame_drop_ctl #(
     if (~rst)
       debt <= {DW{1'b0}};
     else if (clk_en) begin
-      if (~enable)
+      if (~enable || flush)
         debt <= {DW{1'b0}};
       else
         debt <= debt_n;

--- a/dvd/resample_addrgen.v
+++ b/dvd/resample_addrgen.v
@@ -98,8 +98,9 @@ module resample_addrgen (
    * advancing when the first frame actually REACHES THE SCREEN, not when its PES was
    * parsed — the parse leads the display by the whole buffering window (audio_ring +
    * VBUF fill), which is content-dependent and, uncorrected, made the audio genlock
-   * target wrong by that much. Cleared only by rst (not by a clip reload — known
-   * limitation, see docs/av_sync.md). */
+   * target wrong by that much. RE-ARMED per load: a pickup_hold rising edge (the STD
+   * mux-lead hold, asserted from every load/seek flush) clears it again, so a clip
+   * reload behaves like a cold start (the lip-sync v5 fix; see docs/av_sync.md). */
   output reg         video_live;
 
   /* DVD-FORK (STD mux-lead hold, 2026-07-02): while high AND no frame has been

--- a/rtl/mpeg2/mpeg2video.v
+++ b/rtl/mpeg2/mpeg2video.v
@@ -75,6 +75,7 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
              pause,                                                // DVD-FORK (gamepad transport): freeze the displayed frame while paused
              freeze_wd,                                            // DVD-FORK (disc-menu still): watchdog-suppress ONLY (no governor freeze)
              vbuf_flush,                                           // DVD-FORK (gamepad transport): discard the buffered bitstream on a seek
+             soft_flush,                                           // DVD-FORK (mount soft reset): watchdog-equivalent decode-pipeline reset on a file mount
              disp_vscale_mode,                                     // DVD-FORK (CRT anamorphic vscale): 0=fit 1=letterbox(dormant) 2=SIF 2x line repeat
              disp_vscale_en,                                       // DVD-FORK (CRT anamorphic letterbox AA): enable downstream disp_vscale 2-tap blend
              disp_hcrop_en,                                        // DVD-FORK (CRT anamorphic horizontal crop / pan-scan)
@@ -199,6 +200,16 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
    * old buffered ~1 s of video while audio jumped immediately (HW: video lagged the
    * seek by ~1 s, A/V desynced). ORed into the regfile's own flush_vbuf below. */
   input            vbuf_flush;
+  /* DVD-FORK (mount soft reset, 2026-08-28): active-HIGH level from emu (clk_sys-timed,
+   * >= 2.4 us; the reset synchronizers handle the CDC). Requests the SAME decode-pipeline
+   * reset a watchdog expiry produces (sync_rst/mem_rst/dot_rst assert; the regfile is on
+   * hard_rst and SURVIVES, so the modeline keeps its programming — the HW-proven watchdog
+   * recovery path). Fired on a new file MOUNT only, never on seeks: a seek wants display
+   * continuity (held frame) and its references are same-file valid, but a mount must not
+   * carry the old file's in-flight picture or reference frames into the new one (open-GOP
+   * leading B-frames motion-compensated against the previous file = macroblock garbage at
+   * load; the truncated in-flight picture completes on the new file's first start code). */
+  input            soft_flush;
   /* DVD-FORK (CRT anamorphic vertical scaler, emu clk_sys origin — quasi-static menu
    * level). disp_vscale_mode selects the resample_addrgen display mapping (0=fit,
    * 1=letterbox, 2=zoom); 0 outside CRT mode => bit-identical to the pre-scaler path.
@@ -801,13 +812,14 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
   /* reset signal synchronizers */
 
   reset reset (
-    .clk(clk), 
-    .mem_clk(mem_clk), 
-    .dot_clk(dot_clk), 
+    .clk(clk),
+    .mem_clk(mem_clk),
+    .dot_clk(dot_clk),
     .async_rst(rst),
     .watchdog_rst(watchdog_rst),
-    .clk_rst(sync_rst), 
-    .mem_rst(mem_rst), 
+    .soft_rst_n(~soft_flush),                                // DVD-FORK (mount soft reset): active-low request, watchdog-equivalent
+    .clk_rst(sync_rst),
+    .mem_rst(mem_rst),
     .dot_rst(dot_rst),
     .hard_rst(hard_rst)
     );

--- a/rtl/mpeg2/mpeg2video.v
+++ b/rtl/mpeg2/mpeg2video.v
@@ -1071,6 +1071,7 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
                (drop_pic_field ? 4'd1 : (drop_pic_rff ? 4'd3 : 4'd2))),   // field-pair drop: 1/field
     .drop_req(drop_pic_req),
     .bitstream_ok(vbuf_healthy),                       // DVD-FORK: starvation guard (see frame_drop_ctl)
+    .flush(flush_vbuf_eff),                            // DVD-FORK FIX (2026-08-28): clear carried debt on a VBUF flush (mount/seek/mode switch)
     .frames_late_cnt(dbg_frames_late),
     .frames_dropped_cnt(dbg_frames_dropped),
     .debt_out(dbg_debt)

--- a/rtl/mpeg2/reset.v
+++ b/rtl/mpeg2/reset.v
@@ -28,7 +28,7 @@
 
 `include "timescale.v"
 
-module reset (clk, mem_clk, dot_clk, async_rst, watchdog_rst,
+module reset (clk, mem_clk, dot_clk, async_rst, watchdog_rst, soft_rst_n,
               clk_rst, mem_rst, dot_rst, hard_rst);
 
   input clk;                  /* decoder clock */
@@ -36,6 +36,12 @@ module reset (clk, mem_clk, dot_clk, async_rst, watchdog_rst,
   input dot_clk;              /* pixel clock */
   input async_rst;            /* global reset, asynchronous. */
   input watchdog_rst;         /* watchdog-generated reset, synchronous with clk. Goes low when watchdog timer expires. */
+  input soft_rst_n;           /* DVD-FORK (mount soft reset, 2026-08-28): externally requested soft reset,
+                               * async (clk_sys-timed level, >=2.4 us). Goes low to request the same
+                               * decode-pipeline reset a watchdog expiry produces: everything on
+                               * clk_rst/mem_rst/dot_rst clears, the regfile (hard_rst) survives. Used by
+                               * emu on a new file mount so a warm load starts the decoder as cold as a
+                               * core reload (no in-flight picture, no stale reference frames). */
   output clk_rst;             /* global reset, synchronized to decoder clock. Goes low when "async_rst" or "watchdog_rst" goes low. */
   output mem_rst;             /* global reset, synchronized to memory clock. Goes low when "async_rst" or "watchdog_rst" goes low. */
   output dot_rst;             /* global reset, synchronized to pixel clock. Goes low when "async_rst" or "watchdog_rst" goes low. */
@@ -53,13 +59,21 @@ module reset (clk, mem_clk, dot_clk, async_rst, watchdog_rst,
     );
 
   sync_reset clk_swatchdog_0 (
-    .clk(clk), 
+    .clk(clk),
     .asyncrst(watchdog_rst),
     .syncrst(clk_watchdog_0)
     );
 
-  /* combine async_rst and watchdog into a common reset signal */
-  wire comm_rst = clk_rst_0 && clk_watchdog_0;
+  /* DVD-FORK (mount soft reset): synchronize the external soft-reset request like the watchdog */
+  wire clk_soft_0;
+  sync_reset clk_ssoft_0 (
+    .clk(clk),
+    .asyncrst(soft_rst_n),
+    .syncrst(clk_soft_0)
+    );
+
+  /* combine async_rst, watchdog and the external soft reset into a common reset signal */
+  wire comm_rst = clk_rst_0 && clk_watchdog_0 && clk_soft_0;   // DVD-FORK: && clk_soft_0
 
   /* synchronize common reset signal to the three system clocks */
   wire clk_rst_1;


### PR DESCRIPTION
## Summary

Loading a new file while another was playing left audio permanently out of sync (and, for
flat `.VOB`/`.mpg` clips, showed macroblock garbage at load) — only a core reload between
loads avoided it. Root cause was a half-flushed pipeline on mount: `start_streaming` fired
`load_flush` (fresh STC anchor) and `aud_flush` (audio cold start) but **not** the
seek/VBUF flush, so 0.5–2 MB of the old file's bitstream survived in the decoder and the
STC anchored on the new file while the screen played the old one — a forward skew under
the ~15 s re-anchor threshold, i.e. permanent. The old "Seek-only; clip-load path
untouched" exclusion predated the lip-sync v5 `video_live` re-arm and had simply expired.

- **Mount flush trio**: a mount now fires seek/vbuf + load + aud, like `il_switch` and a
  chapter seek (`keep_vbuf`-ungated).
- **Mount decoder soft reset**: the trio flushes buffers only — the decode pipeline
  (in-flight picture, reference frames) survives on `sync_rst` by upstream design, which
  produced the macroblock hash on flat-file loads (open-GOP leading B-frames
  motion-compensated against the previous file). New `flush_ctl.mount_flush` (mount only,
  never seeks) → `mpeg2video.soft_flush` → a third `reset.v` leg requesting the exact
  watchdog-expiry soft reset (regfile/modeline survive on `hard_rst`). A warm load now
  cuts to black and starts as cold as a core reload.
- **flush_ctl extraction**: the flush trigger matrix moved verbatim from emu.sv into
  `dvd/flush_ctl.sv` with a matrix TB (`bench/dvd/flush_ctl_tb.sv`, 11 scenarios, proven
  red against the pre-fix logic).
- **frame_drop_ctl debt-clear**: the drop-debt ledger now clears on any VBUF flush
  (carried-in stale debt could fire spurious B-drops after a mount/seek).
- **film_switch attempted and reverted**: a filmp_eff-edge flush briefly rode this branch
  to fix the menu→film engage skew, and broke T2's menu→Play logo chain on HW (detector
  flapping fired mid-stream flushes → garbage headers → pal_eff feedback → strobe).
  Reverted with a ⛔ comment + post-mortem; the engage skew stays a known issue owned by
  the planned early-film-detect feature. See `docs/film_24p_plan.md` §13.

Docs: post-mortem + flush-trio rule in `docs/av_sync.md`, stale `video_live` text retired
in three places, README Film 24p note adjusted, CLAUDE.md status bullet.

## Test plan

- [x] `flush_ctl_tb` 11-scenario trigger matrix green (mount rows fire all four outputs;
      seek/jump/mode rows prove `mount_flush` stays 0; proven red against pre-fix logic)
- [x] `frame_drop_ctl_tb` incl. new flush-clears-debt case; `film_drift` ×3,
      `cadence_phase` ×2, `cadence_slip`, `gov_field_late`, `frame_drop_sys` green
- [x] `pickup_hold_tb`, `av_sync_tb`, `iso_reader_seek_tb`, `resample_chain` suite green
- [x] Quartus 17.0.2: clk_dec 96.55/92.07 MHz (gate 86.0), 87 % ALM, zero 10236
- [x] HW (user, `DVD_mountflush2_20260828_1537.rbf`): mid-play loads across
      VOB/mpg/ISO/VCD cut to black, start clean, hold A/V sync; T2 menu→Play logo chain
      clean; seeks/chapter jumps/menu nav/cold mount unregressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
