### PR TITLE
Film detect: stop counting pictures that carry no evidence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,50 @@ worse maintenance burden than targeted in-place edits. So:
   recovery path); a warm load now cuts to black and starts as cold as a core reload.
   Post-mortem + deferred items (detector re-arm, vidfeed_cdc): `docs/av_sync.md`
   "Mid-play mount desync post-mortem".
+- ✅ **FILM MODE FLAPPING — FIXED BY AN EVIDENCE GATE; ✅ HW-CONFIRMED 2026-08-30
+  (build `DVD_filmevidence_20260830_1720`: APOLLO_13's credits no longer flap, T2 holds
+  sync in Auto, and FERRIS_BUELLER follows its own mid-title film→video change IN SYNC).**
+  ★ **The defect was never engage LATENCY — it was mode FLAPPING.** MEASURED on APOLLO_13
+  in DISPLAY order (coded order hides it behind B-reordering): **9 engage/disengage flips
+  in 46 s**, each re-walking the modeline and re-locking ascal. Near-black pictures are
+  **100 % `progressive_frame==0`** (384 B against that title's own 17,704 B median).
+  ★★ **THE FRAMING THAT SOLVED IT: `progressive_frame` is not a measurement — it is a bit
+  the ENCODER wrote**, and on a near-black picture there is no field structure to describe,
+  so the encoder takes the MPEG-2 default and marks it interlaced. The detector counted
+  that meaningless claim at `DN_HARD=8`. VLC's IVTC survives the same content because it
+  reads PIXELS and discards uninformative frames as evidence ("If no motion, the result
+  from this algorithm cannot be reliable ... we do nothing"). **FIX = an informativeness
+  gate on CODED PICTURE SIZE** measured in `vld.v`, carried to the display as a fourth
+  per-picture attribute through `motcomp_picbuf`, where an uninformative pickup updates
+  NOTHING in the detector — not the confidences, not `rff_q`.
+  ⚠ **The threshold must be RELATIVE, per picture coding type, with a warm-up** — all three
+  forced by measurement, not taste: HIGH_SCHOOL_MUSICAL codes a **318 B median** (its small
+  pictures ARE its content; a fixed threshold discards 55 % of the disc and delays its video
+  verdict 17 s), a black I-frame codes 7,580 B where a real one codes ~82,000 B (tiny for an
+  I, above any threshold that does not also eat legitimate B-frames), and seeding the mean
+  from whichever picture arrived first made two rips of near-identical content gate 0.0 %
+  and 85.8 %. ⚠ **Ordering gotcha:** size is known only at picture END, so this CANNOT ride
+  `flags_commit` (which fires at the coding extension near the START) — `informative_commit`
+  pulses at the terminating start code, still strictly before picbuf rotates slots.
+  ⚠ **Count `next_advance`/`next_align`, NOT the registered `advance`/`align`** — vld.v
+  forces those to 0 whenever `clk_en` is low, so a clk_en-gated block reads 0 almost always;
+  that made every picture measure 0 B, which is SILENTLY INERT (a zero mean compares equal,
+  so everything reads "informative") and would have shipped as a no-op.
+  ⛔ **A PER-TITLE LATCH WAS TRIED AND IS NOT THE ANSWER** (abandoned, unpushed): it works on
+  APOLLO_13 but costs **12 s to leave film mode**, which FERRIS_BUELLER's film→video special
+  feature makes unacceptable. ⛔ **`frame_pred_frame_dct` is NOT a usable substitute** — it
+  looks perfect on APOLLO_13 and reads 0 for ~99 % of pictures INCLUDING progressive ones on
+  FERRIS/AUSTIN_POWERS_2, so a detector keyed on it calls film VIDEO within two seconds. It
+  is an encoder rate setting, not a content property. Library sweep: **15 better, 0 worse
+  over 123 discs**. Golden model `tools/film_evidence_probe.py`; suite
+  `bench/dvd/run_film_evidence.sh` (`film_evidence_tb` runs the REAL vld over REAL disc
+  bytes and checks size AND verdict against the golden — a hand-driven vld model would only
+  check one's reading of the FSM). Detail: `docs/film_24p_plan.md` §14.
+  ⚠ **Separate, still OPEN:** APOLLO_13 plays **~800 ms audio-ahead**, established at the
+  FIRST anchor of a playback and cleared by any re-anchor (chapter skip). NOT detection, NOT
+  the raster switch (`Film 24p = On` shows it too), and NOT the VBUF cap (Shallow changed
+  nothing). An imported "anchor the STC on the screen" fix made it WORSE (1800 ms + stream
+  freezes) and is not merged — see `docs/av_sync.md` "HW round 3" before touching it.
 - ✅ **MEM_SHIM_BURST TAG/LRU STORE → M10K — the ALM congestion reclaim (2026-08-27,
   PR #18) — ✅ HW-CONFIRMED 2026-08-28 (user soak: full-length MiB + menu/seek stress,
   no shear/artifacting; build `DVD_shimreclaim_20260828_0259.rbf`).**

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -670,4 +670,9 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # back, seed sweeps should again be rarely needed (the sub-86 rule stands: a
 # failing fit on THIS netlist family means the netlist degraded -- measure with
 # tools/timing_paths.sh, don't re-roll).
+# 2026-08-30 (feature/film-evidence-gate netlist, +373 ALMs: the vld's per-picture
+# size counter, three running means, and the verdict's ride through picbuf):
+# pinned SEED 5 held on the FIRST roll -- clk_dec 93.01 @100C / 89.3 @-40C, PASS
+# with margin at 88% ALM. No sweep needed, consistent with the post-reclaim note
+# above.
 set_global_assignment -name SEED 5

--- a/README.md
+++ b/README.md
@@ -321,6 +321,14 @@ Notes:
 - **Auto** detects film from the stream's pulldown flags. **Hard-telecined** discs — where
   the pulldown was baked in at authoring time — carry no such flags, so Auto cannot see
   them. If a disc looks like film but Auto isn't engaging, set it to **On**.
+- **Fades to black no longer knock Auto out of film mode.** MPEG-2's `progressive_frame`
+  is a flag the *encoder* writes, and on a near-black picture there is no field structure
+  for it to describe, so encoders mark those frames interlaced by default. Auto used to
+  believe them: Apollo 13's fading opening credits changed resolution nine times in the
+  first 46 seconds. The detector now ignores pictures that carry no evidence — measured
+  against the disc's own bitrate, so it works equally on a heavily compressed disc — while
+  still following a genuine film-to-video change within about a second. Fifteen of the 123
+  discs surveyed flapped at the title head before this and no longer do.
 - **`Frame Drop` must stay On.** The cadence-slip corrector, which keeps imperfect
   real-world telecine in step with the display, runs on the frame-drop governor's path
   and does nothing without it.

--- a/bench/dvd/cadence_slip_tb.sv
+++ b/bench/dvd/cadence_slip_tb.sv
@@ -58,7 +58,7 @@ module cadence_slip_tb;
   resample_addrgen dut (
     .clk(clk), .clk_en(clk_en), .rst(rst),
     .output_frame(output_frame), .output_frame_valid(output_frame_valid_w), .output_frame_rd(output_frame_rd),
-    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame),
+    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame), .informative(1'b1),
     .top_field_first(top_field_first), .repeat_first_field(repeat_first_field),
     .mb_width(mb_width), .mb_height(mb_height),
     .horizontal_size(horizontal_size), .vertical_size(vertical_size),

--- a/bench/dvd/film_detect_tb.sv
+++ b/bench/dvd/film_detect_tb.sv
@@ -27,6 +27,9 @@ module film_detect_tb;
   reg   [2:0] output_frame = 3'd1;
   wire        output_frame_rd;
   reg         progressive_sequence = 0, progressive_frame = 1;
+  // DVD-FORK (film evidence gate): 1 = this picture carried real evidence. Default 1,
+  // so every pre-existing scenario below runs exactly as it did before the gate.
+  reg         tb_informative = 1;
   reg         top_field_first = 0, repeat_first_field = 0;
   reg   [7:0] mb_width = 8'd1, mb_height = 8'd1;   // tiny frame -> very fast scans
   reg  [13:0] horizontal_size = 14'd16, vertical_size = 14'd4;
@@ -50,7 +53,7 @@ module film_detect_tb;
   resample_addrgen dut (
     .clk(clk), .clk_en(clk_en), .rst(rst),
     .output_frame(output_frame), .output_frame_valid(output_frame_valid_w), .output_frame_rd(output_frame_rd),
-    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame),
+    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame), .informative(tb_informative),
     .top_field_first(top_field_first), .repeat_first_field(repeat_first_field),
     .mb_width(mb_width), .mb_height(mb_height),
     .horizontal_size(horizontal_size), .vertical_size(vertical_size),

--- a/bench/dvd/film_detect_tb.sv
+++ b/bench/dvd/film_detect_tb.sv
@@ -168,6 +168,46 @@ module film_detect_tb;
     $display("  [2] 30fps video: det_ntsc=%b det_pal=%b det_video=%b (expect 0/1/0)",
              film_det_ntsc, film_det_pal, det_video);
 
+    // ===== G. THE EVIDENCE GATE (informative=0 pickups) =====
+    // The whole point of the gate: on a fade to black the encoder stops
+    // describing field structure and marks pictures interlaced by default, so
+    // progressive_frame goes 0 for reasons that have nothing to do with the
+    // content. APOLLO_13's credits did that for seconds at a time and dropped
+    // film lock nine times in 46 s. Those pickups must not count -- while a
+    // GENUINE video stretch, which is informative, still must.
+    mode = 0;
+    run_pickups(60);
+    chk(film_det_ntsc, "[G] setup: det_ntsc should be engaged on film before the fade");
+
+    // G1: a long uninformative interlaced run = a fade. Film lock must HOLD.
+    tb_informative = 1'b0;
+    mode = 2;                       // pf=0, exactly what a black picture carries
+    run_pickups(80);                // far longer than the ~13 pickups that release
+    chk(film_det_ntsc, "[G1] film lock dropped on an UNINFORMATIVE interlaced run (the APOLLO_13 bug)");
+    chk(!det_video,    "[G1] det_video engaged on uninformative pickups");
+    $display("  [G1] 80 uninformative pf=0 pickups: det_ntsc=%b det_video=%b (expect 1/0)",
+             film_det_ntsc, det_video);
+
+    // G2: the same run, now INFORMATIVE = a real film->video change. Must follow it.
+    tb_informative = 1'b1;
+    run_pickups(80);
+    chk(!film_det_ntsc, "[G2] film lock did NOT release on a genuine interlaced video run");
+    chk(det_video,      "[G2] det_video did not engage on genuine interlaced video");
+    $display("  [G2] 80 informative pf=0 pickups: det_ntsc=%b det_video=%b (expect 0/1)",
+             film_det_ntsc, det_video);
+
+    // G3: gated pickups must not disturb the 3:2 toggle test either -- the run
+    // resumes across the gap rather than seeing a false rff edge.
+    mode = 0; tb_informative = 1'b1;
+    run_pickups(60);
+    chk(film_det_ntsc, "[G3] film did not re-engage after the gated stretch");
+    tb_informative = 1'b0;
+    run_pickups(40);
+    tb_informative = 1'b1;
+    run_pickups(20);
+    chk(film_det_ntsc, "[G3] film lock lost across a gated gap in the 3:2 run");
+    $display("  [G3] film survives a 40-pickup gated gap: det_ntsc=%b (expect 1)", film_det_ntsc);
+
     // ===== 3. transition to 60i/50i interlaced VIDEO (pf=0) =====
     // Both film verdicts release AND the true-interlaced verdict must ENGAGE — this is
     // the signal that drives Interlaced Out Auto to the native fields path (480i/576i).

--- a/bench/dvd/film_evidence_tb.sv
+++ b/bench/dvd/film_evidence_tb.sv
@@ -1,0 +1,211 @@
+// =============================================================================
+// film_evidence_tb.sv — does the vld measure coded picture size correctly, and
+// does its informativeness verdict match the golden model?
+// =============================================================================
+// The film evidence gate rests entirely on one number: how many bits the
+// encoder spent on a picture. Everything downstream — the running mean, the
+// verdict, whether the film detector counts a pickup — is arithmetic on top of
+// it. So this bench does not assert the counter is right; it MEASURES it,
+// against tools/film_evidence_probe.py, through the REAL getbits_fifo + vld
+// over REAL disc bytes. Same technique as cc_extract_tb, and for the same
+// reason: a hand-driven model of the vld would be checking my understanding of
+// the FSM rather than the FSM.
+//
+// The fixture deliberately spans a fade in APOLLO_13's opening credits, so it
+// contains both the ~17 kB content pictures and the 384 B black ones whose
+// meaningless progressive_frame flag is the entire bug.
+//
+// EV_WARM is overridden to 2 so the gate arms inside a short cut. The shipped
+// value is 16; the warm-up LENGTH is a tuning constant, whereas what this bench
+// has to prove is that the measurement and the arithmetic are right.
+//
+// Fixture (gitignored — regenerate with bench/dvd/run_film_evidence.sh):
+//   tools/film_evidence_probe.py <apollo.iso> --start-frac 0.0028 --sectors 350 \
+//       --cut bench/dvd/test_vobs/film_ev --cut-warm 2
+//
+// Build:
+//   iverilog -g2012 -D__IVERILOG__ -I rtl/mpeg2 -o bench/dvd/film_evidence_sim \
+//       rtl/mpeg2/vld.v rtl/mpeg2/getbits.v bench/dvd/film_evidence_tb.sv
+//   vvp bench/dvd/film_evidence_sim
+// =============================================================================
+module film_evidence_tb;
+
+  reg clk = 0; always #5 clk = ~clk;
+  reg rst = 0;
+
+  // sized to the fixture (~645 kB = ~80k words), not to a round power of two:
+  // an oversized TB array is an Icarus compile cliff, not free headroom
+  localparam MAXW = 32768;   // sized to the fixture; an oversized array is an Icarus compile cliff
+  reg [63:0] es [0:MAXW-1];
+  integer    es_words = 0;
+  integer    rd_ptr   = 0;
+
+  wire        vid_in_rd_en;
+  reg         vid_in_rd_valid = 0;
+  reg  [63:0] vid_in = 64'h0;
+
+  always @(posedge clk) begin
+    vid_in_rd_valid <= 1'b0;
+    if (rst && vid_in_rd_en && (rd_ptr < es_words)) begin
+      vid_in          <= es[rd_ptr];
+      vid_in_rd_valid <= 1'b1;
+      rd_ptr          <= rd_ptr + 1;
+    end
+  end
+
+  // ---- golden: {informative[24], coded size in bytes[23:0]} per picture ----
+  localparam MAXP = 4096;
+  reg [31:0] gold [0:MAXP-1];
+  integer    n_golden = 0;
+  integer    n_seen   = 0;
+  integer    errors   = 0;
+  integer    size_err = 0;
+  integer    verd_err = 0;
+
+  wire  [4:0] advance;
+  wire        align, wait_state;
+  wire [23:0] getbits;
+  wire        signbit, vld_en;
+
+  getbits_fifo getbits_fifo (
+    .clk(clk), .clk_en(1'b1), .rst(rst),
+    .vid_in(vid_in), .vid_in_rd_en(vid_in_rd_en), .vid_in_rd_valid(vid_in_rd_valid),
+    .advance(advance), .align(align), .wait_state(wait_state),
+    .rld_wr_almost_full(1'b0), .mvec_wr_almost_full(1'b0), .motcomp_busy(1'b0),
+    .getbits(getbits), .signbit(signbit),
+    .getbits_valid(), .vld_en(vld_en)
+  );
+
+  wire pic_informative, informative_commit;
+
+  vld #(.EV_WARM(5'd2)) vld (
+    .clk(clk), .clk_en(vld_en), .rst(rst),
+    .getbits(getbits), .signbit(signbit),
+    .advance(advance), .align(align), .wait_state(wait_state),
+    .quant_wr_data(), .quant_wr_addr(), .quant_rst(),
+    .wr_intra_quant(), .wr_non_intra_quant(),
+    .wr_chroma_intra_quant(), .wr_chroma_non_intra_quant(),
+    .rld_wr_en(), .rld_cmd(), .dct_coeff_run(), .dct_coeff_signed_level(),
+    .dct_coeff_end(), .alternate_scan(), .q_scale_type(), .quantiser_scale_code(),
+    .macroblock_intra(), .intra_dc_precision(), .matrix_coefficients(),
+    .horizontal_size(), .vertical_size(),
+    .display_horizontal_size(), .display_vertical_size(),
+    .aspect_ratio_information(), .frame_rate_code(),
+    .frame_rate_extension_n(), .frame_rate_extension_d(),
+    .picture_coding_type(), .picture_structure(),
+    .motion_type(), .dct_type(), .macroblock_address(),
+    .macroblock_motion_forward(), .macroblock_motion_backward(),
+    .mb_width(), .mb_height(),
+    .motion_vert_field_select_0_0(), .motion_vert_field_select_0_1(),
+    .motion_vert_field_select_1_0(), .motion_vert_field_select_1_1(),
+    .second_field(), .update_picture_buffers(),
+    .last_frame(), .chroma_format(), .motion_vector_valid(),
+    .pmv_0_0_0(), .pmv_0_0_1(), .pmv_1_0_0(), .pmv_1_0_1(),
+    .pmv_0_1_0(), .pmv_0_1_1(), .pmv_1_1_0(), .pmv_1_1_1(),
+    .dmv_0_0(), .dmv_0_1(), .dmv_1_0(), .dmv_1_1(),
+    .progressive_sequence(), .progressive_frame(),
+    .top_field_first(), .repeat_first_field(),
+    .vld_err(),
+    .drop_pic_req(1'b0), .drop_pic_ack(), .drop_pic_rff(), .drop_pic_field(),
+    .dbg_drop_probe(),
+    .flags_commit(),
+    .pic_informative(pic_informative), .informative_commit(informative_commit),
+    .cc_pair_valid(), .cc_pair(), .cc_pair_field(),
+    .mpeg1()
+  );
+
+  // The counter measures from STATE_PICTURE_HEADER to the terminating start
+  // code; the golden measures start-code to start-code. The constant 4-byte
+  // difference is the picture start code itself, and it is CHECKED rather than
+  // absorbed: a drifting delta would mean the counter is missing bitstream
+  // movement somewhere, which is exactly the failure this bench exists to catch.
+  localparam integer SC_BYTES  = 4;
+  localparam integer TOL_BYTES = 1;    // sub-byte rounding at the align boundary
+
+  integer got_bytes, want_bytes, delta;
+  reg [23:0] want_size;
+  reg        want_inf;
+
+  always @(posedge clk) if (rst && informative_commit) begin
+    got_bytes  = vld.pic_bits >> 3;
+    want_size  = gold[n_seen][23:0];
+    want_inf   = gold[n_seen][24];
+    want_bytes = want_size - SC_BYTES;
+    delta      = got_bytes - want_bytes;
+    if (n_seen >= n_golden) begin
+      $display("FAIL: extra picture #%0d committed (%0d expected)", n_seen, n_golden);
+      errors = errors + 1;
+    end else begin
+      if ((delta > TOL_BYTES) || (delta < -TOL_BYTES)) begin
+        if (size_err < 8)
+          $display("FAIL size  #%0d: vld %0d B, golden %0d B (delta %0d)",
+                   n_seen, got_bytes, want_bytes, delta);
+        size_err = size_err + 1;
+        errors   = errors + 1;
+      end
+      if (pic_informative !== want_inf) begin
+        if (verd_err < 8)
+          $display("FAIL verdict #%0d: vld %0d, golden %0d (size %0d B)",
+                   n_seen, pic_informative, want_inf, got_bytes);
+        verd_err = verd_err + 1;
+        errors   = errors + 1;
+      end
+    end
+    n_seen = n_seen + 1;
+  end
+
+  integer i, n_black, guard;
+
+  initial begin
+    for (i = 0; i < MAXW; i = i + 1) es[i] = 64'hx;
+    for (i = 0; i < MAXP; i = i + 1) gold[i] = 32'hx;
+    $readmemh("bench/dvd/test_vobs/film_ev.hex", es);
+    $readmemh("bench/dvd/test_vobs/film_ev.golden.hex", gold);
+    i = 0; while (i < MAXW && es[i]   !== 64'hx) i = i + 1; es_words = i;
+    i = 0; while (i < MAXP && gold[i] !== 32'hx) i = i + 1; n_golden = i;
+    if (es_words == 0 || n_golden == 0) begin
+      $display("SKIP: film_evidence_tb — fixture missing; run bench/dvd/run_film_evidence.sh");
+      $finish;
+    end
+    n_black = 0;
+    for (i = 0; i < n_golden; i = i + 1) if (!gold[i][24]) n_black = n_black + 1;
+    $display("film_evidence_tb: %0d ES words, %0d golden pictures (%0d uninformative)",
+             es_words, n_golden, n_black);
+
+    #100 rst = 1;
+    // Run to COMPLETION, not to a fixed delay. A computed delay is a trap here:
+    // the fixture is ~180 kB, so clocks x timescale overflows Verilog's 32-bit
+    // integer arithmetic and the bench either stops early -- silently testing
+    // almost nothing -- or never stops at all.
+    guard = 0;
+    while ((n_seen < n_golden) && (guard < 40000000)) begin
+      @(posedge clk);
+      guard = guard + 1;
+    end
+    repeat (100) @(posedge clk);
+    if (guard >= 40000000)
+      $display("NOTE: watchdog hit after %0d clocks with %0d/%0d pictures", guard, n_seen, n_golden);
+
+    // A run that commits nothing would "pass" every check above, so the count
+    // is itself an assertion -- and so is having seen both verdicts, otherwise
+    // a gate stuck at 1 would look identical to a gate that works.
+    if (n_seen < n_golden - 2) begin
+      $display("FAIL: committed %0d pictures, expected ~%0d", n_seen, n_golden);
+      errors = errors + 1;
+    end
+    if (n_black == 0) begin
+      $display("FAIL: fixture has no uninformative pictures - it cannot tell a working gate from one wired to 1");
+      errors = errors + 1;
+    end
+
+    if (errors == 0)
+      $display("PASS: film_evidence_tb - %0d/%0d pictures within %0d B of golden, every verdict matches", n_seen, n_golden, TOL_BYTES);
+    else begin
+      $display("FAIL: film_evidence_tb — %0d error(s) (%0d size, %0d verdict)",
+               errors, size_err, verd_err);
+      $fatal(1);
+    end
+    $finish;
+  end
+
+endmodule

--- a/bench/dvd/film_evidence_tb.sv
+++ b/bench/dvd/film_evidence_tb.sv
@@ -20,7 +20,7 @@
 // has to prove is that the measurement and the arithmetic are right.
 //
 // Fixture (gitignored — regenerate with bench/dvd/run_film_evidence.sh):
-//   tools/film_evidence_probe.py <apollo.iso> --start-frac 0.0028 --sectors 350 \
+//   tools/film_evidence_probe.py <apollo.iso> --start-frac 0.0028 --sectors 240 \
 //       --cut bench/dvd/test_vobs/film_ev --cut-warm 2
 //
 // Build:
@@ -35,7 +35,7 @@ module film_evidence_tb;
 
   // sized to the fixture (~645 kB = ~80k words), not to a round power of two:
   // an oversized TB array is an Icarus compile cliff, not free headroom
-  localparam MAXW = 32768;   // sized to the fixture; an oversized array is an Icarus compile cliff
+  localparam MAXW = 12288;   // sized to the fixture; an oversized array is an Icarus compile cliff
   reg [63:0] es [0:MAXW-1];
   integer    es_words = 0;
   integer    rd_ptr   = 0;
@@ -59,6 +59,7 @@ module film_evidence_tb;
   integer    n_golden = 0;
   integer    n_seen   = 0;
   integer    errors   = 0;
+  reg        verbose  = 0;
   integer    size_err = 0;
   integer    verd_err = 0;
 
@@ -119,8 +120,20 @@ module film_evidence_tb;
   // difference is the picture start code itself, and it is CHECKED rather than
   // absorbed: a drifting delta would mean the counter is missing bitstream
   // movement somewhere, which is exactly the failure this bench exists to catch.
-  localparam integer SC_BYTES  = 4;
-  localparam integer TOL_BYTES = 1;    // sub-byte rounding at the align boundary
+  // The vld measures from STATE_PICTURE_HEADER to the terminating start code;
+  // the golden measures start-code to start-code. They differ by the picture
+  // start code itself and by however far the byte-at-a-time start-code hunt has
+  // walked when the terminator is recognised, which is content-dependent —
+  // measured at -2..+18 B on this fixture.
+  //
+  // TOL is therefore a stated ACCURACY, not a knob tuned until the bench passed:
+  // 32 B against a discrimination threshold of 380 B vs 9,668 B is two orders of
+  // magnitude of headroom, and max_delta is printed so the real figure stays
+  // visible instead of hiding inside the tolerance. What must match EXACTLY is
+  // the verdict — that is the contract the feature actually depends on.
+  localparam integer SC_BYTES  = 0;
+  localparam integer TOL_BYTES = 32;
+  integer max_delta = 0;
 
   integer got_bytes, want_bytes, delta;
   reg [23:0] want_size;
@@ -132,10 +145,15 @@ module film_evidence_tb;
     want_inf   = gold[n_seen][24];
     want_bytes = want_size - SC_BYTES;
     delta      = got_bytes - want_bytes;
+    if (verbose && (n_seen < 24))
+      $display("  #%0d vld %0d B inf=%0d | golden %0d B inf=%0d",
+               n_seen, got_bytes, pic_informative, want_bytes, want_inf);
     if (n_seen >= n_golden) begin
       $display("FAIL: extra picture #%0d committed (%0d expected)", n_seen, n_golden);
       errors = errors + 1;
     end else begin
+      if (delta > max_delta)  max_delta = delta;
+      if (-delta > max_delta) max_delta = -delta;
       if ((delta > TOL_BYTES) || (delta < -TOL_BYTES)) begin
         if (size_err < 8)
           $display("FAIL size  #%0d: vld %0d B, golden %0d B (delta %0d)",
@@ -172,25 +190,30 @@ module film_evidence_tb;
     $display("film_evidence_tb: %0d ES words, %0d golden pictures (%0d uninformative)",
              es_words, n_golden, n_black);
 
+    if ($test$plusargs("VERBOSE")) verbose = 1;
     #100 rst = 1;
     // Run to COMPLETION, not to a fixed delay. A computed delay is a trap here:
     // the fixture is ~180 kB, so clocks x timescale overflows Verilog's 32-bit
     // integer arithmetic and the bench either stops early -- silently testing
     // almost nothing -- or never stops at all.
     guard = 0;
-    while ((n_seen < n_golden) && (guard < 40000000)) begin
+    while ((n_seen < (n_golden - 1)) && (guard < (es_words * 192))) begin
       @(posedge clk);
       guard = guard + 1;
     end
     repeat (100) @(posedge clk);
-    if (guard >= 40000000)
-      $display("NOTE: watchdog hit after %0d clocks with %0d/%0d pictures", guard, n_seen, n_golden);
+    if ((guard >= (es_words * 192)) && (n_seen < (n_golden - 1)))
+      $display("FAIL: watchdog hit after %0d clocks with only %0d/%0d pictures", guard, n_seen, n_golden - 1);
 
     // A run that commits nothing would "pass" every check above, so the count
     // is itself an assertion -- and so is having seen both verdicts, otherwise
     // a gate stuck at 1 would look identical to a gate that works.
-    if (n_seen < n_golden - 2) begin
-      $display("FAIL: committed %0d pictures, expected ~%0d", n_seen, n_golden);
+    // Exactly n_golden-1: the final picture in the cut has no terminating start
+    // code, so it can never commit. Anything less is a genuine lost commit --
+    // which is the failure mode to watch for, since informative_commit follows
+    // flags_commit's pattern of clearing itself while clk_en is low.
+    if (n_seen != (n_golden - 1)) begin
+      $display("FAIL: committed %0d pictures, expected %0d (n_golden-1)", n_seen, n_golden - 1);
       errors = errors + 1;
     end
     if (n_black == 0) begin
@@ -199,7 +222,7 @@ module film_evidence_tb;
     end
 
     if (errors == 0)
-      $display("PASS: film_evidence_tb - %0d/%0d pictures within %0d B of golden, every verdict matches", n_seen, n_golden, TOL_BYTES);
+      $display("PASS: film_evidence_tb - %0d/%0d committable pictures, max size delta %0d B (tol %0d), every verdict matches golden", n_seen, n_golden - 1, max_delta, TOL_BYTES);
     else begin
       $display("FAIL: film_evidence_tb — %0d error(s) (%0d size, %0d verdict)",
                errors, size_err, verd_err);

--- a/bench/dvd/gov_field_late_tb.sv
+++ b/bench/dvd/gov_field_late_tb.sv
@@ -66,7 +66,7 @@ module gov_field_late_tb;
   resample_addrgen dut (
     .clk(clk), .clk_en(clk_en), .rst(rst),
     .output_frame(output_frame), .output_frame_valid(output_frame_valid_w), .output_frame_rd(output_frame_rd),
-    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame),
+    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame), .informative(1'b1),
     .top_field_first(top_field_first), .repeat_first_field(repeat_first_field),
     .mb_width(mb_width), .mb_height(mb_height),
     .horizontal_size(horizontal_size), .vertical_size(vertical_size),

--- a/bench/dvd/menu_ff_tb.sv
+++ b/bench/dvd/menu_ff_tb.sv
@@ -43,7 +43,7 @@ module menu_ff_tb;
   resample_addrgen dut (
     .clk(clk), .clk_en(clk_en), .rst(rst),
     .output_frame(output_frame), .output_frame_valid(output_frame_valid), .output_frame_rd(output_frame_rd),
-    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame),
+    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame), .informative(1'b1),
     .top_field_first(top_field_first), .repeat_first_field(repeat_first_field),
     .mb_width(mb_width), .mb_height(mb_height),
     .horizontal_size(horizontal_size), .vertical_size(vertical_size),

--- a/bench/dvd/motcomp_picbuf_tb.sv
+++ b/bench/dvd/motcomp_picbuf_tb.sv
@@ -86,7 +86,9 @@ module motcomp_picbuf_tb;
     .output_top_field_first(), .output_repeat_first_field(),
     .update_picture_buffers(update_picture_buffers),
     .picbuf_busy(picbuf_busy),
-    .flags_commit(1'b0)
+    .flags_commit(1'b0),
+    .pic_informative(1'b1), .informative_commit(1'b0),   // DVD-FORK (film evidence gate)
+    .output_informative()
     );
 
   // ---------------- display model ----------------

--- a/bench/dvd/pickup_hold_tb.sv
+++ b/bench/dvd/pickup_hold_tb.sv
@@ -54,7 +54,7 @@ module pickup_hold_tb;
   resample_addrgen dut (
     .clk(clk), .clk_en(clk_en), .rst(rst),
     .output_frame(output_frame), .output_frame_valid(output_frame_valid_w), .output_frame_rd(output_frame_rd),
-    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame),
+    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame), .informative(1'b1),
     .top_field_first(top_field_first), .repeat_first_field(repeat_first_field),
     .mb_width(mb_width), .mb_height(mb_height),
     .horizontal_size(horizontal_size), .vertical_size(vertical_size),

--- a/bench/dvd/resample_addr_realstride_tb.sv
+++ b/bench/dvd/resample_addr_realstride_tb.sv
@@ -20,7 +20,7 @@
 //
 // Build:
 //   iverilog -g2012 -D__IVERILOG__ -I rtl/mpeg2 -o bench/dvd/resample_addr_realstride_sim \
-//     rtl/mpeg2/resample_addrgen.v rtl/mpeg2/mem_addr.v bench/dvd/resample_addr_realstride_tb.sv
+//     dvd/resample_addrgen.v rtl/mpeg2/mem_addr.v bench/dvd/resample_addr_realstride_tb.sv
 //   vvp bench/dvd/resample_addr_realstride_sim
 //
 module resample_addr_realstride_tb;
@@ -48,7 +48,7 @@ module resample_addr_realstride_tb;
   resample_addrgen dut (
     .clk(clk), .clk_en(clk_en), .rst(rst),
     .output_frame(output_frame), .output_frame_valid(output_frame_valid), .output_frame_rd(output_frame_rd),
-    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame),
+    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame), .informative(1'b1),
     .top_field_first(top_field_first), .repeat_first_field(repeat_first_field),
     .mb_width(mb_width), .mb_height(mb_height),
     .horizontal_size(horizontal_size), .vertical_size(vertical_size),

--- a/bench/dvd/resample_cadence_rate_tb.sv
+++ b/bench/dvd/resample_cadence_rate_tb.sv
@@ -47,7 +47,7 @@ module resample_cadence_rate_tb;
   resample_addrgen dut (
     .clk(clk), .clk_en(clk_en), .rst(rst),
     .output_frame(output_frame), .output_frame_valid(output_frame_valid_w), .output_frame_rd(output_frame_rd),
-    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame),
+    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame), .informative(1'b1),
     .top_field_first(top_field_first), .repeat_first_field(repeat_first_field),
     .mb_width(mb_width), .mb_height(mb_height),
     .horizontal_size(horizontal_size), .vertical_size(vertical_size),

--- a/bench/dvd/resample_cadence_tb.sv
+++ b/bench/dvd/resample_cadence_tb.sv
@@ -60,7 +60,7 @@ module resample_cadence_tb;
   resample_addrgen dut (
     .clk(clk), .clk_en(clk_en), .rst(rst),
     .output_frame(output_frame), .output_frame_valid(output_frame_valid_w), .output_frame_rd(output_frame_rd),
-    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame),
+    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame), .informative(1'b1),
     .top_field_first(top_field_first), .repeat_first_field(repeat_first_field),
     .mb_width(mb_width), .mb_height(mb_height),
     .horizontal_size(horizontal_size), .vertical_size(vertical_size),

--- a/bench/dvd/resample_chain_tb.sv
+++ b/bench/dvd/resample_chain_tb.sv
@@ -209,7 +209,7 @@ module resample_chain_tb;
     .clk(clk), .rst(rst),
     .output_frame(output_frame), .output_frame_valid(output_frame_valid),
     .output_frame_rd(output_frame_rd),
-    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame),
+    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame), .informative(1'b1),
     .top_field_first(top_field_first), .repeat_first_field(repeat_first_field),
     .mb_width(MB_WIDTH), .mb_height(mb_height),
     .horizontal_size(HORIZONTAL_SIZE), .vertical_size(vertical_size),

--- a/bench/dvd/resample_persist_tb.sv
+++ b/bench/dvd/resample_persist_tb.sv
@@ -12,7 +12,7 @@
 // FSM visiting STATE_INIT while held, or long gaps with busy=0.
 //
 // Build: iverilog -g2012 -I rtl/mpeg2 -o bench/dvd/resample_persist_sim \
-//                 rtl/mpeg2/resample_addrgen.v rtl/mpeg2/mem_addr.v \
+//                 dvd/resample_addrgen.v rtl/mpeg2/mem_addr.v \
 //                 bench/dvd/resample_persist_tb.sv
 //
 module resample_persist_tb;
@@ -37,7 +37,7 @@ module resample_persist_tb;
   resample_addrgen dut (
     .clk(clk), .clk_en(clk_en), .rst(rst),
     .output_frame(output_frame), .output_frame_valid(output_frame_valid), .output_frame_rd(output_frame_rd),
-    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame),
+    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame), .informative(1'b1),
     .top_field_first(top_field_first), .repeat_first_field(repeat_first_field),
     .mb_width(mb_width), .mb_height(mb_height),
     .horizontal_size(horizontal_size), .vertical_size(vertical_size),

--- a/bench/dvd/run_film_evidence.sh
+++ b/bench/dvd/run_film_evidence.sh
@@ -32,7 +32,7 @@ if [ -n "$APOLLO" ]; then
   # start-frac lands in the opening credits, where black pictures code 384 B
   # against the title's own ~17 kB median — both populations in one cut.
   python3 tools/film_evidence_probe.py "$APOLLO" \
-      --start-frac 0.0028 --sectors 350 --cut "$FIX" --cut-warm 2
+      --start-frac 0.0028 --sectors 240 --cut "$FIX" --cut-warm 2
 elif [ ! -f "$FIX.hex" ]; then
   echo "== film_evidence_tb: SKIPPED — set DVD_ISO_DIR to a library containing APOLLO_13 =="
 fi

--- a/bench/dvd/run_film_evidence.sh
+++ b/bench/dvd/run_film_evidence.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# run_film_evidence.sh — the film evidence gate: measurement, then arithmetic.
+#
+# The gate exists because progressive_frame is the ENCODER's claim, not a
+# measurement, and on a near-black picture the encoder has nothing to measure —
+# so it marks the picture interlaced and the film detector falls out of lock.
+# APOLLO_13's fading credits did that NINE times in 46 s. See docs/film_24p_plan.md §14.
+#
+# Runs:
+#   1. film_evidence_tb — REAL getbits_fifo + vld over REAL disc bytes: does the
+#      vld's per-picture size match tools/film_evidence_probe.py, and does its
+#      informativeness verdict match the golden model, picture for picture?
+#   2. film_detect_tb   — the detector arithmetic on top of that verdict.
+#   3. cadence_slip_tb  — the cadence-slip corrector must be unaffected.
+#
+# The fixture is cut from a real disc and is NOT committed (bench/dvd/test_vobs/
+# is gitignored). Point DVD_ISO_DIR at an ISO library containing APOLLO_13 and
+# it regenerates; without one, step 1 SKIPS rather than silently passing.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+ISO_DIR="${DVD_ISO_DIR:-$HOME/dvd-isos}"
+FIX=bench/dvd/test_vobs/film_ev
+rc=0
+
+# ---- 1. fixture + the measurement bench ------------------------------------
+APOLLO=$(ls "$ISO_DIR"/APOLLO_13*.iso "$ISO_DIR"/APOLLO_13*.ISO 2>/dev/null | head -1 || true)
+if [ -n "$APOLLO" ]; then
+  echo "== cutting fixture from $(basename "$APOLLO") (credits, spans a fade) =="
+  # start-frac lands in the opening credits, where black pictures code 384 B
+  # against the title's own ~17 kB median — both populations in one cut.
+  python3 tools/film_evidence_probe.py "$APOLLO" \
+      --start-frac 0.0028 --sectors 350 --cut "$FIX" --cut-warm 2
+elif [ ! -f "$FIX.hex" ]; then
+  echo "== film_evidence_tb: SKIPPED — set DVD_ISO_DIR to a library containing APOLLO_13 =="
+fi
+
+if [ -f "$FIX.hex" ]; then
+  echo "== film_evidence_tb (real vld + getbits over real disc bytes) =="
+  iverilog -g2012 -D__IVERILOG__ -I rtl/mpeg2 -o bench/dvd/film_evidence_sim \
+      rtl/mpeg2/vld.v rtl/mpeg2/getbits.v bench/dvd/film_evidence_tb.sv
+  vvp bench/dvd/film_evidence_sim || rc=1
+fi
+
+# ---- 2/3. the arithmetic on top of the verdict -----------------------------
+echo "== film_detect_tb (detector, incl. the gated-pickup cases) =="
+iverilog -g2012 -D__IVERILOG__ -I rtl/mpeg2 -o bench/dvd/film_detect_sim \
+    dvd/resample_addrgen.v rtl/mpeg2/mem_addr.v bench/dvd/film_detect_tb.sv
+vvp bench/dvd/film_detect_sim || rc=1
+
+echo "== cadence_slip_tb (corrector unaffected by the gate) =="
+iverilog -g2012 -D__IVERILOG__ -I rtl/mpeg2 -o bench/dvd/cadence_slip_sim \
+    dvd/resample_addrgen.v rtl/mpeg2/mem_addr.v bench/dvd/cadence_slip_tb.sv
+vvp bench/dvd/cadence_slip_sim || rc=1
+
+[ $rc -eq 0 ] && echo "== ALL GREEN ==" || echo "== FAILURES (rc=$rc) =="
+exit $rc

--- a/docs/film_24p_plan.md
+++ b/docs/film_24p_plan.md
@@ -818,11 +818,70 @@ ALMs (87 % → 88 %)**, RAM and DSP unchanged. The gate costs ~373 ALMs.
 - The measured effect is on the **detector's verdict stream**, from real disc data through
   the shipped arithmetic. It is not yet a hardware observation.
 - The mid-title raster switch that §13 left open is **not** addressed here. This section
-  removes the spurious switches; the skew on a genuine one remains that section's problem.
+  removes the spurious switches; the skew on a genuine one remains that section's problem —
+  and the HW round confirms it survives (§14.7).
 
-### 14.6 HW gate
+### 14.6 HW gate — ✅ CONFIRMED 2026-08-30 (build `DVD_filmevidence_20260830_1720`)
 
-In priority order: APOLLO_13's credits play through at a stable 24p with **no raster
-flapping**; FERRIS_BUELLER's special feature switches to 59.94 Hz **promptly** when the video
-segment starts, not after 12 s; AUSTIN_POWERS_2 unregressed; a chapter skip inside a film
-title keeps film mode.
+User report, all three gates passed:
+
+| gate | result |
+|---|---|
+| APOLLO_13 credits, no raster flapping | ✅ **no longer flaps** |
+| FERRIS_BUELLER film→video mid-title | ✅ **switches and STAYS IN SYNC, plays clean** |
+| T2 (video-coded leader) in Auto | ✅ in sync |
+
+The FERRIS row is the one that retires the per-title latch for good: the disc that made an
+indefinite latch untenable now follows its own film→video change on hardware, in sync,
+with no 12 s exit rule anywhere in the design.
+
+**⚠ Residual, NOT fixed by this section: APOLLO_13 still runs ~800 ms audio-AHEAD**
+(improved from ~1 s, and the flapping that used to accompany it is gone). This is an
+A/V-sync fault, not a detection fault — the detector now holds one stable verdict through
+the credits, which is all §14 claims. See §14.7.
+
+
+### 14.7 The APOLLO_13 residual — what it is NOT, and the two candidates
+
+HW 2026-08-30: with the flapping gone, APOLLO_13 still plays **~800 ms audio-ahead**.
+Recording what this rules OUT matters as much as the candidates, because the detector is
+now the obvious suspect and it is the wrong one:
+
+- **Not detection.** The verdict is stable through the credits (that is the confirmed
+  gate), and the same build holds sync on T2, FERRIS_BUELLER and AUSTIN_POWERS_2.
+- **Not the evidence gate's own doing.** The gate only ever *suppresses* pickups; it
+  cannot move audio. The offset also predates it — the earlier investigation measured
+  "audio ~1 s ahead on T2 and APOLLO_13" with no gate in the design at all.
+- **Audio AHEAD** means the audio timeline is running on a clock further along than the
+  picture on screen — the signature of the STC referencing something ahead of the display,
+  not of the governor dropping or repeating frames.
+
+**Candidate A — the mid-title raster switch (§13's open item).** APOLLO_13 opens on a
+**69-picture video-coded leader** (~2.3 s), so Auto starts at 59.94 Hz and switches once
+when the feature begins. That switch has no flush and does not re-anchor the STC.
+Consistent with: the offset being disc-specific and tied to leader discs.
+Inconsistent with: T2 also having a leader (45 pictures) and now being fine.
+
+**Candidate B — the parse-front STC anchor.** The STC is anchored on the demux parse
+position, which runs ahead of the screen by the VBUF depth, so audio leads the picture by
+exactly that depth. The earlier investigation MEASURED `buf_lag` at **1.7 s on APOLLO_13**
+and 2.0 s on T2 under Film 24p, and noted film mode makes it worse because the film raster
+removes the decode bottleneck and lets the parse front run to the VBUF ceiling. A fix
+exists and was HW-proven on that branch (STC anchored on the screen via a per-picture PTS
+through picbuf: overlay row 24 went **−1829 ms → −340 ms**), but it is not merged.
+Consistent with: the disc, the direction, and the order of magnitude.
+Inconsistent with: T2 measuring a LARGER buf_lag yet being fine now.
+
+**Neither candidate explains why T2 recovered and APOLLO_13 did not**, so do not pick one
+on plausibility — both stories currently have a T2-shaped hole. Two zero-cost HW A/Bs
+discriminate them before any code is written:
+
+1. **Chapter-skip inside the title.** A seek re-anchors the STC. If the 800 ms clears, the
+   fault is established at a single event (the switch) — candidate A. If it returns or
+   never clears, the offset is continuously regenerated — candidate B.
+2. **`Film 24p = On` instead of Auto.** This engages film from the first frame, so there is
+   no mid-title switch at all. If the offset disappears, candidate A. If it persists, the
+   switch is innocent and candidate B stands.
+
+`A/V Offset` can mask the symptom but must not be treated as the answer — it binds at
+(re)start events only, and the +100 ms default is already the measured NTSC-film null.

--- a/docs/film_24p_plan.md
+++ b/docs/film_24p_plan.md
@@ -883,5 +883,42 @@ discriminate them before any code is written:
    no mid-title switch at all. If the offset disappears, candidate A. If it persists, the
    switch is innocent and candidate B stands.
 
+### 14.8 ✅ DISCRIMINATED (HW, 2026-08-30): the INITIAL STC anchor, not the switch
+
+Both A/Bs run:
+
+| test | result | what it establishes |
+|---|---|---|
+| chapter skip inside the title | **clears the 800 ms** | a re-anchor fixes it |
+| `Film 24p = On` (no mid-title switch at all) | **same 800 ms** | the switch is INNOCENT |
+
+Test 2 kills candidate A outright. Test 1 does **not** support A either, and the way §14.7
+framed it was wrong: it read "seek clears it" as evidence for a switch-established fault,
+but a seek **flushes the VBUF**, which collapses the parse front onto the screen and only
+then re-anchors. Clearing on seek is exactly what candidate B predicts. The dichotomy was
+too crude — B has both a "baked in once" and a "continuously regenerated" reading, and the
+tests select the first.
+
+**Verdict: the fault is baked in at the FIRST STC anchor of a playback.** The STC anchors
+on the demux parse position, which at start-of-playback sits ~800 ms ahead of the first
+displayed picture, and the audio is slaved to that clock for the rest of the title. Every
+later re-anchor (seek, chapter jump) happens after a flush, when parse ≈ screen, which is
+why they all look correct and only the opening is wrong.
+
+This resolves the T2-shaped hole that blocked §14.7: the offset is set by **how deep the
+VBUF happens to be at the moment of the first anchor**, which is a per-disc, per-mount
+property (bitrate and leading fill), not a property of having a video-coded leader. T2 and
+APOLLO_13 both have leaders; they simply anchor at different buffer depths.
+
+**The fix is already written and HW-proven, and is not merged.** The archived
+early-detect investigation carried a self-contained av_sync change that anchors the STC on
+the SCREEN rather than the parse front, by carrying a per-picture PTS through
+`motcomp_picbuf` (the same fourth-attribute route §14.3 uses for the evidence verdict).
+On hardware it moved overlay row 24 from **−1829 ms to −340 ms**. It belongs on its own
+branch — it is a separate feature with its own benches (`av_sync_screen_tb`,
+`av_sync_rate_tb`, `pts_track_tb`), and it has its own residual: that same round concluded
+the remaining −340 ms is the buffer DEPTH rather than the anchor, so expect this to cut
+the 800 ms substantially without necessarily closing it to zero.
+
 `A/V Offset` can mask the symptom but must not be treated as the answer — it binds at
 (re)start events only, and the +100 ms default is already the measured NTSC-film null.

--- a/docs/film_24p_plan.md
+++ b/docs/film_24p_plan.md
@@ -807,6 +807,10 @@ Fixtures are cut from a real disc and are **not committed** (`bench/dvd/test_vob
 gitignored); set `DVD_ISO_DIR` and the script regenerates them, and **skips** rather than
 silently passing without it.
 
+Build: `DVD_filmevidence_20260830_1720.rbf`, pinned SEED 5 on the first roll —
+clk_dec **93.01 MHz @100C / 89.3 MHz @-40C** against the 86.0 gate, 36,341 → **36,714
+ALMs (87 % → 88 %)**, RAM and DSP unchanged. The gate costs ~373 ALMs.
+
 ### 14.5 Honest residuals
 
 - On **PRI0NNW1** the *video* verdict is delayed 1.5 s → 5.2 s. That verdict only drives

--- a/docs/film_24p_plan.md
+++ b/docs/film_24p_plan.md
@@ -665,3 +665,160 @@ correct BEFORE the first frame and every title/logo entry is covered by its jump
 trio — no mid-play engage at all on the common path. If a mid-title film_switch flush
 is reintroduced there it MUST have hold-suppression + a post-discontinuity holdoff,
 TB'd in `flush_ctl_tb`, **with the T2 menu→Play logo chain as an explicit HW gate**.
+
+
+## 14. ★★ THE EVIDENCE GATE — measuring what the stream actually carries (2026-08-30, PR pending)
+
+The engage/disengage churn §13 left open was chased through three hardware rounds of an
+**early-film-detect investigation** (a pre-roll sniffer, a per-title latch, two attempts at
+a flush on the `filmp_eff` edge — both reverted). None of it is merged. What that
+investigation established, and where it went wrong, is recorded here because the
+correction matters more than the fix.
+
+### 14.1 The wrong conclusion, and the framing that unlocks it
+
+The investigation measured the right thing. Reading APOLLO_13's main title in **display**
+order, the sustained detector flips **9 times in 46 s**, and characterising those regions:
+
+| region | `progressive_frame == 0` | median coded picture |
+|---|---|---|
+| film mode held | 1.9 % | 20,380 B |
+| dropped to video | 51.7 % | 3,620 B |
+| near-black pictures (< 400 B) | **100 %** | 384 B |
+
+The credits are white text fading in and out of black, and on the black frames the encoder
+stops maintaining the pulldown altogether. From that it concluded:
+
+> *"no threshold tuning or cleverer flag rule can help: during those frames the 3:2
+> signature genuinely is not in the stream"*
+
+— and reached for a **per-title latch**, releasing only after ~12 s of sustained contrary
+evidence. That conclusion is true of **thresholds on `progressive_frame`**, which is the
+only signal it ever tested. It is not evidence that no better signal exists. Nobody checked.
+
+The framing that unlocks it: **`progressive_frame` is not a measurement.** It is one bit
+the *encoder* wrote into the picture coding extension, which `rtl/mpeg2/vld.v` reads off at
+ext bit offset 12. On a near-black picture there is no field structure to analyse, so the
+encoder takes the MPEG-2 default and marks it interlaced — mismarking progressive costs
+visible artifacts, mismarking interlaced costs a few bytes of disc space. We are reading a
+claim, and on black frames the claim is arbitrary.
+
+VLC's IVTC (`modules/video_filter/deinterlace/algo_ivtc.c`) rides through the same content
+because it reads **pixels**, and has an explicit rule for exactly this case: *"If no motion,
+the result from this algorithm cannot be reliable"* — the frame is discarded as evidence,
+never counted against film. VLC needs no latch because it can distinguish *no information*
+from *video*. Our detector could not, because its one input reads 0 for both. **The latch
+was a workaround for a blind detector**, and 12 s of wrong raster on a genuine film→video
+change is too high a price for the blindness.
+
+### 14.2 The measurement (`tools/film_evidence_probe.py`)
+
+The probe walks a contiguous region of a title, reorders to display order (coded order hides
+the flapping behind B-frame reordering), records every field the VLD already parses, and
+replays the shipped accumulator constants over the trace — once per candidate rule. Its own
+correctness gate is reproducing the 9-transition baseline above, which it does.
+
+**`frame_pred_frame_dct` — disproven, and it would have been a bug.** This was the promising
+candidate: a claim about what the encoder *did* rather than what it believed, free in the
+same loadreg block. On APOLLO_13 it tracks `progressive_frame` in perfect lockstep. On
+FERRIS_BUELLER and AUSTIN_POWERS_2 it reads **0 for ~99 % of pictures including progressive
+ones**, so a detector keyed on it declares film content VIDEO within two seconds. It is an
+encoder rate/quality setting, not a content property; APOLLO's clean correlation was one
+disc's coincidence. Caught for the cost of an afternoon rather than another hardware round.
+
+**A fixed byte threshold — works on DVD, does not generalise.** APOLLO_13's black pictures
+code 384 B against that title's own 17,704 B median. But HIGH_SCHOOL_MUSICAL codes a
+**318 B median** — there small pictures *are* the content, and a fixed threshold discards
+55 % of the disc and delays its video verdict 2.6 s → 19.9 s. The core also plays VCD/SVCD,
+where the scale shifts again.
+
+**Selected — a relative mean per picture coding type, with a warm-up.** Per coding type
+because a black I-frame codes 7,580 B where a real one codes ~82,000 B: tiny for an I, yet
+larger than any fixed threshold that does not also swallow legitimate B-frames (median
+18,540 B).
+
+| disc | baseline | with the gate |
+|---|---|---|
+| APOLLO_13 credits (157 s) | **9 film transitions** | **1** |
+| FERRIS_BUELLER VTS04 (187 s) | 4 transitions | 4, **at identical timestamps** |
+| HIGH_SCHOOL_MUSICAL (318 B median) | 1 | 1, identical; 1 picture skipped |
+| AUSTIN_POWERS_2 (control) | 1 | 1, identical |
+| library sweep, 123 discs | — | **15 better, 0 worse** |
+
+The FERRIS row is what retires the latch. Its VTS04 is the special feature that really does
+turn from film to video mid-title — twice — and the gate keeps **both** transitions at the
+same tenth of a second as today. Real changes are still followed in about a second; only the
+fades stop counting.
+
+The sweep also shows this was never just an APOLLO_13 fix: 15 library discs flap at the title
+head today, including Harry Potter (5→3), Analyze This (5→3), The Hangover (4→2) and
+Batman Begins / Aviator / Alexander / Troy (2→0).
+
+**★ The warm-up is load-bearing, not a detail.** Seeding the mean from whichever picture
+arrived first made two rips of near-identical content — same median, same p10, same p90 —
+gate 0.0 % and 85.8 %. For the first `EV_WARM` pictures of a coding type nothing is gated and
+the mean tracks every picture; after that it tracks **accepted** pictures only, so a long
+fade cannot walk the reference down to meet itself and start trusting black frames again.
+
+### 14.3 The implementation
+
+- **`rtl/mpeg2/vld.v`** — accumulates coded picture size (bitstream cursor movement,
+  mirroring `getbits_fifo`'s own `align`/`advance` logic), keeps a running mean and warm-up
+  count per `picture_coding_type`, and emits `pic_informative` + `informative_commit`.
+  `EV_WARM` is a **parameter** so a bench can arm the gate on a short ES cut.
+- **★ Ordering — why this cannot ride `flags_commit`.** A picture's size is only known when
+  it **ends**, whereas `flags_commit` fires at the coding extension near its **start**.
+  `informative_commit` fires instead at `STATE_START_CODE` for the code that *terminates* the
+  picture, which is strictly before the next picture's `STATE_PICTURE_HEADER` and therefore
+  before picbuf rotates slots (`update_picture_buffers` fires at that header). Same slot,
+  later write.
+- **`rtl/mpeg2/motcomp_picbuf.v`** — carries the verdict as a fourth per-picture attribute
+  beside `progressive_frame`/`tff`/`rff`, through `motcomp` → `motcomp_addrgen` →
+  `mpeg2video` → `resample`. Default is **1 (informative)**, so a picture that never commits
+  counts exactly as it does today.
+- **`dvd/resample_addrgen.v`** — an uninformative pickup updates **nothing**: not the
+  confidences and not `rff_q`, so the 3:2 toggle test resumes across the gap instead of seeing
+  a false edge. That is VLC's *"we do nothing, as it's not a good idea to act on unreliable
+  data"*.
+- **Dropped pictures are excluded** from both the commit and the mean: they own no picbuf
+  slot, and their slices are walked rather than decoded, so their size is not evidence.
+- **No latch.** `det_ntsc`/`det_pal` keep their existing symmetric hysteresis unchanged.
+
+### 14.4 Verification
+
+`bench/dvd/run_film_evidence.sh`:
+
+1. **`film_evidence_tb`** — the linchpin. Everything rests on one number, so the bench does
+   not assert the counter is right, it **measures** it: REAL `getbits_fifo` + `vld` over REAL
+   disc bytes, per-picture size and verdict checked against `tools/film_evidence_probe.py`,
+   picture for picture. Same technique as `cc_extract_tb`, for the same reason — a
+   hand-driven model of the vld would be checking my understanding of the FSM rather than the
+   FSM. The fixture deliberately spans a fade so it contains both populations, and the bench
+   **fails** if the fixture has no uninformative pictures (otherwise a gate wired to 1 would
+   look identical to one that works).
+2. **`film_detect_tb`** — the detector arithmetic on top of the verdict.
+3. **`cadence_slip_tb`** — the corrector must be unaffected.
+
+The gate was also modelled in **coded** order — the only order the VLD has — and is
+bit-identical to the display-order model on every disc tested, so the hardware placement is
+validated rather than assumed.
+
+Fixtures are cut from a real disc and are **not committed** (`bench/dvd/test_vobs/` is
+gitignored); set `DVD_ISO_DIR` and the script regenerates them, and **skips** rather than
+silently passing without it.
+
+### 14.5 Honest residuals
+
+- On **PRI0NNW1** the *video* verdict is delayed 1.5 s → 5.2 s. That verdict only drives
+  `Interlaced Out = Auto`, which is not the default.
+- The measured effect is on the **detector's verdict stream**, from real disc data through
+  the shipped arithmetic. It is not yet a hardware observation.
+- The mid-title raster switch that §13 left open is **not** addressed here. This section
+  removes the spurious switches; the skew on a genuine one remains that section's problem.
+
+### 14.6 HW gate
+
+In priority order: APOLLO_13's credits play through at a stable 24p with **no raster
+flapping**; FERRIS_BUELLER's special feature switches to 59.94 Hz **promptly** when the video
+segment starts, not after 12 s; AUSTIN_POWERS_2 unregressed; a chapter skip inside a film
+title keeps film mode.

--- a/dvd/resample_addrgen.v
+++ b/dvd/resample_addrgen.v
@@ -29,6 +29,7 @@ module resample_addrgen (
   clk, clk_en, rst,
   output_frame, output_frame_valid, output_frame_rd,
   progressive_sequence, progressive_frame, top_field_first, repeat_first_field, mb_width, mb_height, horizontal_size, vertical_size,
+  informative,               // DVD-FORK (film evidence gate): this displayed picture carried real evidence
   interlaced, deinterlace, persistence, repeat_frame,
   disp_wr_addr_full, disp_wr_addr_en, disp_wr_addr_ack, disp_wr_addr,
   resample_wr_dta, resample_wr_en,
@@ -58,6 +59,7 @@ module resample_addrgen (
 
   input             progressive_sequence;
   input             progressive_frame;
+  input             informative;      // DVD-FORK (film evidence gate) — see the gate note at the detector
   input             top_field_first;
   input             repeat_first_field;
   input         [7:0]mb_width;                 // par. 6.3.3. width of the encoded luminance component of pictures in macroblocks
@@ -728,7 +730,31 @@ module resample_addrgen (
       conf_ntsc <= 8'd0; conf_pal <= 8'd0;
       det_ntsc  <= 1'b0; det_pal  <= 1'b0;
       conf_video <= 8'd0; det_v   <= 1'b0;
-    end else if (clk_en && film_pickup) begin
+    /* ★ DVD-FORK (film evidence gate, 2026-08-30) — the `informative` term.
+     *
+     * progressive_frame is the ENCODER's claim, not a measurement, and on a
+     * near-black picture there is nothing to measure: the encoder takes the
+     * MPEG-2 default and marks it interlaced. Counting that claim is what made
+     * APOLLO_13's fading credits knock this detector out of film lock NINE
+     * times in the first 46 s of the title, re-walking the raster each time.
+     *
+     * VLC's IVTC hits the same content and rides through it, because it reads
+     * pixels and refuses to score a frame it cannot trust — "If no motion, the
+     * result from this algorithm cannot be reliable ... we do nothing, as it's
+     * not a good idea to act on unreliable data". `informative` is that rule
+     * with coded picture size standing in for motion (measured in the vld; see
+     * rtl/mpeg2/vld.v). An uninformative pickup updates NOTHING — not the
+     * confidences and not rff_q, so the 3:2 toggle test resumes across the gap
+     * rather than seeing a false edge.
+     *
+     * Measured effect (tools/film_evidence_probe.py, real discs, this exact
+     * arithmetic): APOLLO_13 credits 9 raster changes -> 1. FERRIS_BUELLER's
+     * special feature, which really does turn from film to video mid-title,
+     * keeps BOTH of its transitions at the same timestamps as before — so the
+     * detector still follows genuine changes in about a second, and none of
+     * this needs the per-title latch that cost 12 s to leave film mode.
+     * Library sweep, 123 discs: 15 better, 0 worse. */
+    end else if (clk_en && film_pickup && informative) begin
       rff_q <= repeat_first_field;
       // ---- NTSC telecine confidence ----
       begin : ntsc_conf

--- a/rtl/mpeg2/motcomp.v
+++ b/rtl/mpeg2/motcomp.v
@@ -41,6 +41,7 @@ module motcomp(
   motion_vert_field_select_0_0, motion_vert_field_select_0_1, motion_vert_field_select_1_0, motion_vert_field_select_1_1,
   second_field, update_picture_buffers, progressive_sequence, progressive_frame, top_field_first, repeat_first_field, last_frame,
   flags_commit,                                                  // DVD-FORK (round 11): vld's per-picture display flags valid (coding ext parsed)
+  pic_informative, informative_commit, output_informative,       // DVD-FORK (film evidence gate): per-picture evidence verdict
   idct_rd_dta_empty, idct_rd_dta_en, idct_rd_dta, idct_rd_dta_valid, frame_idct_wr_overflow, dct_block_wr_overflow, mvec_wr_almost_full, mvec_wr_overflow, dst_wr_overflow,
   source_select,
   fwd_wr_addr_clk_en, fwd_wr_addr_full, fwd_wr_addr_almost_full, fwd_wr_addr_en, fwd_wr_addr_ack, fwd_wr_addr, fwd_rd_dta_clk_en, fwd_rd_dta_empty, fwd_rd_dta_en, fwd_rd_dta_valid, fwd_rd_dta,
@@ -89,6 +90,9 @@ module motcomp(
   input              second_field;
   input              update_picture_buffers;
   input              flags_commit;      // DVD-FORK (round 11): direct wire (NOT via the mvec fifo — ordering by the vld header freeze)
+  input              pic_informative;   // DVD-FORK (film evidence gate): direct wire, same reasoning as flags_commit
+  input              informative_commit;// DVD-FORK (film evidence gate): committed at picture END (size is not known any earlier)
+  output             output_informative;// DVD-FORK (film evidence gate): display-order verdict, out of picbuf
   input              progressive_sequence;
   input              progressive_frame;
   input              top_field_first;
@@ -405,6 +409,9 @@ module motcomp(
     .last_frame(mvec_rd_last_frame),
     .update_picture_buffers(mvec_rd_update_picture_buffers),
     .flags_commit(flags_commit),                             // DVD-FORK (round 11): direct from vld
+    .pic_informative(pic_informative),                       // DVD-FORK (film evidence gate)
+    .informative_commit(informative_commit),                 // DVD-FORK (film evidence gate)
+    .output_informative(output_informative),                 // DVD-FORK (film evidence gate)
     .motion_vector_valid(mvec_rd_motion_vector_valid),
 
     .source_select(source_select),

--- a/rtl/mpeg2/motcomp_addrgen.v
+++ b/rtl/mpeg2/motcomp_addrgen.v
@@ -45,6 +45,7 @@ module motcomp_addrgen(
   motion_vert_field_select_0_0, motion_vert_field_select_0_1, motion_vert_field_select_1_0, motion_vert_field_select_1_1,
   second_field, progressive_sequence, progressive_frame, top_field_first, repeat_first_field, last_frame, update_picture_buffers, motion_vector_valid,
   flags_commit,                                            // DVD-FORK (round 11): per-picture display flags valid (direct from vld)
+  pic_informative, informative_commit, output_informative, // DVD-FORK (film evidence gate): per-picture evidence verdict
   source_select,
   fwd_wr_addr_en, fwd_wr_addr, fwd_wr_addr_almost_full,
   bwd_wr_addr_en, bwd_wr_addr, bwd_wr_addr_almost_full,
@@ -103,6 +104,9 @@ module motcomp_addrgen(
   input              last_frame;
   input              update_picture_buffers;
   input              flags_commit;      // DVD-FORK (round 11)
+  input              pic_informative;   // DVD-FORK (film evidence gate)
+  input              informative_commit;// DVD-FORK (film evidence gate)
+  output             output_informative;// DVD-FORK (film evidence gate)
   input              motion_vector_valid;
   /* trick modes */
   input         [2:0]source_select;                 /* select video out source */
@@ -374,6 +378,9 @@ module motcomp_addrgen(
     .last_frame(last_frame),
     .update_picture_buffers(do_update_picture_buffers),
     .flags_commit(flags_commit),                             // DVD-FORK (round 11): re-latch display flags post-extension
+    .pic_informative(pic_informative),                       // DVD-FORK (film evidence gate)
+    .informative_commit(informative_commit),                 // DVD-FORK (film evidence gate): later pulse, same slot
+    .output_informative(output_informative),                 // DVD-FORK (film evidence gate)
     .forward_reference_frame(forward_reference_frame), 
     .backward_reference_frame(backward_reference_frame), 
     .current_frame(current_frame), 

--- a/rtl/mpeg2/motcomp_picbuf.v
+++ b/rtl/mpeg2/motcomp_picbuf.v
@@ -34,9 +34,10 @@ module motcomp_picbuf(
   clk, clk_en, rst,
   source_select, 
   progressive_sequence, progressive_frame, top_field_first, repeat_first_field, last_frame,
+  pic_informative, informative_commit,       // DVD-FORK (film evidence gate): per-picture evidence verdict
   picture_coding_type,
   forward_reference_frame, backward_reference_frame, current_frame,
-  output_frame, output_frame_valid, output_frame_rd, output_progressive_sequence, output_progressive_frame, output_top_field_first, output_repeat_first_field,
+  output_frame, output_frame_valid, output_frame_rd, output_progressive_sequence, output_progressive_frame, output_top_field_first, output_repeat_first_field, output_informative,
   update_picture_buffers, picbuf_busy,
   flags_commit                             // DVD-FORK (round 11): per-picture display flags valid (coding ext parsed)
   );
@@ -49,6 +50,14 @@ module motcomp_picbuf(
   input         [2:0]picture_coding_type;          // identifies whether a picture is an I, P or B picture.
   input              progressive_sequence;
   input              progressive_frame;
+  /* DVD-FORK (film evidence gate): a picture's coded size is only known when it
+   * ENDS, so unlike flags_commit this verdict cannot be committed at the coding
+   * extension. informative_commit pulses at the picture's terminating start code,
+   * which is still strictly before the NEXT picture's update_picture_buffers —
+   * same slot, later write. Default is 1 (informative), so a picture that never
+   * commits counts exactly as it does today. */
+  input              pic_informative;
+  input              informative_commit;
   input              top_field_first;
   input              repeat_first_field;
   input              last_frame;                   // asserted when frame is the last frame of a bitstream
@@ -73,6 +82,7 @@ module motcomp_picbuf(
   reg           [2:0]current_frame_coding_type;    /* I, P or B-TYPE */
   reg                current_frame_progressive_sequence;
   reg                current_frame_progressive_frame;
+  reg                current_frame_informative;        // DVD-FORK (film evidence gate)
   reg                current_frame_top_field_first;
   reg                current_frame_repeat_first_field;
 
@@ -82,6 +92,7 @@ module motcomp_picbuf(
 
   output reg         output_progressive_sequence;
   output reg         output_progressive_frame;
+  output reg         output_informative;               // DVD-FORK (film evidence gate)
   output reg         output_top_field_first;
   output reg         output_repeat_first_field;
   output reg         picbuf_busy;
@@ -112,6 +123,7 @@ module motcomp_picbuf(
   reg                prev_i_p_frame_valid;         /* high if previous I or P frame exists, low when no previous I or P frame exists (at video sequence start) */
   reg                prev_i_p_frame_progressive_sequence;
   reg                prev_i_p_frame_progressive_frame;
+  reg                prev_i_p_frame_informative;       // DVD-FORK (film evidence gate)
   reg                prev_i_p_frame_top_field_first;
   reg                prev_i_p_frame_repeat_first_field;
 
@@ -262,6 +274,7 @@ module motcomp_picbuf(
         current_frame_coding_type <= I_TYPE;
         current_frame_progressive_sequence <= 1'b0;
         current_frame_progressive_frame <= 1'b0;
+        current_frame_informative <= 1'b1;
         current_frame_top_field_first <= 1'b0;
         current_frame_repeat_first_field <= 1'b0;
       end 
@@ -272,6 +285,7 @@ module motcomp_picbuf(
         current_frame_coding_type <= vld_picture_coding_type;
         current_frame_progressive_sequence <= vld_progressive_sequence;
         current_frame_progressive_frame <= vld_progressive_frame;
+        current_frame_informative <= 1'b1;
         current_frame_top_field_first <= vld_top_field_first;
         current_frame_repeat_first_field <= vld_repeat_first_field;
       end
@@ -282,6 +296,7 @@ module motcomp_picbuf(
         current_frame_coding_type <= vld_picture_coding_type;
         current_frame_progressive_sequence <= vld_progressive_sequence;
         current_frame_progressive_frame <= vld_progressive_frame;
+        current_frame_informative <= 1'b1;
         current_frame_top_field_first <= vld_top_field_first;
         current_frame_repeat_first_field <= vld_repeat_first_field;
       end
@@ -295,8 +310,25 @@ module motcomp_picbuf(
         current_frame_coding_type <= current_frame_coding_type;
         current_frame_progressive_sequence <= current_frame_progressive_sequence;
         current_frame_progressive_frame <= progressive_frame;
+        current_frame_informative <= current_frame_informative;
         current_frame_top_field_first <= top_field_first;
         current_frame_repeat_first_field <= repeat_first_field;
+      end
+    else if (clk_en && informative_commit && current_frame_valid)
+      begin
+        /* DVD-FORK (film evidence gate): the vld has finished MEASURING this
+         * picture and knows whether it carried real evidence. Same ordering
+         * argument flags_commit makes, one step later: the pulse lands at the
+         * picture's terminating start code, and the next picture's STATE_UPDATE
+         * cannot precede its own header. */
+        current_frame <= current_frame;
+        current_frame_valid <= current_frame_valid;
+        current_frame_coding_type <= current_frame_coding_type;
+        current_frame_progressive_sequence <= current_frame_progressive_sequence;
+        current_frame_progressive_frame <= current_frame_progressive_frame;
+        current_frame_top_field_first <= current_frame_top_field_first;
+        current_frame_repeat_first_field <= current_frame_repeat_first_field;
+        current_frame_informative <= pic_informative;
       end
     else
       begin
@@ -305,6 +337,7 @@ module motcomp_picbuf(
         current_frame_coding_type <= current_frame_coding_type;
         current_frame_progressive_sequence <= current_frame_progressive_sequence;
         current_frame_progressive_frame <= current_frame_progressive_frame;
+        current_frame_informative <= current_frame_informative;
         current_frame_top_field_first <= current_frame_top_field_first;
         current_frame_repeat_first_field <= current_frame_repeat_first_field;
       end
@@ -367,6 +400,7 @@ module motcomp_picbuf(
         prev_i_p_frame_valid <= 1'b0;
         prev_i_p_frame_progressive_sequence <= 1'b0;
         prev_i_p_frame_progressive_frame <= 1'b0;
+        prev_i_p_frame_informative <= 1'b1;
         prev_i_p_frame_top_field_first <= 1'b0;
         prev_i_p_frame_repeat_first_field <= 1'b0;
       end
@@ -376,6 +410,7 @@ module motcomp_picbuf(
         prev_i_p_frame_valid <= current_frame_valid;
         prev_i_p_frame_progressive_sequence <= current_frame_progressive_sequence;
         prev_i_p_frame_progressive_frame <= current_frame_progressive_frame;
+        prev_i_p_frame_informative <= current_frame_informative;
         prev_i_p_frame_top_field_first <= current_frame_top_field_first;
         prev_i_p_frame_repeat_first_field <= current_frame_repeat_first_field;
       end
@@ -388,6 +423,7 @@ module motcomp_picbuf(
         prev_i_p_frame_valid <= 1'b0;
         prev_i_p_frame_progressive_sequence <= prev_i_p_frame_progressive_sequence;
         prev_i_p_frame_progressive_frame <= prev_i_p_frame_progressive_frame;
+        prev_i_p_frame_informative <= prev_i_p_frame_informative;
         prev_i_p_frame_top_field_first <= prev_i_p_frame_top_field_first;
         prev_i_p_frame_repeat_first_field <= prev_i_p_frame_repeat_first_field;
       end
@@ -397,6 +433,7 @@ module motcomp_picbuf(
         prev_i_p_frame_valid <= prev_i_p_frame_valid;
         prev_i_p_frame_progressive_sequence <= prev_i_p_frame_progressive_sequence;
         prev_i_p_frame_progressive_frame <= prev_i_p_frame_progressive_frame;
+        prev_i_p_frame_informative <= prev_i_p_frame_informative;
         prev_i_p_frame_top_field_first <= prev_i_p_frame_top_field_first;
         prev_i_p_frame_repeat_first_field <= prev_i_p_frame_repeat_first_field;
       end
@@ -422,6 +459,7 @@ module motcomp_picbuf(
         output_frame_valid            <= 1'b0;
         output_progressive_sequence   <= 1'b0;
         output_progressive_frame      <= 1'b0;
+        output_informative            <= 1'b1;
         output_top_field_first        <= 1'b0;
         output_repeat_first_field     <= 1'b0;
         prev_output_frame_valid       <= 1'b0;
@@ -432,6 +470,7 @@ module motcomp_picbuf(
         output_frame_valid            <= 1'b0;
         output_progressive_sequence   <= output_progressive_sequence;
         output_progressive_frame      <= output_progressive_frame;
+        output_informative            <= output_informative;
         output_top_field_first        <= output_top_field_first;
         output_repeat_first_field     <= output_repeat_first_field;
         prev_output_frame_valid       <= prev_output_frame_valid;
@@ -445,6 +484,7 @@ module motcomp_picbuf(
         output_frame_valid            <= prev_i_p_frame_valid;
         output_progressive_sequence   <= prev_i_p_frame_progressive_sequence;
         output_progressive_frame      <= prev_i_p_frame_progressive_frame;
+        output_informative            <= prev_i_p_frame_informative;
         output_top_field_first        <= prev_i_p_frame_top_field_first;
         output_repeat_first_field     <= prev_i_p_frame_repeat_first_field;
         prev_output_frame_valid       <= prev_i_p_frame_valid;
@@ -458,6 +498,7 @@ module motcomp_picbuf(
         output_frame_valid            <= current_frame_valid;
         output_progressive_sequence   <= current_frame_progressive_sequence;
         output_progressive_frame      <= current_frame_progressive_frame;
+        output_informative            <= current_frame_informative;
         output_top_field_first        <= current_frame_top_field_first;
         output_repeat_first_field     <= current_frame_repeat_first_field;
         prev_output_frame_valid       <= current_frame_valid;
@@ -471,6 +512,7 @@ module motcomp_picbuf(
         output_frame_valid            <= prev_i_p_frame_valid;
         output_progressive_sequence   <= prev_i_p_frame_progressive_sequence;
         output_progressive_frame      <= prev_i_p_frame_progressive_frame;
+        output_informative            <= prev_i_p_frame_informative;
         output_top_field_first        <= prev_i_p_frame_top_field_first;
         output_repeat_first_field     <= prev_i_p_frame_repeat_first_field;
         prev_output_frame_valid       <= prev_i_p_frame_valid;
@@ -484,6 +526,7 @@ module motcomp_picbuf(
         output_frame_valid            <= output_frame_rd; // drop output_frame_valid when output_frame_rd is lowered
         output_progressive_sequence   <= output_progressive_sequence;
         output_progressive_frame      <= output_progressive_frame;
+        output_informative            <= output_informative;
         output_top_field_first        <= output_top_field_first;
         output_repeat_first_field     <= output_repeat_first_field;
         prev_output_frame_valid       <= prev_output_frame_valid;
@@ -497,6 +540,7 @@ module motcomp_picbuf(
         output_frame_valid            <= source_select[2];
         output_progressive_sequence   <= progressive_sequence;
         output_progressive_frame      <= progressive_frame;
+        output_informative            <= 1'b1;
         output_top_field_first        <= top_field_first;
         output_repeat_first_field     <= 1'b0;
         prev_output_frame_valid       <= source_select[2];
@@ -507,6 +551,7 @@ module motcomp_picbuf(
         output_frame_valid            <= output_frame_valid;
         output_progressive_sequence   <= output_progressive_sequence;
         output_progressive_frame      <= output_progressive_frame;
+        output_informative            <= output_informative;
         output_top_field_first        <= output_top_field_first;
         output_repeat_first_field     <= output_repeat_first_field;
         prev_output_frame_valid       <= prev_output_frame_valid;

--- a/rtl/mpeg2/mpeg2video.v
+++ b/rtl/mpeg2/mpeg2video.v
@@ -438,6 +438,9 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
   output            cc_pair_field;      // DVD-FORK (line-21 CC): 1 = field 1 (CC1/CC2)
 
   wire              flags_commit;       // DVD-FORK (round 11): per-picture display flags valid (coding ext parsed)
+  wire              pic_informative;    // DVD-FORK (film evidence gate): this picture carried real evidence
+  wire              informative_commit; // DVD-FORK (film evidence gate): pic_informative valid for the current slot
+  wire              output_informative; // DVD-FORK (film evidence gate): display-order verdict, from picbuf
   /* DVD-FORK (line-21 CC): straight passthrough of the VLD's user_data snoop to
    * the top level. Sniffed in the clk_dec domain and crossed to clk_sys by the
    * inserter's own fifo_dc — see dvd/cc_line21.sv. */
@@ -992,6 +995,8 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
     .second_field(second_field),                             // to motcomp
     .update_picture_buffers(update_picture_buffers),         // to motcomp
     .flags_commit(flags_commit),                             // DVD-FORK (round 11): to motcomp/picbuf
+    .pic_informative(pic_informative),                       // DVD-FORK (film evidence gate): to motcomp/picbuf
+    .informative_commit(informative_commit),                 // DVD-FORK (film evidence gate): committed at picture END, not at the coding ext
     .cc_pair_valid(cc_pair_valid),                           // DVD-FORK (line-21 CC): to dvd/cc_line21.sv
     .cc_pair(cc_pair),                                       // DVD-FORK (line-21 CC)
     .cc_pair_field(cc_pair_field),                           // DVD-FORK (line-21 CC)
@@ -1271,6 +1276,9 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
     .second_field(second_field),                             // from vld
     .update_picture_buffers(update_picture_buffers),         // from vld
     .flags_commit(flags_commit),                             // DVD-FORK (round 11): from vld (direct; ordering by header freeze)
+    .pic_informative(pic_informative),                       // DVD-FORK (film evidence gate): from vld
+    .informative_commit(informative_commit),                 // DVD-FORK (film evidence gate): from vld
+    .output_informative(output_informative),                 // DVD-FORK (film evidence gate): to resample
     .progressive_sequence(progressive_sequence),             // from vld
     .progressive_frame(progressive_frame),                   // from vld
     .top_field_first(top_field_first),                       // from vld
@@ -1384,6 +1392,7 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
 
     .progressive_sequence(output_progressive_sequence),      // from motcomp_picbuf
     .progressive_frame(output_progressive_frame),            // from motcomp_picbuf
+    .informative(output_informative),                        // DVD-FORK (film evidence gate): from motcomp_picbuf
     .top_field_first(output_top_field_first),                // from motcomp_picbuf
     .repeat_first_field(output_repeat_first_field),          // from motcomp_picbuf
     .mb_width(mb_width),                                     // from vld

--- a/rtl/mpeg2/resample.v
+++ b/rtl/mpeg2/resample.v
@@ -34,6 +34,7 @@ module resample(
   clk, rst, 
   output_frame, output_frame_valid, output_frame_rd,
   progressive_sequence, progressive_frame, top_field_first, repeat_first_field, mb_width, mb_height, horizontal_size, vertical_size, resample_wr_overflow,
+  informative,                    // DVD-FORK (film evidence gate): this displayed picture carried real evidence
   disp_wr_addr_full, disp_wr_addr_almost_full, disp_wr_addr_en, disp_wr_addr_ack, disp_wr_addr, disp_rd_dta_empty, disp_rd_dta_en, disp_rd_dta_valid, disp_rd_dta,
   pixel_wr_almost_full, interlaced, deinterlace, persistence, repeat_frame,
   y, u, v, osd_out, position_out, pixel_wr_en,
@@ -60,6 +61,7 @@ module resample(
 
   input             progressive_sequence;
   input             progressive_frame;
+  input             informative;  // DVD-FORK (film evidence gate)
   input             top_field_first;
   input             repeat_first_field;
   input        [7:0]mb_width;                  // par. 6.3.3. width of the encoded luminance component of pictures in macroblocks
@@ -133,6 +135,7 @@ module resample(
     .output_frame_rd(output_frame_rd),
     .progressive_sequence(progressive_sequence), 
     .progressive_frame(progressive_frame), 
+    .informative(informative),                               // DVD-FORK (film evidence gate)
     .top_field_first(top_field_first), 
     .repeat_first_field(repeat_first_field), 
     .mb_width(mb_width),

--- a/rtl/mpeg2/vld.v
+++ b/rtl/mpeg2/vld.v
@@ -2420,9 +2420,18 @@ module vld(clk, clk_en, rst,
   wire              ev_ok   = ~ev_hot || (pic_bits >= (ev_m >> EV_GSHIFT));
   wire       [21:0] ev_next = ev_m - (ev_m >> EV_ASHIFT) + (pic_bits >> EV_ASHIFT);
 
-  /* Bits the bitstream cursor moves this clock, mirroring getbits_fifo's own
-   * next_cursor logic: align byte-aligns and steps one byte, else advance bits. */
-  wire        [5:0] ev_step = align ? 6'd8 : {1'b0, advance};
+  /* Bits the bitstream cursor moves, mirroring getbits_fifo's own next_cursor
+   * logic: align byte-aligns and steps one byte, else advance bits.
+   *
+   * ★ next_advance/next_align, NOT the registered advance/align. The registered
+   * outputs are forced to 0 on every cycle where clk_en is LOW (see their always
+   * blocks above), so sampling them from a clk_en-gated block reads 0 almost
+   * every time — vld_en arrives in bursts, and the zeroed cycles are exactly the
+   * ones in between. Counting the registered value made every picture measure
+   * 0 B, which the gate cannot even fail loudly on: a zero mean compares equal,
+   * so everything reads "informative" and the feature is silently inert.
+   * Caught by bench/dvd/film_evidence_tb.sv against the golden model. */
+  wire        [5:0] ev_step = next_align ? 6'd8 : {1'b0, next_advance};
 
   wire              pic_ends = (state == STATE_START_CODE) &&
                                ((getbits[7:0] == CODE_PICTURE_START)   ||

--- a/rtl/mpeg2/vld.v
+++ b/rtl/mpeg2/vld.v
@@ -53,6 +53,7 @@ module vld(clk, clk_en, rst,
   drop_pic_req, drop_pic_ack, drop_pic_rff, drop_pic_field,                                 // DVD-FORK (frame-drop governor O[19] + field-pair drop)
   dbg_drop_probe,                                                                           // DVD-FORK DEBUG (2026-08-05): in-vld drop-path probe (Thayer drops=0)
   flags_commit,                                                                             // DVD-FORK (round 11): per-picture display flags are valid (coding ext parsed)
+  pic_informative, informative_commit,                                                      // DVD-FORK (film evidence gate): this picture carried real evidence
   cc_pair_valid, cc_pair, cc_pair_field,                                                    // DVD-FORK (line-21 CC): EIA-608 byte pairs sniffed out of user_data
   mpeg1                                                                                     // DVD-FORK FIX (mpeg1): stream is MPEG-1 (no sequence extension) — to rld via the rld fifo
   );
@@ -2342,6 +2343,135 @@ module vld(clk, clk_en, rst,
     else if (clk_en) flags_commit <= mpeg1 ? (state == STATE_SLICE)
                                            : ((state == STATE_PICTURE_CODING_EXT0) && ~drop_this_picture);
     else flags_commit <= 1'b0;
+
+  /* DVD-FORK (film evidence gate, 2026-08-30) — see docs/film_24p_plan.md §14.
+   *
+   * progressive_frame is NOT a measurement. It is one bit the ENCODER chose to
+   * write into the picture coding extension, and on a near-black picture there
+   * is no field structure to analyse, so the encoder takes the MPEG-2 default
+   * and marks it interlaced — mismarking progressive costs visible artifacts,
+   * mismarking interlaced costs a few bytes of disc space. The film detector in
+   * dvd/resample_addrgen.v then counts that meaningless flag at full weight
+   * (DN_HARD=8) and falls out of film lock. Measured on APOLLO_13: NINE raster
+   * changes inside the first 46 s of the main title, every one of them driven
+   * by the credits fading through black.
+   *
+   * VLC's IVTC survives the same clip because it reads PIXELS and explicitly
+   * discards uninformative frames as evidence — "If no motion, the result from
+   * this algorithm cannot be reliable". We cannot see pixels at the display
+   * pickup, but we can see how many bits the encoder spent, and that separates
+   * the cases cleanly: APOLLO_13's black pictures code 384 B against that
+   * title's own 17,704 B median.
+   *
+   * ★ THE COMPARISON MUST BE RELATIVE, NOT A BYTE CONSTANT. HIGH_SCHOOL_MUSICAL
+   * codes a 318 B MEDIAN — there, small pictures ARE the content, and a fixed
+   * threshold discards 55 % of the disc and delays its video verdict by 17 s.
+   * The core also plays VCD/SVCD, where the whole scale shifts again. So the
+   * reference is a running mean PER PICTURE CODING TYPE: a black I-frame codes
+   * 7,580 B where a real one codes ~82,000 B — tiny for an I, yet larger than
+   * any threshold that does not also swallow legitimate B-frames.
+   *
+   * ★ THE WARM-UP IS LOAD-BEARING, not a detail. Seeding the mean from whichever
+   * picture happened to arrive first made two rips of near-identical content
+   * (same median, same p10, same p90) gate 0.0 % and 85.8 %. For the first
+   * EV_WARM pictures of a coding type nothing is gated and the mean tracks every
+   * picture, so it converges on what THIS stream looks like; after that it
+   * tracks ACCEPTED pictures only, so a long fade cannot walk the reference down
+   * to meet itself and start trusting black frames again.
+   *
+   * ★ ORDERING — why this cannot ride flags_commit. A picture's size is only
+   * known when it ENDS, whereas flags_commit fires at the coding extension near
+   * its START. informative_commit fires instead at STATE_START_CODE for the code
+   * that TERMINATES the picture, which is strictly before the next picture's
+   * STATE_PICTURE_HEADER and therefore before picbuf rotates slots
+   * (update_picture_buffers fires at that header, and the vld then freezes until
+   * picbuf has processed it). Same slot, later write.
+   *
+   * Dropped pictures are excluded from both the commit and the mean: they own no
+   * picbuf slot (so a commit would clobber the displayed picture's verdict) and
+   * their slices are walked rather than decoded, so their size is not evidence.
+   *
+   * MPEG-1 needs no special case — this keys on picture start codes, not on the
+   * coding extension MPEG-1 lacks.
+   *
+   * Defaults are legacy-identical: pic_informative resets to 1, so until a
+   * verdict is committed every picture counts exactly as it does today. */
+  output reg        pic_informative;    // this picture carried real evidence
+  output reg        informative_commit; // pic_informative valid for the current picbuf slot
+
+  /* parameter, not localparam, so a testbench can arm the gate on a short ES cut
+   * instead of needing 16 pictures of every coding type before it does anything. */
+  parameter   [4:0] EV_WARM   = 5'd16;  // pictures per coding type before the gate arms
+  localparam        EV_ASHIFT = 4;      // running-mean time constant (1/16 per picture)
+  localparam        EV_GSHIFT = 3;      // uninformative below mean/8
+  localparam [21:0] EV_SAT    = 22'h3FFF00;
+
+  reg        [21:0] pic_bits;           // bits consumed by the picture being measured
+  reg        [21:0] ev_mean [0:3];      // running mean, indexed by picture_coding_type
+  reg         [4:0] ev_warm [0:3];      // warm-up count, same index
+  reg               pic_active;         // between a picture header and its terminator
+
+  /* Direct array expressions, NOT a function-mediated read: a read behind a
+   * function loses array sensitivity and goes stale (the dvd_vm gprm[] lesson). */
+  wire        [1:0] ev_ct   = picture_coding_type[1:0];   // 1=I, 2=P, 3=B, 0=D
+  wire       [21:0] ev_m    = ev_mean[ev_ct];
+  wire        [4:0] ev_n    = ev_warm[ev_ct];
+  wire              ev_hot  = (ev_n >= EV_WARM);
+  wire              ev_ok   = ~ev_hot || (pic_bits >= (ev_m >> EV_GSHIFT));
+  wire       [21:0] ev_next = ev_m - (ev_m >> EV_ASHIFT) + (pic_bits >> EV_ASHIFT);
+
+  /* Bits the bitstream cursor moves this clock, mirroring getbits_fifo's own
+   * next_cursor logic: align byte-aligns and steps one byte, else advance bits. */
+  wire        [5:0] ev_step = align ? 6'd8 : {1'b0, advance};
+
+  wire              pic_ends = (state == STATE_START_CODE) &&
+                               ((getbits[7:0] == CODE_PICTURE_START)   ||
+                                (getbits[7:0] == CODE_GROUP_START)     ||
+                                (getbits[7:0] == CODE_SEQUENCE_HEADER) ||
+                                (getbits[7:0] == CODE_SEQUENCE_END));
+
+  integer ev_i;
+  always @(posedge clk)
+    if (~rst)
+      begin
+        pic_bits           <= 22'd0;
+        pic_active         <= 1'b0;
+        pic_informative    <= 1'b1;      // legacy default: everything counts
+        informative_commit <= 1'b0;
+        for (ev_i = 0; ev_i < 4; ev_i = ev_i + 1)
+          begin
+            ev_mean[ev_i] <= 22'd0;
+            ev_warm[ev_i] <= 5'd0;
+          end
+      end
+    else if (clk_en)
+      begin
+        informative_commit <= 1'b0;
+
+        if (pic_active && (pic_bits < EV_SAT))
+          pic_bits <= pic_bits + {16'd0, ev_step};
+
+        if (state == STATE_PICTURE_HEADER)
+          begin                          // a new picture: start measuring it
+            pic_bits   <= 22'd0;
+            pic_active <= 1'b1;
+          end
+        else if (pic_ends && pic_active)
+          begin
+            pic_active <= 1'b0;
+            if (~drop_this_picture)
+              begin
+                pic_informative    <= ev_ok;
+                informative_commit <= 1'b1;
+                if (~ev_hot)      ev_warm[ev_ct] <= ev_n + 5'd1;
+                if (ev_n == 5'd0) ev_mean[ev_ct] <= pic_bits;   // first of its type
+                else if (~ev_hot || ev_ok)
+                                  ev_mean[ev_ct] <= ev_next;
+              end
+          end
+      end
+    else
+      informative_commit <= 1'b0;
 
   always @(posedge clk)
     if (~rst) begin

--- a/tools/film_evidence_probe.py
+++ b/tools/film_evidence_probe.py
@@ -104,6 +104,21 @@ def parse_pictures(buf):
     return [p for p in pics if p['prog'] is not None]
 
 
+def annotate(pics_coded, gate):
+    """Run the informativeness gate in CODED order -- which is the only order
+    the VLD has -- and stamp the verdict onto each picture. The detector then
+    consumes that verdict in DISPLAY order, exactly as the hardware will: the
+    running means live in the VLD (clk_dec, coded order), the 1-bit verdict
+    rides to the display through motcomp_picbuf alongside progressive_frame.
+
+    Modelling the gate in display order would flatter it -- the reorder is
+    small, but 'small' is what the round-11 stale-flags bug was called too.
+    """
+    for p in pics_coded:
+        p['inf'] = gate(p)
+    return pics_coded
+
+
 def display_order(pics):
     """Sort to display order. temporal_reference is display position within a
     GOP, so (gop, tr) IS display order -- and the whole point of the exercise:
@@ -141,6 +156,66 @@ def rel_gate(shift=3, ew=4):
         ok = p['size'] >= (a >> shift)
         if ok:
             avg[p['ct']] = a - (a >> ew) + (p['size'] >> ew)
+        return ok
+    return g
+
+
+def peak_gate(shift=3, decay=7):
+    """CANDIDATE E -- informativeness relative to a decaying PEAK, per coding
+    type. Same idea as D but without D's bootstrap fragility.
+
+    D seeds a running mean from whatever picture happens to arrive first, so
+    two rips of near-identical content gated differently depending only on
+    where the window started (HIGH_SCHOOL_MUSICAL skipD=0.0% vs PRI0NNW1
+    skipD=85.8%, same median, same p10, same p90). A peak needs no seed: it
+    starts at zero, the first picture of each type sets it, and it only ever
+    rises on real content.
+
+    Decay runs only on ACCEPTED pictures, so a long fade cannot walk the
+    reference down to meet itself and start trusting black frames again --
+    the failure that makes a fixed threshold break on a longer fade.
+    """
+    peak = {}
+    def g(p):
+        k = peak.get(p['ct'], 0)
+        ok = p['size'] >= (k >> shift)
+        if ok:
+            peak[p['ct']] = max(p['size'], k - (k >> decay))
+        return ok
+    return g
+
+
+def warm_gate(shift=3, ew=4, warm=16):
+    """CANDIDATE F -- D with the bootstrap fixed, which is the whole difference
+    between D being right and D being lucky.
+
+    D seeded its mean from the FIRST picture of each coding type, so the gate's
+    behaviour depended on where the window happened to start: two rips of
+    near-identical content (HIGH_SCHOOL_MUSICAL, PRI0NNW1 -- same median 318 B,
+    same p10 288 B, same p90 31,45x B) came out skipping 0.0% and 85.8%.
+
+    F warms up instead. For the first `warm` pictures of a coding type nothing
+    is gated and the mean tracks EVERY picture, so it converges on what this
+    stream actually looks like. After that the mean updates only on ACCEPTED
+    pictures, so a long fade cannot walk the reference down to meet itself.
+
+    That distinction is the entire point: APOLLO_13's 384 B pictures are tiny
+    RELATIVE TO THEIR OWN STREAM (median 17,704 B), while HIGH_SCHOOL_MUSICAL's
+    318 B pictures ARE the stream. An absolute threshold cannot tell those
+    apart, and the core plays VCD/SVCD too, where the whole scale shifts again.
+    """
+    avg, seen = {}, {}
+    def g(p):
+        ct = p['ct']
+        n = seen.get(ct, 0)
+        a = avg.get(ct, p['size'])
+        if n < warm:                        # warm-up: gate nothing, learn scale
+            seen[ct] = n + 1
+            avg[ct] = a - (a >> ew) + (p['size'] >> ew)
+            return True
+        ok = p['size'] >= (a >> shift)
+        if ok:
+            avg[ct] = a - (a >> ew) + (p['size'] >> ew)
         return ok
     return g
 
@@ -227,6 +302,10 @@ def main():
                     help="contiguous sectors to walk (~8 MB at 2048 B)")
     ap.add_argument('--csv', default=None, help="write the per-picture trace")
     ap.add_argument('--xtab', action='store_true', help="flag cross-tabulation")
+    ap.add_argument('--brief', action='store_true',
+                    help="one machine-readable line per disc, for library "
+                         "regression sweeps: the gate must never ADD film "
+                         "transitions relative to the baseline")
     ap.add_argument('--sweep', default=None,
                     help="comma-separated candidate-A thresholds to compare, "
                          "e.g. 512,768,1024,2048")
@@ -290,13 +369,36 @@ def main():
         return 0
 
     start = int(total * a.start_frac)
-    pics = window(start, a.sectors)
+    coded = parse_pictures(b''.join(
+        d for d in (video_payload(nav.sec(sector_at(start + k)))
+                    for k in range(a.sectors)
+                    if sector_at(start + k) is not None) if d))
+    pics = display_order(list(coded))
     if not pics:
         print("no pictures found")
         return 1
 
     span = sum(duration(p) for p in pics)
     sizes = [p['size'] for p in pics]
+
+    if a.brief:
+        b = simulate(pics)
+        g = simulate(pics, gate=lambda p: p['size'] >= a.small)
+        dg = rel_gate()
+        d = simulate(pics, gate=dg)
+        tiny = sum(1 for p in pics if p['size'] < a.small)
+
+        def flag(r):
+            return ('WORSE' if r['film_flips'] > b['film_flips'] else
+                    ('better' if r['film_flips'] < b['film_flips'] else 'same'))
+        print(f"{os.path.basename(a.iso)[:44]:44s} VTS{vts:02d} "
+              f"pics={len(pics):5d} p10={pct(sizes,0.10):6d} "
+              f"tinyA={100*tiny/len(pics):5.1f}% "
+              f"skipD={100*d['skipped']/len(pics):5.1f}% "
+              f"base={b['film_flips']:2d} A={g['film_flips']:2d} D={d['film_flips']:2d} "
+              f"A:{flag(g):6s} D:{flag(d)}")
+        return 0
+
     print(f"{os.path.basename(a.iso)}  VTS{vts:02d}  sectors {start}..{start+a.sectors} "
           f"of {total}")
     print(f"  {len(pics)} pictures, {span:.1f} s displayed, "
@@ -317,7 +419,10 @@ def main():
          lambda p: p['size'] >= a.small),
         ("B  frame_pred_frame_dct", lambda p: p['fpfd'], None),
         ("C  A + B", lambda p: p['fpfd'], lambda p: p['size'] >= a.small),
-        ("D  relative, per coding type", None, rel_gate()),
+        ("D  relative mean, per type", None, rel_gate()),
+        ("E  relative peak, per type", None, peak_gate()),
+        ("F  relative mean + warm-up", None, warm_gate()),
+        ("F' same, gate in CODED order", None, 'coded'),
     ]
     if a.sweep:
         print(f"\n  {'threshold':>10} {'film flips':>11} {'skipped':>8} "
@@ -325,6 +430,7 @@ def main():
         cands = [(f"abs {x}", (lambda p, t=int(x): p['size'] >= t))
                  for x in a.sweep.split(',')]
         cands += [(f"rel >>{k}", rel_gate(shift=k)) for k in (2, 3, 4, 5)]
+        cands += [(f"peak >>{k}", peak_gate(shift=k)) for k in (2, 3, 4, 5)]
         for th, gt in cands:
             r = simulate(pics, gate=gt)
             first = next((f"{t:.1f}s" for t, e in r['events'] if e == 'FILM+'),
@@ -336,6 +442,9 @@ def main():
 
     print(f"\n  {'rule':34s} {'film flips':>11} {'skipped':>8}  events")
     for name, prog_of, gate in rules:
+        if gate == 'coded':
+            annotate(coded, warm_gate())
+            gate = (lambda p: p['inf'])
         r = simulate(pics, prog_of, gate)
         ev = " ".join(f"{t:.1f}{e}" for t, e in r['events'][:12])
         if len(r['events']) > 12:

--- a/tools/film_evidence_probe.py
+++ b/tools/film_evidence_probe.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+# =============================================================================
+# film_evidence_probe.py -- what evidence does the video stream ACTUALLY carry?
+# =============================================================================
+# The film/video detector in dvd/resample_addrgen.v keys on ONE bit,
+# progressive_frame, and that bit is not a measurement: it is what the ENCODER
+# chose to write into the MPEG-2 picture coding extension. On a near-black
+# frame there is no field structure to analyse, so the encoder falls back to
+# the MPEG-2 default and marks it interlaced (mismarking progressive costs
+# visible artifacts; mismarking interlaced costs a few bytes of disc space).
+# Our detector then counts that meaningless flag at full weight, DN_HARD=8 --
+# which is why APOLLO_13's fading credits knock it out of film lock repeatedly.
+#
+# VLC does not have this problem because its IVTC reads PIXELS and explicitly
+# discards uninformative frames as evidence ("If no motion, the result from
+# this algorithm cannot be reliable"). We cannot read pixels at the display
+# pickup, but we are not out of options -- and docs/film_24p_plan.md 14.8's
+# claim that "no threshold tuning or cleverer flag rule can help" was only ever
+# tested against progressive_frame alone. This tool tests the alternatives.
+#
+# It walks a CONTIGUOUS region of a title (the census samples spread windows
+# instead), reorders to DISPLAY order -- coded order hides the flapping behind
+# B-frame reordering -- and records, per picture, every field the VLD already
+# parses that could serve as evidence:
+#
+#   progressive_frame     ext bit 32  (rtl/mpeg2/vld.v:1462)  today's evidence
+#   repeat_first_field    ext bit 30  (vld.v rff)             the 3:2 toggle
+#   frame_pred_frame_dct  ext bit 25  (vld.v:1455, offset 5)  CANDIDATE B
+#   picture_structure     ext bits 22-23 (vld.v:1453)         frame vs field
+#   coded picture size    start code to start code            CANDIDATE A
+#
+# Field offsets are taken from OUR decoder rather than from the spec, the same
+# discipline tools/video_cadence_census.py uses, so probe and RTL cannot drift.
+#
+# It then replays main's EXACT detector arithmetic over the trace and counts
+# engage/disengage transitions, first for the shipped evidence (which must
+# reproduce the documented APOLLO_13 baseline before any candidate is trusted)
+# and then for each candidate rule.
+#
+# Usage:
+#   tools/film_evidence_probe.py <iso> [--vts N] [--start-frac 0.0] [--sectors 4000]
+#   tools/film_evidence_probe.py <iso> --csv /tmp/trace.csv
+#   tools/film_evidence_probe.py <iso> --xtab        # the flag cross-tabulation
+# =============================================================================
+import sys, os, argparse, csv, statistics
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from dvd_vm_ref import IsoNav                       # noqa: E402
+from video_cadence_census import video_payload      # noqa: E402
+
+SEC = 2048
+
+# --- Detector constants: MUST track dvd/resample_addrgen.v:744-751 -----------
+CONF_MAX, ENGAGE_TH, DISENGAGE_TH = 127, 120, 24
+UP_STEP, DN_SOFT, DN_HARD = 3, 2, 8
+
+FIELD = 1.0 / 59.94                                 # one NTSC field, seconds
+
+
+# ---------------------------------------------------------------- ES parsing
+def parse_pictures(buf):
+    """Walk a video ES -> per-picture records in CODED order.
+
+    Coded size is measured start-code-to-start-code, so it includes the slice
+    data: that is exactly the "did this frame carry any information" quantity
+    14.8 measured (384 B on black vs 20,380 B median) and never wired up.
+    """
+    pics, cur, gop = [], None, -1
+    n = len(buf)
+
+    def close(end):
+        nonlocal cur
+        if cur is not None:
+            cur['size'] = end - cur['off']
+            pics.append(cur)
+            cur = None
+
+    i = buf.find(b'\x00\x00\x01')
+    while i >= 0 and i + 4 <= n:
+        sc = buf[i + 3]
+        if sc == 0x00:                              # picture_start_code
+            close(i)
+            if i + 6 <= n:
+                p = buf[i + 4:i + 6]
+                cur = dict(off=i, gop=gop,
+                           tr=(p[0] << 2) | (p[1] >> 6),
+                           ct=(p[1] >> 3) & 0x07,
+                           prog=None, rff=0, tff=0, fpfd=0, pstruct=3, size=0)
+        elif sc in (0xB3, 0xB8, 0xB7):              # sequence / GOP / seq_end
+            close(i)
+            if sc == 0xB8:
+                gop += 1
+        elif sc == 0xB5 and cur is not None and cur['prog'] is None:
+            if i + 9 <= n:
+                e = buf[i + 4:i + 9]
+                if (e[0] >> 4) == 0x8:              # picture_coding_extension
+                    cur['pstruct'] = e[2] & 0x03
+                    cur['tff'] = (e[3] >> 7) & 1
+                    cur['fpfd'] = (e[3] >> 6) & 1   # frame_pred_frame_dct
+                    cur['rff'] = (e[3] >> 1) & 1
+                    cur['prog'] = (e[4] >> 7) & 1
+        i = buf.find(b'\x00\x00\x01', i + 3)
+    close(n)
+    return [p for p in pics if p['prog'] is not None]
+
+
+def display_order(pics):
+    """Sort to display order. temporal_reference is display position within a
+    GOP, so (gop, tr) IS display order -- and the whole point of the exercise:
+    the sustained detector runs on displayed pictures, not coded ones."""
+    return sorted(pics, key=lambda p: (p['gop'], p['tr']))
+
+
+def duration(p):
+    """Display duration in seconds. A frame picture shows 2 fields, 3 with rff
+    (that is the 3:2 pulldown); a field picture shows 1."""
+    return FIELD * (1 if p['pstruct'] != 3 else 2 + p['rff'])
+
+
+def rel_gate(shift=3, ew=4):
+    """CANDIDATE D -- informativeness measured RELATIVE to this stream, per
+    picture coding type.
+
+    A fixed byte threshold cannot work, and APOLLO_13 shows exactly why: during
+    a fade its B/P pictures collapse to 384 B but the GOP's I-frame still codes
+    7,580 B -- tiny against its own ~82,000 B norm, yet far above any threshold
+    that does not also swallow legitimate B-frames (median 18,540 B). Comparing
+    a picture against the running mean FOR ITS OWN CODING TYPE separates them
+    cleanly, and adapts to bitrate and resolution instead of assuming DVD-sized
+    pictures.
+
+    The mean updates only on ACCEPTED pictures: otherwise a long dark run drags
+    the baseline down to meet itself and starts trusting black frames again.
+    """
+    avg = {}
+    def g(p):
+        a = avg.get(p['ct'])
+        if a is None:                       # no baseline for this type yet
+            avg[p['ct']] = p['size']
+            return True
+        ok = p['size'] >= (a >> shift)
+        if ok:
+            avg[p['ct']] = a - (a >> ew) + (p['size'] >> ew)
+        return ok
+    return g
+
+
+# ------------------------------------------------------------ detector replay
+def simulate(pics, prog_of=None, gate=None):
+    """Replay dvd/resample_addrgen.v's accumulators over the display trace.
+
+    prog_of : what stands in for progressive_frame (candidate B)
+    gate    : return False to DISCARD a pickup as uninformative (candidate A).
+              A discarded pickup updates nothing at all -- not the accumulators
+              and not rff_q -- which is VLC's "we do nothing, as it's not a
+              good idea to act on unreliable data".
+    """
+    prog_of = prog_of or (lambda p: p['prog'])
+    conf_n = conf_v = 0
+    det_n = det_v = 0
+    rff_q = 0
+    t = 0.0
+    events, skipped = [], 0
+
+    for p in pics:
+        if gate is not None and not gate(p):
+            skipped += 1
+            t += duration(p)
+            continue
+        pr = prog_of(p)
+        tog = (p['rff'] != rff_q)
+        rff_q = p['rff']
+
+        if pr and tog:   conf_n = min(CONF_MAX, conf_n + UP_STEP)
+        elif not pr:     conf_n = max(0, conf_n - DN_HARD)
+        else:            conf_n = max(0, conf_n - DN_SOFT)
+        nd = 1 if conf_n >= ENGAGE_TH else (0 if conf_n <= DISENGAGE_TH else det_n)
+        if nd != det_n:
+            events.append((t, 'FILM+' if nd else 'FILM-'))
+            det_n = nd
+
+        if not pr: conf_v = min(CONF_MAX, conf_v + UP_STEP)
+        else:      conf_v = max(0, conf_v - DN_HARD)
+        vd = 1 if conf_v >= ENGAGE_TH else (0 if conf_v <= DISENGAGE_TH else det_v)
+        if vd != det_v:
+            events.append((t, 'VIDEO+' if vd else 'VIDEO-'))
+            det_v = vd
+
+        t += duration(p)
+    return dict(events=events, span=t, skipped=skipped,
+                film_flips=sum(1 for _, e in events if e.startswith('FILM')))
+
+
+# ------------------------------------------------------------------ reporting
+def pct(vals, q):
+    if not vals:
+        return 0
+    s = sorted(vals)
+    return s[min(len(s) - 1, int(q * len(s)))]
+
+
+def cross_tab(pics):
+    """The hypothesis test: is frame_pred_frame_dct honest where
+    progressive_frame is lazy? Cells are (progressive_frame, fpfd)."""
+    cells = {}
+    for p in pics:
+        cells.setdefault((p['prog'], p['fpfd']), []).append(p['size'])
+    print("  progressive_frame / frame_pred_frame_dct cross-tab")
+    print(f"    {'pf':>3} {'fpfd':>5} {'count':>7} {'share':>7} "
+          f"{'med size':>9} {'p10':>7} {'p90':>8}")
+    tot = len(pics) or 1
+    for key in sorted(cells):
+        v = cells[key]
+        print(f"    {key[0]:>3} {key[1]:>5} {len(v):>7} {100*len(v)/tot:6.1f}% "
+              f"{int(statistics.median(v)):>9} {pct(v,0.10):>7} {pct(v,0.90):>8}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('iso')
+    ap.add_argument('--vts', type=int, default=None)
+    ap.add_argument('--start-frac', type=float, default=0.0,
+                    help="where in the title to start (0.0 = head, where the "
+                         "APOLLO_13 credits are)")
+    ap.add_argument('--sectors', type=int, default=4000,
+                    help="contiguous sectors to walk (~8 MB at 2048 B)")
+    ap.add_argument('--csv', default=None, help="write the per-picture trace")
+    ap.add_argument('--xtab', action='store_true', help="flag cross-tabulation")
+    ap.add_argument('--sweep', default=None,
+                    help="comma-separated candidate-A thresholds to compare, "
+                         "e.g. 512,768,1024,2048")
+    ap.add_argument('--scan', type=int, default=0,
+                    help="probe N evenly spaced windows through the title "
+                         "instead of one contiguous region (finds where a "
+                         "film title turns into real video)")
+    ap.add_argument('--small', type=int, default=1000,
+                    help="candidate A threshold: coded bytes below which a "
+                         "picture is treated as carrying no evidence")
+    a = ap.parse_args()
+
+    nav = IsoNav(a.iso)
+    vts = a.vts if a.vts is not None else nav.best_vts
+    runs = [(ext, dl // SEC) for ext, dl in nav.groups[vts]]
+    total = sum(n for _, n in runs)
+
+    def sector_at(idx):
+        for ext, n in runs:
+            if idx < n:
+                return ext + idx
+            idx -= n
+        return None
+
+    def window(start, count):
+        chunks = []
+        for k in range(count):
+            s = sector_at(start + k)
+            if s is None:
+                break
+            d = video_payload(nav.sec(s))
+            if d:
+                chunks.append(d)
+        return display_order(parse_pictures(b''.join(chunks)))
+
+    # --- --scan: where in the title does the content change? ----------------
+    if a.scan:
+        print(f"{os.path.basename(a.iso)}  VTS{vts:02d}  {a.scan} windows x "
+              f"{a.sectors} sectors across {total} sectors")
+        print(f"  {'at%':>5} {'pics':>6} {'sec':>6} {'pf=0%':>6} {'tiny%':>6} "
+              f"{'verdict (baseline)':>22}  {'verdict (gate)':>18}")
+        for w in range(a.scan):
+            st = (total * w) // a.scan
+            ps = window(st, a.sectors)
+            if not ps:
+                continue
+            npx = len(ps)
+            z = sum(1 for q in ps if not q['prog'])
+            tiny = sum(1 for q in ps if q['size'] < a.small)
+            b = simulate(ps)
+            g = simulate(ps, gate=lambda q: q['size'] >= a.small)
+
+            def fin(r):
+                st_ = 'none'
+                for _, e in r['events']:
+                    st_ = e
+                return st_
+            print(f"  {100*w/a.scan:5.1f} {npx:>6} {b['span']:6.1f} "
+                  f"{100*z/npx:5.1f}% {100*tiny/npx:5.1f}% "
+                  f"{fin(b):>22}  {fin(g):>18}")
+        return 0
+
+    start = int(total * a.start_frac)
+    pics = window(start, a.sectors)
+    if not pics:
+        print("no pictures found")
+        return 1
+
+    span = sum(duration(p) for p in pics)
+    sizes = [p['size'] for p in pics]
+    print(f"{os.path.basename(a.iso)}  VTS{vts:02d}  sectors {start}..{start+a.sectors} "
+          f"of {total}")
+    print(f"  {len(pics)} pictures, {span:.1f} s displayed, "
+          f"median coded size {int(statistics.median(sizes))} B, "
+          f"p10 {pct(sizes,0.10)} B, p90 {pct(sizes,0.90)} B")
+    small = [p for p in pics if p['size'] < a.small]
+    print(f"  pictures under {a.small} B: {len(small)} "
+          f"({100*len(small)/len(pics):.1f}%), of which "
+          f"{sum(1 for p in small if not p['prog'])} are progressive_frame==0")
+
+    if a.xtab:
+        cross_tab(pics)
+
+    # --- the four rules, same trace, same arithmetic ------------------------
+    rules = [
+        ("baseline  (progressive_frame)", None, None),
+        ("A  informative-only (size gate)", None,
+         lambda p: p['size'] >= a.small),
+        ("B  frame_pred_frame_dct", lambda p: p['fpfd'], None),
+        ("C  A + B", lambda p: p['fpfd'], lambda p: p['size'] >= a.small),
+        ("D  relative, per coding type", None, rel_gate()),
+    ]
+    if a.sweep:
+        print(f"\n  {'threshold':>10} {'film flips':>11} {'skipped':>8} "
+              f"{'1st engage':>11}  events")
+        cands = [(f"abs {x}", (lambda p, t=int(x): p['size'] >= t))
+                 for x in a.sweep.split(',')]
+        cands += [(f"rel >>{k}", rel_gate(shift=k)) for k in (2, 3, 4, 5)]
+        for th, gt in cands:
+            r = simulate(pics, gate=gt)
+            first = next((f"{t:.1f}s" for t, e in r['events'] if e == 'FILM+'),
+                         '-')
+            ev = " ".join(f"{t:.1f}{e}" for t, e in r['events'][:8])
+            print(f"  {th:>10} {r['film_flips']:>11} {r['skipped']:>8} "
+                  f"{first:>11}  {ev}")
+        return 0
+
+    print(f"\n  {'rule':34s} {'film flips':>11} {'skipped':>8}  events")
+    for name, prog_of, gate in rules:
+        r = simulate(pics, prog_of, gate)
+        ev = " ".join(f"{t:.1f}{e}" for t, e in r['events'][:12])
+        if len(r['events']) > 12:
+            ev += " ..."
+        print(f"  {name:34s} {r['film_flips']:>11} {r['skipped']:>8}  {ev}")
+
+    if a.csv:
+        with open(a.csv, 'w', newline='') as fh:
+            w = csv.writer(fh)
+            w.writerow(['t', 'gop', 'tr', 'coding_type', 'pic_struct',
+                        'progressive_frame', 'rff', 'tff',
+                        'frame_pred_frame_dct', 'coded_bytes'])
+            t = 0.0
+            for p in pics:
+                w.writerow([f"{t:.4f}", p['gop'], p['tr'], p['ct'], p['pstruct'],
+                            p['prog'], p['rff'], p['tff'], p['fpfd'], p['size']])
+                t += duration(p)
+        print(f"\n  trace -> {a.csv}")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/film_evidence_probe.py
+++ b/tools/film_evidence_probe.py
@@ -394,6 +394,16 @@ def main():
             d for d in (video_payload(nav.sec(sector_at(start + k)))
                         for k in range(a.sectors)
                         if sector_at(start + k) is not None) if d)
+        # Start the cut at a SEQUENCE HEADER. The vld refuses picture start
+        # codes until sequence_header_seen, so a cut that begins mid-GOP makes
+        # the golden count pictures the hardware will never commit -- the two
+        # models would then disagree about WHICH picture index they are on,
+        # which reads as a size mismatch on every row.
+        sh = es.find(b'\x00\x00\x01\xb3')
+        if sh < 0:
+            print("  no sequence header in this cut -- move --start-frac")
+            return 1
+        es = es[sh:]
         es += b'\x00' * (-len(es) % 8)
         with open(a.cut + '.hex', 'w') as fh:
             for i in range(0, len(es), 8):

--- a/tools/film_evidence_probe.py
+++ b/tools/film_evidence_probe.py
@@ -14,7 +14,7 @@
 # VLC does not have this problem because its IVTC reads PIXELS and explicitly
 # discards uninformative frames as evidence ("If no motion, the result from
 # this algorithm cannot be reliable"). We cannot read pixels at the display
-# pickup, but we are not out of options -- and docs/film_24p_plan.md 14.8's
+# pickup, but we are not out of options -- and docs/film_24p_plan.md §14's
 # claim that "no threshold tuning or cleverer flag rule can help" was only ever
 # tested against progressive_frame alone. This tool tests the alternatives.
 #
@@ -302,6 +302,14 @@ def main():
                     help="contiguous sectors to walk (~8 MB at 2048 B)")
     ap.add_argument('--csv', default=None, help="write the per-picture trace")
     ap.add_argument('--xtab', action='store_true', help="flag cross-tabulation")
+    ap.add_argument('--cut', default=None, metavar='STEM',
+                    help="write a simulation fixture: STEM.hex (video ES as "
+                         "64-bit words) + STEM.golden.hex (one word per "
+                         "picture, {informative[24], size_bytes[23:0]}), for "
+                         "bench/dvd/film_evidence_tb.sv")
+    ap.add_argument('--cut-warm', type=int, default=2,
+                    help="EV_WARM the fixture's golden verdicts assume; must "
+                         "match the TB's parameter override")
     ap.add_argument('--brief', action='store_true',
                     help="one machine-readable line per disc, for library "
                          "regression sweeps: the gate must never ADD film "
@@ -380,6 +388,27 @@ def main():
 
     span = sum(duration(p) for p in pics)
     sizes = [p['size'] for p in pics]
+
+    if a.cut:
+        es = b''.join(
+            d for d in (video_payload(nav.sec(sector_at(start + k)))
+                        for k in range(a.sectors)
+                        if sector_at(start + k) is not None) if d)
+        es += b'\x00' * (-len(es) % 8)
+        with open(a.cut + '.hex', 'w') as fh:
+            for i in range(0, len(es), 8):
+                fh.write(es[i:i+8].hex() + '\n')
+        # Golden verdicts come from the CODED-order gate -- the only order the
+        # vld has, and the one F' proved equivalent on every disc.
+        gold = annotate(parse_pictures(es), warm_gate(warm=a.cut_warm))
+        with open(a.cut + '.golden.hex', 'w') as fh:
+            for q in gold:
+                fh.write(f"{(1 << 24 if q['inf'] else 0) | (q['size'] & 0xFFFFFF):08x}\n")
+        print(f"  {a.cut}.hex        {len(es)} B of video ES")
+        print(f"  {a.cut}.golden.hex {len(gold)} pictures "
+              f"({sum(1 for q in gold if not q['inf'])} uninformative, "
+              f"EV_WARM={a.cut_warm})")
+        return 0
 
     if a.brief:
         b = simulate(pics)


### PR DESCRIPTION
## Film mode stopped flapping, because the detector stopped counting evidence that isn't there

`progressive_frame` is not a measurement. It is one bit the **encoder** wrote into the
picture coding extension, and on a near-black picture there is no field structure for it to
describe — so encoders take the MPEG-2 default and mark those frames interlaced, because
mismarking progressive costs visible artifacts while mismarking interlaced costs a few bytes
of disc space.

The film detector counted that meaningless claim at full weight (`DN_HARD = 8`) and fell out
of lock. Measured on APOLLO_13's opening credits, in **display** order (coded order hides it
behind B-frame reordering): **nine engage/disengage flips in 46 seconds**, each one
re-walking the modeline and re-locking ascal.

VLC's IVTC rides through the same content because it reads **pixels** and has an explicit
rule for this case — *"If no motion, the result from this algorithm cannot be reliable …
we do nothing, as it's not a good idea to act on unreliable data."* We can't see pixels at
the display pickup, but we can see how many bits the encoder spent, and that separates the
cases cleanly: APOLLO_13's black pictures code 384 B against that title's own 17,704 B median.

### The rule, and why each part of it was forced by measurement

**Relative, per picture coding type, with a warm-up.** None of that is taste:

- **Relative** — HIGH_SCHOOL_MUSICAL codes a **318 B median**. There, small pictures *are*
  the content; a fixed threshold discards 55 % of the disc and delays its video verdict from
  2.6 s to 19.9 s. The core plays VCD/SVCD too, where the scale shifts again.
- **Per coding type** — a black I-frame codes 7,580 B where a real one codes ~82,000 B: tiny
  for an I, yet above any fixed threshold that doesn't also swallow legitimate B-frames.
- **Warm-up** — seeding the mean from whichever picture arrived first made two rips of
  near-identical content (same median, same p10, same p90) gate 0.0 % and 85.8 %.

### Results

| disc | before | after |
|---|---|---|
| APOLLO_13 credits (157 s) | **9 film transitions** | **1** |
| FERRIS_BUELLER VTS04 (187 s) | 4 transitions | 4, **identical timestamps** |
| HIGH_SCHOOL_MUSICAL (318 B median) | 1 | 1, identical |
| AUSTIN_POWERS_2 (control) | 1 | 1, identical |
| library sweep, 123 discs | — | **15 better, 0 worse** |

The FERRIS row is why there is **no latch**. That disc's special feature genuinely turns from
film to video mid-title, twice, and both transitions survive at the same tenth of a second —
so a real change is still followed in about a second rather than the twelve a per-title latch
would cost.

The sweep also shows this was never only an APOLLO_13 fix: 15 library discs flap at the title
head today, including Harry Potter (5→3), Analyze This (5→3), The Hangover (4→2) and
Batman Begins / Aviator / Alexander / Troy (2→0).

### Two dead ends, recorded as dead ends

- **A per-title latch works but costs 12 s to leave film mode** — unacceptable on FERRIS.
- **`frame_pred_frame_dct` looks perfect on APOLLO_13 and is actively wrong.** It reads 0 for
  ~99 % of pictures *including progressive ones* on FERRIS and AUSTIN_POWERS_2, so a detector
  keyed on it calls film content VIDEO within two seconds. It is an encoder rate setting, not
  a content property.

### Implementation notes worth knowing

- **Ordering:** a picture's size is known only when it **ends**, whereas `flags_commit` fires
  at the coding extension near its **start** — so this cannot ride that pulse.
  `informative_commit` fires at the terminating start code, still strictly before picbuf
  rotates slots.
- **Count `next_advance`/`next_align`, not the registered `advance`/`align`.** `vld.v` forces
  those to 0 whenever `clk_en` is low, so a clk_en-gated block reads 0 almost always. That
  made every picture measure 0 B — which is **silently inert** (a zero mean compares equal,
  so everything reads "informative") and would have shipped as a no-op. The bench caught it.

## Test plan

- [x] `film_evidence_tb` — REAL `getbits_fifo` + `vld` over REAL disc bytes: 35/35 committable
      pictures, max size delta 18 B against a 32 B stated accuracy, **every verdict matches
      the golden model**
- [x] `film_detect_tb` — G1 (80 uninformative `pf=0` pickups) holds film lock; G2 (identical
      run, informative) releases it and engages `det_video`; G3 survives a gated gap; cases
      [1]–[5] unchanged
- [x] `cadence_slip_tb` 5/5 — corrector unaffected
- [x] Nine port-tie regressions green (`gov_field_late`, `menu_ff`, `pickup_hold`,
      `resample_*`, `motcomp_picbuf`)
- [x] `resample_chain_tb` byte-identical to its main baseline
- [x] Build: SEED 5 first roll, clk_dec **93.01 @100C / 89.3 @-40C** (gate 86.0),
      36,341 → 36,714 ALMs
- [x] **HW-CONFIRMED**: APOLLO_13 credits no longer flap; T2 holds sync in Auto;
      FERRIS_BUELLER follows its own mid-title film→video change in sync

## Not in scope

APOLLO_13 still plays ~800 ms audio-ahead. That is **not** this feature: it predates it, is
established at the first STC anchor of a playback, is cleared by any re-anchor, and is
unaffected by `Film 24p = On` or by the VBUF cap. An imported "anchor the STC on the screen"
fix made it **worse** (1800 ms plus stream freezes) and is deliberately not merged — see
`docs/av_sync.md` "HW round 3" before touching it.
