### PR TITLE
emu: bump CORE_VERSION to 0.2.1 after publishing 0.2.0

### DIFF
--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -486,7 +486,7 @@ assign CE_PIXEL = 1'b1;
 // builds: it is part of CONF_STR = part of the netlist, so every compile would
 // become a new netlist and re-roll the fitter seed lottery (DVD.qsf's ledger).
 // Same-day dev builds are identified by their build_release.sh --name filename.
-`define CORE_VERSION "0.2.0"
+`define CORE_VERSION "0.2.1"
 
 parameter CONF_STR = {
     "DVD;;",


### PR DESCRIPTION
Post-publish version bump so no dev build re-advertises the shipped 0.2.0. Mirrors #16.