### PR TITLE
emu: bump CORE_VERSION to 0.3.1 after publishing 0.3.0

### DIFF
--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -525,7 +525,7 @@ assign CE_PIXEL = 1'b1;
 // builds: it is part of CONF_STR = part of the netlist, so every compile would
 // become a new netlist and re-roll the fitter seed lottery (DVD.qsf's ledger).
 // Same-day dev builds are identified by their build_release.sh --name filename.
-`define CORE_VERSION "0.3.0"
+`define CORE_VERSION "0.3.1"
 
 parameter CONF_STR = {
     "DVD;;",


### PR DESCRIPTION
Post-publish housekeeping, per the CLAUDE.md rule: bump the moment a release publishes so no dev build advertises a version that already exists on the releases page. The OSD line is the only thing a bug report can quote, so a dev build reporting v0.3.0 would be indistinguishable from what users installed.

0.3.1 is a placeholder for the next release; under the magnitude rule added today it becomes 0.4.0 if that one lands a headline feature.