### PR TITLE
docs-site: state /media/fat/games/DVD as the standard image location

### DIFF
--- a/site/content/getting-started/discs-and-images.md
+++ b/site/content/getting-started/discs-and-images.md
@@ -71,8 +71,18 @@ navigation. Useful for testing and for clips you have already extracted.
 
 ## Where to keep them
 
-DVD images are large, so **loading from a NAS share works and is often more practical than
-filling the SD card**. USB storage works too. One requirement catches people out:
+The standard place is the core's own folder on the SD card:
+
+```
+/media/fat/games/DVD/
+```
+
+The OSD file picker opens there, so images in that folder are the ones you see first.
+Create it if it does not exist — the release zip does not.
+
+DVD images are large, though, so **loading from a NAS share works and is often more
+practical than filling the SD card**. USB storage works too. One requirement catches
+people out:
 
 !!! danger "The share must be mounted read-write"
     The MiSTer framework opens disk images read-write (`O_RDWR|O_SYNC`) whether or not

--- a/site/content/getting-started/install.md
+++ b/site/content/getting-started/install.md
@@ -34,7 +34,9 @@ shipped with this project.
 
 ---
 
-Now launch **DVD** from the MiSTer menu and load a disc or an image.
+Now launch **DVD** from the MiSTer menu and load a disc or an image. Images go in
+**`/media/fat/games/DVD/`** — the folder the file picker opens in. See
+[Loading a movie](loading.md).
 
 !!! tip "Steps 2 and 3 are one-time"
     **To update later, just extract the new release zip.** The `MiSTer.ini` section and

--- a/site/content/getting-started/loading.md
+++ b/site/content/getting-started/loading.md
@@ -1,7 +1,15 @@
 # Loading a movie
 
-Put the image anywhere the MiSTer file browser can reach — SD card, USB storage or a
-network share — and select it from the core's **`Load Video`** entry in the OSD.
+Put your images in the core's folder on the SD card:
+
+```
+/media/fat/games/DVD/
+```
+
+That is where the OSD file picker opens when you choose **`Load Video`** — create the
+folder if it does not exist yet. Anywhere else the MiSTer file browser can reach works
+too — USB storage or a network share — see
+[Where to keep them](discs-and-images.md#where-to-keep-them).
 
 Accepted file types:
 


### PR DESCRIPTION
## Summary

The manual said only "put the image anywhere the MiSTer file browser can reach", leaving users to guess where the OSD file picker opens. Three getting-started pages now name **`/media/fat/games/DVD/`** as the standard image location:

- **loading.md** — leads with the path, says it is where the picker opens on `Load Video`, and to create the folder if missing (the release zip does not create it). USB/NAS still documented via the existing link.
- **discs-and-images.md** — "Where to keep them" opens with the standard folder before the NAS/USB advice and the read-only-share warning.
- **install.md** — the "Now launch DVD" line after step 3 names the folder and links to the loading page.

## Test plan

- [x] `python3 tools/docs_check.py` — OK (22 OSD options, 13 buttons, 7 extensions)
- [x] `mkdocs build --strict` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
