### PR TITLE
DVD drive region tool: read/set a drive's region from the MiSTer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1237,7 +1237,9 @@ that still drain the ring — no STD wedge). Video keeps playing so the disc is
 identifiable. Sim: `ps_demux_scram_tb`, `iec61937_wrap_tb` T8, `transport_hud_tb`
 T13. Detail: `docs/fabric_audio.md` "CSS mute", `docs/transport_hud.md`.
 
-**DVD drive region tool (`main/Scripts/set_dvd_region.sh`, 2026-08-30) — ⏳ HW gate.**
+**DVD drive region tool (`main/Scripts/set_dvd_region.sh`, 2026-08-30) — ✅ READ +
+gamepad menu HW-CONFIRMED 2026-08-31 (Scripts menu, gamepad-driven, 1 and 2 drives);
+⏳ the SET ioctl is the one remaining gate.**
 A drive with no region set refuses the CSS title-key ioctl, so every physical disc pays a
 multi-second crack (`No drive region: cracking`); the Scripts-menu tool reads the region
 (and the remaining-change count) and can set it, via `DVD_AUTH` — no compiled helper, since

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1237,6 +1237,19 @@ that still drain the ring — no STD wedge). Video keeps playing so the disc is
 identifiable. Sim: `ps_demux_scram_tb`, `iec61937_wrap_tb` T8, `transport_hud_tb`
 T13. Detail: `docs/fabric_audio.md` "CSS mute", `docs/transport_hud.md`.
 
+**DVD drive region tool (`main/Scripts/set_dvd_region.sh`, 2026-08-30) — ⏳ HW gate.**
+A drive with no region set refuses the CSS title-key ioctl, so every physical disc pays a
+multi-second crack (`No drive region: cracking`); the Scripts-menu tool reads the region
+(and the remaining-change count) and can set it, via `DVD_AUTH` — no compiled helper, since
+python3 is stock on MiSTer. Two durable facts it is built around, worth knowing before
+writing ANY MiSTer Scripts tool: a Scripts-menu script is run by handing its bare path to
+`agetty`, so it can **never take arguments** (SSH only); and MiSTer injects uinput KEYBOARD
+events from the gamepad while a script runs (D-pad→arrows, B1→Enter, B2→Esc) but **no digits
+or letters** — so interactive means a cursor menu, never a typed prompt. A region set is
+**irreversible** (no un-set, ~5 changes ever), hence cursor-starts-on-Cancel/No throughout.
+Tested by `tools/test_set_dvd_region.py` (fakes the drive, drives the menus through a pty);
+the ioctl itself is the HW gate. Design + ioctl details: `docs/physical_disc.md`.
+
 ### No USB DVD-ROM drive support
 MiSTer's custom Linux kernel almost certainly lacks `sr_mod` (`CONFIG_BLK_DEV_SR`).
 Recompiling the kernel is out of scope. Workflow: rip disc to ISO on PC, copy to SD card,

--- a/README.md
+++ b/README.md
@@ -308,12 +308,47 @@ loaded without libdvdcss present, the core shows `CSS ENCRYPTED` and mutes rathe
 playing static — your cue to run the script.
 
 The first time an encrypted disc's keys are needed they may take a few seconds to
-recover (longer with no drive-region set, or for an ISO where they are always cracked
-from the data); recovered keys are cached under `/media/fat/dvdcss/cache`, so the same
-disc is instant next time.
+recover; recovered keys are cached under `/media/fat/dvdcss/cache`, so the same disc is
+instant next time. For a **physical disc**, how long that first recovery takes depends on
+whether the drive has a region set — see step 4. For an **ISO** the keys are always
+cracked from the data, so the region makes no difference there.
 
 Cracking CSS may be regulated where you live; check the laws that apply to you. This
 project neither distributes libdvdcss nor contains any CSS circumvention code.
+
+### 4. Set the drive region (physical discs — makes them start faster)
+
+A USB DVD drive ships with **no region set**. In that state the drive refuses the CSS key
+exchange, so libdvdcss has to crack every key out of the disc data — that is the
+several-second wait before a title starts. Set the drive's region to match your discs and
+the drive hands the keys over directly, so playback starts almost immediately. (An
+encrypted *ISO* is always cracked from the data, so this only affects physical discs.)
+
+**From the MiSTer** — run **set_dvd_region** from the **Scripts** menu (it's in the
+release zip; otherwise grab the `set_dvd_region.sh` asset and drop it in
+`/media/fat/Scripts/`). It shows the drive's current region and how many changes it has
+left, and setting one is a menu you can drive with the **D-pad and B1** — no keyboard
+needed. Nothing changes until you confirm, and the cursor starts on *Cancel*. Run it with
+no disc playing, since the core holds the drive open while one is mounted.
+
+> ⚠️ **A region change is close to permanent.** Drives allow only a handful of user
+> changes — typically five — and when the counter runs out the region is locked to
+> whatever was set last. **There is no un-set**: a region can only be changed to another
+> region, never back to none, and each change costs one from the counter. The counter
+> lives in the drive's own firmware, so it is not reset by a different PC, a reformat, or
+> a different operating system. Pick the region matching the discs you own and set it once.
+
+Region codes: **1** US/Canada · **2** Europe/Japan/Middle East/South Africa · **3** SE Asia
+· **4** Latin America/Australia/NZ · **5** Africa/Russia/South Asia · **6** China.
+
+If you'd rather do it on a PC, the same setting is reachable there — on **Linux** with
+`regionset` (`sudo regionset /dev/sr0`, which prints the current region and remaining
+changes, then prompts), and on **Windows** through **Device Manager → DVD/CD-ROM drives →**
+the drive **→ Properties → DVD Region**, which shows the remaining count before you commit.
+The region travels with the drive, so a drive set on a PC arrives at the MiSTer ready.
+
+Note that a drive set to one region and asked to play a disc from *another* still falls
+back to cracking — matching the drive to your library is what makes discs start quickly.
 
 The design and current status are in [main/README.md](main/README.md) and
 [docs/physical_disc.md](docs/physical_disc.md).
@@ -503,7 +538,8 @@ cross-compiles for the board's ARM CPU. The overlay, the `user_io.cpp` integrati
 the Docker image are documented in [main/README.md](main/README.md).
 
 Once you have a `.rbf` (`build_release.sh --release`) and `MiSTer_DVDcss`,
-`tools/package_release.sh` assembles them plus `Scripts/install_dvdcss.sh` into a
+`tools/package_release.sh` assembles them plus the two `Scripts/` tools
+(`install_dvdcss.sh`, `set_dvd_region.sh`) into a
 ready-to-extract `releases/MiSTer_DVD_v<ver>.zip` (and prints the individual files to
 attach to a GitHub release alongside the zip).
 

--- a/README.md
+++ b/README.md
@@ -333,8 +333,7 @@ no disc playing, since the core holds the drive open while one is mounted.
 
 > ⚠️ **A region change is close to permanent.** Drives allow only a handful of user
 > changes — typically five — and when the counter runs out the region is locked to
-> whatever was set last. **There is no un-set**: a region can only be changed to another
-> region, never back to none, and each change costs one from the counter. The counter
+> whatever was set last. The counter
 > lives in the drive's own firmware, so it is not reset by a different PC, a reformat, or
 > a different operating system. Pick the region matching the discs you own and set it once.
 
@@ -349,9 +348,6 @@ The region travels with the drive, so a drive set on a PC arrives at the MiSTer 
 
 Note that a drive set to one region and asked to play a disc from *another* still falls
 back to cracking — matching the drive to your library is what makes discs start quickly.
-
-The design and current status are in [main/README.md](main/README.md) and
-[docs/physical_disc.md](docs/physical_disc.md).
 
 ## Film (24p) content
 

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -178,6 +178,11 @@ starts on *Cancel*, selecting a region leads to a confirm screen whose cursor st
 `ucca == 0` is never offered the menu at all. Over SSH the same rules apply, with `--yes`
 required to skip the confirm.
 
+Only regions **1–6** are offered, in the menu and the argument form alike. 7 is unassigned
+and 8 is international venues (aircraft, cruise ships), so no disc a user owns carries
+either — offering them only creates a way to spend a permanent change for nothing. They
+stay in the naming table so a drive that already reports one is still described correctly.
+
 **Testing.** The ioctl itself cannot be tested without a drive; everything guarding it can,
 and that is where the damage would be. `tools/test_set_dvd_region.py` fakes the drive
 (`DVD_REGION_FAKE=<region>:<changes>:<resets>:<scheme>`, honoured by the script) and drives

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -194,9 +194,10 @@ nudges toward it.
 **Testing.** The ioctl itself cannot be tested without a drive; everything guarding it can,
 and that is where the damage would be. `tools/test_set_dvd_region.py` fakes the drive
 (`DVD_REGION_FAKE=<region>:<changes>:<resets>:<scheme>`, honoured by the script) and drives
-the menus through a pty using the exact key sequences MiSTer sends for a gamepad — 8
+the menus through a pty using the exact key sequences MiSTer sends for a gamepad — 13
 scenarios, including "a stray B1 on entry changes nothing" and "the confirm defaults to No".
-⏳ **The ioctl path is an HW gate** (see open items).
+The **read** ioctl and the gamepad-driven console are ✅ **HW-CONFIRMED 2026-08-31**; the
+**set** ioctl is the one part still ungated (see open items).
 
 ## HW status / open items
 
@@ -217,14 +218,19 @@ Remaining:
    against the drive's set region (`REPORT KEY` RPC state) and show the cracking text on a
    mismatch. Needs a region-mismatched disc to verify — a second drive set to a region the
    local library does **not** match is the practical rig (see item 2).
-2. **`set_dvd_region.sh` on hardware (⏳ gate):** confirm the read reports the drive's real
-   region/`ucca`, that the gamepad drives the menu on tty2, and that a set is accepted and
-   reads back. Note the read path is safe to test freely; a **set is one-way and spends one
-   of the drive's ~5 changes**, so it wants a drive you are willing to commit. Bench plan is
-   three drives — one left unset (keeps the `No drive region: cracking` path testable, which
-   a set would destroy forever), one matching the local library, one deliberately mismatched
-   as the permanent Q2 rig. `DVDCSS_METHOD=title` forces the crack path on any drive if the
-   physical unset state is not available.
+2. **`set_dvd_region.sh` on hardware — ✅ READ HW-CONFIRMED 2026-08-31, ⏳ SET still gated.**
+   Run from the Scripts menu and driven with a **gamepad**, with one drive connected and
+   with two: regions read correctly (an unset drive and a region-1 drive each identified),
+   and the multi-drive warning listed both. That confirms everything except the write — the
+   `DVD_AUTH` read, drive enumeration, and the uinput key injection on tty2, which was the
+   design's riskiest assumption (nothing else in the repo depends on it).
+   **Remaining: the SET ioctl** (`DVD_HOST_SEND_RPC_STATE` accepted by the drive and reading
+   back). The read path is safe to re-test freely; a **set is one-way and spends one of the
+   drive's ~5 permanent changes**, so it wants a drive you have decided to commit. Bench plan
+   is three drives — one left unset (keeps the `No drive region: cracking` path testable,
+   which a set would destroy forever), one matching the local library, one deliberately
+   mismatched as the permanent Q2 rig. `DVDCSS_METHOD=title` forces the crack path on any
+   drive if the physical unset state is not available.
 3. **Eject → idle reset (just added):** confirm the `status[0]` pulse returns to the idle
    logo cleanly and a subsequent insert plays.
 4. **Drive lifecycle across re-exec:** confirm `/dev/srN` is free for our Main to re-open.

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -125,6 +125,66 @@ committed to the repo, bundled in a release, or uploaded** — *distributing* CS
 the genuinely fraught act (cf. the AACS "09 F9" case). The cache lives on the SD card,
 nowhere near the repo, so this holds by construction; keep it that way.
 
+## Drive region tool (`main/Scripts/set_dvd_region.sh`)
+
+A drive with **no region set** refuses the CSS title-key ioctl, so libdvdcss cracks every
+key from the data — the multi-second wait `dvd_css.cpp` surfaces as
+`No drive region: cracking`. Setting the drive's region removes that wait for physical
+discs (an encrypted *ISO* always cracks, so it is unaffected). The tool reads the state and
+optionally sets it, from the MiSTer itself.
+
+**Why a script and not part of the Main:** it is a once-per-drive administrative act, not
+part of playback, and it must be usable *before* deciding to buy into the `[DVD] main=`
+setup at all. The Scripts menu is where MiSTer puts exactly this kind of thing, and it is
+already how `install_dvdcss.sh` ships.
+
+**Mechanism.** One ioctl, `DVD_AUTH` (`0x5392`, `linux/cdrom.h`), which the kernel turns
+into the SCSI REPORT KEY / SEND KEY commands for RPC state:
+
+| | value | struct |
+|---|---|---|
+| read  | `DVD_LU_SEND_RPC_STATE` = **10** | `{type:2, vra:3, ucca:3, region_mask, rpc_scheme}` — 3 bytes, bitfields packed from the low end |
+| write | `DVD_HOST_SEND_RPC_STATE` = **11** | `{type, pdrc}` — `pdrc` is the region, 1–8 |
+
+`sizeof(dvd_authinfo)` is 16. `region_mask` has a **clear** bit per playable region, so
+`0xff` = no region set (the same test `dvd_css.cpp:drive_region_set()` already makes over
+SG_IO). The read also returns `ucca` (user changes remaining) and `vra` (vendor resets),
+which is what lets the tool state the cost before spending it. `rpc_scheme == 0` means an
+RPC-1 (region-free) drive — nothing to set.
+
+No compiled helper is needed: `python3` is a stock MiSTer tool (`install_dvdcss.sh` already
+depends on it) and `fcntl.ioctl` covers this.
+
+**Why the UI is a cursor menu.** A Scripts-menu script is launched by handing its bare path
+to `agetty` (`menu.cpp`, `MENU_SCRIPTS_FB`), so **it can never receive arguments** — an
+argument interface only works over SSH. Input does work, though: the launcher calls
+`video_fb_enable(1)` first, and MiSTer's `input.cpp` (`else if (video_fb_state())`) injects
+real uinput **keyboard** events from a gamepad — D-pad → arrows, B1 → Enter, B2 → Esc,
+B3 → Space, B4 → Tab, L/R → PgUp/PgDn. There are **no digits or letters** in that mapping,
+which rules out any typed prompt; hence menus only. Consequences baked into the script:
+
+- The python payload is written to a temp **file**, not fed to `python3` on stdin — stdin is
+  the console the menu is read from, and a `python3 - <<EOF` heredoc would consume it.
+- With `fb_terminal=0` in MiSTer.ini the Scripts menu uses the OSD runner instead
+  (`popen(..., "r")`) — output only, **no stdin at all**. The script detects a non-tty stdin
+  and degrades to printing status rather than blocking on input nobody can give.
+- Esc needs a ~50 ms timeout to be told apart from the start of an arrow's CSI sequence.
+
+**Safety, because a region change is irreversible.** There is no un-set: MMC has no "clear
+region" command, the code field is 1–8 with no none value, each set spends one of ~5 user
+changes, and at zero the drive is locked to the last region. So the entry menu's cursor
+starts on *Cancel*, selecting a region leads to a confirm screen whose cursor starts on
+*No*, the last-change case gets an explicit "locked forever" warning, and a drive already at
+`ucca == 0` is never offered the menu at all. Over SSH the same rules apply, with `--yes`
+required to skip the confirm.
+
+**Testing.** The ioctl itself cannot be tested without a drive; everything guarding it can,
+and that is where the damage would be. `tools/test_set_dvd_region.py` fakes the drive
+(`DVD_REGION_FAKE=<region>:<changes>:<resets>:<scheme>`, honoured by the script) and drives
+the menus through a pty using the exact key sequences MiSTer sends for a gamepad — 8
+scenarios, including "a stray B1 on entry changes nothing" and "the confirm defaults to No".
+⏳ **The ioctl path is an HW gate** (see open items).
+
 ## HW status / open items
 
 **HW CONFIRMED (2026-08-29):** on the DE10-Nano — physical disc (no-region-drive cracking +
@@ -142,8 +202,16 @@ Remaining:
    — but the message still says "Preparing disc" because a region *is* set. To warn
    correctly, compare the disc's region-management byte (`READ DVD STRUCTURE` copyright RMI)
    against the drive's set region (`REPORT KEY` RPC state) and show the cracking text on a
-   mismatch. Needs a region-mismatched disc to verify (easiest: `regionset` the drive to a
-   region that mismatches an existing disc, rather than authoring one).
+   mismatch. Needs a region-mismatched disc to verify — a second drive set to a region the
+   local library does **not** match is the practical rig (see item 2).
+2. **`set_dvd_region.sh` on hardware (⏳ gate):** confirm the read reports the drive's real
+   region/`ucca`, that the gamepad drives the menu on tty2, and that a set is accepted and
+   reads back. Note the read path is safe to test freely; a **set is one-way and spends one
+   of the drive's ~5 changes**, so it wants a drive you are willing to commit. Bench plan is
+   three drives — one left unset (keeps the `No drive region: cracking` path testable, which
+   a set would destroy forever), one matching the local library, one deliberately mismatched
+   as the permanent Q2 rig. `DVDCSS_METHOD=title` forces the crack path on any drive if the
+   physical unset state is not available.
 3. **Eject → idle reset (just added):** confirm the `status[0]` pulse returns to the idle
    logo cleanly and a subsequent insert plays.
 4. **Drive lifecycle across re-exec:** confirm `/dev/srN` is free for our Main to re-open.

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -183,6 +183,14 @@ and 8 is international venues (aircraft, cruise ships), so no disc a user owns c
 either — offering them only creates a way to spend a permanent change for nothing. They
 stay in the naming table so a drive that already reports one is still described correctly.
 
+**More than one drive.** Only the first `/dev/srN` is ever touched. When others are
+present the tool says so and lists every drive with its current region, marking the one it
+will act on — reading the others is harmless, and "which drive am I about to change?" is
+otherwise unanswerable for an act that cannot be undone. A picker was considered and not
+built: the drives are told apart by device node, which says nothing about which physical
+unit it is, so connecting only the target drive is the reliable habit and the warning
+nudges toward it.
+
 **Testing.** The ioctl itself cannot be tested without a drive; everything guarding it can,
 and that is where the damage would be. `tools/test_set_dvd_region.py` fakes the drive
 (`DVD_REGION_FAKE=<region>:<changes>:<resets>:<scheme>`, honoured by the script) and drives

--- a/main/README.md
+++ b/main/README.md
@@ -81,6 +81,22 @@ If an encrypted disc is inserted without libdvdcss present, the core shows
 Cracking CSS may be regulated where you live; check the laws that apply to you. This
 project neither distributes libdvdcss nor contains any CSS circumvention code.
 
+## Drive region (physical discs start faster with one set)
+
+A drive with **no region set** refuses the CSS title-key ioctl, so libdvdcss cracks every
+key from the disc data — that is the wait shown on screen as `No drive region: cracking`.
+Setting the drive's region removes it. The other bundled script reads the drive's region
+and can set it, from the MiSTer, with a menu you can drive on a gamepad:
+
+```
+Scripts/set_dvd_region.sh
+```
+
+⚠️ A region change is close to permanent — a drive allows about five changes ever, there is
+no un-set, and at zero it locks to the last region. The script shows the remaining count
+and defaults every prompt to *don't*. Design notes and the ioctl details are in
+[../docs/physical_disc.md](../docs/physical_disc.md).
+
 ## Status
 
 **Builds (native + Docker); not yet hardware-tested.** The CSS/decrypt modules are

--- a/main/Scripts/set_dvd_region.sh
+++ b/main/Scripts/set_dvd_region.sh
@@ -1,0 +1,375 @@
+#!/bin/bash
+# set_dvd_region.sh — show or set the region code of a USB DVD drive, on the MiSTer.
+#
+# WHY THIS EXISTS: a drive with no region set refuses the CSS key exchange, so
+# libdvdcss has to crack every title key out of the disc data — that is the
+# multi-second wait before a physical disc starts playing. Set the drive's region to
+# match your discs and the drive hands the keys over directly instead.
+#
+# HOW TO USE IT: run "set_dvd_region" from the MiSTer Scripts menu. It shows the
+# drive's current region and how many changes it has left; picking a new region is a
+# menu, driven with the D-pad and B1 (or arrow keys and Enter). Nothing is changed
+# until you confirm.
+#
+# !! A region change is close to permanent. Drives allow only a handful of user
+# !! changes — typically five — and when the counter reaches zero the region is
+# !! locked to whatever was set last. There is no "un-set": the region cannot be
+# !! returned to none, only changed to another region at the cost of one change.
+#
+# Needs only what a stock MiSTer already has: python3. Run it with no disc playing —
+# the DVD core holds the drive open while a disc is mounted.
+#
+# Over SSH you can skip the menu:
+#   ./set_dvd_region.sh          show the current region and changes remaining
+#   ./set_dvd_region.sh 2        set region 2 (asks to confirm)
+#   ./set_dvd_region.sh 2 --yes  set region 2 without asking
+
+set -u
+
+# The python payload goes to a FILE rather than python3's stdin: the MiSTer Scripts
+# menu runs this script on a real console (agetty on tty2), and stdin is the console
+# the menu is read from. A `python3 - <<EOF` heredoc would consume it and the menu
+# could not be driven at all.
+PY="/tmp/set_dvd_region.$$.py"
+trap 'rm -f "$PY"' EXIT
+
+cat > "$PY" <<'PYEOF'
+"""Read or set a DVD drive's RPC region, with a gamepad-driveable menu.
+
+The region lives in the drive's own firmware and is read/written with one ioctl,
+DVD_AUTH (linux/cdrom.h), which the kernel turns into the SCSI REPORT KEY /
+SEND KEY commands for RPC state. No external tool and no compiled helper needed.
+
+Gamepad support is not our doing: while a Scripts-menu script runs, MiSTer's Main
+injects real keyboard events from the gamepad (D-pad -> arrows, B1 -> Enter,
+B2 -> Esc, B3 -> Space, B4 -> Tab). There are no digits or letters in that mapping,
+which is why every choice here is a cursor menu and never a typed value.
+"""
+
+import fcntl
+import glob
+import os
+import select
+import sys
+import termios
+import tty
+
+DVD_AUTH            = 0x5392   # linux/cdrom.h: DVD authentication ioctl
+LU_SEND_RPC_STATE   = 10       # drive -> host: report the current RPC state
+HOST_SEND_RPC_STATE = 11       # host -> drive: set the region
+AUTHINFO_SIZE       = 16       # sizeof(dvd_authinfo)
+
+REGIONS = [
+    (1, "US, Canada"),
+    (2, "Europe, Japan, Middle East, South Africa"),
+    (3, "Southeast Asia, South Korea, Taiwan, Hong Kong"),
+    (4, "Latin America, Australia, New Zealand"),
+    (5, "Africa, Russia, South Asia"),
+    (6, "China"),
+    (7, "reserved"),
+    (8, "international venues (aircraft, cruise ships)"),
+]
+
+
+# ---------------------------------------------------------------- drive access
+
+class Drive:
+    def __init__(self, path, fd):
+        self.path = path
+        self.fd = fd
+
+    def read_state(self):
+        """-> (region or None, changes_left, vendor_resets, rpc_scheme).
+
+        struct dvd_lu_send_rpcstate is {type:2, vra:3, ucca:3, region_mask,
+        rpc_scheme} — three bytes, the bitfields packed from the low end.
+        region_mask has a CLEAR bit per PLAYABLE region, so 0xff means no region
+        is set and exactly one clear bit means that region is the drive's.
+        """
+        buf = bytearray(AUTHINFO_SIZE)
+        buf[0] = LU_SEND_RPC_STATE
+        fcntl.ioctl(self.fd, DVD_AUTH, buf, True)
+        vendor_resets = (buf[0] >> 2) & 7
+        changes_left  = (buf[0] >> 5) & 7
+        mask, scheme  = buf[1], buf[2]
+        playable = [n + 1 for n in range(8) if not (mask >> n) & 1]
+        region = playable[0] if len(playable) == 1 else None
+        return region, changes_left, vendor_resets, scheme
+
+    def set_region(self, region):
+        """struct dvd_host_send_rpcstate is {type, pdrc}; pdrc is the region 1-8."""
+        buf = bytearray(AUTHINFO_SIZE)
+        buf[0] = HOST_SEND_RPC_STATE
+        buf[1] = region
+        fcntl.ioctl(self.fd, DVD_AUTH, buf, True)
+
+
+class FakeDrive:
+    """Test stand-in so the menus can be exercised without an optical drive.
+
+    Enable with DVD_REGION_FAKE=<region>:<changes>:<resets>:<scheme>, region 0
+    meaning none set, e.g. DVD_REGION_FAKE=0:5:4:1. Touches no hardware.
+    """
+    def __init__(self, spec):
+        parts = (spec.split(":") + ["0", "5", "4", "1"])[:4]
+        region, changes, resets, scheme = (int(p) for p in parts)
+        self.path = "(simulated drive)"
+        self.state = [region or None, changes, resets, scheme]
+
+    def read_state(self):
+        return tuple(self.state)
+
+    def set_region(self, region):
+        if self.state[1] <= 0:
+            raise OSError(5, "Input/output error")
+        self.state[0] = region
+        self.state[1] -= 1
+
+
+def find_drives():
+    fake = os.environ.get("DVD_REGION_FAKE")
+    if fake:
+        return [FakeDrive(fake)]
+    drives = []
+    for path in sorted(glob.glob("/dev/sr[0-9]*")):
+        try:
+            # Read-only + non-blocking: opens whether or not media is loaded, and
+            # cannot disturb a disc.
+            drives.append(Drive(path, os.open(path, os.O_RDONLY | os.O_NONBLOCK)))
+        except OSError:
+            continue
+    return drives
+
+
+# ------------------------------------------------------------------ console UI
+
+def out(text=""):
+    # Raw mode turns off the newline translation, so line ends must be explicit.
+    sys.stdout.write(text + "\r\n")
+    sys.stdout.flush()
+
+
+def clear():
+    sys.stdout.write("\x1b[2J\x1b[H")
+    sys.stdout.flush()
+
+
+def read_key(fd):
+    """One keypress -> 'up'/'down'/'enter'/'esc'/'1'..'8'/'' (anything else)."""
+    ch = os.read(fd, 1)
+    if ch == b"\x1b":
+        # Could be a bare Esc (B2 on the gamepad) or the start of an arrow's CSI
+        # sequence. Only a timeout tells them apart.
+        if not select.select([fd], [], [], 0.05)[0]:
+            return "esc"
+        seq = os.read(fd, 2)
+        return {b"[A": "up", b"[B": "down", b"[C": "right", b"[D": "left"}.get(seq, "")
+    if ch in (b"\r", b"\n"):
+        return "enter"
+    if ch in (b"q", b"Q"):
+        return "esc"
+    if ch.isdigit():
+        return ch.decode()
+    return ""
+
+
+def menu(header, items, footer, selected=0):
+    """Cursor menu. Returns the chosen index, or None if cancelled."""
+    fd = sys.stdin.fileno()
+    saved = termios.tcgetattr(fd)
+    try:
+        tty.setcbreak(fd)
+        while True:
+            clear()
+            for row in header:
+                out(row)
+            out()
+            for n, item in enumerate(items):
+                out(("  > " if n == selected else "    ") + item)
+            out()
+            for row in footer:
+                out(row)
+            key = read_key(fd)
+            if key == "up":
+                selected = (selected - 1) % len(items)
+            elif key == "down":
+                selected = (selected + 1) % len(items)
+            elif key == "enter":
+                return selected
+            elif key == "esc":
+                return None
+            elif key.isdigit() and 1 <= int(key) <= len(items):
+                selected = int(key) - 1
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+
+
+def describe(region):
+    if region is None:
+        return "NONE set"
+    for num, name in REGIONS:
+        if num == region:
+            return "%d  (%s)" % (num, name)
+    return str(region)
+
+
+def status_lines(drive, region, changes, resets, rpc1=False):
+    lines = ["  DVD drive region                    %s" % drive.path, ""]
+    lines.append("  Current region : %s" % describe(region))
+    if region is None and not rpc1:
+        lines.append("                   CSS keys must be cracked - slow first play")
+    lines.append("  Changes left   : %d       (vendor resets: %d)" % (changes, resets))
+    return lines
+
+
+# --------------------------------------------------------------------- actions
+
+def apply_region(drive, want):
+    out()
+    out("  Setting region %d ..." % want)
+    try:
+        drive.set_region(want)
+    except OSError as err:
+        out("  FAILED: %s" % err)
+        out("  The drive rejected the change; nothing was altered.")
+        return 1
+    region, changes, _resets, _scheme = drive.read_state()
+    if region == want:
+        out("  Done. The drive is now region %d, with %d changes left."
+            % (region, changes))
+        return 0
+    out("  The drive did not take the change (it now reports %s)." % describe(region))
+    return 1
+
+
+def interactive(drive, region, changes, resets):
+    header = status_lines(drive, region, changes, resets)
+    if changes == 0:
+        header += ["", "  This drive has NO changes left - its region is locked",
+                   "  permanently and cannot be altered."]
+        menu(header, ["Exit"], ["  B1 / Enter = exit"])
+        return 0
+
+    header += ["", "  Pick the region your discs come from:"]
+    items = ["%d  %s" % (num, name) for num, name in REGIONS] + ["Cancel - change nothing"]
+    footer = ["  D-pad = move    B1 = select    B2 = cancel",
+              "",
+              "  A change costs one of the drive's %d remaining changes" % changes,
+              "  and cannot be undone."]
+    # Default the cursor to Cancel so an accidental B1 changes nothing.
+    choice = menu(header, items, footer, selected=len(items) - 1)
+    if choice is None or choice == len(items) - 1:
+        clear()
+        out("  Cancelled. Nothing was changed.")
+        return 0
+
+    want = REGIONS[choice][0]
+    if want == region:
+        clear()
+        out("  The drive is already set to region %d. Nothing was changed." % want)
+        return 0
+
+    confirm_header = ["  Set this drive to region %d?" % want, ""]
+    confirm_header.append("  %s" % describe(want))
+    confirm_header += ["",
+                       "  This uses one of the %d changes the drive has left" % changes,
+                       "  and CANNOT be undone."]
+    if changes == 1:
+        confirm_header += ["",
+                           "  *** This is the LAST change this drive allows.",
+                           "  *** It will be locked to region %d forever." % want]
+    verdict = menu(confirm_header,
+                   ["No  - leave the drive alone", "Yes - set region %d" % want],
+                   ["  D-pad = move    B1 = select    B2 = cancel"],
+                   selected=0)
+    clear()
+    if verdict != 1:
+        out("  Cancelled. Nothing was changed.")
+        return 0
+    for row in status_lines(drive, region, changes, resets):
+        out(row)
+    return apply_region(drive, want)
+
+
+def main():
+    argv = sys.argv[1:]
+    assume_yes = "--yes" in argv
+    args = [a for a in argv if a != "--yes"]
+    want = None
+    if args:
+        if not args[0].isdigit() or not 1 <= int(args[0]) <= 8:
+            out("usage: set_dvd_region.sh [1-8] [--yes]")
+            return 2
+        want = int(args[0])
+
+    drives = find_drives()
+    if not drives:
+        out("  No optical drive found at /dev/sr0.")
+        out("  Check that the drive is plugged in and has power (some USB drives")
+        out("  need a powered hub or a second USB lead).")
+        return 1
+    drive = drives[0]
+
+    try:
+        region, changes, resets, scheme = drive.read_state()
+    except OSError as err:
+        out("  Could not read the drive's region state: %s" % err)
+        out("  The drive may not report RPC state, or the disc may be in use -")
+        out("  stop playback and try again.")
+        return 1
+
+    if scheme == 0:
+        for row in status_lines(drive, region, changes, resets, rpc1=True):
+            out(row)
+        out()
+        out("  This drive is RPC-1 (region-free): it ignores disc regions and")
+        out("  needs no region set. Nothing to do.")
+        return 0
+
+    if want is None:
+        # No controllable console (fb_terminal=0 runs scripts through the OSD with
+        # no stdin at all, and a pipe has none either): report and stop rather than
+        # block on input nobody can give.
+        if not sys.stdin.isatty():
+            for row in status_lines(drive, region, changes, resets):
+                out(row)
+            out()
+            out("  Run this from the MiSTer Scripts menu (with fb_terminal=1) to")
+            out("  change the region, or pass the region number as an argument.")
+            return 0
+        return interactive(drive, region, changes, resets)
+
+    # Argument form (SSH): same safety rules, minus the cursor menu.
+    for row in status_lines(drive, region, changes, resets):
+        out(row)
+    if want == region:
+        out()
+        out("  Already region %d. Nothing was changed." % want)
+        return 0
+    if changes == 0:
+        out()
+        out("  No changes left - the region is locked permanently.")
+        return 1
+    if not assume_yes:
+        if not sys.stdin.isatty():
+            out()
+            out("  Nothing to confirm with: this is not a terminal. Re-run with")
+            out("  --yes if you are sure, or use the MiSTer Scripts menu.")
+            return 1
+        verdict = menu(["  Set this drive to region %d?" % want,
+                        "",
+                        "  Uses one of %d remaining changes; cannot be undone." % changes],
+                       ["No  - leave the drive alone", "Yes - set region %d" % want],
+                       ["  arrows = move    Enter = select    Esc = cancel"],
+                       selected=0)
+        clear()
+        if verdict != 1:
+            out("  Cancelled. Nothing was changed.")
+            return 0
+    return apply_region(drive, want)
+
+
+sys.exit(main())
+PYEOF
+
+python3 "$PY" "$@"

--- a/main/Scripts/set_dvd_region.sh
+++ b/main/Scripts/set_dvd_region.sh
@@ -17,7 +17,9 @@
 # !! returned to none, only changed to another region at the cost of one change.
 #
 # Needs only what a stock MiSTer already has: python3. Run it with no disc playing —
-# the DVD core holds the drive open while a disc is mounted.
+# the DVD core holds the drive open while a disc is mounted. If several drives are
+# connected it only ever touches the first, and says so; connect just the one you
+# mean to change.
 #
 # Over SSH you can skip the menu:
 #   ./set_dvd_region.sh          show the current region and changes remaining
@@ -114,12 +116,13 @@ class FakeDrive:
     """Test stand-in so the menus can be exercised without an optical drive.
 
     Enable with DVD_REGION_FAKE=<region>:<changes>:<resets>:<scheme>, region 0
-    meaning none set, e.g. DVD_REGION_FAKE=0:5:4:1. Touches no hardware.
+    meaning none set, e.g. DVD_REGION_FAKE=0:5:4:1. Several drives can be
+    simulated by separating them with commas. Touches no hardware.
     """
-    def __init__(self, spec):
+    def __init__(self, spec, index=0):
         parts = (spec.split(":") + ["0", "5", "4", "1"])[:4]
         region, changes, resets, scheme = (int(p) for p in parts)
-        self.path = "(simulated drive)"
+        self.path = "(simulated sr%d)" % index
         self.state = [region or None, changes, resets, scheme]
 
     def read_state(self):
@@ -135,7 +138,7 @@ class FakeDrive:
 def find_drives():
     fake = os.environ.get("DVD_REGION_FAKE")
     if fake:
-        return [FakeDrive(fake)]
+        return [FakeDrive(spec, n) for n, spec in enumerate(fake.split(","))]
     drives = []
     for path in sorted(glob.glob("/dev/sr[0-9]*")):
         try:
@@ -219,6 +222,31 @@ def describe(region):
     return str(region)
 
 
+def sibling_lines(drives):
+    """Warning + inventory when more than one optical drive is connected.
+
+    Only the first drive is ever touched. Reading the others is harmless (the RPC
+    state ioctl changes nothing), and naming them with their regions is what makes
+    the warning actionable: you can tell which drive is which without unplugging
+    anything, and see that the one about to change is the one you meant.
+    """
+    if len(drives) < 2:
+        return []
+    lines = ["",
+             "  !! %d optical drives are connected. This tool only looks at" % len(drives),
+             "  !! %s, the first one:" % drives[0].path]
+    for drive in drives:
+        try:
+            region, _changes, _resets, scheme = drive.read_state()
+            what = "region-free (RPC-1)" if scheme == 0 else describe(region)
+        except OSError:
+            what = "(could not be read)"
+        lines.append("       %-16s %s%s"
+                     % (drive.path, what, "   <- this one" if drive is drives[0] else ""))
+    lines.append("  !! Connect only the drive you want to change, to be certain.")
+    return lines
+
+
 def status_lines(drive, region, changes, resets, rpc1=False):
     lines = ["  DVD drive region                    %s" % drive.path, ""]
     lines.append("  Current region : %s" % describe(region))
@@ -248,8 +276,8 @@ def apply_region(drive, want):
     return 1
 
 
-def interactive(drive, region, changes, resets):
-    header = status_lines(drive, region, changes, resets)
+def interactive(drive, region, changes, resets, extra=()):
+    header = status_lines(drive, region, changes, resets) + list(extra)
     if changes == 0:
         header += ["", "  This drive has NO changes left - its region is locked",
                    "  permanently and cannot be altered."]
@@ -275,7 +303,7 @@ def interactive(drive, region, changes, resets):
         out("  The drive is already set to region %d. Nothing was changed." % want)
         return 0
 
-    confirm_header = ["  Set this drive to region %d?" % want, ""]
+    confirm_header = ["  Set %s to region %d?" % (drive.path, want), ""]
     confirm_header.append("  %s" % describe(want))
     confirm_header += ["",
                        "  This uses one of the %d changes the drive has left" % changes,
@@ -328,8 +356,10 @@ def main():
         out("  stop playback and try again.")
         return 1
 
+    extra = sibling_lines(drives)
+
     if scheme == 0:
-        for row in status_lines(drive, region, changes, resets, rpc1=True):
+        for row in status_lines(drive, region, changes, resets, rpc1=True) + extra:
             out(row)
         out()
         out("  This drive is RPC-1 (region-free): it ignores disc regions and")
@@ -341,16 +371,16 @@ def main():
         # no stdin at all, and a pipe has none either): report and stop rather than
         # block on input nobody can give.
         if not sys.stdin.isatty():
-            for row in status_lines(drive, region, changes, resets):
+            for row in status_lines(drive, region, changes, resets) + extra:
                 out(row)
             out()
             out("  Run this from the MiSTer Scripts menu (with fb_terminal=1) to")
             out("  change the region, or pass the region number as an argument.")
             return 0
-        return interactive(drive, region, changes, resets)
+        return interactive(drive, region, changes, resets, extra)
 
     # Argument form (SSH): same safety rules, minus the cursor menu.
-    for row in status_lines(drive, region, changes, resets):
+    for row in status_lines(drive, region, changes, resets) + extra:
         out(row)
     if want == region:
         out()
@@ -366,7 +396,7 @@ def main():
             out("  Nothing to confirm with: this is not a terminal. Re-run with")
             out("  --yes if you are sure, or use the MiSTer Scripts menu.")
             return 1
-        verdict = menu(["  Set this drive to region %d?" % want,
+        verdict = menu(["  Set %s to region %d?" % (drive.path, want),
                         "",
                         "  Uses one of %d remaining changes; cannot be undone." % changes],
                        ["No  - leave the drive alone", "Yes - set region %d" % want],

--- a/main/Scripts/set_dvd_region.sh
+++ b/main/Scripts/set_dvd_region.sh
@@ -21,7 +21,7 @@
 #
 # Over SSH you can skip the menu:
 #   ./set_dvd_region.sh          show the current region and changes remaining
-#   ./set_dvd_region.sh 2        set region 2 (asks to confirm)
+#   ./set_dvd_region.sh 2        set region 2, 1-6 (asks to confirm)
 #   ./set_dvd_region.sh 2 --yes  set region 2 without asking
 
 set -u
@@ -69,6 +69,12 @@ REGIONS = [
     (7, "reserved"),
     (8, "international venues (aircraft, cruise ships)"),
 ]
+
+# Regions 7 and 8 are named above so a drive reporting one is still described
+# correctly, but they are never OFFERED: 7 is unassigned and 8 is for aircraft and
+# cruise ships, so no disc a user owns carries either. Spending one of a drive's
+# handful of permanent changes on one would be a mistake with no way back.
+CHOOSABLE = [entry for entry in REGIONS if entry[0] <= 6]
 
 
 # ---------------------------------------------------------------- drive access
@@ -251,7 +257,7 @@ def interactive(drive, region, changes, resets):
         return 0
 
     header += ["", "  Pick the region your discs come from:"]
-    items = ["%d  %s" % (num, name) for num, name in REGIONS] + ["Cancel - change nothing"]
+    items = ["%d  %s" % (num, name) for num, name in CHOOSABLE] + ["Cancel - change nothing"]
     footer = ["  D-pad = move    B1 = select    B2 = cancel",
               "",
               "  A change costs one of the drive's %d remaining changes" % changes,
@@ -263,7 +269,7 @@ def interactive(drive, region, changes, resets):
         out("  Cancelled. Nothing was changed.")
         return 0
 
-    want = REGIONS[choice][0]
+    want = CHOOSABLE[choice][0]
     if want == region:
         clear()
         out("  The drive is already set to region %d. Nothing was changed." % want)
@@ -297,8 +303,12 @@ def main():
     args = [a for a in argv if a != "--yes"]
     want = None
     if args:
-        if not args[0].isdigit() or not 1 <= int(args[0]) <= 8:
-            out("usage: set_dvd_region.sh [1-8] [--yes]")
+        if args[0] in ("7", "8"):
+            out("  Regions 7 and 8 are not consumer regions (7 is unassigned, 8 is")
+            out("  aircraft and cruise ships), so this tool does not set them.")
+            return 2
+        if not args[0].isdigit() or not 1 <= int(args[0]) <= 6:
+            out("usage: set_dvd_region.sh [1-6] [--yes]")
             return 2
         want = int(args[0])
 

--- a/tools/package_release.sh
+++ b/tools/package_release.sh
@@ -4,7 +4,8 @@
 # Bundles the three things a user installs into ONE zip that extracts to the SD-card
 # root (/media/fat): the core .rbf, the custom Main (MiSTer_DVDcss — physical discs +
 # encrypted ISOs), and Scripts/install_dvdcss.sh (so the libdvdcss installer lands in
-# the MiSTer Scripts menu automatically). It BUILDS nothing — point it at an already-
+# the MiSTer Scripts menu automatically, alongside the drive-region tool). It
+# BUILDS nothing — point it at an already-
 # built .rbf and MiSTer_DVDcss:
 #
 #   ./build_release.sh --release                 # -> releases/DVD_YYYYMMDD.rbf
@@ -60,6 +61,9 @@ fi
 INSTALLER="$REPO/main/Scripts/install_dvdcss.sh"
 [ -f "$INSTALLER" ] || { echo "!! missing $INSTALLER" >&2; exit 1; }
 
+REGIONTOOL="$REPO/main/Scripts/set_dvd_region.sh"
+[ -f "$REGIONTOOL" ] || { echo "!! missing $REGIONTOOL" >&2; exit 1; }
+
 command -v python3 >/dev/null 2>&1 || { echo "!! 'python3' not found on PATH" >&2; exit 1; }
 
 [ -n "$OUT" ] || OUT="$REPO/releases/MiSTer_DVD_v${VER}.zip"
@@ -78,6 +82,8 @@ cp "$RBF"       "$STAGE/${RBF_DIR:+$RBF_DIR/}$(basename "$RBF")"
 cp "$MAIN_BIN"  "$STAGE/MiSTer_DVDcss"
 cp "$INSTALLER" "$STAGE/Scripts/install_dvdcss.sh"
 chmod +x "$STAGE/Scripts/install_dvdcss.sh"
+cp "$REGIONTOOL" "$STAGE/Scripts/set_dvd_region.sh"
+chmod +x "$STAGE/Scripts/set_dvd_region.sh"
 
 RBF_SHOWN="${RBF_DIR:+$RBF_DIR/}$(basename "$RBF")"
 cat > "$STAGE/DVD_INSTALL.txt" <<EOF
@@ -88,6 +94,7 @@ MiSTer DVD Player v${VER}
      ${RBF_SHOWN}   - the core (in ${RBF_DIR:-the SD root}; move it elsewhere if you prefer)
      MiSTer_DVDcss         - custom Main (physical discs + encrypted ISOs); keep at the root
      Scripts/install_dvdcss.sh
+     Scripts/set_dvd_region.sh
 
 2. To play PHYSICAL discs or ENCRYPTED ISOs, add to /media/fat/MiSTer.ini
    (add the section; do NOT replace the file):
@@ -101,7 +108,13 @@ MiSTer DVD Player v${VER}
    Run "install_dvdcss" once from the MiSTer Scripts menu to fetch it. Unencrypted
    discs and already-decrypted ISOs need nothing.
 
-4. Launch DVD from the MiSTer menu.
+4. PHYSICAL DISCS ONLY: a drive with no region set makes every disc slow to start,
+   because the CSS keys have to be cracked instead of read from the drive. Run
+   "set_dvd_region" from the Scripts menu to see the drive's region and, if you
+   want, set it. Read its warnings first - a drive allows only about five region
+   changes, ever, and the region cannot be un-set.
+
+5. Launch DVD from the MiSTer menu.
 EOF
 
 rm -f "$OUT"
@@ -126,10 +139,13 @@ echo
 echo "Attach these to the GitHub release (zip for a full install; bare files for"
 echo "users who just want one piece — most want only the .rbf):"
 echo "  $OUT"
-echo "      ^ complete install: core + MiSTer_DVDcss + Scripts/install_dvdcss.sh"
+echo "      ^ complete install: core + MiSTer_DVDcss + Scripts/ (dvdcss installer,"
+echo "        drive-region tool)"
 echo "  $RBF"
 echo "      ^ core only (ISO-only users; physical disc is opt-in)"
 echo "  $MAIN_BIN"
 echo "      ^ custom Main only (physical discs + encrypted ISOs); needs [DVD] main="
 echo "  $INSTALLER"
 echo "      ^ libdvdcss installer (also inside the zip's Scripts/)"
+echo "  $REGIONTOOL"
+echo "      ^ DVD drive-region tool (also inside the zip's Scripts/)"

--- a/tools/test_set_dvd_region.py
+++ b/tools/test_set_dvd_region.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""test_set_dvd_region.py — drive main/Scripts/set_dvd_region.sh's menus and check them.
+
+Run from the repository root:  ./tools/test_set_dvd_region.py
+
+The script's one real action is an ioctl to a DVD drive, which cannot be tested
+without one; what CAN be tested is everything guarding that ioctl, and that is where
+the risk lives — a region change spends one of a drive's ~5 permanent changes, so a
+menu that selects the wrong entry or treats a stray keypress as consent does real,
+unrecoverable damage. So the drive is faked (DVD_REGION_FAKE, honoured by the script
+itself) and the menus are driven through a pty with the exact key sequences MiSTer
+sends for a gamepad: D-pad -> arrows, B1 -> Enter, B2 -> Esc.
+"""
+import os, pty, subprocess, select, time, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, os.pardir, "main", "Scripts", "set_dvd_region.sh")
+
+UP, DOWN, ENTER, ESC = b"\x1b[A", b"\x1b[B", b"\r", b"\x1b"
+
+def drain(fd, wait=0.25):
+    buf = b""
+    end = time.time() + wait
+    while time.time() < end:
+        if select.select([fd], [], [], 0.05)[0]:
+            try:
+                chunk = os.read(fd, 65536)
+            except OSError:
+                break
+            if not chunk:
+                break
+            buf += chunk
+    return buf
+
+def run(keys, fake="0:5:4:1", args=()):
+    m, s = pty.openpty()
+    env = dict(os.environ, DVD_REGION_FAKE=fake, TERM="linux")
+    p = subprocess.Popen([SCRIPT, *args],
+                         stdin=s, stdout=s, stderr=s, env=env, close_fds=True)
+    os.close(s)
+    out = b""
+    for k in keys:
+        out += drain(m)
+        os.write(m, k)
+    out += drain(m, 0.6)
+    try:
+        p.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        p.kill(); out += b"<<TIMEOUT>>"
+    os.close(m)
+    return out.decode(errors="replace"), p.returncode
+
+FAIL = 0
+def check(name, keys, must_have, must_not=(), fake="0:5:4:1", rc=0):
+    global FAIL
+    text, code = run(keys, fake)
+    bad = [n for n in must_have if n not in text]
+    bad += ["(unexpected) " + n for n in must_not if n in text]
+    if code != rc:
+        bad.append("exit=%s want %s" % (code, rc))
+    print(("PASS  " if not bad else "FAIL  ") + name)
+    for b in bad:
+        print("        missing/wrong: " + b)
+        FAIL += 1
+
+# The cursor starts on Cancel, so a stray B1 must change nothing.
+check("Enter on entry = cancel (safe default)", [ENTER],
+      ["Cancelled. Nothing was changed."], ["Setting region"])
+check("Esc/B2 backs out", [ESC],
+      ["Cancelled. Nothing was changed."], ["Setting region"])
+# Down from Cancel wraps to region 1; the confirm screen defaults to No.
+check("confirm defaults to No", [DOWN, ENTER, ENTER],
+      ["Set this drive to region 1?", "Cancelled. Nothing was changed."],
+      ["Setting region"])
+check("Down+Enter on confirm applies", [DOWN, ENTER, DOWN, ENTER],
+      ["Setting region 1 ...", "Done. The drive is now region 1, with 4 changes left."])
+check("digit key jumps the cursor", [b"3", ENTER, DOWN, ENTER],
+      ["Set this drive to region 3?", "Done. The drive is now region 3"])
+check("last-change warning shown", [DOWN, ENTER, ESC],
+      ["This is the LAST change this drive allows."], fake="0:1:4:1")
+check("locked drive offers only Exit", [ENTER],
+      ["NO changes left", "Exit"], ["Pick the region"], fake="2:0:4:1")
+check("picking the current region is a no-op", [b"2", ENTER],
+      ["already set to region 2"], ["Setting region"], fake="2:4:4:1")
+
+print("\n%s" % ("ALL PASS" if not FAIL else "%d FAILURES" % FAIL))
+sys.exit(1 if FAIL else 0)

--- a/tools/test_set_dvd_region.py
+++ b/tools/test_set_dvd_region.py
@@ -82,6 +82,16 @@ check("locked drive offers only Exit", [ENTER],
       ["NO changes left", "Exit"], ["Pick the region"], fake="2:0:4:1")
 check("picking the current region is a no-op", [b"2", ENTER],
       ["already set to region 2"], ["Setting region"], fake="2:4:4:1")
+# 7 (unassigned) and 8 (aircraft/cruise) are not offered - no disc carries them,
+# and choosing one would spend a permanent change for nothing.
+check("menu offers regions 1-6 only", [ESC],
+      ["6  China"], ["7  reserved", "international venues"])
+
+text, code = run([], args=("8",))
+print(("PASS  " if code == 2 and "not consumer regions" in text else "FAIL  ")
+      + "argument form refuses region 8")
+if code != 2 or "not consumer regions" not in text:
+    FAIL += 1
 
 print("\n%s" % ("ALL PASS" if not FAIL else "%d FAILURES" % FAIL))
 sys.exit(1 if FAIL else 0)

--- a/tools/test_set_dvd_region.py
+++ b/tools/test_set_dvd_region.py
@@ -70,12 +70,12 @@ check("Esc/B2 backs out", [ESC],
       ["Cancelled. Nothing was changed."], ["Setting region"])
 # Down from Cancel wraps to region 1; the confirm screen defaults to No.
 check("confirm defaults to No", [DOWN, ENTER, ENTER],
-      ["Set this drive to region 1?", "Cancelled. Nothing was changed."],
+      ["Set (simulated sr0) to region 1?", "Cancelled. Nothing was changed."],
       ["Setting region"])
 check("Down+Enter on confirm applies", [DOWN, ENTER, DOWN, ENTER],
       ["Setting region 1 ...", "Done. The drive is now region 1, with 4 changes left."])
 check("digit key jumps the cursor", [b"3", ENTER, DOWN, ENTER],
-      ["Set this drive to region 3?", "Done. The drive is now region 3"])
+      ["Set (simulated sr0) to region 3?", "Done. The drive is now region 3"])
 check("last-change warning shown", [DOWN, ENTER, ESC],
       ["This is the LAST change this drive allows."], fake="0:1:4:1")
 check("locked drive offers only Exit", [ENTER],
@@ -86,6 +86,18 @@ check("picking the current region is a no-op", [b"2", ENTER],
 # and choosing one would spend a permanent change for nothing.
 check("menu offers regions 1-6 only", [ESC],
       ["6  China"], ["7  reserved", "international venues"])
+
+# Only the first drive is ever touched, so a second one must be called out by
+# name - "which drive am I about to change?" is unanswerable otherwise, and the
+# change cannot be undone.
+check("multi-drive warning names every drive", [ESC],
+      ["2 optical drives are connected", "(simulated sr0)  NONE set   <- this one",
+       "(simulated sr1)  1  (US, Canada)", "Connect only the drive you want"],
+      fake="0:5:4:1,1:3:4:1")
+check("single drive gets no warning", [ESC],
+      ["Current region : NONE set"], ["optical drives are connected"])
+check("confirm screen names the drive", [DOWN, ENTER, ESC],
+      ["Set (simulated sr0) to region 1?"], fake="0:5:4:1,1:3:4:1")
 
 text, code = run([], args=("8",))
 print(("PASS  " if code == 2 and "not consumer regions" in text else "FAIL  ")


### PR DESCRIPTION
## Summary

A USB DVD drive with **no region set** refuses the CSS title-key ioctl, so libdvdcss cracks
every key out of the disc data — the multi-second wait before a physical disc starts, which
the core already surfaces as `No drive region: cracking`. Setting the drive's region removes
it, but there was no way to do that from the MiSTer, and the README mentioned the slowness
only in passing, never that it was fixable.

**`main/Scripts/set_dvd_region.sh`** reads the drive's RPC state (region, user changes
remaining, vendor resets) and can set the region, through one ioctl — `DVD_AUTH`, type 10 to
read, 11 to set. No compiled helper: python3 is stock on MiSTer, as `install_dvdcss.sh`
already establishes.

### Two platform facts shape the UI

Both verified against the Main sources rather than assumed:

- A Scripts-menu script is launched by handing its bare path to `agetty`, so it can **never
  receive arguments**. The argument form is SSH-only.
- MiSTer injects uinput **keyboard** events from the gamepad while a script runs (D-pad →
  arrows, B1 → Enter, B2 → Esc) but **no digits or letters** — so every choice is a cursor
  menu, never a typed prompt. With `fb_terminal=0` the Scripts menu uses the OSD runner,
  which has no stdin at all; the script detects a non-tty and prints status instead of
  blocking on input nobody can give.

### Safety, because a region change is irreversible

There is no un-set: each set spends one of a drive's ~5 user changes and at zero it locks to
the last region. So the entry menu's cursor starts on *Cancel*, the confirm starts on *No*,
the last-change case says "locked forever" explicitly, and a drive with none left is never
offered the menu. Regions 7 and 8 are never offered (7 unassigned, 8 aircraft/cruise ships) —
they remain in the naming table so a drive already reporting one is still described. With
several drives connected, only the first is touched: the tool says so and lists every drive
with its region, marking the one it would change.

### Also

- `tools/package_release.sh` bundles the script into the zip's `Scripts/` and lists it as a
  release asset.
- README gains the drive-region section (MiSTer script first, Linux `regionset` / Windows
  Device Manager as the PC route); its key-recovery paragraph now points there.
- `main/README.md` and `docs/physical_disc.md` record the design, the ioctl details, and the
  remaining gate.

## Test plan

- [x] `tools/test_set_dvd_region.py` — 13 scenarios, fakes the drive (`DVD_REGION_FAKE`) and
      drives the menus through a pty with the exact keys MiSTer sends for a gamepad
- [x] Stray B1 on entry changes nothing; confirm defaults to No; Esc backs out
- [x] Menu offers regions 1–6 only; argument form refuses 7/8
- [x] Multi-drive warning names every drive; a single drive gets no warning
- [x] Locked drive (0 changes) is never offered the menu
- [x] Non-tty stdin degrades to status instead of blocking
- [x] Release packaging: dummy zip built, `Scripts/set_dvd_region.sh` present and executable
- [x] **HW: read path + multi-drive warning + gamepad-driven menu** — Scripts menu,
      gamepad, with one and two drives; unset and region-1 drives each identified correctly
- [ ] **HW: the SET ioctl** — `DVD_HOST_SEND_RPC_STATE` accepted and reading back. Untested
      on purpose: a set is one-way and spends one of a drive's ~5 permanent changes, so it
      wants a drive the owner has decided to commit. Tracked as open item 2 in
      `docs/physical_disc.md`.
