### PR TITLE
IEC 61937 bitstream over HDMI (DD/DTS 5.1, no I/O board)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ compile_output.log
 *.ppm
 *.mpg
 bench/**/*_sim
+bench/dvd/*.log
 mpeg2_sim
 sim_mpg
 bench/dvd/chain_*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1494,6 +1494,21 @@ Two identifiers, deliberately at different granularities:
   ONE re-roll instead of a second one at release time. (The saved-settings `"v,N;"`
   config version is a SEPARATE, coarser counter — bump that one only on an incompatible
   `O[..]` relayout, see `docs/idle_screen.md`.)
+  **★ HOW FAR to bump (instituted 2026-08-31, by user decision — the rule existed only
+  as precedent until someone had to ask):**
+  - **patch** (`0.2.0` → `0.2.1`) — bug fixes, doc-only changes, internal rework with no
+    change in what the user can do.
+  - **minor** (`0.2.1` → `0.3.0`) — ANY new user-visible capability: a new format or
+    output path, a new OSD option, or content that used to be silent/broken now working.
+    If the release notes would lead with it, it is a minor bump.
+  - **major** — reserved; nothing has warranted it yet (`1.0` would be a
+    "this is finished" statement, not a size-of-change one).
+  The failure this prevents is a release whose version says "fixes" while its own notes
+  lead with a headline feature — the version line is what a user quotes in a bug report,
+  so it should not understate what they are running. Precedent: `0.1d` → `0.2.0` for
+  physical-disc playback; `0.2.1` → `0.3.0` for HDMI bitstream + multichannel AC-3.
+  ⚠ Judge the bump against the WHOLE unreleased delta on `main`, not just the branch in
+  hand — several patch-looking merges can add up to a minor release.
 - **`BUILD_DATE`** — `yymmdd`, regenerated per compile by `sys/build_id.tcl`. ⚠ Do NOT
   extend it with a time or a git SHA to separate same-day builds: it is part of
   `CONF_STR`, hence part of the netlist, so every compile would become a new netlist and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -453,6 +453,33 @@ worse maintenance burden than targeted in-place edits. So:
   `aud_resync` (menu audio continuity, §5d). Golden: `dvd_vm_ref.py aud_stream_map()`
   + `nav_extract.py --audio-map`; 2,026-vector bit-exact TB + reader/demux suites
   green. Detail: `docs/track_selection.md` "Logical→physical audio mapping".
+- 🔧 **IEC 61937 BITSTREAM NOW ALSO LEAVES OVER HDMI (2026-08-30, branch
+  `feature/hdmi-bitstream`); ⏳ HW-confirm pending.** `Audio Out = Passthru` used to be
+  optical-only, so 5.1 needed the Digital I/O board. It doesn't: 61937 rides inside an
+  ordinary 2-ch/48 kHz/16-bit IEC 60958 stream (1.536 Mbit/s — exactly AC-3's max), which
+  is precisely what the DE10-Nano's single wired I2S line to the ADV7513 carries. (That one
+  line is also why **multichannel LPCM is impossible** here — the board routes no other
+  audio data pin; confirmed in its pin table.) `dvd/i2s_iec958.sv` serializes the SAME
+  subframes `spdif_pass` biphase-encodes — one source, two link layers, so they cannot
+  drift. ★ **Chosen route is IEC958-direct (`0x0C[1:0]=3`), NOT an I2C channel-status bit**:
+  it is what mainline Linux uses for IEC958 subframes, and crucially it keeps the non-PCM
+  flag **DYNAMIC**, preserving the fj#110 ROUND 2 fix (receivers cannot acquire across
+  non-PCM null bursts) instead of pinning the flag high for a session. ★ **Stock Main is
+  safe BY CONSTRUCTION**: the ADV7513's I2C is HPS-only, so a bitstream sent to a sink still
+  expecting PCM is full-scale noise — the core therefore refuses to emit one without the
+  `cfg[14]` ack that only MiSTer_DVDcss sets (after checking EDID Short Audio Descriptors,
+  which stock Main never parses at all). ⚠ **The ack, not `pass_mode`, owns the HDMI audio
+  format** — leaving Passthru is instant in fabric but the chip stays non-PCM until Main's
+  next poll, so that window must be digital silence; Main sequences engage/release
+  asymmetrically. ⚠ **MEASURED phase step:** the first pair interval after `rst_audio_n` is
+  509 clk_audio, not 512 (`bit_ce` and `spdif_pass`'s counter re-align three cycles in), and
+  that reset pulses on every audio-track switch and `aud_flush` — hence the ~100 ms hold-off.
+  Tests: `bench/dvd/run_hdmi_bitstream.sh` — `iec61937_wrap_tb` TEST 9 (pacing exact over 513
+  strobes) and `i2s_iec958_tb`, a **demodulator** that reads subframes back off the wire
+  (it failed all four checks first run and the serializer was correct — the demod was
+  free-running instead of framing on `ws`; a register-peek test would have proven nothing).
+  ⚠ Open: the preamble nibble for IEC958-direct is an assumption (Z=1,Y=2,X=4) — first thing
+  to change if HW round 1 mis-locks. Design: **`docs/hdmi_bitstream.md`**.
 - 🔧 **AUDIO IS NOW DECODED IN FABRIC (2026-06-27, branch `feature/fabric-ac3-audio`).**
   AC-3 and LPCM are decoded entirely in the FPGA: `ps_demux` → `audio_ring` →
   `dvd/dvd_audio_decode.sv` (AC-3 via the ported `dvd/ac3/*` `ac3_front`+`pcm_out`,

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -678,11 +678,14 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # pinned SEED 5 held on the FIRST roll -- clk_dec 93.01 @100C / 89.3 @-40C, PASS
 # with margin at 88% ALM. No sweep needed, consistent with the post-reclaim note
 # above.
-# 2026-08-30 (feature/hdmi-bitstream netlist, +~300 ALMs: dvd/i2s_iec958.sv, the
+# 2026-08-30/31 (feature/hdmi-bitstream netlist, +~300 ALMs: dvd/i2s_iec958.sv, the
 # spdif_pass parallel subframe export, the emu ack/hold-off and the sys_top pin
-# mux): pinned SEED 5 held on the FIRST roll again -- clk_dec 90.83 @100C /
-# 90.15 @-40C, PASS both corners at 87% ALM. RAM UNCHANGED at 506/553: the new
-# serializer is a shift register and counters, so it inferred no memory, which
-# was the design prediction. Third consecutive first-roll fit since the mem_shim
-# reclaim -- the sub-86 rule continues to hold.
+# mux): pinned SEED 5 held on the FIRST roll, twice. Pre-rebase (2026-08-30, on
+# 6b7e1ba): clk_dec 90.83 @100C / 90.15 @-40C at 87% ALM. REBASED onto dd8fd0e
+# (2026-08-31, i.e. with the acmod 1..7 multichannel AC-3 work, which is the
+# netlist that actually ships): clk_dec 91.26 @100C / 88.21 @-40C at 88% ALM --
+# PASS both corners again, still SEED 5, still no sweep. RAM UNCHANGED at 506/553
+# across both: the serializer is a shift register and counters, so it inferred no
+# memory, which was the design prediction. Fourth consecutive first-roll fit since
+# the mem_shim reclaim -- the sub-86 rule continues to hold.
 set_global_assignment -name SEED 5

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -678,4 +678,11 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # pinned SEED 5 held on the FIRST roll -- clk_dec 93.01 @100C / 89.3 @-40C, PASS
 # with margin at 88% ALM. No sweep needed, consistent with the post-reclaim note
 # above.
+# 2026-08-30 (feature/hdmi-bitstream netlist, +~300 ALMs: dvd/i2s_iec958.sv, the
+# spdif_pass parallel subframe export, the emu ack/hold-off and the sys_top pin
+# mux): pinned SEED 5 held on the FIRST roll again -- clk_dec 90.83 @100C /
+# 90.15 @-40C, PASS both corners at 87% ALM. RAM UNCHANGED at 506/553: the new
+# serializer is a shift register and counters, so it inferred no memory, which
+# was the design prediction. Third consecutive first-roll fit since the mem_shim
+# reclaim -- the sub-86 rule continues to hold.
 set_global_assignment -name SEED 5

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -68,6 +68,9 @@ set_global_assignment -name SYSTEMVERILOG_FILE dvd/lpcm_unpack.sv
 # AC-3/DTS frames into 61937 bursts; spdif_pass is the biphase encoder (a copy of
 # sys/spdif.v with the non-PCM channel-status bit set). See docs/iec61937.md.
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/spdif_pass.sv
+# HDMI leg: the same IEC 60958 subframes serialized for the ADV7513's I2S input
+# in IEC958-direct mode, so Passthru reaches an AVR over HDMI too.
+set_global_assignment -name SYSTEMVERILOG_FILE dvd/i2s_iec958.sv
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/iec61937_wrap.sv
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/av_sync.sv
 # Flush/reset trigger matrix (extracted from emu.sv 2026-08-28 for TB coverage of

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ with a caption decoder (every US television 13" and larger since 1993 has one).
 
 **Audio** — AC-3 and MPEG-1 Layer II (MP2) decoded entirely in fabric (AC-3 5.1
 downmixed to stereo) to HDMI; LPCM at 16/20/24-bit; AC-3 and DTS as IEC 61937 bitstream
-over S/PDIF to a receiver.
+to a receiver — over optical S/PDIF, or over HDMI itself with the custom Main, so 5.1
+needs no add-on board.
 
 **DVD navigation** — the core reads an ISO directly, parses the IFOs, and runs a real
 **DVD virtual machine** validated command-by-command against libdvdnav's behaviour. The
@@ -117,16 +118,15 @@ is opt-in and additive. See
   discs put their randomisation setup in the boot sequence and jump past it when you press
   **Menu** to skip the intro — the game then repeats one question. That is how the disc is
   authored (a real player and libdvdnav do the same); let the intro play.
-- **No DTS decode** — S/PDIF passthrough to a receiver only.
-- **Audio formats:** AC-3 (mono 1/0, stereo 2/0 and 5.1 3/2), MPEG-1 Layer II
-  (MP2), LPCM, and DTS (passthrough only). A few discs use rarer AC-3 channel
-  layouts the decoder does not implement yet (3/0, 2/1, 3/1 and 2/2 quad); those
-  tracks are silent rather than distorted. Dolby Digital **1.0 mono** used to be
-  silent for the same reason and works as of 0.2.1.
+- **No DTS decode** — passthrough to an AV receiver only (optical S/PDIF or HDMI).
+- **Audio formats:** AC-3 (every channel mode from 1.0 mono through 5.1, downmixed to
+  stereo), MPEG-1 Layer II (MP2), LPCM, and DTS (passthrough only). AC-3 **1+1 dual
+  mono** (`acmod 0`, two independent programmes) is deliberately refused and plays
+  silent — 4 frames on 1 disc out of 491 surveyed.
   The one gap left is the MPEG-2 multichannel *extension* (a rare 5.1 variant of MP2):
   its backwards-compatible stereo core should play, but no disc was available to verify,
-  so such a track still reports `AUDIO UNSUPPORTED`. MP2 has no S/PDIF passthrough —
-  in Passthru mode an MP2 track is silent.
+  so such a track still reports `AUDIO UNSUPPORTED`. MP2 has no passthrough encoding —
+  in Passthru mode an MP2 track is silent on both outputs.
 - **Changing the audio track while a disc menu is open silences the menu audio** until
   you leave the menu. Menu audio otherwise plays normally on the default track.
 - No parental-control enforcement, no UOP enforcement.
@@ -402,8 +402,8 @@ Defaults are chosen to be correct for most users; the first value listed is the 
 | **D-Pad Seek** | On / **Off** | Puts fixed-time seeking on the D-pad: Left/Right jump ∓10 s, Down/Up ∓1 min, and repeated taps build a longer jump. On a DVD the targets come from the disc's own seek tables, so they land on real frames. Off by default because some interactive/game DVDs play seekable video while expecting the D-pad as game input. |
 | **Aspect Ratio** | **Auto** / 4:3 / 16:9 | Auto reads the MPEG-2 sequence header. |
 | **Audio** | **On** / Off | |
-| **Audio Out** | **Decode HDMI** / Passthru SPDIF | Passthru sends undecoded AC-3/DTS to a receiver and mutes HDMI. Required for DTS. |
-| **SPDIF Byte Order** | **Normal** / Swap | If the receiver names the format but plays static, toggle this. |
+| **Audio Out** | **Decode PCM** / Passthru (SPDIF+HDMI) | Passthru sends undecoded AC-3/DTS to an AV receiver to decode — over optical S/PDIF, and over HDMI too if you run the custom Main and your receiver advertises AC-3/DTS. Required for DTS. On a TV that can't decode them, HDMI stays silent — use Decode. |
+| **SPDIF Byte Order** | **Normal** / Swap | Applies to both bitstream outputs despite the name. If the receiver names the format but plays static, toggle this. |
 | **Player Language** | **English** / … | Sets the player's menu/audio/subtitle language preference, like a set-top player's setup screen. |
 | **Video Standard** | **Auto** / NTSC / PAL | Auto detects from the stream's vertical size. |
 | **Interlaced Out** | **Off** / Auto / On | Native 480i/576i to HDMI. Auto switches mid-title and still has a slight A/V skew — opt-in. |
@@ -588,8 +588,8 @@ genuinely leaned on.
   headers) and MPEG-2 Video.
 - **ISO/IEC 11172-2 and 11172-3** — MPEG-1 Video (the decoder's MPEG-1 mode) and MPEG-1
   Audio (the Layer II decoder's tables and algorithms).
-- **IEC 61937-3 / 61937-5 / 60958-1** — AC-3 and DTS over S/PDIF, and the channel-status
-  non-PCM flag that makes receivers lock onto a bitstream.
+- **IEC 61937-3 / 61937-5 / 60958-1** — AC-3 and DTS over S/PDIF and HDMI, and the
+  channel-status non-PCM flag that makes receivers lock onto a bitstream.
 - ***DVD Demystified*, Jim Taylor** — the practical DVD-Video reference for VOB/IFO
   structure. Repeatedly the fastest route to understanding how discs are actually
   authored, as opposed to how the spec says they could be.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ onto **line 21 of the analog output**, exactly as a real DVD player does, so you
 television's own caption decoder displays them. Analog output only, and it needs a set
 with a caption decoder (every US television 13" and larger since 1993 has one).
 
-**Audio** — AC-3 and MPEG-1 Layer II (MP2) decoded entirely in fabric (AC-3 5.1
-downmixed to stereo) to HDMI; LPCM at 16/20/24-bit; AC-3 and DTS as IEC 61937 bitstream
+**Audio** — AC-3 and MPEG-1 Layer II (MP2) decoded entirely in fabric (every AC-3
+channel mode, downmixed to stereo) to HDMI; LPCM at 16/20/24-bit; AC-3 and DTS as IEC 61937 bitstream
 to a receiver — over optical S/PDIF, or over HDMI itself with the custom Main, so 5.1
 needs no add-on board.
 

--- a/README.md
+++ b/README.md
@@ -125,8 +125,12 @@ is opt-in and additive. See
   silent — 4 frames on 1 disc out of 491 surveyed.
   The one gap left is the MPEG-2 multichannel *extension* (a rare 5.1 variant of MP2):
   its backwards-compatible stereo core should play, but no disc was available to verify,
-  so such a track still reports `AUDIO UNSUPPORTED`. MP2 has no passthrough encoding —
-  in Passthru mode an MP2 track is silent on both outputs.
+  so such a track still reports `AUDIO UNSUPPORTED`.
+- **Passthru carries AC-3 and DTS only.** IEC 61937 exists to carry *compressed*
+  audio, so there is nothing for it to do with an **LPCM** or **MP2** track — those
+  are silent in Passthru, on both S/PDIF and HDMI. Use **Decode** for LPCM discs.
+  (On HDMI the receiver will likely show "decoder off" rather than a PCM indication
+  while this happens; it is silence either way.)
 - **Changing the audio track while a disc menu is open silences the menu audio** until
   you leave the menu. Menu audio otherwise plays normally on the default track.
 - No parental-control enforcement, no UOP enforcement.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ is opt-in and additive. See
   The one gap left is the MPEG-2 multichannel *extension* (a rare 5.1 variant of MP2):
   its backwards-compatible stereo core should play, but no disc was available to verify,
   so such a track still reports `AUDIO UNSUPPORTED`.
+- **Passthru can take a few seconds to lock at the start of a title**, and again
+  after switching audio track: the receiver flaps between naming the format and
+  showing no decode. It settles on its own, and a **chapter skip** locks it
+  immediately. Affects optical and HDMI alike, and predates the HDMI output.
 - **Passthru carries AC-3 and DTS only.** IEC 61937 exists to carry *compressed*
   audio, so there is nothing for it to do with an **LPCM** or **MP2** track — those
   are silent in Passthru, on both S/PDIF and HDMI. Use **Decode** for LPCM discs.

--- a/bench/dvd/i2s_iec958_tb.sv
+++ b/bench/dvd/i2s_iec958_tb.sv
@@ -33,10 +33,11 @@ module i2s_iec958_tb;
         .sub_w_o(sub_w), .sub_load_o(sub_load)
     );
 
+    reg [1:0] variant = 2'd0;    // [0] 1=MSB-first, [1] 1=zeroed preamble
     wire sck, ws, sd;
     i2s_iec958 u_i2s (
         .clk(clk), .rst_n(rst_n), .ce_i(ce),
-        .sub_w_i(sub_w), .sub_load_i(sub_load),
+        .sub_w_i(sub_w), .sub_load_i(sub_load), .variant_i(variant),
         .sck_o(sck), .ws_o(ws), .sd_o(sd)
     );
 
@@ -69,7 +70,8 @@ module i2s_iec958_tb;
                 nbits = 0; acc = 32'd0;
             end
             if (sck && !sck_d) begin             // rising sck: sample the line
-                acc = {sd, acc[31:1]};           // LSB-first fill
+                // undo whichever order the DUT is sending in
+                acc = variant[0] ? {acc[30:0], sd} : {sd, acc[31:1]};
                 nbits = nbits + 1;
                 if (nbits == 32) begin
                     if (rec_n < 256) begin
@@ -83,7 +85,7 @@ module i2s_iec958_tb;
         end
     end
 
-    integer errors = 0, i;
+    integer errors = 0, i, v;
     integer chkA = 0, chkB = 0, badpar = 0, badpre = 0;
     reg [31:0] w;
 
@@ -141,6 +143,39 @@ module i2s_iec958_tb;
             $display("  FAIL: %0d subframes with the wrong channel's audio -", chkA);
             $display("        bit order or A/B mapping is inverted");
             errors = errors + 1; end
+
+        // ---- sweep the other three variants -------------------------------
+        // Correctness against the real ADV7513 is a HW question (that is why the
+        // selector exists), but the MUX must be right in all four: each channel
+        // still carries its own audio, and the preamble field is zeroed exactly
+        // when asked. A broken variant would waste a whole HW round.
+        for (v = 1; v < 4; v = v + 1) begin
+            variant = v[1:0];
+            rec_n = 0;
+            repeat (60000) @(posedge clk);
+            chkA = 0; chkB = 0;
+            for (i = 4; i < (rec_n > 120 ? 120 : rec_n); i = i + 1) begin
+                w = rec_q[i];
+                // channel identity comes from ws when the preamble is zeroed
+                if (rec_ws[i]) begin
+                    if (w[27:24] !== 4'hA) chkA = chkA + 1;
+                end else begin
+                    if (w[27:24] !== 4'h5) chkA = chkA + 1;
+                end
+                if (variant[1] && w[3:0] !== 4'd0) chkB = chkB + 1;
+                if (!variant[1] && w[3:0] !== 4'b0001
+                                && w[3:0] !== 4'b0010
+                                && w[3:0] !== 4'b0100) chkB = chkB + 1;
+            end
+            $display("  variant %0d: %0d subframes, audio_mismatch=%0d preamble_bad=%0d",
+                     v, rec_n, chkA, chkB);
+            if (rec_n < 40)  begin $display("  FAIL: variant %0d produced nothing", v);
+                                   errors = errors + 1; end
+            if (chkA != 0)   begin $display("  FAIL: variant %0d audio/channel mismatch", v);
+                                   errors = errors + 1; end
+            if (chkB != 0)   begin $display("  FAIL: variant %0d preamble field wrong", v);
+                                   errors = errors + 1; end
+        end
 
         if (errors == 0) $display("\nPASS: i2s_iec958");
         else begin $display("\n%0d FAILURES", errors); $fatal(1, "i2s_iec958_tb failed"); end

--- a/bench/dvd/i2s_iec958_tb.sv
+++ b/bench/dvd/i2s_iec958_tb.sv
@@ -33,11 +33,11 @@ module i2s_iec958_tb;
         .sub_w_o(sub_w), .sub_load_o(sub_load), .sub_chb_o(sub_chb)
     );
 
-    reg [1:0] variant = 2'd0;    // [0] 1=MSB-first, [1] 1=zeroed preamble
+    reg [2:0] variant = 3'd0;    // [0] 1=MSB-first, [1] 1=zeroed preamble
     wire sck, ws, sd;
     i2s_iec958 u_i2s (
         .clk(clk), .rst_n(rst_n), .ce_i(ce),
-        .sub_w_i(sub_w), .sub_load_i(sub_load), .sub_chb_i(sub_chb), .variant_i(variant),
+        .sub_w_i(sub_w), .sub_load_i(sub_load), .sub_chb_i(sub_chb), .variant_i(variant), .pcm_l_i(sample[15:0]), .pcm_r_i(sample[31:16]),
         .sck_o(sck), .ws_o(ws), .sd_o(sd)
     );
 
@@ -137,7 +137,7 @@ module i2s_iec958_tb;
         $display("  format: preamble_zero=OK block_starts=%0d", blk);
 
         // ---- MSB-first variant still carries the same content ---------------
-        variant = 2'd1;
+        variant = 3'd1;
         rec_n = 0;
         repeat (60000) @(posedge clk);
         chkA = 0;
@@ -154,7 +154,7 @@ module i2s_iec958_tb;
             $display("  FAIL: MSB-first variant broken"); errors = errors + 1; end
 
         // ---- legacy variant reproduces the pre-document guess ---------------
-        variant = 2'd2;
+        variant = 3'd2;
         rec_n = 0;
         repeat (60000) @(posedge clk);
         badpre = 0;
@@ -168,7 +168,26 @@ module i2s_iec958_tb;
             $display("  FAIL: legacy variant does not reproduce the old format");
             errors = errors + 1; end
 
-        variant = 2'd0;
+        // ---- route (i): plain 16-bit standard I2S ------------------------
+        // Different framing entirely (16 bits/channel, MSB first), so just
+        // prove it produces a live word select and a moving data line - the
+        // serializer itself is sys/i2s.v, which ships PCM to this chip daily.
+        variant = 3'd4;
+        begin : pcm16_chk
+            integer ws_edges, sd_edges;
+            reg wsd, sdd;
+            ws_edges = 0; sd_edges = 0; wsd = ws; sdd = sd;
+            repeat (40000) @(posedge clk) begin
+                if (ws != wsd) ws_edges = ws_edges + 1;
+                if (sd != sdd) sd_edges = sd_edges + 1;
+                wsd = ws; sdd = sd;
+            end
+            $display("  variant 4 (PCM16): ws_edges=%0d sd_edges=%0d", ws_edges, sd_edges);
+            if (ws_edges < 20 || sd_edges < 20) begin
+                $display("  FAIL: PCM16 transport not running"); errors = errors + 1; end
+        end
+
+        variant = 3'd0;
 
         if (errors == 0) $display("\nPASS: i2s_iec958");
         else begin $display("\n%0d FAILURES", errors); $fatal(1, "i2s_iec958_tb failed"); end

--- a/bench/dvd/i2s_iec958_tb.sv
+++ b/bench/dvd/i2s_iec958_tb.sv
@@ -1,0 +1,156 @@
+// -----------------------------------------------------------------
+// bench/dvd/i2s_iec958_tb.sv
+// Proves the HDMI IEC958-direct path carries the same subframes the S/PDIF
+// biphase encoder does.
+//
+// The check is a DEMODULATOR, not a register peek: it recovers 32-bit subframes
+// off sck_o/ws_o/sd_o the way the ADV7513 would, then compares the audio field
+// against the samples that were fed in. Bit order (LSB/timeslot first) and
+// channel mapping are the two things that fail silently here - "receiver names
+// the format but plays static" - so they have to be read back off the wire.
+// -----------------------------------------------------------------
+`timescale 1ns/1ps
+
+module i2s_iec958_tb;
+
+    reg  clk = 0, rst_n = 0;
+    always #20.3 clk = ~clk;              // 24.576 MHz
+
+    // 6.144 MHz enable, 1-in-4 - the same strobe spdif_pass runs on
+    reg [1:0] ce_cnt = 0;
+    always @(posedge clk) ce_cnt <= ce_cnt + 2'd1;
+    wire ce = (ce_cnt == 2'd0);
+
+    reg  [31:0] sample = 32'd0;           // {R, L}
+    reg         nonpcm = 1'b1;
+    wire [31:0] sub_w;
+    wire        sub_load, sample_req, spdif_o;
+
+    spdif_pass u_sp (
+        .clk_i(clk), .rst_i(~rst_n), .bit_out_en_i(ce),
+        .spdif_o(spdif_o), .nonpcm_i(nonpcm),
+        .sample_i(sample), .sample_req_o(sample_req),
+        .sub_w_o(sub_w), .sub_load_o(sub_load)
+    );
+
+    wire sck, ws, sd;
+    i2s_iec958 u_i2s (
+        .clk(clk), .rst_n(rst_n), .ce_i(ce),
+        .sub_w_i(sub_w), .sub_load_i(sub_load),
+        .sck_o(sck), .ws_o(ws), .sd_o(sd)
+    );
+
+    // feed a fresh known pair each time the encoder asks for one
+    integer pair_n = 0;
+    always @(posedge clk) if (sample_req) begin
+        pair_n <= pair_n + 1;
+        sample <= {16'hA000 + pair_n[15:0], 16'h5000 + pair_n[15:0]};
+    end
+
+    // ---- demodulator: recover subframes off the wire ------------------------
+    reg  [31:0] acc;
+    integer     nbits = 0;
+    reg         sck_d = 0;
+    reg  [31:0] rec_q  [0:255];
+    reg         rec_ws [0:255];
+    integer     rec_n = 0;
+
+    // Frame on ws the way a receiver does, rather than free-running a bit count
+    // from reset - otherwise a single hiccup slips the framing permanently and
+    // every later subframe reads as garbage.
+    reg ws_d = 0;
+    always @(posedge clk) begin
+        sck_d <= sck;
+        ws_d  <= ws;
+        if (!rst_n) begin
+            nbits = 0; acc = 32'd0;
+        end else begin
+            if (ws != ws_d) begin                // subframe boundary: resync
+                nbits = 0; acc = 32'd0;
+            end
+            if (sck && !sck_d) begin             // rising sck: sample the line
+                acc = {sd, acc[31:1]};           // LSB-first fill
+                nbits = nbits + 1;
+                if (nbits == 32) begin
+                    if (rec_n < 256) begin
+                        rec_q[rec_n]  = acc;
+                        rec_ws[rec_n] = ws;
+                    end
+                    rec_n = rec_n + 1;
+                    nbits = 0;
+                end
+            end
+        end
+    end
+
+    integer errors = 0, i;
+    integer chkA = 0, chkB = 0, badpar = 0, badpre = 0;
+    reg [31:0] w;
+
+    initial begin
+        repeat (8) @(posedge clk);
+        rst_n = 1;
+
+        // let a couple of channel-status blocks go by
+        repeat (200000) @(posedge clk);
+
+        $display("i2s_iec958_tb: recovered %0d subframes", rec_n);
+        if (rec_n < 64) begin
+            $display("  FAIL: serializer produced almost nothing (%0d)", rec_n);
+            errors = errors + 1;
+        end
+
+        // Skip the first few (reset re-phase, and the demod locks mid-subframe
+        // until the first full 32-bit window completes).
+        for (i = 4; i < (rec_n > 200 ? 200 : rec_n); i = i + 1) begin
+            w = rec_q[i];
+
+            // preamble code must be one of the three one-hot values
+            if (w[3:0] !== 4'b0001 && w[3:0] !== 4'b0010 && w[3:0] !== 4'b0100)
+                badpre = badpre + 1;
+
+            // even parity over timeslots 4..31
+            if (^w[31:4] !== 1'b0) badpar = badpar + 1;
+
+            // channel A carries the low (left) word, B the high (right) word
+            if (w[3:0] == 4'b0010) chkB = chkB + 1; else chkA = chkA + 1;
+        end
+
+        if (badpre != 0) begin
+            $display("  FAIL: %0d subframes with a bogus preamble code", badpre);
+            errors = errors + 1; end
+        if (badpar != 0) begin
+            $display("  FAIL: %0d subframes with bad even parity", badpar);
+            errors = errors + 1; end
+        if (chkA == 0 || chkB == 0) begin
+            $display("  FAIL: only one channel present (A=%0d B=%0d)", chkA, chkB);
+            errors = errors + 1; end
+
+        // The audio field of consecutive A/B subframes must be the 0x5000/0xA000
+        // pattern that was fed in, proving LSB-first order and channel mapping.
+        chkA = 0;
+        for (i = 4; i < (rec_n > 200 ? 200 : rec_n); i = i + 1) begin
+            w = rec_q[i];
+            if (w[3:0] == 4'b0010) begin
+                if (w[27:24] !== 4'hA) chkA = chkA + 1;   // channel B = right = 0xAxxx
+            end else begin
+                if (w[27:24] !== 4'h5) chkA = chkA + 1;   // channel A = left  = 0x5xxx
+            end
+        end
+        if (chkA != 0) begin
+            $display("  FAIL: %0d subframes with the wrong channel's audio -", chkA);
+            $display("        bit order or A/B mapping is inverted");
+            errors = errors + 1; end
+
+        if (errors == 0) $display("\nPASS: i2s_iec958");
+        else begin $display("\n%0d FAILURES", errors); $fatal(1, "i2s_iec958_tb failed"); end
+        $finish;
+    end
+
+    initial begin
+        #40_000_000;
+        $display("TIMEOUT");
+        $fatal(1, "i2s_iec958_tb timeout");
+    end
+
+endmodule

--- a/bench/dvd/i2s_iec958_tb.sv
+++ b/bench/dvd/i2s_iec958_tb.sv
@@ -24,20 +24,20 @@ module i2s_iec958_tb;
     reg  [31:0] sample = 32'd0;           // {R, L}
     reg         nonpcm = 1'b1;
     wire [31:0] sub_w;
-    wire        sub_load, sample_req, spdif_o;
+    wire        sub_load, sub_chb, sample_req, spdif_o;
 
     spdif_pass u_sp (
         .clk_i(clk), .rst_i(~rst_n), .bit_out_en_i(ce),
         .spdif_o(spdif_o), .nonpcm_i(nonpcm),
         .sample_i(sample), .sample_req_o(sample_req),
-        .sub_w_o(sub_w), .sub_load_o(sub_load)
+        .sub_w_o(sub_w), .sub_load_o(sub_load), .sub_chb_o(sub_chb)
     );
 
     reg [1:0] variant = 2'd0;    // [0] 1=MSB-first, [1] 1=zeroed preamble
     wire sck, ws, sd;
     i2s_iec958 u_i2s (
         .clk(clk), .rst_n(rst_n), .ce_i(ce),
-        .sub_w_i(sub_w), .sub_load_i(sub_load), .variant_i(variant),
+        .sub_w_i(sub_w), .sub_load_i(sub_load), .sub_chb_i(sub_chb), .variant_i(variant),
         .sck_o(sck), .ws_o(ws), .sd_o(sd)
     );
 
@@ -86,7 +86,7 @@ module i2s_iec958_tb;
     end
 
     integer errors = 0, i, v;
-    integer chkA = 0, chkB = 0, badpar = 0, badpre = 0;
+    integer chkA = 0, chkB = 0, badpar = 0, badpre = 0, blk = 0;
     reg [31:0] w;
 
     initial begin
@@ -102,80 +102,73 @@ module i2s_iec958_tb;
             errors = errors + 1;
         end
 
-        // Skip the first few (reset re-phase, and the demod locks mid-subframe
-        // until the first full 32-bit window completes).
+        // ---- documented AES3-direct format (Programming Guide 4.4.1.1) ------
+        //   [3:0]  preamble LEFT OUT -> zero
+        //   [31]   BLOCK START flag, not parity (the chip computes parity)
+        //   V/U/C stay at 28/29/30
+        // Channel identity comes from ws, since there is no preamble to carry it.
+        badpre = 0; chkA = 0; chkB = 0; blk = 0;
         for (i = 4; i < (rec_n > 200 ? 200 : rec_n); i = i + 1) begin
             w = rec_q[i];
-
-            // preamble code must be one of the three one-hot values
-            if (w[3:0] !== 4'b0001 && w[3:0] !== 4'b0010 && w[3:0] !== 4'b0100)
-                badpre = badpre + 1;
-
-            // even parity over timeslots 4..31
-            if (^w[31:4] !== 1'b0) badpar = badpar + 1;
-
-            // channel A carries the low (left) word, B the high (right) word
-            if (w[3:0] == 4'b0010) chkB = chkB + 1; else chkA = chkA + 1;
+            if (w[3:0] !== 4'd0)                      badpre = badpre + 1;
+            if (w[31])                                blk    = blk + 1;
+            if (w[31] && rec_ws[i])                   chkB   = chkB + 1;  // must be ch A
+            if (rec_ws[i]) begin
+                if (w[27:24] !== 4'hA) chkA = chkA + 1;
+            end else begin
+                if (w[27:24] !== 4'h5) chkA = chkA + 1;
+            end
         end
 
         if (badpre != 0) begin
-            $display("  FAIL: %0d subframes with a bogus preamble code", badpre);
+            $display("  FAIL: %0d subframes with a non-zero preamble field", badpre);
             errors = errors + 1; end
-        if (badpar != 0) begin
-            $display("  FAIL: %0d subframes with bad even parity", badpar);
-            errors = errors + 1; end
-        if (chkA == 0 || chkB == 0) begin
-            $display("  FAIL: only one channel present (A=%0d B=%0d)", chkA, chkB);
-            errors = errors + 1; end
-
-        // The audio field of consecutive A/B subframes must be the 0x5000/0xA000
-        // pattern that was fed in, proving LSB-first order and channel mapping.
-        chkA = 0;
-        for (i = 4; i < (rec_n > 200 ? 200 : rec_n); i = i + 1) begin
-            w = rec_q[i];
-            if (w[3:0] == 4'b0010) begin
-                if (w[27:24] !== 4'hA) chkA = chkA + 1;   // channel B = right = 0xAxxx
-            end else begin
-                if (w[27:24] !== 4'h5) chkA = chkA + 1;   // channel A = left  = 0x5xxx
-            end
-        end
         if (chkA != 0) begin
             $display("  FAIL: %0d subframes with the wrong channel's audio -", chkA);
             $display("        bit order or A/B mapping is inverted");
             errors = errors + 1; end
+        if (chkB != 0) begin
+            $display("  FAIL: block start asserted on a channel-B subframe (%0d)", chkB);
+            errors = errors + 1; end
+        // 196 subframes spans about half a 384-subframe block, so expect 0 or 1.
+        if (blk > 2) begin
+            $display("  FAIL: block start asserted %0d times in ~196 subframes", blk);
+            errors = errors + 1; end
+        $display("  format: preamble_zero=OK block_starts=%0d", blk);
 
-        // ---- sweep the other three variants -------------------------------
-        // Correctness against the real ADV7513 is a HW question (that is why the
-        // selector exists), but the MUX must be right in all four: each channel
-        // still carries its own audio, and the preamble field is zeroed exactly
-        // when asked. A broken variant would waste a whole HW round.
-        for (v = 1; v < 4; v = v + 1) begin
-            variant = v[1:0];
-            rec_n = 0;
-            repeat (60000) @(posedge clk);
-            chkA = 0; chkB = 0;
-            for (i = 4; i < (rec_n > 120 ? 120 : rec_n); i = i + 1) begin
-                w = rec_q[i];
-                // channel identity comes from ws when the preamble is zeroed
-                if (rec_ws[i]) begin
-                    if (w[27:24] !== 4'hA) chkA = chkA + 1;
-                end else begin
-                    if (w[27:24] !== 4'h5) chkA = chkA + 1;
-                end
-                if (variant[1] && w[3:0] !== 4'd0) chkB = chkB + 1;
-                if (!variant[1] && w[3:0] !== 4'b0001
-                                && w[3:0] !== 4'b0010
-                                && w[3:0] !== 4'b0100) chkB = chkB + 1;
+        // ---- MSB-first variant still carries the same content ---------------
+        variant = 2'd1;
+        rec_n = 0;
+        repeat (60000) @(posedge clk);
+        chkA = 0;
+        for (i = 4; i < (rec_n > 120 ? 120 : rec_n); i = i + 1) begin
+            w = rec_q[i];
+            if (rec_ws[i]) begin
+                if (w[27:24] !== 4'hA) chkA = chkA + 1;
+            end else begin
+                if (w[27:24] !== 4'h5) chkA = chkA + 1;
             end
-            $display("  variant %0d: %0d subframes, audio_mismatch=%0d preamble_bad=%0d",
-                     v, rec_n, chkA, chkB);
-            if (rec_n < 40)  begin $display("  FAIL: variant %0d produced nothing", v);
-                                   errors = errors + 1; end
-            if (chkA != 0)   begin $display("  FAIL: variant %0d audio/channel mismatch", v);
-                                   errors = errors + 1; end
-            if (chkB != 0)   begin $display("  FAIL: variant %0d preamble field wrong", v);
-                                   errors = errors + 1; end
         end
+        $display("  variant 1 (MSB): %0d subframes, audio_mismatch=%0d", rec_n, chkA);
+        if (rec_n < 40 || chkA != 0) begin
+            $display("  FAIL: MSB-first variant broken"); errors = errors + 1; end
+
+        // ---- legacy variant reproduces the pre-document guess ---------------
+        variant = 2'd2;
+        rec_n = 0;
+        repeat (60000) @(posedge clk);
+        badpre = 0;
+        for (i = 4; i < (rec_n > 120 ? 120 : rec_n); i = i + 1) begin
+            w = rec_q[i];
+            if (w[3:0] !== 4'b0100) badpre = badpre + 1;   // one-hot code restored
+            if (^w[31:4] !== 1'b0)  badpre = badpre + 1;   // even parity restored
+        end
+        $display("  variant 2 (legacy): %0d subframes, deviations=%0d", rec_n, badpre);
+        if (rec_n < 40 || badpre != 0) begin
+            $display("  FAIL: legacy variant does not reproduce the old format");
+            errors = errors + 1; end
+
+        variant = 2'd0;
 
         if (errors == 0) $display("\nPASS: i2s_iec958");
         else begin $display("\n%0d FAILURES", errors); $fatal(1, "i2s_iec958_tb failed"); end

--- a/bench/dvd/i2s_iec958_tb.sv
+++ b/bench/dvd/i2s_iec958_tb.sv
@@ -33,7 +33,7 @@ module i2s_iec958_tb;
         .sub_w_o(sub_w), .sub_load_o(sub_load), .sub_chb_o(sub_chb)
     );
 
-    reg [2:0] variant = 3'd0;    // [0] 1=MSB-first, [1] 1=zeroed preamble
+    reg [2:0] variant = 3'd1;   // AES3 LSB+blkstart (PCM16 is now 0)    // [0] 1=MSB-first, [1] 1=zeroed preamble
     wire sck, ws, sd;
     i2s_iec958 u_i2s (
         .clk(clk), .rst_n(rst_n), .ce_i(ce),
@@ -71,7 +71,9 @@ module i2s_iec958_tb;
             end
             if (sck && !sck_d) begin             // rising sck: sample the line
                 // undo whichever order the DUT is sending in
-                acc = variant[0] ? {acc[30:0], sd} : {sd, acc[31:1]};
+                // MSB-first is variants 2 and 4 (see dvd/i2s_iec958.sv)
+                acc = (variant == 3'd2 || variant == 3'd4)
+                    ? {acc[30:0], sd} : {sd, acc[31:1]};
                 nbits = nbits + 1;
                 if (nbits == 32) begin
                     if (rec_n < 256) begin
@@ -134,10 +136,10 @@ module i2s_iec958_tb;
         if (blk > 2) begin
             $display("  FAIL: block start asserted %0d times in ~196 subframes", blk);
             errors = errors + 1; end
-        $display("  format: preamble_zero=OK block_starts=%0d", blk);
+        $display("  format: preamble_bad=%0d block_starts=%0d", badpre, blk);
 
         // ---- MSB-first variant still carries the same content ---------------
-        variant = 3'd1;
+        variant = 3'd2;   // AES3 MSB
         rec_n = 0;
         repeat (60000) @(posedge clk);
         chkA = 0;
@@ -149,12 +151,12 @@ module i2s_iec958_tb;
                 if (w[27:24] !== 4'h5) chkA = chkA + 1;
             end
         end
-        $display("  variant 1 (MSB): %0d subframes, audio_mismatch=%0d", rec_n, chkA);
+        $display("  variant 2 (AES3 MSB): %0d subframes, audio_mismatch=%0d", rec_n, chkA);
         if (rec_n < 40 || chkA != 0) begin
             $display("  FAIL: MSB-first variant broken"); errors = errors + 1; end
 
         // ---- legacy variant reproduces the pre-document guess ---------------
-        variant = 3'd2;
+        variant = 3'd3;   // AES3 legacy
         rec_n = 0;
         repeat (60000) @(posedge clk);
         badpre = 0;
@@ -163,7 +165,7 @@ module i2s_iec958_tb;
             if (w[3:0] !== 4'b0100) badpre = badpre + 1;   // one-hot code restored
             if (^w[31:4] !== 1'b0)  badpre = badpre + 1;   // even parity restored
         end
-        $display("  variant 2 (legacy): %0d subframes, deviations=%0d", rec_n, badpre);
+        $display("  variant 3 (AES3 legacy): %0d subframes, deviations=%0d", rec_n, badpre);
         if (rec_n < 40 || badpre != 0) begin
             $display("  FAIL: legacy variant does not reproduce the old format");
             errors = errors + 1; end
@@ -172,7 +174,7 @@ module i2s_iec958_tb;
         // Different framing entirely (16 bits/channel, MSB first), so just
         // prove it produces a live word select and a moving data line - the
         // serializer itself is sys/i2s.v, which ships PCM to this chip daily.
-        variant = 3'd4;
+        variant = 3'd0;   // PCM16 - the shipping default
         begin : pcm16_chk
             integer ws_edges, sd_edges;
             reg wsd, sdd;
@@ -182,12 +184,12 @@ module i2s_iec958_tb;
                 if (sd != sdd) sd_edges = sd_edges + 1;
                 wsd = ws; sdd = sd;
             end
-            $display("  variant 4 (PCM16): ws_edges=%0d sd_edges=%0d", ws_edges, sd_edges);
+            $display("  variant 0 (PCM16, default): ws_edges=%0d sd_edges=%0d", ws_edges, sd_edges);
             if (ws_edges < 20 || sd_edges < 20) begin
                 $display("  FAIL: PCM16 transport not running"); errors = errors + 1; end
         end
 
-        variant = 3'd0;
+        variant = 3'd1;
 
         if (errors == 0) $display("\nPASS: i2s_iec958");
         else begin $display("\n%0d FAILURES", errors); $fatal(1, "i2s_iec958_tb failed"); end

--- a/bench/dvd/iec61937_wrap_tb.sv
+++ b/bench/dvd/iec61937_wrap_tb.sv
@@ -13,6 +13,7 @@ module iec61937_wrap_tb;
     reg         clk_sys = 0, clk_audio = 0;
     reg         rst_sys_n = 0, rst_audio_n = 0;
     reg         enable = 0, byte_swap = 0, mute = 0;
+    reg  [1:0]  hold_style = 2'd0;
 
     // ring model
     reg  [7:0]  ring_byte;
@@ -45,7 +46,7 @@ module iec61937_wrap_tb;
     // the layout capture.
     iec61937_wrap #(.FIFO_AW(12)) dut (
         .clk_sys(clk_sys), .rst_sys_n(rst_sys_n), .enable(enable), .byte_swap(byte_swap),
-        .mute_i(mute),
+        .mute_i(mute), .hold_style(hold_style),
         .ring_byte(ring_byte), .ring_valid(ring_valid), .ring_ready(ring_ready),
         .frame_valid(frame_valid), .frame_len(frame_len), .frame_type(frame_type),
         .frame_samples(frame_samples),
@@ -81,7 +82,8 @@ module iec61937_wrap_tb;
     integer tap_incoherent = 0;
     integer tap_badperiod  = 0;  // steady-state deviations: must be ZERO
     integer tap_startup    = 0;  // transient deviations: one per reset, bounded
-    integer tap_strobes    = 0;
+    integer tap_strobes    = 0;   // since the last reset (period checking)
+    integer tap_total      = 0;   // cumulative; survives the do_reset calls
     integer tap_resets     = 0;
     always @(posedge clk_audio) begin : tap_mon
         reg [15:0] gap;
@@ -98,6 +100,7 @@ module iec61937_wrap_tb;
                     else                          tap_badperiod = tap_badperiod + 1;
                 end
                 tap_strobes = tap_strobes + 1;
+                tap_total   = tap_total + 1;
                 gap = 16'd0;
             end
         end
@@ -374,11 +377,61 @@ module iec61937_wrap_tb;
         if (dut.cur_nonpcm !== 1'b1) begin
             $display("  FAIL: unmuted burst not tagged non-PCM"); errors=errors+1; end
 
+        // ---- TEST 8d: hold FILL styles --------------------------------------
+        // The hold itself is the pacing loop and is NOT touched here (see
+        // docs/iec61937.md - one-shotting it cost A/V sync). Only its fill
+        // changes, and only after a real burst has gone out, so pre-content
+        // behaviour stays the fj#110 round-2 PCM silence.
+        frame_valid = 0; do_reset;
+        hold_style = 2'd2;                            // pause bursts
+        sync_armed_r = 1; stc_anch_r = 1; fptsv_r = 1;
+        fpts_r = 33'd100000; stc_r = 33'd200000;      // due -> a real burst first
+        frame_len = 16'd8; plen = 8; frame_type = 2'd0; frame_valid = 1;
+        enable = 1;
+        wait (pulses >= 3072);
+        @(posedge clk_sys);
+        if (dut.burst_seen !== 1'b1) begin
+            $display("  FAIL 8d: burst_seen not set"); errors=errors+1; end
+
+        // now starve it: the hold must emit a REAL pause burst, still non-PCM
+        frame_valid = 0;
+        wait (pulses >= 3*3072);      // burst 2 may already have been latched real
+        @(posedge clk_sys); @(posedge clk_sys);
+        $display("TEST 8d: pause-burst hold, cur_nonpcm=%0b", dut.cur_nonpcm);
+        expect_word(0, PA,       "pause-Pa");
+        expect_word(1, PB,       "pause-Pb");
+        expect_word(2, 16'h0003, "pause-Pc");
+        if (dut.cur_nonpcm !== 1'b1) begin
+            $display("  FAIL 8d: pause burst not tagged non-PCM"); errors=errors+1; end
+
+        // style 1: zero words but the format still must not change
+        frame_valid = 0; do_reset;
+        hold_style = 2'd1;
+        stc_r = 33'd200000; frame_valid = 1; enable = 1;
+        wait (pulses >= 3072); @(posedge clk_sys);
+        frame_valid = 0;
+        wait (pulses >= 3*3072); @(posedge clk_sys); @(posedge clk_sys);
+        $display("TEST 8d2: nonpcm hold, cur_nonpcm=%0b", dut.cur_nonpcm);
+        expect_word(0, 16'h0000, "nonpcm-hold-w0");   // still no Pa/Pb
+        if (dut.cur_nonpcm !== 1'b1) begin
+            $display("  FAIL 8d2: nonpcm hold dropped the flag"); errors=errors+1; end
+
+        // style 0 PRE-content must still be PCM silence (the round-2 fix)
+        frame_valid = 0; do_reset;
+        hold_style = 2'd0; enable = 1;
+        wait (pulses >= 3072); @(posedge clk_sys);
+        $display("TEST 8d3: pre-content default, cur_nonpcm=%0b", dut.cur_nonpcm);
+        if (dut.cur_nonpcm !== 1'b0) begin
+            $display("  FAIL 8d3: pre-content hold is not PCM silence -");
+            $display("            that is the fj#110 round-1 regression");
+            errors=errors+1; end
+        hold_style = 2'd0;
+
         // ---- TEST 9: HDMI bitstream tap -------------------------------------
-        $display("TEST 9: HDMI tap, strobes=%0d incoherent=%0d steady_bad=%0d startup_dev=%0d (resets=%0d)",
-                 tap_strobes, tap_incoherent, tap_badperiod, tap_startup, tap_resets);
-        if (tap_strobes < 100) begin
-            $display("  FAIL: tap strobe never ran (%0d)", tap_strobes); errors=errors+1; end
+        $display("TEST 9: HDMI tap, total=%0d incoherent=%0d steady_bad=%0d startup_dev=%0d (resets=%0d)",
+                 tap_total, tap_incoherent, tap_badperiod, tap_startup, tap_resets);
+        if (tap_total < 100) begin
+            $display("  FAIL: tap strobe never ran (%0d)", tap_total); errors=errors+1; end
         if (tap_incoherent != 0) begin
             $display("  FAIL: tap diverged from the pair spdif_pass is playing (%0d cycles)",
                      tap_incoherent); errors=errors+1; end

--- a/bench/dvd/iec61937_wrap_tb.sv
+++ b/bench/dvd/iec61937_wrap_tb.sv
@@ -81,7 +81,8 @@ module iec61937_wrap_tb;
     integer tap_incoherent = 0;
     integer tap_badperiod  = 0;  // steady-state deviations: must be ZERO
     integer tap_startup    = 0;  // transient deviations: one per reset, bounded
-    integer tap_strobes    = 0;
+    integer tap_strobes    = 0;   // since the last reset (period checking)
+    integer tap_total      = 0;   // cumulative; never cleared
     integer tap_resets     = 0;
     always @(posedge clk_audio) begin : tap_mon
         reg [15:0] gap;
@@ -98,6 +99,7 @@ module iec61937_wrap_tb;
                     else                          tap_badperiod = tap_badperiod + 1;
                 end
                 tap_strobes = tap_strobes + 1;
+                tap_total   = tap_total + 1;
                 gap = 16'd0;
             end
         end
@@ -374,11 +376,48 @@ module iec61937_wrap_tb;
         if (dut.cur_nonpcm !== 1'b1) begin
             $display("  FAIL: unmuted burst not tagged non-PCM"); errors=errors+1; end
 
+        // ---- TEST 8c: the one-shot hold gate --------------------------------
+        // Once a real burst has gone out, a frame that is NOT yet due must NOT be
+        // held again. Re-holding punches a silence gap into a stream the receiver
+        // has already acquired, and that real->silence->real flap is what fj#110
+        // identified as breaking acquisition (symptom: the receiver flaps between
+        // the codec and "decoder off" at every title start, and on optical never
+        // settles without a chapter skip).
+        frame_valid = 0; do_reset;
+        sync_armed_r = 1; stc_anch_r = 1; fptsv_r = 1;
+        fpts_r = 33'd100000; stc_r = 33'd200000;      // due -> first burst goes out
+        frame_len = 16'd8; plen = 8; frame_type = 2'd0; frame_valid = 1;
+        enable = 1;
+        wait (pulses >= 3072);
+        @(posedge clk_sys);
+        if (dut.burst_seen !== 1'b1) begin
+            $display("  FAIL 8c: burst_seen not set after a real burst"); errors=errors+1; end
+
+        // now make the front frame NOT due; it must still be emitted
+        stc_r = 33'd50000;                            // STC behind the PTS again
+        i = pop_count;
+        wait (pulses >= 2*3072);
+        @(posedge clk_sys); @(posedge clk_sys);
+        $display("TEST 8c: post-burst not-due frame, cur_nonpcm=%0b pops=%0d",
+                 dut.cur_nonpcm, pop_count - i);
+        if (dut.cur_nonpcm !== 1'b1) begin
+            $display("  FAIL 8c: re-held after the stream started (silence gap ->");
+            $display("           receiver re-acquires; this is the fj#110 flap)");
+            errors=errors+1; end
+        if (pop_count == i) begin
+            $display("  FAIL 8c: no frame consumed while un-due post-start"); errors=errors+1; end
+
+        // a flush must re-arm the gate, so a cold start still holds
+        frame_valid = 0; do_reset;
+        sync_armed_r = 1; stc_anch_r = 0;             // armed, not yet anchored
+        if (dut.burst_seen !== 1'b0) begin
+            $display("  FAIL 8c: flush did not re-arm the hold gate"); errors=errors+1; end
+
         // ---- TEST 9: HDMI bitstream tap -------------------------------------
-        $display("TEST 9: HDMI tap, strobes=%0d incoherent=%0d steady_bad=%0d startup_dev=%0d (resets=%0d)",
-                 tap_strobes, tap_incoherent, tap_badperiod, tap_startup, tap_resets);
-        if (tap_strobes < 100) begin
-            $display("  FAIL: tap strobe never ran (%0d)", tap_strobes); errors=errors+1; end
+        $display("TEST 9: HDMI tap, total=%0d incoherent=%0d steady_bad=%0d startup_dev=%0d (resets=%0d)",
+                 tap_total, tap_incoherent, tap_badperiod, tap_startup, tap_resets);
+        if (tap_total < 100) begin
+            $display("  FAIL: tap strobe never ran (%0d)", tap_total); errors=errors+1; end
         if (tap_incoherent != 0) begin
             $display("  FAIL: tap diverged from the pair spdif_pass is playing (%0d cycles)",
                      tap_incoherent); errors=errors+1; end

--- a/bench/dvd/iec61937_wrap_tb.sv
+++ b/bench/dvd/iec61937_wrap_tb.sv
@@ -34,6 +34,8 @@ module iec61937_wrap_tb;
     wire        spdif_o;
     wire [15:0] dbg_word;
     wire        dbg_word_stb;
+    wire [15:0] bs_l, bs_r;
+    wire        bs_nonpcm, bs_stb;
 
     // ~27 MHz and 24.576 MHz
     always #18.5 clk_sys   = ~clk_sys;
@@ -51,8 +53,55 @@ module iec61937_wrap_tb;
         .sync_armed(sync_armed_r), .stc_anchored(stc_anch_r), .stc(stc_r), .av_ofs(avofs_r),
         .frame_pop(frame_pop),
         .clk_audio(clk_audio), .rst_audio_n(rst_audio_n), .spdif_o(spdif_o),
+        .bs_l_o(bs_l), .bs_r_o(bs_r), .bs_nonpcm_o(bs_nonpcm), .bs_stb_o(bs_stb),
         .dbg_word(dbg_word), .dbg_word_stb(dbg_word_stb)
     );
+
+    // ---- HDMI bitstream tap monitors (TEST 9) --------------------------------
+    // The tap feeds the HDMI I2S serializer. Two properties must hold or the
+    // HDMI path silently diverges from S/PDIF:
+    //  (a) COHERENCE - the tap presents exactly the pair spdif_pass is playing,
+    //      so both outputs carry the same burst. Structural today, but this
+    //      guards a future refactor that gates one path and not the other.
+    //  (b) PACING - in STEADY STATE the strobe is exactly one per 512 clk_audio
+    //      (48.000 kHz). The whole no-handshake argument rests on this: the I2S
+    //      frame is also 512 clk, so a fixed offset means one frame per pair,
+    //      forever.
+    //
+    // MEASURED startup transient: the FIRST interval after an audio-domain reset
+    // is 509, not 512. `bit_ce` is (ce_cnt==0) of a free-running 2-bit counter
+    // that reset clears, while spdif_pass's own subframe counter restarts from
+    // its reset state, so the two re-align three clk_audio into the first frame.
+    // That is a genuine PHASE STEP against the I2S frame counter, and it is
+    // exactly what the post-reset hold-off in sys/audio_out.v and dvd/emu.sv
+    // exists to hide -- rst_audio_n pulses on every audio-track switch and
+    // aud_flush, not just at power-on. Steady state must still be exact, so the
+    // hard check starts once the transient has passed.
+    localparam TAP_SETTLE = 4;   // strobes to ignore after a reset
+    integer tap_incoherent = 0;
+    integer tap_badperiod  = 0;  // steady-state deviations: must be ZERO
+    integer tap_startup    = 0;  // transient deviations: one per reset, bounded
+    integer tap_strobes    = 0;
+    integer tap_resets     = 0;
+    always @(posedge clk_audio) begin : tap_mon
+        reg [15:0] gap;
+        if (!rst_audio_n) begin
+            if (tap_strobes != 0) tap_resets = tap_resets + 1;
+            gap = 16'd0; tap_strobes = 0;
+        end else begin
+            if ({bs_r, bs_l} !== dut.u_spdif.sample_i || bs_nonpcm !== dut.u_spdif.nonpcm_i)
+                tap_incoherent = tap_incoherent + 1;
+            gap = gap + 16'd1;
+            if (bs_stb) begin
+                if (tap_strobes > 0 && gap != 16'd512) begin
+                    if (tap_strobes < TAP_SETTLE) tap_startup   = tap_startup + 1;
+                    else                          tap_badperiod = tap_badperiod + 1;
+                end
+                tap_strobes = tap_strobes + 1;
+                gap = 16'd0;
+            end
+        end
+    end
 
     // captured producer word stream, indexed by the DUT's word index so a
     // burst always lands at cap[0..N]; count committed words since reset.
@@ -324,6 +373,25 @@ module iec61937_wrap_tb;
         expect_word(2, PC_AC3, "unmute-Pc");
         if (dut.cur_nonpcm !== 1'b1) begin
             $display("  FAIL: unmuted burst not tagged non-PCM"); errors=errors+1; end
+
+        // ---- TEST 9: HDMI bitstream tap -------------------------------------
+        $display("TEST 9: HDMI tap, strobes=%0d incoherent=%0d steady_bad=%0d startup_dev=%0d (resets=%0d)",
+                 tap_strobes, tap_incoherent, tap_badperiod, tap_startup, tap_resets);
+        if (tap_strobes < 100) begin
+            $display("  FAIL: tap strobe never ran (%0d)", tap_strobes); errors=errors+1; end
+        if (tap_incoherent != 0) begin
+            $display("  FAIL: tap diverged from the pair spdif_pass is playing (%0d cycles)",
+                     tap_incoherent); errors=errors+1; end
+        if (tap_badperiod != 0) begin
+            $display("  FAIL: steady-state tap strobe not 512 clk_audio -- the fixed-offset");
+            $display("        pacing argument is void and HDMI would slip against S/PDIF (%0d)",
+                     tap_badperiod); errors=errors+1; end
+        // The transient is expected and hold-off-covered, but it must stay a
+        // transient: at most one short interval per reset. More than that means
+        // the re-alignment is not settling and the hold-off cannot bound it.
+        if (tap_startup > tap_resets + 1) begin
+            $display("  FAIL: post-reset re-alignment not settling (%0d deviations, %0d resets)",
+                     tap_startup, tap_resets); errors=errors+1; end
 
         if (errors==0) $display("\nALL TESTS PASSED");
         else           $display("\n%0d FAILURES", errors);

--- a/bench/dvd/iec61937_wrap_tb.sv
+++ b/bench/dvd/iec61937_wrap_tb.sv
@@ -81,8 +81,7 @@ module iec61937_wrap_tb;
     integer tap_incoherent = 0;
     integer tap_badperiod  = 0;  // steady-state deviations: must be ZERO
     integer tap_startup    = 0;  // transient deviations: one per reset, bounded
-    integer tap_strobes    = 0;   // since the last reset (period checking)
-    integer tap_total      = 0;   // cumulative; never cleared
+    integer tap_strobes    = 0;
     integer tap_resets     = 0;
     always @(posedge clk_audio) begin : tap_mon
         reg [15:0] gap;
@@ -99,7 +98,6 @@ module iec61937_wrap_tb;
                     else                          tap_badperiod = tap_badperiod + 1;
                 end
                 tap_strobes = tap_strobes + 1;
-                tap_total   = tap_total + 1;
                 gap = 16'd0;
             end
         end
@@ -376,48 +374,11 @@ module iec61937_wrap_tb;
         if (dut.cur_nonpcm !== 1'b1) begin
             $display("  FAIL: unmuted burst not tagged non-PCM"); errors=errors+1; end
 
-        // ---- TEST 8c: the one-shot hold gate --------------------------------
-        // Once a real burst has gone out, a frame that is NOT yet due must NOT be
-        // held again. Re-holding punches a silence gap into a stream the receiver
-        // has already acquired, and that real->silence->real flap is what fj#110
-        // identified as breaking acquisition (symptom: the receiver flaps between
-        // the codec and "decoder off" at every title start, and on optical never
-        // settles without a chapter skip).
-        frame_valid = 0; do_reset;
-        sync_armed_r = 1; stc_anch_r = 1; fptsv_r = 1;
-        fpts_r = 33'd100000; stc_r = 33'd200000;      // due -> first burst goes out
-        frame_len = 16'd8; plen = 8; frame_type = 2'd0; frame_valid = 1;
-        enable = 1;
-        wait (pulses >= 3072);
-        @(posedge clk_sys);
-        if (dut.burst_seen !== 1'b1) begin
-            $display("  FAIL 8c: burst_seen not set after a real burst"); errors=errors+1; end
-
-        // now make the front frame NOT due; it must still be emitted
-        stc_r = 33'd50000;                            // STC behind the PTS again
-        i = pop_count;
-        wait (pulses >= 2*3072);
-        @(posedge clk_sys); @(posedge clk_sys);
-        $display("TEST 8c: post-burst not-due frame, cur_nonpcm=%0b pops=%0d",
-                 dut.cur_nonpcm, pop_count - i);
-        if (dut.cur_nonpcm !== 1'b1) begin
-            $display("  FAIL 8c: re-held after the stream started (silence gap ->");
-            $display("           receiver re-acquires; this is the fj#110 flap)");
-            errors=errors+1; end
-        if (pop_count == i) begin
-            $display("  FAIL 8c: no frame consumed while un-due post-start"); errors=errors+1; end
-
-        // a flush must re-arm the gate, so a cold start still holds
-        frame_valid = 0; do_reset;
-        sync_armed_r = 1; stc_anch_r = 0;             // armed, not yet anchored
-        if (dut.burst_seen !== 1'b0) begin
-            $display("  FAIL 8c: flush did not re-arm the hold gate"); errors=errors+1; end
-
         // ---- TEST 9: HDMI bitstream tap -------------------------------------
-        $display("TEST 9: HDMI tap, total=%0d incoherent=%0d steady_bad=%0d startup_dev=%0d (resets=%0d)",
-                 tap_total, tap_incoherent, tap_badperiod, tap_startup, tap_resets);
-        if (tap_total < 100) begin
-            $display("  FAIL: tap strobe never ran (%0d)", tap_total); errors=errors+1; end
+        $display("TEST 9: HDMI tap, strobes=%0d incoherent=%0d steady_bad=%0d startup_dev=%0d (resets=%0d)",
+                 tap_strobes, tap_incoherent, tap_badperiod, tap_startup, tap_resets);
+        if (tap_strobes < 100) begin
+            $display("  FAIL: tap strobe never ran (%0d)", tap_strobes); errors=errors+1; end
         if (tap_incoherent != 0) begin
             $display("  FAIL: tap diverged from the pair spdif_pass is playing (%0d cycles)",
                      tap_incoherent); errors=errors+1; end

--- a/bench/dvd/run_hdmi_bitstream.sh
+++ b/bench/dvd/run_hdmi_bitstream.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Suite for the IEC 61937 bitstream outputs (optical S/PDIF + HDMI).
+#
+# Also the first runner iec61937_wrap_tb has ever had - it was run by hand from
+# docs/iec61937.md, which is how a TB quietly rots. `set -e` plus explicit exit
+# checks matter here: CLAUDE.md records vvp exit-0 masking hiding failing
+# testbenches for weeks after the M17 DRC change.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+OUT=bench/dvd
+fail=0
+
+run() {
+    local name="$1"; shift
+    echo "=== $name"
+    iverilog -g2012 -o "$OUT/${name}_sim" "$@"
+    if ! vvp "$OUT/${name}_sim" | tee "$OUT/${name}.log" | tail -3; then
+        echo "  !! $name: vvp returned non-zero"; fail=1; return
+    fi
+    # vvp exits 0 even on $fatal in some builds - check the text too.
+    if grep -qE 'FAIL|FAILURES|TIMEOUT|ERROR' "$OUT/${name}.log"; then
+        echo "  !! $name: failure text in log"; fail=1
+    fi
+}
+
+# 61937 burst assembly + the S/PDIF channel-status block + the HDMI pair tap
+run iec61937_wrap dvd/spdif_pass.sv dvd/iec61937_wrap.sv bench/dvd/iec61937_wrap_tb.sv
+
+# IEC958-direct serialization for the ADV7513's I2S input, read back off the wire
+run i2s_iec958 dvd/spdif_pass.sv dvd/i2s_iec958.sv bench/dvd/i2s_iec958_tb.sv
+
+if [ "$fail" -ne 0 ]; then echo; echo "SUITE FAILED"; exit 1; fi
+echo; echo "SUITE PASSED"

--- a/bench/dvd/run_hdmi_bitstream.sh
+++ b/bench/dvd/run_hdmi_bitstream.sh
@@ -25,11 +25,11 @@ run() {
 }
 
 # 61937 burst assembly + the S/PDIF channel-status block + the HDMI pair tap
-run iec61937_wrap dvd/spdif_pass.sv dvd/i2s_iec958.sv dvd/iec61937_wrap.sv \
+run iec61937_wrap dvd/spdif_pass.sv dvd/i2s_iec958.sv sys/i2s.v dvd/iec61937_wrap.sv \
     bench/dvd/iec61937_wrap_tb.sv
 
 # IEC958-direct serialization for the ADV7513's I2S input, read back off the wire
-run i2s_iec958 dvd/spdif_pass.sv dvd/i2s_iec958.sv bench/dvd/i2s_iec958_tb.sv
+run i2s_iec958 dvd/spdif_pass.sv dvd/i2s_iec958.sv sys/i2s.v bench/dvd/i2s_iec958_tb.sv
 
 if [ "$fail" -ne 0 ]; then echo; echo "SUITE FAILED"; exit 1; fi
 echo; echo "SUITE PASSED"

--- a/bench/dvd/run_hdmi_bitstream.sh
+++ b/bench/dvd/run_hdmi_bitstream.sh
@@ -25,7 +25,8 @@ run() {
 }
 
 # 61937 burst assembly + the S/PDIF channel-status block + the HDMI pair tap
-run iec61937_wrap dvd/spdif_pass.sv dvd/iec61937_wrap.sv bench/dvd/iec61937_wrap_tb.sv
+run iec61937_wrap dvd/spdif_pass.sv dvd/i2s_iec958.sv dvd/iec61937_wrap.sv \
+    bench/dvd/iec61937_wrap_tb.sv
 
 # IEC958-direct serialization for the ADV7513's I2S input, read back off the wire
 run i2s_iec958 dvd/spdif_pass.sv dvd/i2s_iec958.sv bench/dvd/i2s_iec958_tb.sv

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -5,10 +5,13 @@
 > drive `AUDIO_L/R` directly — the HPS-decode path described below is **retired**.
 > See [`fabric_audio.md`](fabric_audio.md). The codec/PES details in this file
 > (substream IDs, frame sizes, IEC 61937 constants) are still accurate reference.
-> DTS was dropped in fabric; **Path B (IEC 61937 passthrough over optical S/PDIF) is now
-> IMPLEMENTED** — `dvd/iec61937_wrap.sv` + `dvd/spdif_pass.sv`, toggle `O6` Audio Out.
-> Milestone A (AC-3 passthrough) is sim-verified with a HW gate pending; DTS (Milestone B,
-> a DTS reframer) is next. Full design: [`iec61937.md`](iec61937.md).
+> DTS was dropped in fabric; **Path B (IEC 61937 passthrough) is now IMPLEMENTED** —
+> `dvd/iec61937_wrap.sv` + `dvd/spdif_pass.sv`, toggle `O6` Audio Out. AC-3 and DTS are
+> both ✅ HW-CONFIRMED over optical S/PDIF (PRs fj#109/fj#110).
+> **As of 2026-08-30 the same bitstream also leaves over HDMI** (`dvd/i2s_iec958.sv`,
+> IEC958-direct into the ADV7513), so an AV receiver on HDMI gets 5.1 with no Digital I/O
+> board — ⏳ HW-confirm pending. Full design: [`iec61937.md`](iec61937.md) and
+> [`hdmi_bitstream.md`](hdmi_bitstream.md).
 
 ## Overview
 
@@ -19,11 +22,13 @@ consumer DVD players worked:
   written to the MiSTer ALSA dummy device, auto-mixed into HDMI audio output.
   Works on any TV or monitor with no extra hardware.
 
-- **Path B — S/PDIF optical (IMPLEMENTED, Milestone A):** the undecoded AC-3/DTS
-  frames are wrapped in IEC 61937 and biphase-encoded onto the S/PDIF pin for AV
-  receivers that decode AC-3/DTS natively. `dvd/iec61937_wrap.sv` (burst formatter +
-  async FIFO) + `dvd/spdif_pass.sv` (IEC 60958 encoder with the non-PCM bit set), toggle
-  `O6`. See [`iec61937.md`](iec61937.md).
+- **Path B — bitstream to a receiver (IMPLEMENTED):** the undecoded AC-3/DTS frames are
+  wrapped in IEC 61937 for AV receivers that decode them natively.
+  `dvd/iec61937_wrap.sv` (burst formatter + async FIFO) + `dvd/spdif_pass.sv` (IEC 60958
+  subframes with the non-PCM bit), toggle `O6`. Two link layers off **one** subframe
+  source: biphase onto the S/PDIF pin, and `dvd/i2s_iec958.sv` serializing the same
+  subframes into the ADV7513's I2S input in IEC958-direct mode for **HDMI**.
+  See [`iec61937.md`](iec61937.md) and [`hdmi_bitstream.md`](hdmi_bitstream.md).
 
   **Optical is NOT exclusive to the Digital I/O board.** The framework routes its
   S/PDIF signal to *two* destinations (both fed by the same internal `spdif` net in

--- a/docs/hdmi_bitstream.md
+++ b/docs/hdmi_bitstream.md
@@ -129,6 +129,17 @@ volume keypress** (`audio.cpp` `setFilter()` → `sys_top.v:359-369`), restartin
 bitstream: attenuation lives in `aud_mix_top`, which this path bypasses
 entirely. That is correct player behaviour, not a bug.
 
+### Note on the SV-function silent-silicon trap
+
+`docs/ac3_decoder.md` records (2026-08-31) that `function automatic` helpers in the
+AC-3 decoder simulated perfectly and produced **silent hardware** under Quartus 17,
+with no warning. Worth stating plainly for this path: **the HDMI leg adds no
+functions.** `dvd/i2s_iec958.sv` is one always block; the `spdif_pass` export is
+wires. The two functions in `iec61937_wrap.sv` (`mkword`, `bin2gray`) are
+pre-existing and sit on the HW-CONFIRMED S/PDIF path — and since HDMI reuses that
+same word stream, a fault in either would already show up on optical. So this
+feature carries no new exposure to that trap.
+
 ### Serial format
 
 `dvd/i2s_iec958.sv`, 64 bits per frame = two 32-bit subframes, channel A then B.

--- a/docs/hdmi_bitstream.md
+++ b/docs/hdmi_bitstream.md
@@ -146,12 +146,45 @@ feature carries no new exposure to that trap.
 Bits leave in **timeslot order, LSB first** — the opposite of `sys/i2s.v`'s
 MSB-first PCM. `sck` = 64·Fs = 3.072 MHz, `ws` = 48 kHz.
 
-⚠ **Open assumption.** The exact preamble nibble the ADV7513 expects in
-IEC958-direct is unconfirmed. The upper nibble of the biphase patterns is
-already a clean one-hot (Z=1, Y=2, X=4) and that is what is exported. **If HW
-round 1 shows the receiver locking to the wrong channel or never finding block
-start, this table is the first thing to change** — it is flagged in both
-`dvd/spdif_pass.sv` and `dvd/i2s_iec958.sv`.
+### ★ HW ROUND 1 (2026-08-31): the chip switches, the receiver cannot sync
+
+Receiver reported **PCM + silence** on the first attempt and **"decoder off"**
+once bitstream mode actually engaged. That progression is the useful part:
+
+- "PCM + silence" was the **designed safe fallback** — the ack had not engaged,
+  so `pass_mode` muted `AUDIO_L/R` and `HDMI_BS_EN` stayed low. Nothing made
+  noise, which is the gate working.
+- "decoder off" means the ADV7513 **did** switch to IEC958-direct (it stopped
+  calling the stream PCM) but the receiver could not find IEC 61937 sync
+  (Pa=`F872`, Pb=`4E1F`) inside our subframes.
+
+So Main, the EDID path, the ack and the register write are all **confirmed
+working end to end**. What remains is purely the subframe content, i.e. exactly
+the two things the Programming Guide would have settled and that had to be
+assumed (§ below).
+
+⚠ **Diagnostic lesson, worth keeping:** the round-1 popup was invisible.
+`InfoMessage` no-ops unless the menu FSM is idle, and Audio Out is toggled from
+*inside* the OSD, so a single call at the transition is always dropped —
+`dvd_css` had hit the identical trap. The state is now also written to
+`/tmp/dvd_hdmi_audio.log`, which does not care about menu state:
+`state: passthru=N sink_ok=N declared=N ini_mode=N acked=N`.
+
+### The two unknowns, and the runtime A/B
+
+`P1O[47:46] HDMI BS Variant` selects all four combinations from one build,
+because each guess would otherwise cost a 30-minute fit:
+
+| variant | bit order | preamble field |
+|---|---|---|
+| 0 `LSB+code` | LSB / timeslot first (IEC 60958 on the wire) | one-hot Z=1, Y=2, X=4 |
+| 1 `MSB+code` | MSB first (what plain I2S does) | one-hot |
+| 2 `LSB+zero` | LSB first | zeroed — chip derives framing from `ws` |
+| 3 `MSB+zero` | MSB first | zeroed |
+
+Variant 0 is the original assumption. Sim proves the **mux** in all four (each
+channel still carries its own audio, preamble zeroed exactly when asked); which
+one the real chip wants is the HW question the selector exists to answer.
 
 ---
 

--- a/docs/hdmi_bitstream.md
+++ b/docs/hdmi_bitstream.md
@@ -1,0 +1,272 @@
+# IEC 61937 bitstream over HDMI
+
+**Status: 🔧 built, sim-verified, ⏳ HW-confirm pending** (2026-08-30, branch
+`feature/hdmi-bitstream`). Design + the open HW questions are below; the S/PDIF
+half this builds on is `docs/iec61937.md`.
+
+`Audio Out = Passthru` wraps undecoded AC-3/DTS in IEC 61937. Until now that
+only ever left over optical S/PDIF, so 5.1 required the Digital I/O board and
+`docs/iec61937.md` recorded "inaudible on a plain HDMI TV" as a hard boundary.
+It isn't one. The same burst now also goes out HDMI, and an AV receiver decodes
+DD/DTS 5.1 with no add-on board.
+
+---
+
+## 1. Why this fits on one wire
+
+The DE10-Nano routes exactly **one** I2S data line to the ADV7513 — `HDMI_I2S`
+(PIN_T13), plus MCLK/SCLK/LRCLK. Confirmed in the board's own pin table; there
+is no FPGA connection to the chip's other I2S inputs or its S/PDIF pin.
+
+That kills multichannel LPCM permanently (6 ch would need three more wires — a
+board mod, see §7) but it does **not** limit compressed audio, because IEC 61937
+rides *inside* an ordinary 2-channel / 48 kHz / 16-bit IEC 60958 stream:
+
+```
+48000 samples/s x 2 ch x 16 bit = 1.536 Mbit/s = AC-3's maximum rate
+```
+
+That equality is not a coincidence — it is what 61937 was designed around. So
+the payload needs no new formatting at all; only the link layer changes.
+
+---
+
+## 2. Route decision: IEC958-direct, not an I2C channel-status bit
+
+There were two ways to tell the ADV7513 "this is not PCM".
+
+**(i) Keep I2S Standard, set channel status from I2C registers** (`0x0C[6]=1`
+plus a non-PCM bit somewhere in `0x12`/`0x13`).
+
+**(ii) IEC958-direct** (`0x0C[1:0] = 3`) — feed the chip complete IEC 60958
+subframes and let the channel status travel inside them.
+
+**Route (ii) was chosen**, on two grounds.
+
+The mainline Linux `adv7511` driver reaches for exactly this mode, and only this
+mode, for IEC958 subframe data:
+
+```c
+i2s_format = ADV7511_I2S_FORMAT_I2S;
+if (fmt->bit_fmt == SNDRV_PCM_FORMAT_IEC958_SUBFRAME_LE)
+        i2s_format = ADV7511_I2S_IEC958_DIRECT;   /* 0x0C[1:0] = 3 */
+```
+
+It never writes a non-PCM channel-status register anywhere. (It *does* set
+`0x12` bit 5 for "not copyrighted", which proves `0x12` carries channel-status
+fields — but that bit doesn't line up with IEC 60958 byte 0 bit 2, so the
+mapping isn't derivable from the driver and route (i)'s key register stayed
+unconfirmed. analog.com blocked every attempt at the Programming Guide.)
+
+★ **The stronger reason is that route (ii) keeps the non-PCM flag DYNAMIC.**
+On S/PDIF, `spdif_pass` latches it per 192-frame block, which is the fj#110
+ROUND 2 fix: receivers could not acquire across non-PCM null bursts, so holds
+present real linear-PCM silence and there is exactly one clean PCM→non-PCM
+switch when the burst starts. An I2C channel-status register can only pin the
+flag high for a whole session, putting us straight back in the regime that fix
+exists to avoid. Route (ii) inherits the proven behaviour instead of
+re-litigating it.
+
+---
+
+## 3. Data flow
+
+```
+audio_ring ──▶ iec61937_wrap (clk_sys)          producer: Pa,Pb,Pc,Pd,payload,pad
+                    │  33-bit {nonpcm,R,L} pairs
+                    ▼  async FIFO
+               cur_pair (clk_audio, held one 48 kHz frame)
+                    │
+              spdif_pass ── subframe assembly + channel status
+                    ├──────────────▶ biphase encoder ──▶ SPDIF_PASS  (optical)
+                    └── sub_w_o/sub_load_o ──▶ i2s_iec958 ──▶ HDMI_BS_SCK/WS/SD
+```
+
+**One subframe source, two link layers.** `spdif_pass` exports the very subframe
+it is about to biphase-encode, so the outputs cannot drift apart — there is
+nothing to keep in sync. Exporting rather than duplicating also matters because
+the channel-status table it feeds is HW-proven; a second copy would drift from
+it over time.
+
+Two details the export had to get right:
+
+- **Parity and the preamble code are filled in for the parallel consumer.** The
+  biphase stage derives both serially as it emits, which is far too late for
+  someone taking the word in parallel.
+- **`sub_load_o` is delayed one cycle.** `preamble_r` already describes the
+  subframe about to start while `audio_sample_q` still holds the previous one —
+  they are valid on *opposite* sides of the load edge, so the strobe is placed
+  where both have settled.
+
+### Pacing: why there is no handshake
+
+Three counters, all exact integer dividers of the same 24.576 MHz clock:
+
+| | period |
+|---|---|
+| `spdif_pass` pair request | 512 clk (64 bit-CE x 2 subframes) |
+| `audio_out` `sample_ce` | 512 clk |
+| I2S frame (either serializer) | 512 clk |
+
+A fixed offset, established at reset, that **never drifts** — so it is exactly
+one frame per pair, forever. There is nothing to hand-shake with; both sides are
+free-running dividers of one crystal. (Same same-crystal reasoning that retired
+the NCO trim.)
+
+⚠ **The one real hazard is a PHASE STEP, and it is measured, not theoretical.**
+`bench/dvd/iec61937_wrap_tb.sv` TEST 9 found the first interval after an
+audio-domain reset is **509 clk, not 512**: `bit_ce` is `(ce_cnt==0)` of a
+free-running 2-bit counter that reset clears, while `spdif_pass`'s subframe
+counter restarts from its own reset state, so the two re-align three cycles in.
+`rst_audio_n` pulses on **every audio-track switch and `aud_flush`**, so this is
+recurring, not a power-on curiosity. Hence the ~100 ms hold-off in `dvd/emu.sv`:
+across a re-phase the HDMI leg mutes, so a receiver sees clean silence and one
+switch rather than a torn subframe.
+
+The framework's own `areset` is the mirror image — it is pulsed by **every OSD
+volume keypress** (`audio.cpp` `setFilter()` → `sys_top.v:359-369`), restarting
+`audio_out`. Note also that the OSD volume slider has **no effect** on a
+bitstream: attenuation lives in `aud_mix_top`, which this path bypasses
+entirely. That is correct player behaviour, not a bug.
+
+### Serial format
+
+`dvd/i2s_iec958.sv`, 64 bits per frame = two 32-bit subframes, channel A then B.
+Bits leave in **timeslot order, LSB first** — the opposite of `sys/i2s.v`'s
+MSB-first PCM. `sck` = 64·Fs = 3.072 MHz, `ws` = 48 kHz.
+
+⚠ **Open assumption.** The exact preamble nibble the ADV7513 expects in
+IEC958-direct is unconfirmed. The upper nibble of the biphase patterns is
+already a clean one-hot (Z=1, Y=2, X=4) and that is what is exported. **If HW
+round 1 shows the receiver locking to the wrong channel or never finding block
+start, this table is the first thing to change** — it is flagged in both
+`dvd/spdif_pass.sv` and `dvd/i2s_iec958.sv`.
+
+---
+
+## 4. Safety: why stock Main cannot make noise
+
+The ADV7513's I2C is HPS-only (`sys/sys_top.v:1095-1105` ties it to a hard
+macro), so only Main can put the chip in non-PCM mode. If the core emitted a
+bitstream while the sink still expected PCM, the result is **full-scale noise**.
+The custom Main is opt-in, so this had to be safe by construction, not by
+instruction.
+
+Three independent layers, any one of which suffices:
+
+1. **`cfg[14]` is set only by MiSTer_DVDcss**, and only after it has configured
+   the chip *and* confirmed the sink advertises AC-3/DTS. Stock Main never sets
+   it — bits 14 and 15 are the only ones it leaves free.
+2. `HDMI_BS_EN = pass_mode & hdmi_bs_ack & ~hold`.
+3. With `hdmi_bs_en` low, every HDMI audio signal is the stock PCM net through a
+   mux with select 0.
+
+★ **INVARIANT — the ack owns the HDMI audio format, not `pass_mode`.** Leaving
+Passthru is instant in fabric, but the chip stays non-PCM until Main's next
+poll. That window must be digital silence, never PCM. So `hdmi_bs_ack` joins the
+`AUDIO_L/R` mute term (`pcm_mute` in `dvd/emu.sv`), and Main sequences the two
+directions **asymmetrically**:
+
+- **Engaging:** configure the chip FIRST, then raise the ack.
+- **Releasing:** drop the ack FIRST so the core stops emitting, restore the PCM
+  registers 50 ms later.
+
+Also guarded: `SW[0]`/`mcp_en` route the HDMI audio signals to the analog
+board's audio pins, where an I2S DAC would render a bitstream as noise. The mux
+falls back to PCM in that case.
+
+**Old Main + new core** → no ack → today's behaviour exactly.
+**New Main + old core** → no `OX6` declaration → Main never reconfigures the chip.
+
+---
+
+## 5. HPS side
+
+`main/support/dvd/dvd_hdmi_audio.cpp`, integration steps 12-21 (see
+`main/integration/INTEGRATION.md` — these are the overlay's first edits to
+`video.cpp`/`video.h`/`cfg.*`).
+
+- **EDID Short Audio Descriptors.** Stock Main never reads audio capability:
+  `edid_parse_cea_ext()` handles CEA tags 0x03/0x07 for VRR and lets tag 0x01
+  fall through. Rather than patch that, we re-walk the blocks off the exported
+  `video_get_edid()` buffer. The test is deliberately strict — the sink must
+  NAME AC-3 (format 2) or DTS (format 7) *and* claim 48 kHz — because the
+  permissive failure is the one that makes noise.
+- **`hdmi_config_set_audio()`** writes only the audio registers. Reusing
+  `hdmi_config_init()` would rewrite ~50 registers plus the CSC and blank the
+  picture on every toggle. But that full init *does* revert the audio block
+  (boot, and `video_reinit()` on hotplug), so a generation counter notices and
+  re-applies, dropping the ack across the gap.
+- **`OX6`** marks Audio Out as "also handled by the HPS". The bit still reaches
+  the core unchanged; the declaration is how Main learns the build has the HDMI
+  path.
+
+Registers written for bitstream / PCM:
+
+| reg | bitstream | PCM | meaning |
+|---|---|---|---|
+| `0x0A` | `0x00` | `0x00` | audio select = I2S |
+| `0x0C` | `0x07` | `0x04` | I2S0 enable; `[1:0]` 3 = IEC958 direct, 0 = standard |
+| `0x14` | `0x02` | `0x02` | word length 16 bit |
+| `0x15` | rate | rate | sampling rate (follows `hdmi_audio_96k`) |
+| `0x73` | `0x00` | `0x01` | InfoFrame CC: 0 = refer to stream header |
+
+**N and CTS are unchanged.** 61937 at 48 kHz *is* a 48 kHz stream — which is a
+large part of why this feature is small.
+
+MiSTer.ini: `dvd_hdmi_bitstream` — `0` auto (EDID-gated, default), `1` off,
+`2` force. Force exists because sinks do mis-report, especially over ARC.
+
+---
+
+## 6. Verification
+
+`bench/dvd/run_hdmi_bitstream.sh` (also the first runner `iec61937_wrap_tb` has
+ever had — it was run by hand out of `docs/iec61937.md`, which is how a TB
+quietly rots).
+
+- **`iec61937_wrap_tb` TEST 9** — tap coherence, and steady-state pacing exact
+  over 513 strobes with the post-reset transient bounded to one short interval
+  per reset.
+- **`i2s_iec958_tb`** — a **demodulator**, not a register peek: recovers
+  subframes off `sck`/`ws`/`sd` the way a sink would and checks preamble codes,
+  even parity, both channels present, and each channel carrying its own audio.
+
+★ Writing it as a demodulator paid for itself on the first run. All four checks
+failed — and the serializer was *correct* (exactly 32 `sck` per load); the
+demodulator was free-running a bit counter from reset instead of framing on
+`ws`. A register-peek test would have passed and proven nothing. The two things
+that fail silently here are bit order and channel mapping, which is exactly why
+they have to be read back off the wire.
+
+### HW gate — nothing about the ADV7513 is simulable
+
+1. AVR shows "Dolby Digital" / "DTS" and plays 5.1.
+2. **Locks at startup without a chapter skip**; survives 5 consecutive
+   audio-track switches, a chapter skip and a D-pad seek. (This is the §3
+   phase-step / hold-off gate.)
+3. Volume keypress mid-bitstream recovers.
+4. Picture unaffected across repeated Audio Out toggles.
+5. **Negatives:** a plain TV stays muted and **silent, never noisy**; the same
+   `.rbf` on **stock** Main behaves exactly as today.
+
+If (1) fails with the receiver naming nothing or mis-locking, try the §3
+preamble table before anything else.
+
+---
+
+## 7. Known limitations
+
+- **Multichannel LPCM is impossible** on this board — one I2S data line. The
+  DVD spec allows up to 8 channels of LPCM (48/96 kHz, 16/20/24-bit, capped at
+  6.144 Mbit/s), but it is rare on DVD-Video and cannot ride the bitstream
+  workaround either: 6 ch/48/16 is 4.608 Mbit/s against 1.536, and IEC 61937
+  carries no LPCM burst type.
+- **DTS-HD / TrueHD (HBR)** would need 4 data lines and 8x the bandwidth.
+- **MP2 and LPCM tracks are silent in Passthru**, as before — and now under a
+  permanent non-PCM flag, so an AVR may report no signal rather than silence.
+- **Simultaneous decoded-PCM-on-HDMI + bitstream-on-S/PDIF is deferred.** It
+  needs two consumers of the single `audio_ring` read side. Measured cost of the
+  clean fix (a second ring) is **34 M10K** against 47 free — RAM 92% → 97.6% on
+  a design that has needed fit rescue twice. An 8 KB clone (~8 M10K) is the
+  cheaper lever if it ever becomes a priority.

--- a/docs/hdmi_bitstream.md
+++ b/docs/hdmi_bitstream.md
@@ -217,6 +217,35 @@ reaches the HDMI audio sample packet, which is the whole mechanism. (The SPDIF
 input really is unreachable, though: it is **pin 3**, physically separate from
 I2S0 on pin 5, and the DE10-Nano routes only I2S0/MCLK/SCLK/LRCLK.)
 
+### ★ HW ROUND 4: block-start did not fix it — and route (i) exists
+
+The documented format still gives "decoder off" (now flapping to PCM), silent,
+with Main provably correct in the log. AES3-direct has cost four rounds.
+
+**Route (i) is now fully specified**, which is exactly what was missing when it
+was abandoned at Step 0:
+
+| what | where |
+|---|---|
+| non-PCM flag ("audio sample word", CS bit 1) | **`0x12[7]`** (Table 84) |
+| channel-status source | `0x0C[6]` — 1 = from the register map |
+| transport | plain 16-bit **standard I2S** carrying the raw 61937 words |
+
+It needs no preamble, no block-start flag and no word-select derivation, and the
+serializer is `sys/i2s.v` — the framework's own, already carrying PCM to this
+chip daily. The cost is a **static** non-PCM flag rather than per-block.
+
+Select with fabric variant **4 (PCM16)** *and* ini `dvd_hdmi_bs_mode=1`; one
+picks the transport, the other the chip config, so they must agree.
+
+### Instrument: what the chip actually detected
+
+`0x42[3]` is read back and logged: SCLK periods per LRCLK period, 0 = 32-bit
+mode, 1 = **64-bit** mode. AES3-direct carries 32 bits per channel and therefore
+*requires* 64-bit mode — if the chip reports 32-bit it is taking half of every
+subframe, which would explain the whole saga and which nothing on our side could
+have revealed by reasoning.
+
 ### What the runtime A/B is still for
 
 `P1O[47:46] HDMI BS Variant` now selects:
@@ -227,6 +256,7 @@ I2S0 on pin 5, and the DE10-Nano routes only I2S0/MCLK/SCLK/LRCLK.)
 | 1 `MSB+blkstart` | MSB-first, insurance against a bit-order misreading |
 | 2 `LSB+legacy` | reproduces the pre-document guess (parity in `[31]`, one-hot preamble) |
 | 3 `MSB+legacy` | both |
+| 4 `PCM16` | route (i) — standard 16-bit I2S, channel status from registers |
 
 Variant 2 exists so the fix can be A/B'd against the exact thing that failed,
 rather than trusting that anything changed.

--- a/docs/hdmi_bitstream.md
+++ b/docs/hdmi_bitstream.md
@@ -170,6 +170,97 @@ assumed (§ below).
 `/tmp/dvd_hdmi_audio.log`, which does not care about menu state:
 `state: passthru=N sink_ok=N declared=N ini_mode=N acked=N`.
 
+### ★★ THE FORMAT, from the Programming Guide §4.4.1.1 (obtained 2026-08-31)
+
+Three HW rounds were spent guessing at this. The document settles it in one
+paragraph:
+
+> "In the direct AES3 stream I2S format, the user can send an IEC60958 sub-frame
+> ... with the **Preamble left out** ... Notice that the **parity bit is replaced
+> by the block start flag**. The parity bit will be calculated automatically. The
+> information contained in "C" of I2S0 is used in the HDMI audio sample packet."
+
+So the AES3-direct subframe is the IEC 60958 subframe with **both ends changed**:
+
+| slots | content |
+|---|---|
+| `[3:0]` | preamble **left out** → zero (the chip regenerates preambles) |
+| `[27:4]` | audio + aux, unchanged |
+| `[28] [29] [30]` | V, U, C — unchanged |
+| `[31]` | **BLOCK START flag**, *not* parity (parity is computed by the chip) |
+
+**The missing block-start flag was the bug.** Without it the chip can never find
+the head of a 192-frame channel-status block, so it cannot assemble the status
+the sink needs. That is exactly what HW round 3 showed: a *stable* non-PCM
+indication (proving V/U/C were already in the right slots) with no 61937 lock —
+and it is why zeroing the preamble alone made the receiver FLAP between PCM and
+"decoder off", since block start then landed wherever the old parity bit
+happened to be 1.
+
+⚠ **Word select must come from `spdif_pass`, not from the word.** With no
+preamble the subframe no longer identifies its own channel. Deriving `ws` from
+the preamble code — which worked while a code was present — left `ws` stuck at 0
+once it was correctly zeroed: no word select at all, a total and silent failure.
+`sub_chb_o` now carries it explicitly.
+
+⚠ **Channel Count `0x73[2:0]` must be 1, not 0.** §4.4.1.1: "If I2S0 only is
+needed, setting the Channel Count register (0x73[2:0]) and I2S enable (0x0C[2])
+to 1 will select this." CC also drives the Audio Sample Packet layout bit and
+`sample_present.spX` (Figure 23), so 0 mis-frames the packet. A 61937 burst is a
+two-channel carrier, so stereo is correct for bitstream as well.
+
+**Correction to an earlier reading of Table 11.** Its Output Format column lists
+"AES3 Direct" for this mode and "IEC61937" only for the SPDIF pin and HBR, which
+looked like a statement that I2S AES3-direct *cannot* carry 61937. It is not —
+that column describes the input encoding. §4.4.1.1 is explicit that C from I2S0
+reaches the HDMI audio sample packet, which is the whole mechanism. (The SPDIF
+input really is unreachable, though: it is **pin 3**, physically separate from
+I2S0 on pin 5, and the DE10-Nano routes only I2S0/MCLK/SCLK/LRCLK.)
+
+### What the runtime A/B is still for
+
+`P1O[47:46] HDMI BS Variant` now selects:
+
+| variant | meaning |
+|---|---|
+| 0 `LSB+blkstart` | the documented format above — **the expected answer** |
+| 1 `MSB+blkstart` | MSB-first, insurance against a bit-order misreading |
+| 2 `LSB+legacy` | reproduces the pre-document guess (parity in `[31]`, one-hot preamble) |
+| 3 `MSB+legacy` | both |
+
+Variant 2 exists so the fix can be A/B'd against the exact thing that failed,
+rather than trusting that anything changed.
+
+### Serial format
+
+`dvd/i2s_iec958.sv`, 64 bits per frame = two 32-bit subframes, channel A then B.
+Bits leave in **timeslot order, LSB first** — the opposite of `sys/i2s.v`'s
+MSB-first PCM. `sck` = 64·Fs = 3.072 MHz, `ws` = 48 kHz.
+
+### ★ HW ROUND 1 (2026-08-31): the chip switches, the receiver cannot sync
+
+Receiver reported **PCM + silence** on the first attempt and **"decoder off"**
+once bitstream mode actually engaged. That progression is the useful part:
+
+- "PCM + silence" was the **designed safe fallback** — the ack had not engaged,
+  so `pass_mode` muted `AUDIO_L/R` and `HDMI_BS_EN` stayed low. Nothing made
+  noise, which is the gate working.
+- "decoder off" means the ADV7513 **did** switch to IEC958-direct (it stopped
+  calling the stream PCM) but the receiver could not find IEC 61937 sync
+  (Pa=`F872`, Pb=`4E1F`) inside our subframes.
+
+So Main, the EDID path, the ack and the register write are all **confirmed
+working end to end**. What remains is purely the subframe content, i.e. exactly
+the two things the Programming Guide would have settled and that had to be
+assumed (§ below).
+
+⚠ **Diagnostic lesson, worth keeping:** the round-1 popup was invisible.
+`InfoMessage` no-ops unless the menu FSM is idle, and Audio Out is toggled from
+*inside* the OSD, so a single call at the transition is always dropped —
+`dvd_css` had hit the identical trap. The state is now also written to
+`/tmp/dvd_hdmi_audio.log`, which does not care about menu state:
+`state: passthru=N sink_ok=N declared=N ini_mode=N acked=N`.
+
 ### The two unknowns, and the runtime A/B
 
 `P1O[47:46] HDMI BS Variant` selects all four combinations from one build,

--- a/docs/hdmi_bitstream.md
+++ b/docs/hdmi_bitstream.md
@@ -1,8 +1,12 @@
 # IEC 61937 bitstream over HDMI
 
-**Status: 🔧 built, sim-verified, ⏳ HW-confirm pending** (2026-08-30, branch
-`feature/hdmi-bitstream`). Design + the open HW questions are below; the S/PDIF
-half this builds on is `docs/iec61937.md`.
+**Status: ✅ HW-CONFIRMED 2026-08-31** — DD and DTS both decode on a real receiver
+over HDMI, with no Digital I/O board, via **route (i)** (§ below). Default build,
+no ini needed. ⚠ It inherits the **pre-existing** startup / track-change lock flap
+documented in `docs/iec61937.md` — that affects optical identically and reproduces
+on the shipped v0.2.0, so it is not a property of this feature.
+
+Design below; the S/PDIF half this builds on is `docs/iec61937.md`.
 
 `Audio Out = Passthru` wraps undecoded AC-3/DTS in IEC 61937. Until now that
 only ever left over optical S/PDIF, so 5.1 required the Digital I/O board and

--- a/docs/iec61937.md
+++ b/docs/iec61937.md
@@ -88,9 +88,11 @@ The core decodes AC-3 and LPCM to PCM in fabric (`dvd/dvd_audio_decode.sv`), but
 disproportionate from-scratch RTL project (`docs/audio.md`, CLAUDE.md audio decision).
 The realistic way to make DTS (and AC-3) audible without decoding it in fabric is
 **IEC 61937 passthrough**: wrap the *undecoded* elementary frames in IEC 61937 data-bursts
-and send them as a bitstream over optical S/PDIF for an AV receiver to decode. This is the
-documented "Path B" in `docs/audio.md`. It requires an AV receiver with an optical input
-(it is inaudible on a plain HDMI TV — for that, use Decode mode, which is unchanged).
+and send them as a bitstream for an AV receiver to decode. This is the documented "Path B"
+in `docs/audio.md`. It requires an AV receiver — over optical S/PDIF, and **as of
+2026-08-30 also over HDMI** (`docs/hdmi_bitstream.md`), so the Digital I/O board is no
+longer required. On a plain TV that cannot decode AC-3/DTS it stays inaudible; for that,
+use Decode mode, which is unchanged.
 
 Raw AC-3/DTS frames already reach `dvd/audio_ring.sv` (ps_demux strips the
 private_stream_1 sub-header; the AC-3 reframer makes AC-3 frame-granular). The work is a
@@ -281,10 +283,12 @@ The clock is already right too: `CLK_AUDIO` = 24.576 MHz, 48 kHz S/PDIF = 6.144 
 
 ### The two caveats that bound it
 
-- **Receiver-only feature.** Audio leaves via optical/coax to an AV receiver/DAC — **not** the
-  TV's HDMI audio. HDMI-only users get nothing from this path, so keep a **16/48 HDMI LPCM
-  fallback** (the existing `lpcm_unpack` Decode path, truncated) so they're not silent. This
-  becomes an "S/PDIF hi-res LPCM" mode alongside HDMI, not a replacement.
+- **Receiver-only feature.** Audio leaves to an AV receiver/DAC — optical/coax, or HDMI
+  since 2026-08-30 (`docs/hdmi_bitstream.md`). Either way a plain TV that cannot decode
+  AC-3/DTS gets nothing from this path, so keep a **16/48 HDMI LPCM fallback** (the existing
+  `lpcm_unpack` Decode path, truncated) so those users aren't silent. ⚠ Note the hi-res-LPCM
+  plan below is S/PDIF-only: the HDMI leg carries *compressed* bursts, and multichannel or
+  24-bit LPCM cannot ride it (see `docs/hdmi_bitstream.md` §7).
 - **A `SetSTN`/track-switch to an LPCM track must route it as PCM S/PDIF**, mirroring the
   AC-3/DTS mode switch (channel-status PCM↔non-PCM already handled per-block).
 
@@ -305,8 +309,9 @@ Cross-ref: `docs/fabric_audio.md` "LPCM" (the HDMI decode path + the stripped su
   audio-switch reset reaches the wrapper only via `aud_rst_n`; (b) the DTS burst-period/fit
   for a 1509 kbps core DTS track ≈ 2048 B, which fills the whole 512-sample burst — snoop
   `NBLKS` and/or bump the burst period.)*
-- Needs an AV receiver with an optical input; inaudible on a plain HDMI TV. (PCM S/PDIF in
-  Decode mode works on anything, as before.)
+- Needs an AV receiver that decodes AC-3/DTS — over optical, or over HDMI since 2026-08-30
+  (`docs/hdmi_bitstream.md`). Inaudible on a plain TV that decodes neither. (PCM in Decode
+  mode works on anything, as before.)
 - **DTS burst period is fixed at 512 samples** (`PERIOD_DTS`). Correct for the common DVD
   DTS case (NBLKS=15, verified on the T2 track and HW-confirmed working), but a
   1024-sample-frame DTS stream would drift the receiver buffer. **Refinement:** snoop

--- a/docs/iec61937.md
+++ b/docs/iec61937.md
@@ -77,9 +77,42 @@
   frame re-asserts it, ≥2 blocks), TEST 7 (anchor-gate hold + DTS 512-sample period). All
   green. **HW gate:** T2 passthru, menus off — receiver locks at startup WITHOUT a chapter
   skip (showing PCM then switching to DD/DTS), and holds through repeated audio-track
-  switches on ALL tracks (5.1 DD, DTS, 2.0, commentary). If it *still* flaps after this,
+  switches on ALL tracks (5.1 DD, DTS, 2.0, commentary).
+  ⚠ **2026-08-31: this gate does NOT hold on current hardware** — see "startup /
+  track-change flap is still open" below. The claim is left in place as the record
+  of what was confirmed in July, not as a statement about today.
+  If it *still* flaps after this,
   the evidence would point away from our burst generation (suspect the receiver's DTS-fit
   handling, or the cable — though a bitrate-correlated fault is not cable-shaped).
+
+### ⚠ STARTUP / TRACK-CHANGE FLAP IS STILL OPEN — and is PRE-EXISTING (2026-08-31)
+
+★ **The fj#110 HW gate above ("locks at startup WITHOUT a chapter skip") does NOT
+hold on current hardware.** On both outputs the receiver flaps between the codec
+and "no decode" at the start of a title and across a track change, and a **chapter
+seek** locks it. That is the same symptom fj#110 was written against, so treat the
+round-2 confirmation as disc- and receiver-specific rather than general.
+
+**It is NOT caused by the HDMI bitstream work.** Verified the honest way: the
+shipped **v0.2.0 release build** (`releases/DVD_20260830.rbf`) flaps over optical
+in exactly the same way. Establish this BEFORE debugging - three rounds were spent
+on it here on the assumption that the branch had caused it.
+
+**Ruled out by measurement, do not re-try:**
+- **The hold FILL is not the variable.** All three of `P1O[50:49]` - PCM silence,
+  non-PCM hold, and a real IEC 61937 **pause burst** (Pc=3) - flap identically.
+  Note this also means Pc=3 is now a tried negative, distinct from the Pc=0 null
+  bursts of round 1; this receiver does not treat a pause burst as lock-holding.
+- **The hold itself must not be touched** - see the one-shot gate below.
+- A chapter seek fixing it, while changing no fill at all, says the same thing:
+  what the seek changes is the flush and the re-anchor, not the burst contents.
+
+**The next lead, untested:** the burst REPETITION PERIOD at startup. `cur_period`
+resets to `PERIOD_AC3` (1536) and only updates once a frame is queued, so the
+first real burst of a **DTS** track jumps the Pa/Pb grid 1536 → 512 - which root
+cause 2 above already identifies as dropping receiver lock. That fits startup and
+track changes and not chapter seeks (where a period is already latched). It does
+not obviously explain an AC-3-only case, so it is a lead rather than an answer.
 
 ### ⛔ ONE-SHOT HOLD GATE — TRIED 2026-08-31 AND REVERTED (do not retry)
 

--- a/docs/iec61937.md
+++ b/docs/iec61937.md
@@ -81,6 +81,35 @@
   the evidence would point away from our burst generation (suspect the receiver's DTS-fit
   handling, or the cable — though a bitrate-correlated fault is not cable-shaped).
 
+### ⛔ ONE-SHOT HOLD GATE — TRIED 2026-08-31 AND REVERTED (do not retry)
+
+**The hold is not a startup aligner. It is the CONTINUOUS pacing loop.** Making it
+one-shot (apply until the first real burst since a flush, then stop) looked like
+it should only remove redundant re-holds. On HW it produced **audio running ~1 s
+AHEAD of video**, plus track-change flapping that had not been there before.
+
+Why: the gate *is* how passthrough audio is paced against the video timeline —
+the module header says so ("Holding fills the ring → engages the demux STD
+backpressure, so the lead is bounded without dropping frames"). Disabling it
+after the first burst removes A/V sync for passthrough entirely, and audio then
+free-runs at ring-delivery rate, which leads the display by roughly the VBUF
+depth.
+
+★ **The corollary is the useful part: the hold/release chatter at startup is not
+a bug, it is the controller working.** It is a bang-bang loop — hold, release,
+hold, release — and that is *how* it bounds the lead. So any fix that tries to
+stop the chattering stops the pacing. It measurably improved lock (optical went
+from never locking to locking) precisely because it stopped pacing.
+
+**Therefore the flap must be addressed at the CHANNEL-STATUS layer, not the hold
+layer** — keep the bang-bang data pacing, but stop the non-PCM bit following it
+once the stream is running, so the receiver sees a continuous non-PCM stream with
+brief data gaps rather than repeated PCM↔non-PCM format changes. ⚠ Untested, and
+it sits close to the round-1 failure mode above (non-PCM asserted with no data),
+so it needs the same "locks at startup without a chapter skip" HW gate — the
+difference being that round 1 asserted it for ~1 s BEFORE any content, where this
+would only bridge gaps in an already-acquired stream.
+
 ## Why
 
 The core decodes AC-3 and LPCM to PCM in fabric (`dvd/dvd_audio_decode.sv`), but

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -408,14 +408,28 @@ finds the main feature, navigates to it, and plays from start.
 
 ---
 
-## Phase 5 — DTS Audio (via IEC 61937 S/PDIF passthrough)
+## Phase 5 — DTS Audio (via IEC 61937 passthrough)
 
-> **⚠️ APPROACH (2026-07-11): DTS is delivered by IEC 61937 bitstream passthrough over
-> optical S/PDIF, NOT by decoding** (there is no in-fabric DCA decoder; a from-scratch
-> one is out of scope, and the HPS libdca path is retired with the rest of the HPS audio
-> daemon). An AV receiver decodes the bitstream. Design: **`docs/iec61937.md`**.
+> **⚠️ APPROACH (2026-07-11): DTS is delivered by IEC 61937 bitstream passthrough, NOT by
+> decoding** (there is no in-fabric DCA decoder; a from-scratch one is out of scope, and
+> the HPS libdca path is retired with the rest of the HPS audio daemon). An AV receiver
+> decodes the bitstream. Design: **`docs/iec61937.md`**.
 
-**Goal:** make DTS (and AC-3) tracks audible on an AV receiver with an optical input.
+**Goal:** make DTS (and AC-3) tracks audible on an AV receiver.
+
+### 🔧 Milestone C — the same bitstream over HDMI (2026-08-30, ⏳ HW-confirm pending)
+- [x] `dvd/i2s_iec958.sv` — IEC 60958 subframes into the ADV7513's I2S input in
+  IEC958-direct mode (`0x0C[1:0]=3`), so **an AV receiver on HDMI gets DD/DTS 5.1 with no
+  Digital I/O board**. One subframe source, two link layers — `spdif_pass` exports the
+  very subframe it biphase-encodes, so the outputs cannot drift.
+- [x] Chosen over an I2C channel-status bit because IEC958-direct keeps the non-PCM flag
+  **dynamic**, preserving the fj#110 ROUND 2 behaviour instead of pinning it high.
+- [x] HPS half: `main/support/dvd/dvd_hdmi_audio.cpp` (EDID Short Audio Descriptors +
+  `hdmi_config_set_audio()`), gated by a `cfg[14]` ack so **stock Main is safe by
+  construction** — no ack, no bitstream, no noise.
+- [ ] **HW gate:** receiver names DD/DTS and plays 5.1; locks at startup without a chapter
+  skip; a plain TV stays silent, never noisy; stock Main unchanged.
+- Design + the open preamble-nibble assumption: **`docs/hdmi_bitstream.md`**.
 
 ### ✅ Milestone A — passthrough machinery + AC-3 (HW-CONFIRMED 2026-07-11)
 - [x] `dvd/spdif_pass.sv` — IEC 60958 biphase encoder (copy of `sys/spdif.v`) with the

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -61,6 +61,16 @@ module emu (
 	output        SPDIF_PASS,
 	output        SPDIF_PASS_EN,
 
+	// DVD-FORK: the same IEC 61937 bitstream over HDMI. These are IEC 60958
+	// subframes in the ADV7513's "IEC958 direct" format, NOT PCM samples;
+	// sys_top substitutes them for the framework's PCM I2S on HDMI_SCLK/LRCLK/
+	// I2S while HDMI_BS_EN. Gated on the HPS ack, so a Main that has not put the
+	// chip in non-PCM mode never sees them. See docs/hdmi_bitstream.md.
+	output        HDMI_BS_SCK,
+	output        HDMI_BS_WS,
+	output        HDMI_BS_SD,
+	output        HDMI_BS_EN,
+
 	inout   [3:0] ADC_BUS,
 
 	output        SD_SCK,
@@ -176,6 +186,8 @@ wire pal_eff;
 wire direct_video;                        // hps_io cfg[10] (declared early for the gating here)
 wire forced_scandoubler;                  // hps_io cfg[4]
 wire ini_vga_scaler, ini_csync, ini_ypbpr, ini_sog;  // hps_io MiSTer.ini exports (DVD-FORK)
+wire hdmi_bs_ack;                                    // cfg[14] HPS ack (DVD-FORK, HDMI bitstream)
+wire bs_stb_w;                                       // 48 kHz pair strobe from iec61937_wrap
 wire [1:0] analog_mode = status[27:26];   // 0=Auto 1=Interlaced 2=Progressive 3=Native Fields
 // Debug "Title VTS" override (P1, two BCD digits -> VTS 1..99; 0 = Auto).
 // See the CONF_STR note at the retired O[31:28] slot.
@@ -346,14 +358,41 @@ always @(posedge clk_sys) begin
     else if (probe_act_p != 0) probe_act_p <= probe_act_p - 20'd1;
 end
 wire signed [15:0] probe_tone = probe_sq ? 16'sd8000 : -16'sd8000;
-assign AUDIO_L = (probe_act_s != 0) ? probe_tone : ((pass_mode | css_scrambled) ? 16'sd0 : dec_audio_l);
-assign AUDIO_R = (probe_act_p != 0) ? probe_tone : ((pass_mode | css_scrambled) ? 16'sd0 : dec_audio_r);
+assign AUDIO_L = (probe_act_s != 0) ? probe_tone : (pcm_mute ? 16'sd0 : dec_audio_l);
+assign AUDIO_R = (probe_act_p != 0) ? probe_tone : (pcm_mute ? 16'sd0 : dec_audio_r);
 // =============================================================================
 `else
-assign AUDIO_L      = (pass_mode | css_scrambled) ? 16'sd0 : dec_audio_l;
-assign AUDIO_R      = (pass_mode | css_scrambled) ? 16'sd0 : dec_audio_r;
+assign AUDIO_L      = pcm_mute ? 16'sd0 : dec_audio_l;
+assign AUDIO_R      = pcm_mute ? 16'sd0 : dec_audio_r;
 `endif
 assign SPDIF_PASS_EN = pass_mode;
+
+// -----------------------------------------------------------------------------
+// DVD-FORK: HDMI IEC 61937 bitstream (docs/hdmi_bitstream.md)
+// -----------------------------------------------------------------------------
+// hdmi_bs_ack is cfg[14] from MiSTer_DVDcss: "the ADV7513 is in IEC958-direct /
+// non-PCM mode". Stock Main never sets it, so everything below stays inert and
+// the core behaves exactly as it does today.
+//
+// ⚠ INVARIANT - the ACK owns the HDMI audio format, not pass_mode. While the ack
+// is set the sink has been told to expect non-PCM, so the core must never put PCM
+// on HDMI: a receiver would decode it as a data burst. Leaving Passthru is
+// instant in fabric but the chip stays in non-PCM mode until Main's next poll, so
+// that window has to be digital silence rather than decoded audio. Hence
+// hdmi_bs_ack joins the mute term above instead of pass_mode alone.
+wire pcm_mute = pass_mode | css_scrambled | hdmi_bs_ack;
+
+// Post-reset hold-off. rst_audio_n pulses on every audio-track switch and
+// aud_flush, and it re-phases the subframe pacing (MEASURED: the first interval
+// after a reset is 509 clk_audio, not 512 - see bench/dvd/iec61937_wrap_tb.sv
+// TEST 9). Mute the HDMI leg for ~100 ms across that so a receiver sees clean
+// silence and one switch, never a torn subframe.
+reg [12:0] bs_hold;
+always @(posedge CLK_AUDIO or negedge rst_audio_n)
+    if (!rst_audio_n)                 bs_hold <= 13'd4800;   // ~100 ms at 48 kHz
+    else if (bs_stb_w && |bs_hold)    bs_hold <= bs_hold - 13'd1;
+
+assign HDMI_BS_EN = pass_mode & hdmi_bs_ack & ~|bs_hold;
 
 assign SD_SCK       = 0;
 assign SD_MOSI      = 0;
@@ -774,6 +813,7 @@ hps_io #(.CONF_STR(CONF_STR), .BLKSZ(4)) hps_io_inst (
     .ini_csync      (ini_csync),
     .ini_ypbpr      (ini_ypbpr),
     .ini_sog        (ini_sog),
+    .ini_hdmi_bs_ok (hdmi_bs_ack),
 
     // SD sector-level access (virtual disk for MPG streaming)
     .sd_lba         ('{sd_lba}),
@@ -2840,6 +2880,13 @@ iec61937_wrap #(.FIFO_AW(8)) iec61937_wrap_inst (
     .clk_audio    (CLK_AUDIO),
     .rst_audio_n  (rst_audio_n),
     .spdif_o      (SPDIF_PASS),
+    .hdmi_sck_o   (HDMI_BS_SCK),
+    .hdmi_ws_o    (HDMI_BS_WS),
+    .hdmi_sd_o    (HDMI_BS_SD),
+    .bs_l_o       (),
+    .bs_r_o       (),
+    .bs_nonpcm_o  (),
+    .bs_stb_o     (bs_stb_w),
     .dbg_word     (),
     .dbg_word_stb ()
 );

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -720,7 +720,7 @@ parameter CONF_STR = {
     // ADV7513 Programming Guide would have settled (bit order, preamble code).
     // Round 1 gave "decoder off": the chip HAD switched to IEC958-direct but the
     // receiver could not find 61937 sync. status[47:46]. docs/hdmi_bitstream.md §3.
-    "P1O[47:46],HDMI BS Variant,LSB+blkstart,MSB+blkstart,LSB+legacy,MSB+legacy;",
+    "P1O[48:46],HDMI BS Variant,AES3 LSB,AES3 MSB,AES3 legacy,AES3 legacyM,PCM16;",
     // Film 24p/25p Out: emit a progressive-film raster (one film frame per refresh, no
     // in-core 3:2) and let the framework scaler (ascal) do the pulldown to the HDMI
     // output — NTSC 23.976 Hz (2:5 -> 59.94) / PAL 25.000 Hz (1:2 -> 50). Fixes the
@@ -2900,7 +2900,7 @@ iec61937_wrap #(.FIFO_AW(8)) iec61937_wrap_inst (
     .bs_r_o       (),
     .bs_nonpcm_o  (),
     .bs_stb_o     (bs_stb_w),
-    .hdmi_variant (status[47:46]),
+    .hdmi_variant (status[48:46]),
     .dbg_word     (),
     .dbg_word_stb ()
 );

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -720,7 +720,7 @@ parameter CONF_STR = {
     // ADV7513 Programming Guide would have settled (bit order, preamble code).
     // Round 1 gave "decoder off": the chip HAD switched to IEC958-direct but the
     // receiver could not find 61937 sync. status[47:46]. docs/hdmi_bitstream.md §3.
-    "P1O[47:46],HDMI BS Variant,LSB+code,MSB+code,LSB+zero,MSB+zero;",
+    "P1O[47:46],HDMI BS Variant,LSB+blkstart,MSB+blkstart,LSB+legacy,MSB+legacy;",
     // Film 24p/25p Out: emit a progressive-film raster (one film frame per refresh, no
     // in-core 3:2) and let the framework scaler (ascal) do the pulldown to the HDMI
     // output — NTSC 23.976 Hz (2:5 -> 59.94) / PAL 25.000 Hz (1:2 -> 50). Fixes the

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -720,7 +720,7 @@ parameter CONF_STR = {
     // ADV7513 Programming Guide would have settled (bit order, preamble code).
     // Round 1 gave "decoder off": the chip HAD switched to IEC958-direct but the
     // receiver could not find 61937 sync. status[47:46]. docs/hdmi_bitstream.md §3.
-    "P1O[48:46],HDMI BS Variant,AES3 LSB,AES3 MSB,AES3 legacy,AES3 legacyM,PCM16;",
+    "P1O[48:46],HDMI BS Variant,PCM16,AES3 LSB,AES3 MSB,AES3 legacy,AES3 legacyM;",
     // Film 24p/25p Out: emit a progressive-film raster (one film frame per refresh, no
     // in-core 3:2) and let the framework scaler (ascal) do the pulldown to the HDMI
     // output — NTSC 23.976 Hz (2:5 -> 59.94) / PAL 25.000 Hz (1:2 -> 50). Fixes the

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -525,7 +525,7 @@ assign CE_PIXEL = 1'b1;
 // builds: it is part of CONF_STR = part of the netlist, so every compile would
 // become a new netlist and re-roll the fitter seed lottery (DVD.qsf's ledger).
 // Same-day dev builds are identified by their build_release.sh --name filename.
-`define CORE_VERSION "0.2.1"
+`define CORE_VERSION "0.3.0"
 
 parameter CONF_STR = {
     "DVD;;",

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -572,10 +572,18 @@ parameter CONF_STR = {
     "O5,Audio,On,Off;",
     // Audio Out: Decode = AC-3/LPCM decoded in fabric to HDMI PCM (default).
     // Passthru = the UNDECODED AC-3/DTS frames are wrapped in IEC 61937 and
-    // sent as a bitstream over optical S/PDIF for an AV receiver to decode
-    // (Path B; enables DTS, which has no in-fabric decoder). HDMI PCM is muted
-    // in Passthru. status[6]. See docs/iec61937.md.
-    "O6,Audio Out,Decode HDMI,Passthru SPDIF;",
+    // sent as a bitstream for an AV receiver to decode (Path B; enables DTS,
+    // which has no in-fabric decoder). Always out optical S/PDIF, and ALSO over
+    // HDMI when MiSTer_DVDcss has put the ADV7513 in IEC958-direct mode and the
+    // sink advertises AC-3/DTS; otherwise HDMI stays muted as before.
+    // status[6]. See docs/iec61937.md and docs/hdmi_bitstream.md.
+    //
+    // ★ OX (not O) marks it "also handled by the HPS": the bit still reaches the
+    // core exactly as before, but Main sees the declaration in parse_config and
+    // learns this build HAS the HDMI bitstream path. A core without it never
+    // declares OX6, so Main never reconfigures the chip for a core that cannot
+    // drive it. Bit layout is unchanged, so no CONF_STR "v,N" bump is needed.
+    "OX6,Audio Out,Decode PCM,Passthru (SPDIF+HDMI);",
     // SPDIF Byte Order: flips the 61937 payload byte packing. If the receiver
     // recognises the format (e.g. "Dolby D"/"DTS") but plays static, toggle
     // this. status[7]. Only meaningful in Passthru.

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -716,6 +716,11 @@ parameter CONF_STR = {
     // freed when O[14] "CRT 480i Out" was retired.
     "P1O[14],Line-21 CC,On,Off;",
     "P1O[44],CC Test Line,Off,On;",
+    // HDMI bitstream subframe variant — the HW A/B for the two unknowns the
+    // ADV7513 Programming Guide would have settled (bit order, preamble code).
+    // Round 1 gave "decoder off": the chip HAD switched to IEC958-direct but the
+    // receiver could not find 61937 sync. status[47:46]. docs/hdmi_bitstream.md §3.
+    "P1O[47:46],HDMI BS Variant,LSB+code,MSB+code,LSB+zero,MSB+zero;",
     // Film 24p/25p Out: emit a progressive-film raster (one film frame per refresh, no
     // in-core 3:2) and let the framework scaler (ascal) do the pulldown to the HDMI
     // output — NTSC 23.976 Hz (2:5 -> 59.94) / PAL 25.000 Hz (1:2 -> 50). Fixes the
@@ -2895,6 +2900,7 @@ iec61937_wrap #(.FIFO_AW(8)) iec61937_wrap_inst (
     .bs_r_o       (),
     .bs_nonpcm_o  (),
     .bs_stb_o     (bs_stb_w),
+    .hdmi_variant (status[47:46]),
     .dbg_word     (),
     .dbg_word_stb ()
 );

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -721,6 +721,10 @@ parameter CONF_STR = {
     // Round 1 gave "decoder off": the chip HAD switched to IEC958-direct but the
     // receiver could not find 61937 sync. status[47:46]. docs/hdmi_bitstream.md §3.
     "P1O[48:46],HDMI BS Variant,PCM16,AES3 LSB,AES3 MSB,AES3 legacy,AES3 legacyM;",
+    // What a bitstream HOLD looks like once the stream is running. The hold is
+    // the pacing loop and is untouched; this is only its fill. Default PCM
+    // silence = shipped behaviour. See docs/iec61937.md. status[50:49].
+    "P1O[50:49],BS Hold Style,PCM silence,NonPCM hold,Pause burst;",
     // Film 24p/25p Out: emit a progressive-film raster (one film frame per refresh, no
     // in-core 3:2) and let the framework scaler (ascal) do the pulldown to the HDMI
     // output — NTSC 23.976 Hz (2:5 -> 59.94) / PAL 25.000 Hz (1:2 -> 50). Fixes the
@@ -2873,6 +2877,7 @@ iec61937_wrap #(.FIFO_AW(8)) iec61937_wrap_inst (
     .rst_sys_n    (aud_rst_n),
     .enable       (pass_mode),
     .byte_swap    (pass_bswap),
+    .hold_style   (status[50:49]),
     .mute_i       (css_scrambled),   // CSS source: drain frames, emit PCM silence
     .ring_byte    (aud_ring_byte),
     .ring_valid   (aud_ring_valid),

--- a/dvd/i2s_iec958.sv
+++ b/dvd/i2s_iec958.sv
@@ -47,6 +47,16 @@ module i2s_iec958 (
     input  wire [31:0] sub_w_i,    // timeslot order: [3:0] preamble code .. [31] parity
     input  wire        sub_load_i, // 1 clk pulse: sub_w_i is the new subframe
 
+    // ⚠ HW A/B for the two things the Programming Guide would have told us.
+    // [0] bit order : 0 = LSB/timeslot first (IEC 60958 on the wire), 1 = MSB first
+    //                 (what plain I2S does, which the chip may expect instead)
+    // [1] preamble  : 0 = one-hot code in [3:0], 1 = zeroed, letting the chip
+    //                 derive framing from ws + its own 192-frame counter
+    // HW round 1 got "decoder off" from the receiver: the chip HAD switched to
+    // IEC958-direct (it stopped reporting PCM) but could not find 61937 sync, so
+    // one of these two is wrong. Four combinations, one build.
+    input  wire [1:0]  variant_i,
+
     // Serial output to the ADV7513
     output reg         sck_o,      // 3.072 MHz bit clock
     output reg         ws_o,       // 48 kHz word select: 0 = channel A, 1 = B
@@ -78,7 +88,7 @@ module i2s_iec958 (
                 // Re-arm on the producer's boundary. This is what keeps the two
                 // serializers frame-aligned across a reset re-phase instead of
                 // free-running into a slip.
-                shift_q <= sub_w_i;
+                shift_q <= variant_i[1] ? {sub_w_i[31:4], 4'd0} : sub_w_i;
                 bit_cnt <= 6'd0;
                 msck    <= 1'b0;
                 // spdif_pass loads channel A on even subframe counts; its
@@ -90,10 +100,11 @@ module i2s_iec958 (
                 // Advance on the rising half so the bit is presented for a full
                 // sck period.
                 if (msck) begin
-                    shift_q <= {1'b0, shift_q[31:1]};
+                    shift_q <= variant_i[0] ? {shift_q[30:0], 1'b0}   // MSB first
+                                            : {1'b0, shift_q[31:1]};  // LSB first
                     bit_cnt <= bit_cnt + 6'd1;
                 end else begin
-                    sd_o <= shift_q[0];     // LSB first = timeslot order
+                    sd_o <= variant_i[0] ? shift_q[31] : shift_q[0];
                 end
             end
         end

--- a/dvd/i2s_iec958.sv
+++ b/dvd/i2s_iec958.sv
@@ -55,13 +55,43 @@ module i2s_iec958 (
     //                 slots zeroed - Programming Guide §4.4.1.1), 1 = the old
     //                 pre-document guess (parity in [31], one-hot preamble code),
     //                 kept only so the fix can be A/B'd against what failed.
-    input  wire [1:0]  variant_i,
+    // [2] transport: 0 = AES3-direct 32-bit subframes (this module's own
+    //                serializer), 1 = PLAIN 16-BIT STANDARD I2S carrying the raw
+    //                61937 words, with the ADV7513 supplying channel status from
+    //                its I2C registers (0x0C[6]=1, non-PCM in 0x12[7]). That
+    //                route needs none of the subframe machinery and reuses the
+    //                framework's proven serializer - see docs/hdmi_bitstream.md.
+    input  wire [2:0]  variant_i,
+    input  wire [15:0] pcm_l_i,     // raw 61937 words for the 16-bit route
+    input  wire [15:0] pcm_r_i,
 
     // Serial output to the ADV7513
-    output reg         sck_o,      // 3.072 MHz bit clock
-    output reg         ws_o,       // 48 kHz word select: 0 = channel A, 1 = B
-    output reg         sd_o        // serial data, LSB (timeslot 0) first
+    output wire        sck_o,      // bit clock
+    output wire        ws_o,       // 48 kHz word select: 0 = channel A, 1 = B
+    output wire        sd_o        // serial data
 );
+
+    // ---- route (i): plain 16-bit standard I2S -------------------------------
+    // sys/i2s.v is the framework's own serializer, already carrying PCM to this
+    // exact chip every day, so it is the least risky way to present the words.
+    // It needs ce = 2 x BCLK = 64 x Fs = 3.072 MHz; bit_ce here is 6.144 MHz.
+    reg  ce_div;
+    always @(posedge clk or negedge rst_n)
+        if (!rst_n)   ce_div <= 1'b0;
+        else if (ce_i) ce_div <= ~ce_div;
+    wire ce16 = ce_i & ce_div;
+
+    wire pcm_sck, pcm_ws, pcm_sd;
+    i2s u_pcm16 (
+        .reset(~rst_n), .clk(clk), .ce(ce16),
+        .sclk(pcm_sck), .lrclk(pcm_ws), .sdata(pcm_sd),
+        .left_chan(pcm_l_i), .right_chan(pcm_r_i)
+    );
+
+    reg  aes_sck, aes_ws, aes_sd;
+    assign sck_o = variant_i[2] ? pcm_sck : aes_sck;
+    assign ws_o  = variant_i[2] ? pcm_ws  : aes_ws;
+    assign sd_o  = variant_i[2] ? pcm_sd  : aes_sd;
 
     // Shift register and bit counter. spdif_pass emits one subframe per 64 of
     // its bit strobes; we emit one per 32 sck = 64 ce, so the two stay in
@@ -75,14 +105,14 @@ module i2s_iec958 (
             shift_q <= 32'd0;
             bit_cnt <= 6'd0;
             msck    <= 1'b0;
-            sck_o   <= 1'b0;
-            ws_o    <= 1'b0;
-            sd_o    <= 1'b0;
+            aes_sck <= 1'b0;
+            aes_ws  <= 1'b0;
+            aes_sd  <= 1'b0;
         end else begin
             // sck follows msck one clk later, so sd_o changes on the FALLING
             // sck edge and the receiver samples it on the rising edge - the
             // same convention sys/i2s.v uses.
-            sck_o <= msck;
+            aes_sck <= msck;
 
             if (sub_load_i) begin
                 // Re-arm on the producer's boundary. This is what keeps the two
@@ -101,7 +131,7 @@ module i2s_iec958 (
                 // longer identifies the channel - deriving ws from it left ws
                 // stuck at 0 (no word select at all), which is a silent and
                 // total failure.
-                ws_o    <= sub_chb_i;
+                aes_ws  <= sub_chb_i;
             end else if (ce_i) begin
                 msck <= ~msck;
                 // Advance on the rising half so the bit is presented for a full
@@ -111,7 +141,7 @@ module i2s_iec958 (
                                             : {1'b0, shift_q[31:1]};  // LSB first
                     bit_cnt <= bit_cnt + 6'd1;
                 end else begin
-                    sd_o <= variant_i[0] ? shift_q[31] : shift_q[0];
+                    aes_sd <= variant_i[0] ? shift_q[31] : shift_q[0];
                 end
             end
         end

--- a/dvd/i2s_iec958.sv
+++ b/dvd/i2s_iec958.sv
@@ -55,12 +55,15 @@ module i2s_iec958 (
     //                 slots zeroed - Programming Guide §4.4.1.1), 1 = the old
     //                 pre-document guess (parity in [31], one-hot preamble code),
     //                 kept only so the fix can be A/B'd against what failed.
-    // [2] transport: 0 = AES3-direct 32-bit subframes (this module's own
-    //                serializer), 1 = PLAIN 16-BIT STANDARD I2S carrying the raw
-    //                61937 words, with the ADV7513 supplying channel status from
-    //                its I2C registers (0x0C[6]=1, non-PCM in 0x12[7]). That
-    //                route needs none of the subframe machinery and reuses the
-    //                framework's proven serializer - see docs/hdmi_bitstream.md.
+    // 0 = PCM16   plain 16-bit standard I2S carrying the raw 61937 words, with
+    //             the ADV7513 supplying channel status from its I2C registers
+    //             (0x0C[6]=1, non-PCM in 0x12[7]). ★ HW-CONFIRMED 2026-08-31 -
+    //             DD and DTS both decode on a real receiver. This is variant 0
+    //             so it is what a default build does.
+    // 1 = AES3 LSB+blkstart, 2 = AES3 MSB+blkstart  (documented AES3 format)
+    // 3 = AES3 legacy LSB,   4 = AES3 legacy MSB    (the pre-document guess)
+    // The AES3 transport never worked on hardware over four rounds; it is kept
+    // selectable rather than deleted so the finding stays reproducible.
     input  wire [2:0]  variant_i,
     input  wire [15:0] pcm_l_i,     // raw 61937 words for the 16-bit route
     input  wire [15:0] pcm_r_i,
@@ -88,10 +91,14 @@ module i2s_iec958 (
         .left_chan(pcm_l_i), .right_chan(pcm_r_i)
     );
 
+    wire pcm16_sel = (variant_i == 3'd0);
+    wire aes_msb    = (variant_i == 3'd2) || (variant_i == 3'd4);
+    wire aes_legacy = (variant_i == 3'd3) || (variant_i == 3'd4);
+
     reg  aes_sck, aes_ws, aes_sd;
-    assign sck_o = variant_i[2] ? pcm_sck : aes_sck;
-    assign ws_o  = variant_i[2] ? pcm_ws  : aes_ws;
-    assign sd_o  = variant_i[2] ? pcm_sd  : aes_sd;
+    assign sck_o = pcm16_sel ? pcm_sck : aes_sck;
+    assign ws_o  = pcm16_sel ? pcm_ws  : aes_ws;
+    assign sd_o  = pcm16_sel ? pcm_sd  : aes_sd;
 
     // Shift register and bit counter. spdif_pass emits one subframe per 64 of
     // its bit strobes; we emit one per 32 sck = 64 ce, so the two stay in
@@ -121,7 +128,7 @@ module i2s_iec958 (
                 // sub_w_i already carries the documented format. The legacy
                 // option reconstructs the pre-document guess for comparison:
                 // even parity over 4..31 back into [31], one-hot code into [3:0].
-                shift_q <= variant_i[1]
+                shift_q <= aes_legacy
                          ? {^sub_w_i[30:4], sub_w_i[30:4], 4'b0100}
                          : sub_w_i;
                 bit_cnt <= 6'd0;
@@ -137,11 +144,11 @@ module i2s_iec958 (
                 // Advance on the rising half so the bit is presented for a full
                 // sck period.
                 if (msck) begin
-                    shift_q <= variant_i[0] ? {shift_q[30:0], 1'b0}   // MSB first
-                                            : {1'b0, shift_q[31:1]};  // LSB first
+                    shift_q <= aes_msb ? {shift_q[30:0], 1'b0}   // MSB first
+                                       : {1'b0, shift_q[31:1]};  // LSB first
                     bit_cnt <= bit_cnt + 6'd1;
                 end else begin
-                    aes_sd <= variant_i[0] ? shift_q[31] : shift_q[0];
+                    aes_sd <= aes_msb ? shift_q[31] : shift_q[0];
                 end
             end
         end

--- a/dvd/i2s_iec958.sv
+++ b/dvd/i2s_iec958.sv
@@ -46,15 +46,15 @@ module i2s_iec958 (
     // Parallel subframe source (dvd/spdif_pass.sv exports)
     input  wire [31:0] sub_w_i,    // timeslot order: [3:0] preamble code .. [31] parity
     input  wire        sub_load_i, // 1 clk pulse: sub_w_i is the new subframe
+    input  wire        sub_chb_i,  // 0 = channel A (left), 1 = channel B
 
     // ⚠ HW A/B for the two things the Programming Guide would have told us.
     // [0] bit order : 0 = LSB/timeslot first (IEC 60958 on the wire), 1 = MSB first
     //                 (what plain I2S does, which the chip may expect instead)
-    // [1] preamble  : 0 = one-hot code in [3:0], 1 = zeroed, letting the chip
-    //                 derive framing from ws + its own 192-frame counter
-    // HW round 1 got "decoder off" from the receiver: the chip HAD switched to
-    // IEC958-direct (it stopped reporting PCM) but could not find 61937 sync, so
-    // one of these two is wrong. Four combinations, one build.
+    // [1] legacy    : 0 = documented format (block-start flag in [31], preamble
+    //                 slots zeroed - Programming Guide §4.4.1.1), 1 = the old
+    //                 pre-document guess (parity in [31], one-hot preamble code),
+    //                 kept only so the fix can be A/B'd against what failed.
     input  wire [1:0]  variant_i,
 
     // Serial output to the ADV7513
@@ -88,13 +88,20 @@ module i2s_iec958 (
                 // Re-arm on the producer's boundary. This is what keeps the two
                 // serializers frame-aligned across a reset re-phase instead of
                 // free-running into a slip.
-                shift_q <= variant_i[1] ? {sub_w_i[31:4], 4'd0} : sub_w_i;
+                // sub_w_i already carries the documented format. The legacy
+                // option reconstructs the pre-document guess for comparison:
+                // even parity over 4..31 back into [31], one-hot code into [3:0].
+                shift_q <= variant_i[1]
+                         ? {^sub_w_i[30:4], sub_w_i[30:4], 4'b0100}
+                         : sub_w_i;
                 bit_cnt <= 6'd0;
                 msck    <= 1'b0;
-                // spdif_pass loads channel A on even subframe counts; its
-                // preamble code distinguishes them, and ws follows the same
-                // parity so the ADV7513 sees a conventional word select.
-                ws_o    <= (sub_w_i[3:0] == 4'b0010);   // Y(W) = channel B
+                // ⚠ ws MUST come from spdif_pass, not from the word. The
+                // documented AES3-direct format has no preamble, so the word no
+                // longer identifies the channel - deriving ws from it left ws
+                // stuck at 0 (no word select at all), which is a silent and
+                // total failure.
+                ws_o    <= sub_chb_i;
             end else if (ce_i) begin
                 msck <= ~msck;
                 // Advance on the rising half so the bit is presented for a full

--- a/dvd/i2s_iec958.sv
+++ b/dvd/i2s_iec958.sv
@@ -1,0 +1,102 @@
+// -----------------------------------------------------------------
+// dvd/i2s_iec958.sv  —  IEC 60958 subframes over the ADV7513's I2S input
+// -----------------------------------------------------------------
+// Clocks the parallel IEC 60958 subframes produced by dvd/spdif_pass.sv onto a
+// serial data line in the ADV7513's "IEC958 direct" I2S format (register
+// 0x0C[1:0] = 3), so the SAME IEC 61937 data-burst that leaves over optical
+// S/PDIF also leaves over HDMI and an AV receiver decodes DD/DTS 5.1 with no
+// Digital I/O board. See docs/hdmi_bitstream.md.
+//
+// WHY THIS FORMAT rather than plain 16-bit I2S plus an I2C "non-PCM" register:
+// in IEC958-direct the channel status travels INSIDE the subframe, so the
+// non-PCM bit stays DYNAMIC exactly as it is on S/PDIF. That is the fj#110
+// ROUND 2 behaviour (receivers could not acquire across non-PCM null bursts, so
+// holds present real linear-PCM silence and there is one clean PCM->non-PCM
+// switch when the burst starts). Pinning the flag high for a whole session -
+// which is all an I2C channel-status register can do - would put us back in the
+// regime that fix exists to avoid. The mainline Linux ADV7511 driver reaches for
+// this same mode for IEC958 subframe data.
+//
+// FORMAT (per IEC 60958):
+//   64 bits per frame = two 32-bit subframes, channel A (left) then channel B.
+//   Bits leave in TIMESLOT order, i.e. LSB (timeslot 0) FIRST - the opposite of
+//   sys/i2s.v, which is MSB-first PCM. Getting this backwards is silent garbage,
+//   so bench/dvd/i2s_iec958_tb.sv demodulates the wire rather than trusting it.
+//
+// CLOCKING (clk_audio = 24.576 MHz = 512 x 48 kHz):
+//   ce_i     6.144 MHz (1-in-4)  — same strobe spdif_pass runs on
+//   sck_o    3.072 MHz = 64 x Fs — one ce toggles it, so 2 ce per bit
+//   ws_o     48.000 kHz          — 64 bits per frame = 512 clk_audio
+// The frame period is therefore EXACTLY the framework's I2S frame period, which
+// is what lets sys_top swap the two sources on a pin without a rate change.
+// MCLK is untouched (clk_audio = 512.Fs either way).
+//
+// ⚠ The data line is only ever muxed onto the pin while the HPS has put the
+// ADV7513 into IEC958-direct mode (the cfg[14] ack). A sink told to expect PCM
+// would render this as full-scale noise.
+// -----------------------------------------------------------------
+
+`timescale 1ns/1ps
+
+module i2s_iec958 (
+    input  wire        clk,        // clk_audio, 24.576 MHz
+    input  wire        rst_n,      // async, active-low
+    input  wire        ce_i,       // 6.144 MHz enable (2 per sck period)
+
+    // Parallel subframe source (dvd/spdif_pass.sv exports)
+    input  wire [31:0] sub_w_i,    // timeslot order: [3:0] preamble code .. [31] parity
+    input  wire        sub_load_i, // 1 clk pulse: sub_w_i is the new subframe
+
+    // Serial output to the ADV7513
+    output reg         sck_o,      // 3.072 MHz bit clock
+    output reg         ws_o,       // 48 kHz word select: 0 = channel A, 1 = B
+    output reg         sd_o        // serial data, LSB (timeslot 0) first
+);
+
+    // Shift register and bit counter. spdif_pass emits one subframe per 64 of
+    // its bit strobes; we emit one per 32 sck = 64 ce, so the two stay in
+    // lockstep off the same load pulse with no handshake.
+    reg [31:0] shift_q;
+    reg [5:0]  bit_cnt;   // 0..31 within the subframe
+    reg        msck;
+
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            shift_q <= 32'd0;
+            bit_cnt <= 6'd0;
+            msck    <= 1'b0;
+            sck_o   <= 1'b0;
+            ws_o    <= 1'b0;
+            sd_o    <= 1'b0;
+        end else begin
+            // sck follows msck one clk later, so sd_o changes on the FALLING
+            // sck edge and the receiver samples it on the rising edge - the
+            // same convention sys/i2s.v uses.
+            sck_o <= msck;
+
+            if (sub_load_i) begin
+                // Re-arm on the producer's boundary. This is what keeps the two
+                // serializers frame-aligned across a reset re-phase instead of
+                // free-running into a slip.
+                shift_q <= sub_w_i;
+                bit_cnt <= 6'd0;
+                msck    <= 1'b0;
+                // spdif_pass loads channel A on even subframe counts; its
+                // preamble code distinguishes them, and ws follows the same
+                // parity so the ADV7513 sees a conventional word select.
+                ws_o    <= (sub_w_i[3:0] == 4'b0010);   // Y(W) = channel B
+            end else if (ce_i) begin
+                msck <= ~msck;
+                // Advance on the rising half so the bit is presented for a full
+                // sck period.
+                if (msck) begin
+                    shift_q <= {1'b0, shift_q[31:1]};
+                    bit_cnt <= bit_cnt + 6'd1;
+                end else begin
+                    sd_o <= shift_q[0];     // LSB first = timeslot order
+                end
+            end
+        end
+    end
+
+endmodule

--- a/dvd/iec61937_wrap.sv
+++ b/dvd/iec61937_wrap.sv
@@ -399,7 +399,7 @@ module iec61937_wrap #(
     assign bs_stb_o    = sample_req;
 
     wire [31:0] sub_w;
-    wire        sub_load;
+    wire        sub_load, sub_chb;
 
     spdif_pass u_spdif (
         .clk_i       (clk_audio),
@@ -410,7 +410,8 @@ module iec61937_wrap #(
         .sample_i    (cur_pair[31:0]),
         .sample_req_o(sample_req),
         .sub_w_o     (sub_w),
-        .sub_load_o  (sub_load)
+        .sub_load_o  (sub_load),
+        .sub_chb_o   (sub_chb)
     );
 
     // HDMI leg: the same subframes, serialized for the ADV7513 instead of
@@ -422,6 +423,7 @@ module iec61937_wrap #(
         .ce_i      (bit_ce),
         .sub_w_i   (sub_w),
         .sub_load_i(sub_load),
+        .sub_chb_i (sub_chb),
         .variant_i (hdmi_variant),
         .sck_o     (hdmi_sck_o),
         .ws_o      (hdmi_ws_o),

--- a/dvd/iec61937_wrap.sv
+++ b/dvd/iec61937_wrap.sv
@@ -41,6 +41,21 @@ module iec61937_wrap #(
     input  wire        rst_sys_n,
     input  wire        enable,        // passthrough active (else producer idles)
     input  wire        byte_swap,     // 0: first byte in word[15:8]; 1: swapped
+    // How to fill a HOLD once the bitstream is already running. The hold itself
+    // is the pacing loop and must not be touched (see docs/iec61937.md "one-shot
+    // hold gate"); this only changes what the gap LOOKS like to the receiver:
+    //   0 PCM silence  all-zero words, non-PCM bit CLEARED (shipped behaviour).
+    //                  The receiver re-negotiates PCM<->DD on every hold, which
+    //                  is the startup/track-change flapping.
+    //   1 NonPCM hold  same zero words but the non-PCM bit stays SET, so the
+    //                  format never changes - only the data pauses.
+    //   2 Pause burst  a real IEC 61937 PAUSE burst (Pa/Pb/Pc=3): what the
+    //                  standard defines for exactly this, and what a real player
+    //                  emits between bursts.
+    // 1 and 2 apply ONLY after the first real burst since a flush, so pre-content
+    // behaviour is unchanged and the fj#110 round-1 finding (a receiver cannot
+    // ACQUIRE across non-PCM-with-no-data) is not re-litigated.
+    input  wire [1:0]  hold_style,
     input  wire        mute_i,        // CSS-scrambled source: consume frames but
                                       // emit PCM silence (scrambled AC-3/DTS sent
                                       // raw = loud noise bursts on the receiver)
@@ -113,6 +128,7 @@ module iec61937_wrap #(
     localparam [15:0] PB = 16'h4E1F;
     localparam [15:0] PC_AC3 = 16'h0001; // burst-info data type 1
     localparam [15:0] PC_DTS = 16'h000B; // burst-info data type 11 (DTS I/II/III)
+    localparam [15:0] PC_PAUSE = 16'h0003; // data type 3 = PAUSE (see hold_style)
 
     localparam [15:0] PERIOD_AC3 = 16'd1536; // samples (6144 bytes)
     localparam [15:0] PERIOD_DTS = 16'd512;  // samples (2048 bytes, core DTS)
@@ -226,6 +242,12 @@ module iec61937_wrap #(
     wire sync_en = sync_armed && stc_anchored;
     wire signed [34:0] head_delta =
         $signed({2'b0, stc}) - $signed({2'b0, frame_pts}) - 35'($signed(av_ofs));
+    // Set by the first real burst since a flush; cleared by rst_sys_n (= aud_rst_n,
+    // which pulses on seeks, track switches and aud_flush). Used ONLY to choose the
+    // hold FILL above - it must never gate hold_frame itself, which is the pacing
+    // loop (docs/iec61937.md "one-shot hold gate" records what that cost).
+    reg burst_seen;
+
     wire hold_frame = is_codec &&
         ( (sync_armed && !stc_anchored)                              // wait for the anchor
        || (sync_en && frame_pts_valid && (head_delta < 35'sd0)) );   // anchored but not yet due
@@ -256,6 +278,7 @@ module iec61937_wrap #(
             wr_en       <= 1'b0;
             burst_silent<= 1'b1;
             cur_nonpcm  <= 1'b0;
+            burst_seen  <= 1'b0;
             frame_pop_r <= 1'b0;
             dbg_word    <= 16'd0;
             dbg_word_stb<= 1'b0;
@@ -284,6 +307,7 @@ module iec61937_wrap #(
                         words_total <= {period_sel, 1'b0};
                         burst_silent<= 1'b0;   // real data-burst
                         cur_nonpcm  <= 1'b1;   // -> set the channel-status non-PCM bit
+                        burst_seen  <= 1'b1;   // hold-fill selection only
                         frame_pop_r <= 1'b1;
                         st <= S_PA;
                     end else if (frame_valid && is_codec && mute_i) begin
@@ -315,18 +339,29 @@ module iec61937_wrap #(
                         st <= S_PA;
                     end else begin
                         // No frame ready, OR a codec frame HELD (pre-anchor / not due).
-                        // Emit LINEAR-PCM SILENCE (all-zero words, non-PCM bit cleared)
-                        // rather than a Pc=0 non-PCM null burst: a real player presents
-                        // PCM before the bitstream starts, and HW showed the receiver
-                        // fails to acquire across non-PCM null bursts (it re-locks fine
-                        // on the single clean PCM->DD/DTS switch). Period-matched so the
-                        // producer re-checks S_IDLE on the codec's burst cadence.
+                        // BEFORE the first real burst this is LINEAR-PCM SILENCE, which
+                        // is the fj#110 round-2 fix: a real player presents PCM before
+                        // the bitstream starts, and HW showed the receiver cannot
+                        // ACQUIRE across non-PCM null bursts. AFTER the stream is
+                        // running the problem is the opposite one - dropping back to PCM
+                        // makes the receiver re-negotiate the format on every hold - so
+                        // hold_style can keep the format steady instead.
                         bytes_left  <= 16'd0;
-                        pc_val      <= 16'd0;
                         pd_bits     <= 16'd0;
                         words_total <= {null_period, 1'b0};
-                        burst_silent<= 1'b1;
-                        cur_nonpcm  <= 1'b0;
+                        if (burst_seen && hold_style == 2'd2) begin
+                            pc_val      <= PC_PAUSE;   // real 61937 pause burst
+                            burst_silent<= 1'b0;       // ... so Pa/Pb ARE emitted
+                            cur_nonpcm  <= 1'b1;
+                        end else if (burst_seen && hold_style == 2'd1) begin
+                            pc_val      <= 16'd0;
+                            burst_silent<= 1'b1;       // zero words, format unchanged
+                            cur_nonpcm  <= 1'b1;
+                        end else begin
+                            pc_val      <= 16'd0;
+                            burst_silent<= 1'b1;
+                            cur_nonpcm  <= 1'b0;       // PCM silence (shipped default)
+                        end
                         st <= S_PA;
                     end
                 end

--- a/dvd/iec61937_wrap.sv
+++ b/dvd/iec61937_wrap.sv
@@ -99,6 +99,7 @@ module iec61937_wrap #(
     output wire        hdmi_sck_o,
     output wire        hdmi_ws_o,
     output wire        hdmi_sd_o,
+    input  wire [1:0]  hdmi_variant,   // HW A/B, see dvd/i2s_iec958.sv
 
     // ---- debug taps (producer word stream, clk_sys) ----
     output reg  [15:0] dbg_word,      // word committed this cycle
@@ -421,6 +422,7 @@ module iec61937_wrap #(
         .ce_i      (bit_ce),
         .sub_w_i   (sub_w),
         .sub_load_i(sub_load),
+        .variant_i (hdmi_variant),
         .sck_o     (hdmi_sck_o),
         .ws_o      (hdmi_ws_o),
         .sd_o      (hdmi_sd_o)

--- a/dvd/iec61937_wrap.sv
+++ b/dvd/iec61937_wrap.sv
@@ -99,7 +99,7 @@ module iec61937_wrap #(
     output wire        hdmi_sck_o,
     output wire        hdmi_ws_o,
     output wire        hdmi_sd_o,
-    input  wire [1:0]  hdmi_variant,   // HW A/B, see dvd/i2s_iec958.sv
+    input  wire [2:0]  hdmi_variant,   // HW A/B, see dvd/i2s_iec958.sv
 
     // ---- debug taps (producer word stream, clk_sys) ----
     output reg  [15:0] dbg_word,      // word committed this cycle
@@ -425,6 +425,8 @@ module iec61937_wrap #(
         .sub_load_i(sub_load),
         .sub_chb_i (sub_chb),
         .variant_i (hdmi_variant),
+        .pcm_l_i   (cur_pair[15:0]),
+        .pcm_r_i   (cur_pair[31:16]),
         .sck_o     (hdmi_sck_o),
         .ws_o      (hdmi_ws_o),
         .sd_o      (hdmi_sd_o)

--- a/dvd/iec61937_wrap.sv
+++ b/dvd/iec61937_wrap.sv
@@ -226,7 +226,23 @@ module iec61937_wrap #(
     wire sync_en = sync_armed && stc_anchored;
     wire signed [34:0] head_delta =
         $signed({2'b0, stc}) - $signed({2'b0, frame_pts}) - 35'($signed(av_ofs));
-    wire hold_frame = is_codec &&
+    // ★ ONE-SHOT GATE (2026-08-31). The hold's job is to align the START of audio
+    // to the video timeline; once the bitstream is running, re-entering it just
+    // punches a silence gap into a stream the receiver has already acquired -
+    // and a real->silence->real flap is exactly what fj#110 identified as what
+    // breaks acquisition. Symptom without this: at every title start the
+    // receiver flaps between the codec and "decoder off", and on optical - where
+    // the transition ALSO flips the channel-status non-PCM bit and so forces a
+    // full format re-negotiation - it may never settle until a chapter skip.
+    //
+    // The gate therefore applies only until the first real burst since the last
+    // flush. `burst_seen` is cleared by rst_sys_n = aud_rst_n, which pulses on
+    // seeks, audio-track switches and aud_flush: exactly the discontinuities
+    // where a fresh hold IS wanted. Ongoing drift is not this gate's job - the
+    // drop/catch-up path handles that.
+    reg burst_seen;
+
+    wire hold_frame = is_codec && !burst_seen &&
         ( (sync_armed && !stc_anchored)                              // wait for the anchor
        || (sync_en && frame_pts_valid && (head_delta < 35'sd0)) );   // anchored but not yet due
 
@@ -256,6 +272,7 @@ module iec61937_wrap #(
             wr_en       <= 1'b0;
             burst_silent<= 1'b1;
             cur_nonpcm  <= 1'b0;
+            burst_seen  <= 1'b0;
             frame_pop_r <= 1'b0;
             dbg_word    <= 16'd0;
             dbg_word_stb<= 1'b0;
@@ -284,6 +301,7 @@ module iec61937_wrap #(
                         words_total <= {period_sel, 1'b0};
                         burst_silent<= 1'b0;   // real data-burst
                         cur_nonpcm  <= 1'b1;   // -> set the channel-status non-PCM bit
+                        burst_seen  <= 1'b1;   // one-shot gate: see hold_frame
                         frame_pop_r <= 1'b1;
                         st <= S_PA;
                     end else if (frame_valid && is_codec && mute_i) begin

--- a/dvd/iec61937_wrap.sv
+++ b/dvd/iec61937_wrap.sv
@@ -74,6 +74,22 @@ module iec61937_wrap #(
     input  wire        rst_audio_n,
     output wire        spdif_o,
 
+    // ---- HDMI bitstream tap (clk_audio) ----
+    // Aliases of the already-CDC'd, already-paced `cur_pair`, exported so the
+    // SAME burst can also leave over HDMI (the ADV7513's I2S input) without a
+    // second formatter. cur_pair is HELD for a whole 48 kHz frame, so a consumer
+    // anywhere on this clock samples it exactly once — see docs/hdmi_bitstream.md
+    // "Pacing". NOT a second FIFO reader: the FIFO has one read pointer and two
+    // independent readers would diverge.
+    //
+    // Mute (`mute_i`), A/V-sync holds and PCM-silence are all applied BEFORE the
+    // FIFO, so this tap already carries them and needs no gating of its own.
+    output wire [15:0] bs_l_o,       // = cur_pair[15:0]  -> IEC 60958 channel A / I2S left
+    output wire [15:0] bs_r_o,       // = cur_pair[31:16] -> channel B / I2S right
+    output wire        bs_nonpcm_o,  // = cur_pair[32]    -> 1 = 61937 data burst
+    output wire        bs_stb_o,     // 48 kHz pair strobe (slip instrument; not needed
+                                     // for correctness — see "Pacing")
+
     // ---- debug taps (producer word stream, clk_sys) ----
     output reg  [15:0] dbg_word,      // word committed this cycle
     output reg         dbg_word_stb
@@ -362,6 +378,14 @@ module iec61937_wrap #(
     always @(posedge clk_audio or negedge rst_audio_n)
         if (!rst_audio_n) cur_pair <= 33'd0;       // underflow -> PCM zeros (flag 0)
         else if (sample_req) cur_pair <= fifo_empty ? 33'd0 : fifo_rd_data;
+
+    // HDMI bitstream tap: pure aliases, no added logic. `sample_req` is the same
+    // strobe that reloads cur_pair, so bs_stb_o marks the frame boundary of the
+    // pair the consumer is about to see.
+    assign bs_l_o      = cur_pair[15:0];
+    assign bs_r_o      = cur_pair[31:16];
+    assign bs_nonpcm_o = cur_pair[32];
+    assign bs_stb_o    = sample_req;
 
     spdif_pass u_spdif (
         .clk_i       (clk_audio),

--- a/dvd/iec61937_wrap.sv
+++ b/dvd/iec61937_wrap.sv
@@ -226,23 +226,7 @@ module iec61937_wrap #(
     wire sync_en = sync_armed && stc_anchored;
     wire signed [34:0] head_delta =
         $signed({2'b0, stc}) - $signed({2'b0, frame_pts}) - 35'($signed(av_ofs));
-    // ★ ONE-SHOT GATE (2026-08-31). The hold's job is to align the START of audio
-    // to the video timeline; once the bitstream is running, re-entering it just
-    // punches a silence gap into a stream the receiver has already acquired -
-    // and a real->silence->real flap is exactly what fj#110 identified as what
-    // breaks acquisition. Symptom without this: at every title start the
-    // receiver flaps between the codec and "decoder off", and on optical - where
-    // the transition ALSO flips the channel-status non-PCM bit and so forces a
-    // full format re-negotiation - it may never settle until a chapter skip.
-    //
-    // The gate therefore applies only until the first real burst since the last
-    // flush. `burst_seen` is cleared by rst_sys_n = aud_rst_n, which pulses on
-    // seeks, audio-track switches and aud_flush: exactly the discontinuities
-    // where a fresh hold IS wanted. Ongoing drift is not this gate's job - the
-    // drop/catch-up path handles that.
-    reg burst_seen;
-
-    wire hold_frame = is_codec && !burst_seen &&
+    wire hold_frame = is_codec &&
         ( (sync_armed && !stc_anchored)                              // wait for the anchor
        || (sync_en && frame_pts_valid && (head_delta < 35'sd0)) );   // anchored but not yet due
 
@@ -272,7 +256,6 @@ module iec61937_wrap #(
             wr_en       <= 1'b0;
             burst_silent<= 1'b1;
             cur_nonpcm  <= 1'b0;
-            burst_seen  <= 1'b0;
             frame_pop_r <= 1'b0;
             dbg_word    <= 16'd0;
             dbg_word_stb<= 1'b0;
@@ -301,7 +284,6 @@ module iec61937_wrap #(
                         words_total <= {period_sel, 1'b0};
                         burst_silent<= 1'b0;   // real data-burst
                         cur_nonpcm  <= 1'b1;   // -> set the channel-status non-PCM bit
-                        burst_seen  <= 1'b1;   // one-shot gate: see hold_frame
                         frame_pop_r <= 1'b1;
                         st <= S_PA;
                     end else if (frame_valid && is_codec && mute_i) begin

--- a/dvd/iec61937_wrap.sv
+++ b/dvd/iec61937_wrap.sv
@@ -90,6 +90,16 @@ module iec61937_wrap #(
     output wire        bs_stb_o,     // 48 kHz pair strobe (slip instrument; not needed
                                      // for correctness — see "Pacing")
 
+    // ---- HDMI IEC958-direct serial output (clk_audio) ----
+    // The same burst, clocked out for the ADV7513's I2S input in IEC958-direct
+    // mode (reg 0x0C[1:0]=3). sys_top muxes these three onto HDMI_SCLK/LRCLK/I2S
+    // while the HPS ack is set; MCLK is unaffected. All three come from HERE
+    // rather than from the framework's serializer so the word select and bit
+    // clock are phase-consistent with the subframes by construction.
+    output wire        hdmi_sck_o,
+    output wire        hdmi_ws_o,
+    output wire        hdmi_sd_o,
+
     // ---- debug taps (producer word stream, clk_sys) ----
     output reg  [15:0] dbg_word,      // word committed this cycle
     output reg         dbg_word_stb
@@ -387,6 +397,9 @@ module iec61937_wrap #(
     assign bs_nonpcm_o = cur_pair[32];
     assign bs_stb_o    = sample_req;
 
+    wire [31:0] sub_w;
+    wire        sub_load;
+
     spdif_pass u_spdif (
         .clk_i       (clk_audio),
         .rst_i       (~rst_audio_n),
@@ -394,7 +407,23 @@ module iec61937_wrap #(
         .spdif_o     (spdif_o),
         .nonpcm_i    (cur_pair[32]),  // per-pair PCM/non-PCM flag (latched per block)
         .sample_i    (cur_pair[31:0]),
-        .sample_req_o(sample_req)
+        .sample_req_o(sample_req),
+        .sub_w_o     (sub_w),
+        .sub_load_o  (sub_load)
+    );
+
+    // HDMI leg: the same subframes, serialized for the ADV7513 instead of
+    // biphase-encoded. Driven off the SAME load pulse as the S/PDIF encoder, so
+    // the two outputs cannot drift apart — there is one subframe source.
+    i2s_iec958 u_hdmi_i2s (
+        .clk       (clk_audio),
+        .rst_n     (rst_audio_n),
+        .ce_i      (bit_ce),
+        .sub_w_i   (sub_w),
+        .sub_load_i(sub_load),
+        .sck_o     (hdmi_sck_o),
+        .ws_o      (hdmi_ws_o),
+        .sd_o      (hdmi_sd_o)
     );
 
 endmodule

--- a/dvd/spdif_pass.sv
+++ b/dvd/spdif_pass.sv
@@ -68,7 +68,24 @@ module spdif_pass
 
     // Audio interface (16-bit x 2 = RL)
     input [31:0]    sample_i,
-    output reg      sample_req_o
+    output reg      sample_req_o,
+
+    // ---- DVD-FORK: parallel IEC 60958 subframe export (HDMI path) ----------
+    // The SAME subframe this module is about to biphase-encode, handed out in
+    // parallel so dvd/i2s_iec958.sv can clock it into the ADV7513's I2S input in
+    // "IEC958 direct" mode (reg 0x0C[1:0]=3). Exporting rather than duplicating
+    // matters: the channel-status table below (esp. the non-PCM bit, the fj#110
+    // ROUND 2 fix) is HW-proven, and a second copy would drift from it.
+    //
+    // Purely additive - nothing above consumes these, so the biphase output is
+    // bit-identical whether or not they are used.
+    //
+    // sub_w_o is in IEC 60958 TIMESLOT order: [3:0] preamble code, [27:4] audio,
+    // [28] V, [29] U, [30] C, [31] P. Unlike the internal subframe_w, the parity
+    // and preamble fields are FILLED here - the biphase stage computes those as
+    // it emits, which is too late for a parallel consumer.
+    output [31:0]   sub_w_o,
+    output          sub_load_o
 );
 
 //-----------------------------------------------------------------
@@ -233,6 +250,41 @@ begin
         channel_status_bit_q <= channel_status_bit_r;
     end
 end
+
+//-----------------------------------------------------------------
+// DVD-FORK: parallel subframe export (see sub_w_o in the port list)
+//-----------------------------------------------------------------
+// Preamble CODE for the parallel interface. The 8-bit patterns above are
+// half-bit-time biphase cell patterns and cannot be sent over a plain serial
+// data line; a parallel/"direct" interface carries a code instead. Their upper
+// nibbles are already a clean one-hot (Z=0001, Y=0010, X=0100), so that is what
+// is exported.
+// ⚠ ASSUMPTION - the exact nibble the ADV7513 expects in IEC958-direct mode is
+// unconfirmed (the Programming Guide could not be obtained; the mainline Linux
+// driver selects the mode but never writes the field). If HW round 1 shows the
+// receiver locking to the wrong channel or never seeing block start, this table
+// is the first thing to change. See docs/hdmi_bitstream.md.
+// Built from the REGISTERED preamble_q / audio_sample_q (via subframe_w), so the
+// exported word is the coherent set for the subframe currently being emitted.
+// preamble_r and audio_sample_q are valid on OPPOSITE sides of the load edge -
+// preamble_r already describes the subframe about to start while audio_sample_q
+// still holds the previous one - so sub_load_o is delayed one cycle to land
+// where both are settled. A consumer latches sub_w_o on sub_load_o.
+wire [3:0] sub_pre_code = preamble_q[7:4];
+
+// Even parity over timeslots 4..31: choose [31] so that range holds an even
+// number of ones. The biphase stage derives the same value serially
+// (parity_count_q); subframe_w[31] is the zero placeholder, so this is just the
+// XOR of the rest.
+wire       sub_parity   = ^subframe_w[30:4];
+
+reg        sub_load_q;
+always @ (posedge rst_i or posedge clk_i)
+    if (rst_i) sub_load_q <= 1'b0;
+    else       sub_load_q <= load_subframe_q;
+
+assign sub_w_o    = {sub_parity, subframe_w[30:4], sub_pre_code};
+assign sub_load_o = sub_load_q;
 
 //-----------------------------------------------------------------
 // Parity Counter

--- a/dvd/spdif_pass.sv
+++ b/dvd/spdif_pass.sv
@@ -85,7 +85,12 @@ module spdif_pass
     // and preamble fields are FILLED here - the biphase stage computes those as
     // it emits, which is too late for a parallel consumer.
     output [31:0]   sub_w_o,
-    output          sub_load_o
+    output          sub_load_o,
+    // Channel of the subframe being emitted: 0 = A (left), 1 = B (right). Must
+    // come from here rather than be inferred from the exported word - the
+    // documented AES3-direct format has NO preamble, so the word itself no
+    // longer identifies the channel.
+    output          sub_chb_o
 );
 
 //-----------------------------------------------------------------
@@ -254,36 +259,36 @@ end
 //-----------------------------------------------------------------
 // DVD-FORK: parallel subframe export (see sub_w_o in the port list)
 //-----------------------------------------------------------------
-// Preamble CODE for the parallel interface. The 8-bit patterns above are
-// half-bit-time biphase cell patterns and cannot be sent over a plain serial
-// data line; a parallel/"direct" interface carries a code instead. Their upper
-// nibbles are already a clean one-hot (Z=0001, Y=0010, X=0100), so that is what
-// is exported.
-// ⚠ ASSUMPTION - the exact nibble the ADV7513 expects in IEC958-direct mode is
-// unconfirmed (the Programming Guide could not be obtained; the mainline Linux
-// driver selects the mode but never writes the field). If HW round 1 shows the
-// receiver locking to the wrong channel or never seeing block start, this table
-// is the first thing to change. See docs/hdmi_bitstream.md.
-// Built from the REGISTERED preamble_q / audio_sample_q (via subframe_w), so the
-// exported word is the coherent set for the subframe currently being emitted.
-// preamble_r and audio_sample_q are valid on OPPOSITE sides of the load edge -
-// preamble_r already describes the subframe about to start while audio_sample_q
-// still holds the previous one - so sub_load_o is delayed one cycle to land
-// where both are settled. A consumer latches sub_w_o on sub_load_o.
-wire [3:0] sub_pre_code = preamble_q[7:4];
+// ★ AES3-DIRECT FRAME FORMAT, from the ADV7511 Programming Guide §4.4.1.1
+// (obtained 2026-08-31, after HW rounds 1-3 were spent guessing at it):
+//
+//   "In the direct AES3 stream I2S format, the user can send an IEC60958
+//    sub-frame ... with the Preamble LEFT OUT ... Notice that the PARITY BIT IS
+//    REPLACED BY THE BLOCK START FLAG. The parity bit will be calculated
+//    automatically."
+//
+// So the exported word is the IEC 60958 subframe with two ends changed:
+//   [3:0]  preamble slots -> ZERO (left out; the chip re-generates preambles)
+//   [31]   parity         -> BLOCK START (1 on frame 0 of each 192-frame block)
+//
+// V/U/C keep their slots 28/29/30 - confirmed empirically before the document
+// arrived: the chip read our channel-status bit correctly (the receiver reported
+// non-PCM), which can only happen if C is where it expects it.
+//
+// The block-start flag is what was missing. Without it the chip can never find
+// the head of a channel-status block, so it cannot assemble the status the sink
+// needs - which is exactly why HW round 3 saw a stable non-PCM indication and
+// yet no 61937 lock, and why zeroing the preamble alone made it FLAP (block
+// start then landed wherever the old parity bit happened to be 1).
+wire sub_blk_start = (preamble_q == PREAMBLE_Z);   // Z(B) == frame 0 of the block
 
-// Even parity over timeslots 4..31: choose [31] so that range holds an even
-// number of ones. The biphase stage derives the same value serially
-// (parity_count_q); subframe_w[31] is the zero placeholder, so this is just the
-// XOR of the rest.
-wire       sub_parity   = ^subframe_w[30:4];
-
-reg        sub_load_q;
+reg  sub_load_q;
 always @ (posedge rst_i or posedge clk_i)
     if (rst_i) sub_load_q <= 1'b0;
     else       sub_load_q <= load_subframe_q;
 
-assign sub_w_o    = {sub_parity, subframe_w[30:4], sub_pre_code};
+assign sub_w_o    = {sub_blk_start, subframe_w[30:4], 4'b0000};
+assign sub_chb_o  = (preamble_q == PREAMBLE_Y);   // Y(W) = channel B
 assign sub_load_o = sub_load_q;
 
 //-----------------------------------------------------------------

--- a/main/build_main.sh
+++ b/main/build_main.sh
@@ -64,6 +64,7 @@ mkdir -p "$STOCK/support/dvd" "$STOCK/Scripts"
 cp "$HERE"/support/dvd/dvd_css.cpp  "$HERE"/support/dvd/dvd_css.h  "$STOCK/support/dvd/"
 cp "$HERE"/support/dvd/dvd_detect.cpp "$HERE"/support/dvd/dvd_detect.h "$STOCK/support/dvd/"
 cp "$HERE"/support/dvd/dvd_phys.cpp "$HERE"/support/dvd/dvd_phys.h "$STOCK/support/dvd/"
+cp "$HERE"/support/dvd/dvd_hdmi_audio.cpp "$HERE"/support/dvd/dvd_hdmi_audio.h "$STOCK/support/dvd/"
 cp "$HERE"/Scripts/install_dvdcss.sh "$STOCK/Scripts/"
 
 # 3. Patch user_io.cpp / user_io.h / Makefile.

--- a/main/integration/INTEGRATION.md
+++ b/main/integration/INTEGRATION.md
@@ -127,9 +127,61 @@ and in the two sd block-read branches, before the `else if (sd_image[disk].size)
 `buffer_lba[disk] = -1` on failure — see `dvd_phys`/fork history for the exact
 form; `build_main.sh` inserts both.)
 
+## HDMI IEC 61937 bitstream (steps 12-21)
+
+Lets `Audio Out = Passthru` reach an AV receiver over **HDMI** as well as optical
+S/PDIF. The core serializes IEC 60958 subframes into the ADV7513's I2S input, but
+only the HPS can put that chip into IEC958-direct mode over I2C — so the core
+refuses to emit a bitstream until Main sets the `cfg[14]` ack. **Stock Main never
+sets it**, which is what makes a stock-Main user safe: without the mode change the
+sink expects PCM, and a bitstream would arrive as full-scale noise.
+
+> ⚠ These are the overlay's **first edits to `video.cpp`, `video.h` and `cfg.*`**.
+> Everything before step 12 touches only `user_io.*` and the `Makefile`. On a
+> `MAIN_MISTER_REF` bump, re-verify these specifically.
+
+| Step | File | What |
+|---|---|---|
+| 12 | `user_io.cpp` | include `support/dvd/dvd_hdmi_audio.h` |
+| 13 | `user_io.cpp` | `dvd_hdmi_audio_tick()` on the step-7 poll site |
+| 14 | `user_io.cpp` | `CONF_DVD_HDMI_BS` into the `cfg[]` word sent to the core |
+| 15 | `user_io.cpp` | `dvd_hdmi_audio_declare()` off the `OX` arm in `parse_config()` |
+| 16 | `user_io.h` | `#define CONF_DVD_HDMI_BS 0b0100000000000000` (bit 14) |
+| 17 | `video.h` | export `hdmi_config_set_audio()` + `video_hdmi_config_generation()` |
+| 18 | `video.cpp` | `static int hdmi_cfg_generation` beside the other file statics |
+| 19 | `video.cpp` | bump that counter in `hdmi_config_init()` |
+| 20 | `video.cpp` | `hdmi_config_set_audio()` — the audio-only register writer |
+| 21 | `cfg.h` / `cfg.cpp` | `dvd_hdmi_bitstream` ini key (0=auto, 1=off, 2=force) |
+
+Three things here are easy to get subtly wrong:
+
+- **Step 19's anchor is the `for (uint i = 0; ...)` write-loop header, not
+  `hdmi_config_set_csc();`.** That second string appears again later in
+  `video.cpp`, and `insert_after` takes the FIRST match — it would apply today and
+  silently land in the wrong function after any stock reorder.
+- **Step 20 is a small audio-only writer on purpose.** Reusing
+  `hdmi_config_init()` would rewrite ~50 registers plus the CSC and blank the
+  picture on every Audio Out toggle. But that full init *does* revert the audio
+  block, so step 18/19's generation counter exists to notice and re-apply.
+- **Bit 14 is nearly the last free `cfg[]` bit.** Stock defines up to
+  `CONF_DIRECT_VIDEO2` (bit 13); only 14 and 15 remain. If a future stock version
+  claims 14, this step must move rather than collide silently.
+
+The core marks the option `OX6` rather than `O6`. `OX` means "also handled by the
+HPS": the bit still reaches the core exactly as before, but Main sees the
+declaration and learns this build *has* the HDMI path. A core without it never
+declares `OX6`, so Main never reconfigures the chip for a core that cannot drive
+it.
+
 ## MiSTer.ini (end user)
 
 ```
 [DVD]
 main=MiSTer_DVDcss
+
+; HDMI bitstream for Audio Out = Passthru.
+;   0 = auto  (default) engage only when the sink's EDID advertises AC-3/DTS
+;   1 = off   never engage; HDMI behaves as it did before
+;   2 = force engage regardless of EDID (sinks do mis-report, especially over ARC)
+dvd_hdmi_bitstream=0
 ```

--- a/main/integration/apply_integration.py
+++ b/main/integration/apply_integration.py
@@ -193,4 +193,137 @@ if ' -ldl ' not in mk and '-ldl' not in mk:
 else:
     print("[integration] Makefile: -ldl already present")
 
+# =============================================================================
+# HDMI IEC 61937 bitstream (steps 12-21). See INTEGRATION.md.
+# The overlay's FIRST edits to video.cpp / video.h / cfg.* — re-verify these
+# specifically on a MAIN_MISTER_REF bump.
+# =============================================================================
+
+# ---------------------------------------------------------------- user_io.cpp
+u = read(uio_path)
+
+# 12. include
+u = insert_after(u, '#include "support/dvd/dvd_phys.h"',
+    '#include "support/dvd/dvd_hdmi_audio.h"\n',
+    12, 'support/dvd/dvd_hdmi_audio.h')
+
+# 13. poll tick (reuses the step-7 tick site)
+u = insert_after(u, 'dvd_phys_tick();   // auto-mount / unmount the optical drive',
+    '\tdvd_hdmi_audio_tick();  // ADV7513 non-PCM mode + the cfg[14] ack\n',
+    13, 'dvd_hdmi_audio_tick();')
+
+# 14. the ack into the cfg[] word sent to the core
+u = insert_after(u, 'if (vga_fb) map |= CONF_VGA_FB;',
+    '\tif (dvd_hdmi_audio_ack()) map |= CONF_DVD_HDMI_BS;   // dvd:hdmibs\n',
+    14, '// dvd:hdmibs')
+
+# 15. capability declaration off the OX arm. The core marks Audio Out as OX6 so
+# Main learns the build HAS the HDMI tap; a core without it never declares, and
+# we never reconfigure the chip for a core that cannot drive it.
+u = insert_after(u, 'printf("found OX option: %s: %d\\n", p, x);',
+    '\t\t\t\tif (is_dvd() && p[2] == \'6\') dvd_hdmi_audio_declare();\n',
+    15, 'dvd_hdmi_audio_declare()')
+
+write(uio_path, u)
+print("[integration] user_io.cpp patched (hdmi bitstream)")
+
+# ---------------------------------------------------------------- user_io.h
+h = read(h_path)
+# 16. cfg[] bit 14. Stock defines up to CONF_DIRECT_VIDEO2 (bit 13); 14 and 15
+# are the only free bits, so this is the last cheap one - if a future stock
+# version claims it, this step must move rather than silently collide.
+h = insert_after(h, '#define CONF_DIRECT_VIDEO2      0b0010000000000000',
+    '#define CONF_DVD_HDMI_BS        0b0100000000000000\n',
+    16, 'CONF_DVD_HDMI_BS')
+write(h_path, h)
+print("[integration] user_io.h patched (hdmi bitstream)")
+
+# ---------------------------------------------------------------- video.h
+vh_path = os.path.join(ROOT, "video.h")
+vh = read(vh_path)
+# 17. exports
+vh = insert_after(vh, 'int   video_get_edid(uint8_t **buf, int *size);',
+    'void  hdmi_config_set_audio(int bitstream);   // dvd:hdmibs\n'
+    'int   video_hdmi_config_generation(void);\n',
+    17, 'hdmi_config_set_audio')
+write(vh_path, vh)
+print("[integration] video.h patched")
+
+# ---------------------------------------------------------------- video.cpp
+vc_path = os.path.join(ROOT, "video.cpp")
+vc = read(vc_path)
+
+# 18. generation counter storage, with the other file statics
+vc = insert_after(vc, 'static int edid_version = 0;',
+    'static int hdmi_cfg_generation = 0;   // dvd:hdmibs\n',
+    18, 'hdmi_cfg_generation')
+
+# 19. bump it whenever the full init rewrites the audio block. Anchored on the
+# write loop's header, NOT on "hdmi_config_set_csc();" - that string also occurs
+# later in the file and insert_after takes the FIRST match, which would land the
+# bump in the wrong function.
+vc = insert_before(vc, 'for (uint i = 0; i < sizeof(init_data); i += 2)',
+    'hdmi_cfg_generation++;   // dvd:hdmibs - audio block is about to revert to PCM\n',
+    19, 'hdmi_cfg_generation++')
+
+# 20. the audio-only register writer
+vc = insert_before(vc, 'static void hdmi_config_set_hdr()', r"""
+// dvd:hdmibs - switch the ADV7513's audio input between PCM I2S and IEC958
+// direct (IEC 61937 bitstream), writing ONLY the audio registers.
+//
+// Deliberately not a hdmi_config_init() call: that rewrites ~50 registers plus
+// the CSC and would blank the picture on every Audio Out toggle.
+//
+// IEC958-direct (0x0C[1:0]=3) is how the mainline Linux adv7511 driver carries
+// IEC958 subframe data, and it is the mode where channel status travels inside
+// the subframe - so the non-PCM flag stays dynamic exactly as it is on S/PDIF,
+// instead of being pinned high for the whole session.
+void hdmi_config_set_audio(int bitstream)
+{
+	if (hdmi_main_fd < 0) return;
+
+	uint8_t audio_data[] = {
+		0x0A, 0x00,                                  // [6:4] audio select = I2S
+		0x0C, (uint8_t)(bitstream ? 0x07 : 0x04),    // [2] I2S0 en; [1:0] 3=IEC958 direct, 0=standard
+		0x14, 0x02,                                  // audio word length = 16 bit
+		0x15, (uint8_t)((cfg.hdmi_audio_96k ? 0x80 : 0x00) | 0x20),   // sample rate
+		0x73, (uint8_t)(bitstream ? 0x00 : 0x01),    // InfoFrame CC: 0 = refer to stream header
+	};
+
+	for (uint i = 0; i < sizeof(audio_data); i += 2)
+	{
+		int res = i2c_smbus_write_byte_data(hdmi_main_fd, audio_data[i], audio_data[i + 1]);
+		if (res < 0) printf("i2c: audio write error (%02X %02X): %d\n",
+		                    audio_data[i], audio_data[i + 1], res);
+	}
+	printf("ADV7513: audio input set to %s\n", bitstream ? "IEC958 direct (bitstream)" : "PCM I2S");
+}
+
+int video_hdmi_config_generation(void)
+{
+	return hdmi_cfg_generation;
+}
+
+""", 20, 'hdmi_config_set_audio')
+
+write(vc_path, vc)
+print("[integration] video.cpp patched")
+
+# ---------------------------------------------------------------- cfg.h / cfg.cpp
+cfgh_path = os.path.join(ROOT, "cfg.h")
+ch = read(cfgh_path)
+# 21. ini field. 0 = auto (EDID-gated), 1 = off, 2 = force.
+ch = insert_after(ch, '\tuint8_t hdmi_audio_96k;',
+    '\tuint8_t dvd_hdmi_bitstream;   // dvd:hdmibs 0=auto 1=off 2=force\n',
+    21, 'dvd_hdmi_bitstream')
+write(cfgh_path, ch)
+
+cfgc_path = os.path.join(ROOT, "cfg.cpp")
+cc = read(cfgc_path)
+cc = insert_after(cc, '{ "HDMI_AUDIO_96K", (void*)(&(cfg.hdmi_audio_96k)), UINT8, 0, 1 },',
+    '\t{ "DVD_HDMI_BITSTREAM", (void*)(&(cfg.dvd_hdmi_bitstream)), UINT8, 0, 2 },\n',
+    21, 'DVD_HDMI_BITSTREAM')
+write(cfgc_path, cc)
+print("[integration] cfg.h/cfg.cpp patched")
+
 print("[integration] done")

--- a/main/integration/apply_integration.py
+++ b/main/integration/apply_integration.py
@@ -292,6 +292,15 @@ void hdmi_config_set_audio(int bitstream)
 	//          our zero padding instead of the payload.
 	//   bit 1  invert the I2S bit clock (0x0B[6]). Wrong latching edge shifts
 	//          every bit.
+	// dvd_hdmi_bs_mode: 0 = AES3-direct (32-bit IEC60958 subframes from fabric),
+	//                   1 = ROUTE (i): plain 16-bit standard I2S carrying the raw
+	//                       61937 words, with channel status supplied HERE.
+	// Route (i) needs none of the subframe machinery and reuses the framework's
+	// proven serializer; its cost is that the non-PCM flag is static for the
+	// session rather than per-block. Programming Guide Table 84 gives the bit:
+	// channel status bit 1 "audio sample word" = 0x12[7], and 0x0C[6]=1 selects
+	// the register map as the channel-status source.
+	int route_i = bitstream && (cfg.dvd_hdmi_bs_mode == 1);
 	int tweak = bitstream ? cfg.dvd_hdmi_bs_tweak : 0;
 	uint8_t wordlen  = (tweak & 1) ? 0x0B : 0x02;   // IEC 60958: 1011=24bit, 0010=16bit
 	uint8_t audiocfg = (uint8_t)(0x0E | ((tweak & 2) ? 0x40 : 0x00));
@@ -299,7 +308,13 @@ void hdmi_config_set_audio(int bitstream)
 	uint8_t audio_data[] = {
 		0x0A, 0x00,                              // [6:4] audio select = I2S
 		0x0B, audiocfg,                          // [6] bit-clock invert (tweak bit 1)
-		0x0C, (uint8_t)(bitstream ? 0x07 : 0x04),    // [2] I2S0 en; [1:0] 3=IEC958 direct, 0=standard
+		// [2] I2S0 en; [1:0] 3 = IEC958 direct / 0 = standard I2S;
+		// [6] = 1 takes channel status from the register map (route i)
+		0x0C, (uint8_t)(route_i ? 0x44 : (bitstream ? 0x07 : 0x04)),
+		// Channel status byte 0 via Table 84: [7] audio sample word
+		// (1 = NOT linear PCM), [6] consumer use = 0, [5] copyright
+		// (1 = not protected). Only consulted when 0x0C[6] = 1.
+		0x12, (uint8_t)(route_i ? 0xA0 : 0x20),
 		0x14, wordlen,                           // audio word length (tweak bit 0)
 		0x15, (uint8_t)((cfg.hdmi_audio_96k ? 0x80 : 0) | 0x20),   // 48 kHz
 		0x73, 0x01,                              // Channel Count = 1 (stereo).
@@ -320,11 +335,19 @@ void hdmi_config_set_audio(int bitstream)
 		if (res < 0) printf("i2c: audio write error (%02X %02X): %d\n",
 		                    audio_data[i], audio_data[i + 1], res);
 	}
-	printf("ADV7513: audio %s tweak=%d wl=%02X r0B=%02X\n",
-	       bitstream ? "IEC958-direct" : "PCM I2S", tweak, wordlen, audiocfg);
+	// Read back what the chip DETECTED, rather than assuming it agrees with us.
+	// 0x42[3]: SCLK periods per LRCLK period - 0 = 32-bit mode, 1 = 64-bit mode.
+	// AES3-direct carries 32 bits per channel and so REQUIRES 64-bit mode; if
+	// this reads 0 the chip is only taking half of every subframe.
+	int r42 = i2c_smbus_read_byte_data(hdmi_main_fd, 0x42);
+	const char *mode = bitstream ? (route_i ? "std-I2S+CSreg" : "IEC958-direct") : "PCM I2S";
+	printf("ADV7513: audio %s tweak=%d wl=%02X r0B=%02X r42=%02X (%s)\n",
+	       mode, tweak, wordlen, audiocfg, r42 & 0xFF,
+	       (r42 >= 0) ? ((r42 & 0x08) ? "64-bit detected" : "32-bit detected") : "read failed");
 	FILE *lf = fopen("/tmp/dvd_hdmi_audio.log", "a");
-	if (lf) { fprintf(lf, "adv7513: %s tweak=%d wordlen=%02X reg0B=%02X\n",
-	                  bitstream ? "IEC958-direct" : "PCM", tweak, wordlen, audiocfg); fclose(lf); }
+	if (lf) { fprintf(lf, "adv7513: %s tweak=%d wordlen=%02X reg0B=%02X r42=%02X %s\n",
+	                  mode, tweak, wordlen, audiocfg, r42 & 0xFF,
+	                  (r42 >= 0) ? ((r42 & 0x08) ? "64bit" : "32bit") : "readfail"); fclose(lf); }
 }
 
 int video_hdmi_config_generation(void)
@@ -343,7 +366,8 @@ ch = read(cfgh_path)
 # 21. ini field. 0 = auto (EDID-gated), 1 = off, 2 = force.
 ch = insert_after(ch, '\tuint8_t hdmi_audio_96k;',
     '\tuint8_t dvd_hdmi_bitstream;   // dvd:hdmibs 0=auto 1=off 2=force\n'
-    '\tuint8_t dvd_hdmi_bs_tweak;    // dvd:hdmibs ADV7513 register sweep, 0..3\n',
+    '\tuint8_t dvd_hdmi_bs_tweak;    // dvd:hdmibs ADV7513 register sweep, 0..3\n'
+    '\tuint8_t dvd_hdmi_bs_mode;     // dvd:hdmibs 0=AES3-direct 1=std I2S + CS regs\n',
     21, 'dvd_hdmi_bitstream')
 write(cfgh_path, ch)
 
@@ -351,7 +375,8 @@ cfgc_path = os.path.join(ROOT, "cfg.cpp")
 cc = read(cfgc_path)
 cc = insert_after(cc, '{ "HDMI_AUDIO_96K", (void*)(&(cfg.hdmi_audio_96k)), UINT8, 0, 1 },',
     '\t{ "DVD_HDMI_BITSTREAM", (void*)(&(cfg.dvd_hdmi_bitstream)), UINT8, 0, 2 },\n'
-    '\t{ "DVD_HDMI_BS_TWEAK", (void*)(&(cfg.dvd_hdmi_bs_tweak)), UINT8, 0, 3 },\n',
+    '\t{ "DVD_HDMI_BS_TWEAK", (void*)(&(cfg.dvd_hdmi_bs_tweak)), UINT8, 0, 3 },\n'
+    '\t{ "DVD_HDMI_BS_MODE", (void*)(&(cfg.dvd_hdmi_bs_mode)), UINT8, 0, 1 },\n',
     21, 'DVD_HDMI_BITSTREAM')
 write(cfgc_path, cc)
 print("[integration] cfg.h/cfg.cpp patched")

--- a/main/integration/apply_integration.py
+++ b/main/integration/apply_integration.py
@@ -300,7 +300,10 @@ void hdmi_config_set_audio(int bitstream)
 	// session rather than per-block. Programming Guide Table 84 gives the bit:
 	// channel status bit 1 "audio sample word" = 0x12[7], and 0x0C[6]=1 selects
 	// the register map as the channel-status source.
-	int route_i = bitstream && (cfg.dvd_hdmi_bs_mode == 1);
+	// mode 0 (the zero default) = route (i). HW-CONFIRMED 2026-08-31: DD and DTS
+	// both decode on a real receiver. Mode 1 selects the AES3-direct transport,
+	// which never worked over four HW rounds and is kept only for reproducing it.
+	int route_i = bitstream && (cfg.dvd_hdmi_bs_mode == 0);
 	int tweak = bitstream ? cfg.dvd_hdmi_bs_tweak : 0;
 	uint8_t wordlen  = (tweak & 1) ? 0x0B : 0x02;   // IEC 60958: 1011=24bit, 0010=16bit
 	uint8_t audiocfg = (uint8_t)(0x0E | ((tweak & 2) ? 0x40 : 0x00));
@@ -367,7 +370,7 @@ ch = read(cfgh_path)
 ch = insert_after(ch, '\tuint8_t hdmi_audio_96k;',
     '\tuint8_t dvd_hdmi_bitstream;   // dvd:hdmibs 0=auto 1=off 2=force\n'
     '\tuint8_t dvd_hdmi_bs_tweak;    // dvd:hdmibs ADV7513 register sweep, 0..3\n'
-    '\tuint8_t dvd_hdmi_bs_mode;     // dvd:hdmibs 0=AES3-direct 1=std I2S + CS regs\n',
+    '\tuint8_t dvd_hdmi_bs_mode;     // dvd:hdmibs 0=std I2S + CS regs (works) 1=AES3-direct\n',
     21, 'dvd_hdmi_bitstream')
 write(cfgh_path, ch)
 

--- a/main/integration/apply_integration.py
+++ b/main/integration/apply_integration.py
@@ -302,7 +302,16 @@ void hdmi_config_set_audio(int bitstream)
 		0x0C, (uint8_t)(bitstream ? 0x07 : 0x04),    // [2] I2S0 en; [1:0] 3=IEC958 direct, 0=standard
 		0x14, wordlen,                           // audio word length (tweak bit 0)
 		0x15, (uint8_t)((cfg.hdmi_audio_96k ? 0x80 : 0) | 0x20),   // 48 kHz
-		0x73, (uint8_t)(bitstream ? 0x00 : 0x01),    // CT/CC = refer to stream header
+		0x73, 0x01,                              // Channel Count = 1 (stereo).
+		                                         // NOT 0: Programming Guide 4.4.1.1 -
+		                                         // "If I2S0 only is needed, setting the
+		                                         // Channel Count register (0x73[2:0]) and
+		                                         // I2S enable (0x0C[2]) to 1 will select
+		                                         // this". CC also drives the Audio Sample
+		                                         // Packet layout bit and sample_present.spX
+		                                         // (Figure 23), so 0 mis-frames the packet.
+		                                         // A 61937 burst is a 2-channel carrier, so
+		                                         // stereo is right for bitstream too.
 	};
 
 	for (uint i = 0; i < sizeof(audio_data); i += 2)

--- a/main/integration/apply_integration.py
+++ b/main/integration/apply_integration.py
@@ -282,12 +282,27 @@ void hdmi_config_set_audio(int bitstream)
 {
 	if (hdmi_main_fd < 0) return;
 
+	// dvd_hdmi_bs_tweak: an ini-selectable sweep of the values that had to be
+	// ASSUMED, so trying a candidate costs a core reload rather than a 30-minute
+	// Quartus fit. HW round 2 proved optical carries both DD and DTS on the SAME
+	// build, so the 61937 word stream is right and only the chip's reading of it
+	// is in question.
+	//   bit 0  word length 24-bit instead of 16-bit (0x14). If the chip counts the
+	//          sample up from timeslot 4 rather than 12, "16-bit" makes it read
+	//          our zero padding instead of the payload.
+	//   bit 1  invert the I2S bit clock (0x0B[6]). Wrong latching edge shifts
+	//          every bit.
+	int tweak = bitstream ? cfg.dvd_hdmi_bs_tweak : 0;
+	uint8_t wordlen  = (tweak & 1) ? 0x0B : 0x02;   // IEC 60958: 1011=24bit, 0010=16bit
+	uint8_t audiocfg = (uint8_t)(0x0E | ((tweak & 2) ? 0x40 : 0x00));
+
 	uint8_t audio_data[] = {
-		0x0A, 0x00,                                  // [6:4] audio select = I2S
+		0x0A, 0x00,                              // [6:4] audio select = I2S
+		0x0B, audiocfg,                          // [6] bit-clock invert (tweak bit 1)
 		0x0C, (uint8_t)(bitstream ? 0x07 : 0x04),    // [2] I2S0 en; [1:0] 3=IEC958 direct, 0=standard
-		0x14, 0x02,                                  // audio word length = 16 bit
-		0x15, (uint8_t)((cfg.hdmi_audio_96k ? 0x80 : 0x00) | 0x20),   // sample rate
-		0x73, (uint8_t)(bitstream ? 0x00 : 0x01),    // InfoFrame CC: 0 = refer to stream header
+		0x14, wordlen,                           // audio word length (tweak bit 0)
+		0x15, (uint8_t)((cfg.hdmi_audio_96k ? 0x80 : 0) | 0x20),   // 48 kHz
+		0x73, (uint8_t)(bitstream ? 0x00 : 0x01),    // CT/CC = refer to stream header
 	};
 
 	for (uint i = 0; i < sizeof(audio_data); i += 2)
@@ -296,7 +311,11 @@ void hdmi_config_set_audio(int bitstream)
 		if (res < 0) printf("i2c: audio write error (%02X %02X): %d\n",
 		                    audio_data[i], audio_data[i + 1], res);
 	}
-	printf("ADV7513: audio input set to %s\n", bitstream ? "IEC958 direct (bitstream)" : "PCM I2S");
+	printf("ADV7513: audio %s tweak=%d wl=%02X r0B=%02X\n",
+	       bitstream ? "IEC958-direct" : "PCM I2S", tweak, wordlen, audiocfg);
+	FILE *lf = fopen("/tmp/dvd_hdmi_audio.log", "a");
+	if (lf) { fprintf(lf, "adv7513: %s tweak=%d wordlen=%02X reg0B=%02X\n",
+	                  bitstream ? "IEC958-direct" : "PCM", tweak, wordlen, audiocfg); fclose(lf); }
 }
 
 int video_hdmi_config_generation(void)
@@ -314,14 +333,16 @@ cfgh_path = os.path.join(ROOT, "cfg.h")
 ch = read(cfgh_path)
 # 21. ini field. 0 = auto (EDID-gated), 1 = off, 2 = force.
 ch = insert_after(ch, '\tuint8_t hdmi_audio_96k;',
-    '\tuint8_t dvd_hdmi_bitstream;   // dvd:hdmibs 0=auto 1=off 2=force\n',
+    '\tuint8_t dvd_hdmi_bitstream;   // dvd:hdmibs 0=auto 1=off 2=force\n'
+    '\tuint8_t dvd_hdmi_bs_tweak;    // dvd:hdmibs ADV7513 register sweep, 0..3\n',
     21, 'dvd_hdmi_bitstream')
 write(cfgh_path, ch)
 
 cfgc_path = os.path.join(ROOT, "cfg.cpp")
 cc = read(cfgc_path)
 cc = insert_after(cc, '{ "HDMI_AUDIO_96K", (void*)(&(cfg.hdmi_audio_96k)), UINT8, 0, 1 },',
-    '\t{ "DVD_HDMI_BITSTREAM", (void*)(&(cfg.dvd_hdmi_bitstream)), UINT8, 0, 2 },\n',
+    '\t{ "DVD_HDMI_BITSTREAM", (void*)(&(cfg.dvd_hdmi_bitstream)), UINT8, 0, 2 },\n'
+    '\t{ "DVD_HDMI_BS_TWEAK", (void*)(&(cfg.dvd_hdmi_bs_tweak)), UINT8, 0, 3 },\n',
     21, 'DVD_HDMI_BITSTREAM')
 write(cfgc_path, cc)
 print("[integration] cfg.h/cfg.cpp patched")

--- a/main/support/dvd/dvd_hdmi_audio.cpp
+++ b/main/support/dvd/dvd_hdmi_audio.cpp
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
+#include <time.h>
 
 #include "../../user_io.h"
 #include "../../video.h"
@@ -96,13 +97,38 @@ static int sink_supports_bitstream(void)
 // custom Main never ran, the core never declared, EDID said no, or the chip was
 // configured and the receiver could not parse our subframes. Rather than make
 // the user iterate blind, say on screen which stage was reached.
+#define HDMI_LOG_PATH "/tmp/dvd_hdmi_audio.log"
+
 static const char *stage_msg = 0;
+static time_t      show_until = 0;
+
+// ⚠ InfoMessage no-ops unless the menu FSM is idle, and the user changes Audio
+// Out from INSIDE the OSD - so a single call at the transition is dropped every
+// time. dvd_css hit this exact trap with its libdvdcss popup and solved it by
+// re-asserting once a second until the launch settles; do the same. The log file
+// is the reliable channel regardless of menu state.
 static void report(const char *msg)
 {
 	if (stage_msg == msg) return;      // only on transition
-	stage_msg = msg;
+	stage_msg  = msg;
+	show_until = time(NULL) + 6;       // re-assert until the OSD closes
 	printf("dvd_hdmi_audio: %s\n", msg);
-	InfoMessage(msg, 3000, "HDMI Audio");
+	FILE *f = fopen(HDMI_LOG_PATH, "a");
+	if (f) { fprintf(f, "%s\n", msg); fclose(f); }
+}
+
+static void report_pump(void)
+{
+	if (!show_until || !stage_msg) return;
+	time_t now = time(NULL);
+	if (now >= show_until) { show_until = 0; return; }
+
+	static time_t last = 0;
+	if (now != last)                   // 2 s timeout bridges the 1 s cadence
+	{
+		last = now;
+		InfoMessage(stage_msg, 2000, "HDMI Audio");
+	}
 }
 
 static int declared   = 0;   // the core declared OX6, so it has the HDMI tap
@@ -130,6 +156,8 @@ static void set_ack(int on)
 
 void dvd_hdmi_audio_tick(void)
 {
+	report_pump();
+
 	if (!declared || !is_dvd())
 	{
 		if (acked) { set_ack(0); hdmi_config_set_audio(0); }
@@ -150,6 +178,20 @@ void dvd_hdmi_audio_tick(void)
 
 	// Name the stage whenever the user has ASKED for passthru but we are not
 	// engaging - that is exactly the "no sound and the receiver says PCM" case.
+	static int last_dbg = -1;
+	int dbg = (passthru ? 1 : 0) | (sink_ok ? 2 : 0) | (declared ? 4 : 0) | (mode << 3);
+	if (dbg != last_dbg)
+	{
+		last_dbg = dbg;
+		FILE *f = fopen(HDMI_LOG_PATH, "a");
+		if (f)
+		{
+			fprintf(f, "state: passthru=%d sink_ok=%d declared=%d ini_mode=%d acked=%d\n",
+			        passthru, sink_ok, declared, mode, acked);
+			fclose(f);
+		}
+	}
+
 	if (passthru && !want)
 	{
 		if (mode == 1)      report("Bitstream disabled\n\ndvd_hdmi_bitstream=1 in MiSTer.ini");

--- a/main/support/dvd/dvd_hdmi_audio.cpp
+++ b/main/support/dvd/dvd_hdmi_audio.cpp
@@ -1,0 +1,169 @@
+// dvd_hdmi_audio.cpp — HDMI IEC 61937 bitstream support for the DVD core.
+// See dvd_hdmi_audio.h and MiSTer_DVD/docs/hdmi_bitstream.md.
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "../../user_io.h"
+#include "../../video.h"
+#include "../../cfg.h"
+#include "../../hardware.h"
+#include "dvd_hdmi_audio.h"
+
+// ---------------------------------------------------------------------------
+// EDID: does the sink actually accept a compressed bitstream?
+// ---------------------------------------------------------------------------
+// Stock Main never looks at audio capability - edid_parse_cea_ext() walks the
+// CEA data blocks but only handles tags 0x03/0x07 for VRR, so tag 0x01 (the
+// Audio Data Block) falls straight through. Rather than patch that function we
+// re-walk the blocks here off the exported buffer, which keeps video.cpp's diff
+// to the two things that genuinely need to live there.
+//
+// Getting this wrong in the permissive direction is the bad failure: telling a
+// plain TV to expect non-PCM and then feeding it a data burst is noise. So the
+// test is deliberately strict - the sink must NAME AC-3 or DTS and claim 48 kHz.
+
+#define SAD_FMT_AC3   2
+#define SAD_FMT_DTS   7
+
+static int scan_sads(const uint8_t *edid, int size)
+{
+	if (!edid || size < 256) return 0;
+	if (edid[126] == 0) return 0;                 // no extension blocks at all
+
+	int nblocks = edid[126];
+	for (int b = 1; b <= nblocks; b++)
+	{
+		int off = 128 * b;
+		if (off + 128 > size) break;              // truncated: stop, don't guess
+		const uint8_t *cea = edid + off;
+
+		if (cea[0] != 0x02) continue;             // not a CEA extension
+		int dtd = cea[2];                         // start of the detailed timings
+		if (dtd < 4 || dtd > 128) continue;       // malformed header
+
+		int p = 4;
+		while (p < dtd)
+		{
+			int tag = (cea[p] >> 5) & 0x07;
+			int len = cea[p] & 0x1F;
+			if (len == 0 || p + 1 + len > dtd) break;
+
+			if (tag == 0x01)                      // Audio Data Block
+			{
+				// 3-byte Short Audio Descriptors
+				for (int s = p + 1; s + 2 < p + 1 + len; s += 3)
+				{
+					int fmt   = (cea[s] >> 3) & 0x0F;
+					int rates = cea[s + 1];
+					// bit 2 = 48 kHz, which is the only rate DVD bitstream uses
+					if ((fmt == SAD_FMT_AC3 || fmt == SAD_FMT_DTS) && (rates & 0x04))
+						return 1;
+				}
+			}
+			p += 1 + len;
+		}
+	}
+	return 0;
+}
+
+static int sink_supports_bitstream(void)
+{
+	static int cached_ver = -1;
+	static int cached_ok  = 0;
+
+	uint8_t *buf = 0;
+	int size = 0;
+	int ver = video_get_edid(&buf, &size);
+	if (ver != cached_ver)
+	{
+		cached_ver = ver;
+		cached_ok  = scan_sads(buf, size);
+		printf("dvd_hdmi_audio: EDID v%d - sink %s AC-3/DTS bitstream\n",
+		       ver, cached_ok ? "ACCEPTS" : "does NOT accept");
+	}
+	return cached_ok;
+}
+
+// ---------------------------------------------------------------------------
+// State machine
+// ---------------------------------------------------------------------------
+static int declared   = 0;   // the core declared OX6, so it has the HDMI tap
+static int acked      = 0;   // cfg[14] is currently set
+static int seen_gen   = -1;  // last hdmi_config_init() generation we applied over
+static unsigned long restore_at = 0;
+
+void dvd_hdmi_audio_declare(void)
+{
+	if (!declared) printf("dvd_hdmi_audio: core declares HDMI bitstream capability\n");
+	declared = 1;
+}
+
+int dvd_hdmi_audio_ack(void)
+{
+	return acked;
+}
+
+static void set_ack(int on)
+{
+	if (acked == on) return;
+	acked = on;
+	user_io_send_buttons(1);        // pushes cfg[], incl. our bit, to the core
+}
+
+void dvd_hdmi_audio_tick(void)
+{
+	if (!declared || !is_dvd())
+	{
+		if (acked) { set_ack(0); hdmi_config_set_audio(0); }
+		return;
+	}
+
+	// cfg.dvd_hdmi_bitstream: 0 = auto (EDID-gated), 1 = off, 2 = force.
+	// "force" exists because a sink can decode a format it fails to advertise,
+	// and because ARC/soundbar topologies routinely mis-report.
+	int mode = cfg.dvd_hdmi_bitstream;
+	int want = (mode != 1)
+	        && user_io_status_get("6")            // Audio Out = Passthru
+	        && (mode == 2 || sink_supports_bitstream());
+
+	// A full hdmi_config_init() (boot, and video_reinit() on hotplug) rewrites
+	// the audio block back to PCM behind our back. Watch its generation counter
+	// and re-apply, dropping the ack across the gap so the core cannot be
+	// emitting a bitstream while the chip is momentarily back in PCM mode.
+	int gen = video_hdmi_config_generation();
+	if (acked && gen != seen_gen)
+	{
+		printf("dvd_hdmi_audio: ADV7513 re-initialised, re-applying non-PCM\n");
+		set_ack(0);
+		hdmi_config_set_audio(1);
+		seen_gen = gen;
+		set_ack(1);
+		return;
+	}
+	seen_gen = gen;
+
+	if (want && !acked)
+	{
+		// ORDER MATTERS: configure the chip FIRST, then let the core start.
+		hdmi_config_set_audio(1);
+		set_ack(1);
+		printf("dvd_hdmi_audio: HDMI bitstream ENGAGED\n");
+	}
+	else if (!want && acked)
+	{
+		// ORDER MATTERS the other way: drop the ack FIRST so the core stops
+		// emitting, and only restore the PCM registers once it has. In between
+		// the core presents digital silence, never PCM into a non-PCM link.
+		set_ack(0);
+		restore_at = GetTimer(50);
+		printf("dvd_hdmi_audio: HDMI bitstream released\n");
+	}
+
+	if (restore_at && CheckTimer(restore_at))
+	{
+		restore_at = 0;
+		if (!acked) hdmi_config_set_audio(0);
+	}
+}

--- a/main/support/dvd/dvd_hdmi_audio.cpp
+++ b/main/support/dvd/dvd_hdmi_audio.cpp
@@ -9,6 +9,7 @@
 #include "../../video.h"
 #include "../../cfg.h"
 #include "../../hardware.h"
+#include "../../menu.h"
 #include "dvd_hdmi_audio.h"
 
 // ---------------------------------------------------------------------------
@@ -89,6 +90,21 @@ static int sink_supports_bitstream(void)
 // ---------------------------------------------------------------------------
 // State machine
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Self-reporting. The failure this feature can produce is ambiguous from the
+// listening position: "receiver says PCM, no sound" looks identical whether the
+// custom Main never ran, the core never declared, EDID said no, or the chip was
+// configured and the receiver could not parse our subframes. Rather than make
+// the user iterate blind, say on screen which stage was reached.
+static const char *stage_msg = 0;
+static void report(const char *msg)
+{
+	if (stage_msg == msg) return;      // only on transition
+	stage_msg = msg;
+	printf("dvd_hdmi_audio: %s\n", msg);
+	InfoMessage(msg, 3000, "HDMI Audio");
+}
+
 static int declared   = 0;   // the core declared OX6, so it has the HDMI tap
 static int acked      = 0;   // cfg[14] is currently set
 static int seen_gen   = -1;  // last hdmi_config_init() generation we applied over
@@ -117,6 +133,10 @@ void dvd_hdmi_audio_tick(void)
 	if (!declared || !is_dvd())
 	{
 		if (acked) { set_ack(0); hdmi_config_set_audio(0); }
+		// A core built before the HDMI tap never declares OX6. Say so, but only
+		// once the user actually selects passthru, so it cannot nag.
+		if (is_dvd() && !declared && user_io_status_get("6"))
+			report("Core has no HDMI bitstream\n\nOld .rbf - rebuild/reflash");
 		return;
 	}
 
@@ -124,9 +144,17 @@ void dvd_hdmi_audio_tick(void)
 	// "force" exists because a sink can decode a format it fails to advertise,
 	// and because ARC/soundbar topologies routinely mis-report.
 	int mode = cfg.dvd_hdmi_bitstream;
-	int want = (mode != 1)
-	        && user_io_status_get("6")            // Audio Out = Passthru
-	        && (mode == 2 || sink_supports_bitstream());
+	int passthru = user_io_status_get("6");       // Audio Out = Passthru
+	int sink_ok  = (mode == 2) || sink_supports_bitstream();
+	int want = (mode != 1) && passthru && sink_ok;
+
+	// Name the stage whenever the user has ASKED for passthru but we are not
+	// engaging - that is exactly the "no sound and the receiver says PCM" case.
+	if (passthru && !want)
+	{
+		if (mode == 1)      report("Bitstream disabled\n\ndvd_hdmi_bitstream=1 in MiSTer.ini");
+		else if (!sink_ok)  report("Sink does not list AC-3/DTS\n\nSet dvd_hdmi_bitstream=2 to force");
+	}
 
 	// A full hdmi_config_init() (boot, and video_reinit() on hotplug) rewrites
 	// the audio block back to PCM behind our back. Watch its generation counter
@@ -149,7 +177,7 @@ void dvd_hdmi_audio_tick(void)
 		// ORDER MATTERS: configure the chip FIRST, then let the core start.
 		hdmi_config_set_audio(1);
 		set_ack(1);
-		printf("dvd_hdmi_audio: HDMI bitstream ENGAGED\n");
+		report("HDMI bitstream ENGAGED\n\nADV7513 in IEC958-direct mode");
 	}
 	else if (!want && acked)
 	{
@@ -158,6 +186,7 @@ void dvd_hdmi_audio_tick(void)
 		// the core presents digital silence, never PCM into a non-PCM link.
 		set_ack(0);
 		restore_at = GetTimer(50);
+		stage_msg = 0;   // re-arm reporting for the next engage attempt
 		printf("dvd_hdmi_audio: HDMI bitstream released\n");
 	}
 

--- a/main/support/dvd/dvd_hdmi_audio.h
+++ b/main/support/dvd/dvd_hdmi_audio.h
@@ -1,0 +1,30 @@
+// dvd_hdmi_audio.h — HDMI IEC 61937 bitstream support for the DVD core.
+//
+// The DVD core's "Audio Out = Passthru" wraps undecoded AC-3/DTS in IEC 61937.
+// It has always gone out optical S/PDIF; the core can now also clock the same
+// IEC 60958 subframes into the ADV7513's I2S input, so an AV receiver on HDMI
+// decodes DD/DTS 5.1 with no Digital I/O board.
+//
+// The ADV7513's I2C is HPS-only, so putting it in IEC958-direct mode is our job.
+// Until we have done it the sink expects PCM, and a bitstream would come out as
+// full-scale noise — so the core will not emit one until we set the cfg[14] ack.
+// Stock Main never sets it, which is exactly why a stock-Main user is safe.
+//
+// See MiSTer_DVD/docs/hdmi_bitstream.md.
+
+#ifndef DVD_HDMI_AUDIO_H
+#define DVD_HDMI_AUDIO_H
+
+// Called from parse_config()'s OX arm when the core declares OX6 ("Audio Out").
+// A core build without the HDMI tap never declares it, so we never reconfigure
+// the chip for a core that cannot drive it.
+void dvd_hdmi_audio_declare(void);
+
+// Called every user_io_poll(). Watches the Audio Out status bit and the sink's
+// EDID, drives the ADV7513, and raises/clears the ack.
+void dvd_hdmi_audio_tick(void);
+
+// The cfg[14] ack, read by user_io_send_buttons().
+int  dvd_hdmi_audio_ack(void);
+
+#endif

--- a/sys/hps_io.sv
+++ b/sys/hps_io.sv
@@ -117,6 +117,17 @@ module hps_io #(parameter CONF_STR, CONF_STR_BRAM=0, PS2DIV=0, WIDE=0, VDNUM=1, 
 	output            ini_csync,        // cfg[3]  composite_sync=
 	output            ini_ypbpr,        // cfg[5]  ypbpr / vga_mode=ypbpr
 	output            ini_sog,          // cfg[9]  vga_sog=
+
+	// DVD-FORK (HDMI bitstream): the HPS ack. Set ONLY by MiSTer_DVDcss, and
+	// only once it has put the ADV7513 into IEC958-direct mode and confirmed the
+	// sink advertises AC-3/DTS in its EDID. The core refuses to put a bitstream
+	// on the I2S pin without it, so a stock Main - which never sets cfg[14] -
+	// gets exactly today's behaviour and can never be fed a bitstream it has
+	// told the sink to expect as PCM (that would be full-scale noise).
+	// cfg[14]/cfg[15] are the only bits stock Main leaves free (CONF_DIRECT_VIDEO2
+	// at bit 13 is the highest it defines).
+	output            ini_hdmi_bs_ok,   // cfg[14] MiSTer_DVDcss: ADV7513 is in
+	                                    //         IEC958-direct/non-PCM mode
 	input             video_rotated,
 
 	//toggle to force notify of video mode change
@@ -213,6 +224,8 @@ assign ini_vga_scaler = cfg[2];
 assign ini_csync      = cfg[3];
 assign ini_ypbpr      = cfg[5];
 assign ini_sog        = cfg[9];
+// DVD-FORK (HDMI bitstream): HPS ack, see the port comment
+assign ini_hdmi_bs_ok = cfg[14];
 
 reg [3:0] sdn;
 reg [3:0] sd_rrb = 0;

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -1573,6 +1573,25 @@ assign SDCD_SPDIF = (mcp_en & ~spdif_out) ? 1'b0 : 1'bZ;
 	assign AUDIO_L     = av_dis ? 1'bZ : (SW[0] | mcp_en) ? HDMI_SCLK  : analog_l;
 `endif
 
+// DVD-FORK: IEC 61937 bitstream over HDMI. When the core asserts hdmi_bs_en it
+// drives IEC 60958 subframes in the ADV7513's "IEC958 direct" format, and all
+// three audio signals come from the CORE's serializer rather than audio_out's -
+// bit clock, word select and data have to stay phase-consistent with each other,
+// and IEC958-direct needs sck at 64.Fs where the PCM path runs 32.Fs. MCLK is
+// untouched (clk_audio = 512.Fs either way), and with hdmi_bs_en low every one of
+// these is bit-for-bit the stock PCM path.
+//
+// The SW[0]/mcp_en guard matters: those route HDMI_I2S/SCLK/LRCLK to the analog
+// board's audio pins (see the AUDIO_* assigns above), where an I2S DAC would turn
+// a bitstream into full-scale noise.
+wire hdmi_bs_sck, hdmi_bs_ws, hdmi_bs_sd, hdmi_bs_en;
+wire hdmi_bs_ok = hdmi_bs_en & ~(SW[0] | mcp_en);
+
+wire i2s_bclk_pcm, i2s_lrclk_pcm, i2s_data_pcm;
+assign HDMI_SCLK  = hdmi_bs_ok ? hdmi_bs_sck : i2s_bclk_pcm;
+assign HDMI_LRCLK = hdmi_bs_ok ? hdmi_bs_ws  : i2s_lrclk_pcm;
+assign HDMI_I2S   = hdmi_bs_ok ? hdmi_bs_sd  : i2s_data_pcm;
+
 assign HDMI_MCLK = clk_audio;
 wire clk_audio;
 
@@ -1611,9 +1630,9 @@ audio_out audio_out
 	.alsa_r(alsa_r),
 `endif
 
-	.i2s_bclk(HDMI_SCLK),
-	.i2s_lrclk(HDMI_LRCLK),
-	.i2s_data(HDMI_I2S),
+	.i2s_bclk(i2s_bclk_pcm),
+	.i2s_lrclk(i2s_lrclk_pcm),
+	.i2s_data(i2s_data_pcm),
 `ifndef MISTER_DUAL_SDRAM
 	.dac_l(analog_l),
 	.dac_r(analog_r),
@@ -1860,6 +1879,12 @@ emu emu
 	// output assigns above).
 	.SPDIF_PASS(spdif_pass),
 	.SPDIF_PASS_EN(spdif_pass_en),
+
+	// DVD-FORK: the same bitstream over HDMI - see the mux above.
+	.HDMI_BS_SCK(hdmi_bs_sck),
+	.HDMI_BS_WS(hdmi_bs_ws),
+	.HDMI_BS_SD(hdmi_bs_sd),
+	.HDMI_BS_EN(hdmi_bs_en),
 
 	.ADC_BUS({ADC_SCK,ADC_SDO,ADC_SDI,ADC_CONVST}),
 


### PR DESCRIPTION
Sends the IEC 61937 bitstream over **HDMI** as well as optical S/PDIF, so an AV
receiver decodes DD/DTS 5.1 with **no Digital I/O board**. Same toggle, both outputs.

✅ **HW-CONFIRMED** on ULTIMATE_T2: Dolby Digital and DTS both decode over HDMI.

## How

IEC 61937 rides inside an ordinary 2-channel / 48 kHz / 16-bit IEC 60958 stream
(1.536 Mbit/s — exactly why DVD caps DTS at 1509.75), which is what the single I2S
line the DE10-Nano wires to the ADV7513 already carries. The board routes no other
audio data pin, which is also why multichannel *LPCM* remains impossible here.

- **Fabric** — `dvd/i2s_iec958.sv` serializes the words for the ADV7513, fed from a
  tap on the existing `cur_pair` in `dvd/iec61937_wrap.sv`. One subframe source, two
  link layers, so the outputs cannot drift apart.
- **HPS** — `main/support/dvd/dvd_hdmi_audio.cpp` puts the chip in standard I2S with
  channel status from its register map (`0x0C[6]=1`, non-PCM in `0x12[7]`), gated on
  EDID Short Audio Descriptors. Integration steps 12–21; the overlay's first edits to
  `video.cpp`/`video.h`/`cfg.*`.
- **Safety is structural.** The ADV7513's I2C is HPS-only, so a bitstream sent to a
  sink still expecting PCM is full-scale noise. The core refuses to emit one without
  a `cfg[14]` ack that only `MiSTer_DVDcss` sets. Stock Main never sets it ⇒ exactly
  today's behaviour, no user action, no noise. Three independent layers back that up.

## Notes

- `O6` → `OX6` so Main learns the build has the HDMI path. Bit 6 is unchanged, so no
  `"v,N"` config bump and saved settings survive.
- `CORE_VERSION` → **0.3.0**. `CLAUDE.md` now documents *how far* to bump, which was
  precedent-only before.
- Route selection stays on the debug page (`HDMI BS Variant`, `BS Hold Style`). Both
  encode hardware findings that would otherwise cost a build to re-derive.
- ⚠ The **startup / track-change lock flap is pre-existing** — it reproduces on the
  shipped v0.2.0 over optical and is not caused by this work. Documented as open in
  `docs/iec61937.md` with the tried negatives and the next lead.

## Test plan

- [x] DD and DTS decode over HDMI on a real receiver (ULTIMATE_T2)
- [x] Engages on EDID alone with `dvd_hdmi_bitstream` omitted — validates the SAD parser
- [x] Optical passthrough still carries DD and DTS
- [x] Sim suite green: `bench/dvd/run_hdmi_bitstream.sh`
- [x] Fit clean: ALM 88%, RAM 506/553 unchanged (0 M10K added), clk_dec passes both corners
- [x] `MiSTer_DVDcss` builds from a clean tree; patcher idempotent across all 21 steps
- [ ] Plain TV with no AC-3/DTS SAD stays silent, never noisy
- [ ] Stock Main unchanged (no ack ⇒ HDMI silent, as before)
