### PR TITLE
docs: LPCM discs exist now, correct the stale no-test-vehicle blocker

### DIFF
--- a/docs/iec61937.md
+++ b/docs/iec61937.md
@@ -460,10 +460,24 @@ integer divide (`ce_cnt`), matching `sys/audio_out.v`'s `mclk_ce`. A reset synch
 
 ## Hi-res LPCM over S/PDIF (PLANNED — sidestep the 16-bit HDMI cap)
 
-**Status: 📋 design only, no RTL. Implement when a 96 kHz/24-bit LPCM disc is in hand to
-verify against** (per the project's "don't build without a test vehicle" rule). Motivating
-gap: the local library has **no LPCM disc at all** (`docs/test_disc_shopping_list.md` Tier 1),
-and 24-bit/96 kHz LPCM is the deferred `lpcm_unpack` case.
+**Status: 📋 design only, no RTL — but the test-vehicle blocker is now PARTLY GONE.**
+
+⚠ This section used to read "the local library has **no LPCM disc at all**", which has
+been false since the 2026-07-31 re-census and contradicted the very file it cited.
+`docs/test_disc_shopping_list.md` records LPCM vehicles (**Three Tenors**, **Roger
+Waters**), and lists only row #2 — **LPCM 24-bit/96 kHz** — as still having none.
+
+That splits the work in two:
+
+- **Plain LPCM as linear PCM out S/PDIF** — testable NOW against those discs. No longer
+  blocked by "don't build without a test vehicle".
+- **The hi-res (24-bit / 96 kHz) claims** — still unverifiable; that disc row is one of
+  only two on the shopping list with no vehicle. ⚠ Whether either library disc is
+  actually 24-bit or 96 kHz has NOT been checked; `tools/dvd_census.py` reports
+  `lpcm_24bit` / `lpcm_96k` per disc, so confirm before assuming the hi-res path is
+  covered.
+
+24-bit/96 kHz LPCM remains the deferred `lpcm_unpack` case either way.
 
 ### The idea
 


### PR DESCRIPTION
`docs/iec61937.md` justified keeping the hi-res LPCM work as design-only with "the
local library has **no LPCM disc at all**", citing the shopping list. That has been
false since the **2026-07-31 re-census**, and it contradicted the very file it cited:
`docs/test_disc_shopping_list.md` already records **Three Tenors** and **Roger Waters**
as LPCM vehicles, and lists only row #2 (LPCM 24-bit/96 kHz) as still lacking one.

This mattered beyond tidiness — the false claim was the stated **reason** the work had
not started, so a blocker that lifted six weeks ago was still deterring a feature.

Split accordingly:

- **Plain LPCM as linear PCM out S/PDIF** — has a vehicle, testable now, no longer
  blocked by the "don't build without a test vehicle" rule
- **Hi-res 24-bit / 96 kHz** — still unverifiable; one of only two shopping-list rows
  with no disc

⚠ Also records what is still unknown: nobody has checked whether either disc is
*actually* 24-bit or 96 kHz. `tools/dvd_census.py` reports `lpcm_24bit` / `lpcm_96k`
per disc, so that wants confirming before anyone assumes the hi-res path is covered —
the point being to avoid replacing one wrong claim with a rosier one.

Docs only; no RTL, no behaviour change.
