### PR TITLE
Bug-report bundles: sparse-sector nav repros, from a PC or the player itself

### DIFF
--- a/.claude/commands/merge.md
+++ b/.claude/commands/merge.md
@@ -1,0 +1,58 @@
+Merge the current feature branch into main via its PR, then clean up.
+
+A merge request is authorisation to publish THIS branch. If the branch has never been
+pushed, or has no open PR, create those first (steps 4–5) rather than stopping — but do
+not take it as permission to push anything else.
+
+**Host detection.** Read `git remote get-url origin` first and use the matching CLI for
+every remote operation below:
+- contains `github.com` → **`gh`**
+- anything else (Forgejo) → **`tea`**, passing `--repo owenb321/MiSTer_DVD`
+
+Steps:
+1. Check the current branch. If it's already `main`, tell the user and stop.
+2. Confirm the working tree is clean. If there are uncommitted changes, tell the user and
+   stop — do not commit on their behalf.
+3. **Sweep the user docs before publishing anything.** A merge deploys the manual, so a
+   stale page goes live on merge. Invoke the `docs-sweep` skill for `main...HEAD`, or at
+   minimum run:
+
+   ```bash
+   python3 tools/docs_check.py
+   mkdocs build --strict
+   grep -on "](#[a-z0-9-]*)" README.md
+   ```
+
+   If the branch changed anything user-visible — an OSD option, a control, an on-screen
+   message, install steps, a limitation removed — and the manual does not reflect it, fix
+   that first and commit it to the branch. If something needs a judgement call, report it
+   and stop rather than merging stale documentation.
+4. **If the branch has no upstream** (`git rev-parse --abbrev-ref @{u}` fails), push it:
+   `git push -u origin <branch>`. Say that you are publishing it.
+5. **Find the open PR** for this branch and match the head ref:
+   - gh: `gh pr list --head <branch> --state open`
+   - tea: `tea pr list --repo owenb321/MiSTer_DVD --state open`
+
+   If none exists, create one — write the body to a temp file, never inline:
+   - gh: `gh pr create --base main --head <branch> --title "<title>" --body-file /tmp/pr_body.md`
+   - tea: `tea pr create --repo owenb321/MiSTer_DVD --base main --head <branch> --title "<title>" --description "$(cat /tmp/pr_body.md)"`
+
+   Derive the title from the branch's commits. Include a short summary and a markdown
+   test-plan checklist reflecting what was actually verified.
+6. **Merge it:**
+   - gh: `gh pr merge <number> --merge`
+   - tea: `tea pr merge --repo owenb321/MiSTer_DVD <index>` — pass ONLY the index.
+     `--merge` is not a valid flag there; the merge kind is `--style` and already
+     defaults to a regular merge commit.
+
+   If the merge fails immediately after another merge, re-check the PR state before
+   retrying — it is usually a transient server-side recompute, not a real conflict.
+7. Switch to main: `git checkout main`
+8. Pull latest: `git pull`
+9. Prune remote-tracking refs: `git fetch --prune`
+10. Delete the local feature branch: `git branch -d <branch-name>` (use `-D` only if `-d`
+   fails due to merge-detection issues with the host's merge commit).
+
+Report the PR URL, the branch deleted, and confirm main is up to date. If steps 3 or 4
+had to publish or create anything, say so explicitly — the user expects branches to stay
+local until asked, so publishing is worth reporting rather than doing silently.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:api.github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)"
+    ]
+  }
+}

--- a/.claude/skills/docs-sweep/SKILL.md
+++ b/.claude/skills/docs-sweep/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: docs-sweep
+description: Audit README.md and the site/ user manual against the changes in a diff range, update whatever went stale, and report what changed. Use before merging a feature branch, before cutting a release, or whenever asked to check whether the docs match the code.
+---
+
+# Sweeping the user docs against a change
+
+The manual is published from `main` and deploys on merge, so **a stale page goes live the
+moment a branch lands**. This sweep is what stops that.
+
+Default range is `main...HEAD` (the current branch's changes). A release sweep passes
+`<prev_tag>..HEAD` instead.
+
+## 1. Mechanical checks first
+
+```bash
+python3 tools/docs_check.py     # OSD options/buttons/extensions <-> manual parity
+mkdocs build --strict           # broken cross-link = failure
+```
+
+Both must pass. `docs_check.py` failing means an OSD option, gamepad button or file
+extension changed without the manual following — fix that before anything else.
+
+These do **not** cover README.md. Check its self-anchors by hand, because nothing else
+does:
+
+```bash
+grep -on "](#[a-z0-9-]*)" README.md   # every anchor must match a heading that still exists
+```
+
+## 2. Signal pass
+
+```bash
+git diff --stat <range>
+```
+
+Map what changed to what must be reviewed:
+
+| Changed | Review |
+|---|---|
+| `dvd/emu.sv` CONF_STR literal | `playback/settings.md` (normative), `controls.md`, `getting-started/loading.md` |
+| `dvd/transport_hud.sv` `pop_type`, `dvd/hud_font.mem` | `playback/on-screen-messages.md` **and** `reference/troubleshooting.md` |
+| `tools/*.py`, `tools/*.sh`, `main/Scripts/*` | the owning page — `customising/idle-logo.md`, `formats/physical-discs.md`, `about/building.md` |
+| A new codec/format module in `dvd/` | `reference/compatibility.md`, `audio/formats.md` |
+| `main/support/dvd/*`, release-asset list | `getting-started/what-you-need.md` — the tier matrix is a claim about what each piece buys, and a change there can falsify a row |
+| `main/`, `build_release.sh`, `tools/package_release.sh` | `about/building.md`, `getting-started/install.md` |
+| Video output paths (`re_interlace`, `syncgen`, modeline) | `video/analog-crt.md`, `video/interlaced.md`, `video/film-24p.md` |
+| `README.md` changed but `site/content/` did not, or the reverse | **drift flag** — check the two still agree |
+| `docs/*.md` changed | harvest check: did user-facing material land in an engineering note instead of the manual? |
+
+## 3. Semantic pass
+
+Read the range's commit messages and PR body. For each user-visible claim, ask **which page
+currently states the old truth**.
+
+The highest-value case is a **removed limitation**: `reference/compatibility.md` and the
+README's headline bullets both assert things a branch may have just fixed. Grep the manual
+for the feature's keywords and read every hit — a limitation that is no longer true is the
+same class of bug as a stale status marker.
+
+Also check:
+
+- Does anything need an `!!! info "Unreleased"` admonition? The site documents `main`; a
+  feature not in the newest release must say so.
+- Does a new on-screen message string need a row in **both** `on-screen-messages.md` and
+  `troubleshooting.md`?
+- Did a default change? Defaults are stated on the settings page and often repeated in the
+  page that explains the feature.
+
+## 4. Apply, verify, report
+
+Make the edits, then re-run both checks from step 1.
+
+Report a table of page / signal / verdict — `current`, `updated`, or `needs a decision`.
+Apply what is unambiguous. **Stop and ask** on anything that turns on a judgement about
+user-facing behaviour rather than editing on a guess.
+
+If the sweep runs as part of a merge and finds unresolved items, say so and stop rather
+than merging stale documentation.

--- a/.claude/skills/field-report/SKILL.md
+++ b/.claude/skills/field-report/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: field-report
+description: Turn a field report pasted from Discord (or anywhere else) into a tracked GitHub issue on owenb321/MiSTer_DVD, plus a ready-to-paste reply asking for whatever is missing. Use when the user pastes a user's bug report and wants it filed, tracked, or turned into an issue.
+---
+
+# Filing a field report as an issue
+
+Most users report on Discord and will never open an issue. That is fine — but nothing gets
+tracked, and there is no link to point them at for status. This turns a pasted report into
+an issue that matches what the issue forms produce, so triage is uniform whichever route a
+report arrived by.
+
+**The output is three things**, in this order:
+
+1. A drafted issue, shown for approval before anything is created.
+2. A short **reply to paste back into Discord** asking for what is missing.
+3. After creation, the issue URL and a one-line message to send the reporter.
+
+## Rules — these are the point of the skill
+
+**Never invent a detail.** A Discord report is two sentences and a shrug. Everything not
+stated goes under **Not stated** in the issue body — never guessed, never inferred from
+what would be typical, never silently filled with a default. If the report says "the menu
+doesn't work", the version is *unknown*, not "presumably latest". A fabricated version line
+or output path sends the maintainer chasing the wrong thing, and unlike a missing field it
+will not be noticed.
+
+**Strip personal information — the repository is public.** Remove Discord handles, display
+names, real names, server and channel names, DM references, invite links, avatar URLs, and
+any filesystem paths from the reporter's machine. The default attribution is exactly:
+
+> _Reported via Discord, YYYY-MM-DD._
+
+Include a handle **only** if the user explicitly asks for it in this conversation. Do not
+offer to add one.
+
+**Confirm before creating.** Filing a public issue is outward-facing and awkward to undo.
+Show the full drafted body and wait for a clear go-ahead. Never create on your own judgment
+that the draft looks good.
+
+**Check for duplicates first.** Discord reports repeat, and the same disc surfaces
+repeatedly. Search before drafting, and if something matches, propose commenting on the
+existing issue instead of opening a new one.
+
+## Step 1 — classify
+
+Pick the one category that fits best. These mirror `.github/ISSUE_TEMPLATE/`, and the
+labels must match so both routes land in the same buckets.
+
+| The report is about | Label | Bundle helps? |
+|---|---|---|
+| Menus, buttons, `LINK FAIL`, wrong title, chapters | `area:navigation` | **Yes** |
+| A silent track, wrong language, `AUDIO UNSUPPORTED` | `area:audio` | **Yes** |
+| Nothing loads, black screen, `CSS ENCRYPTED`, `UNSUPPORTED IMAGE` | `area:loading` | Sometimes |
+| Stutter, artefacts, lip sync, subtitles, captions | `area:playback` | No |
+| Analog / CRT picture, sync, geometry | `area:analog` | No |
+| Physical drive, `MiSTer_DVDcss`, libdvdcss, region | `area:physical-disc` | No |
+
+Always add `bug`. If the report is a request rather than a defect, use `enhancement` and
+drop `bug`.
+
+⚠ **A silent or wrong-language audio track is `area:navigation`-shaped even though it
+sounds like audio** — track-to-soundtrack mapping lives in the IFO tables, so a bundle
+reproduces it. Label it `area:audio`, but ask for a bundle.
+
+If the paste plainly contains **several unrelated problems**, do not merge them into one
+issue. Say so and ask which to file, or offer one issue each.
+
+## Step 2 — draft the body
+
+```markdown
+_Reported via Discord, 2026-09-01._
+
+### What was reported
+
+<the report in the reporter's own terms, tidied for spelling and line breaks only —
+do not paraphrase away specifics, and do not add any>
+
+### Details given
+
+| | |
+|---|---|
+| Core version | `v0.3.0 260901` |
+| Disc | <title>, region 1 |
+| Playing from | decrypted image |
+| On-screen message | `LINK FAIL 12` |
+
+### Not stated
+
+- Core version
+- Whether Disc Menus is on
+- Whether it worked in an earlier version
+
+### Next step
+
+Asked on Discord for a repro bundle (`tools/dvd_report.py`) and the version line.
+```
+
+Keep **Details given** to fields the report actually supports; drop the row otherwise. The
+**Not stated** list is not padding — it is what stops a thin report being mistaken for a
+complete one later.
+
+## Step 3 — write the Discord reply
+
+A short, friendly message the user can paste straight back into the thread. Ask only for
+what is genuinely missing and genuinely useful — three items at most, or people don't
+answer. Lead with the version line, since it is cheap and always needed.
+
+For a navigation- or audio-shaped report, include the bundle ask:
+
+> Thanks — tracking this at <URL>.
+>
+> Two things that would help a lot: the version line at the top of the OSD (like
+> `v0.3.0 260901`), and — if you have the disc ripped on a PC — a repro bundle. It is a
+> ~60 KB file with just the disc's menu tables in it, no video or audio:
+> download `dvd_report.py` from the repo and run `python3 dvd_report.py YOUR_DISC.iso`,
+> then drop the zip it makes in here.
+
+Adjust the tone to the thread. Do not paste a wall of instructions at someone who wrote one
+line.
+
+## Step 4 — search, confirm, create
+
+`gh` is **not authenticated** on this machine; pull the token from the git credential store
+and keep it in a subshell. Run every `gh` call inside one `bash -c` (the login shell is
+fish):
+
+```bash
+bash -c 'TOK=$(printf "protocol=https\nhost=github.com\n\n" | git credential fill \
+  | sed -n "s/^password=//p"); GH_TOKEN="$TOK" gh issue list --repo owenb321/MiSTer_DVD \
+  --search "<disc> menu" --state all --limit 10'
+```
+
+Then, only after the user approves the draft:
+
+```bash
+bash -c 'TOK=$(printf "protocol=https\nhost=github.com\n\n" | git credential fill \
+  | sed -n "s/^password=//p"); GH_TOKEN="$TOK" gh issue create \
+  --repo owenb321/MiSTer_DVD --title "<title>" --label bug --label area:navigation \
+  --body-file /tmp/issue_body.md'
+```
+
+Write the body to a file — long markdown with backticks and tables does not survive shell
+quoting reliably.
+
+**Titles:** `<Disc or area>: <symptom>`, concrete and searchable. `<Disc>: language menu
+"next page" starts the feature` beats `Menu bug`. If the disc is unknown, lead with the
+area: `Analog CRT: no picture with composite_sync=1`.
+
+⚠ The `area:*` labels may not exist yet. If `gh issue create` rejects a label, create them
+once:
+
+```bash
+bash -c 'TOK=$(printf "protocol=https\nhost=github.com\n\n" | git credential fill \
+  | sed -n "s/^password=//p"); for a in navigation audio loading playback analog \
+  physical-disc; do GH_TOKEN="$TOK" gh label create "area:$a" \
+  --repo owenb321/MiSTer_DVD --color BFD4F2 --force; done'
+```
+
+## Step 5 — hand back
+
+Give the user the issue URL and the Discord reply, ready to copy. Nothing else.
+
+## When a follow-up arrives
+
+The reporter answers in the thread days later. Paste the follow-up and this skill should
+**comment on the existing issue** rather than open a second one, and strike items off the
+**Not stated** list by editing the body:
+
+```bash
+gh issue comment <n> --repo owenb321/MiSTer_DVD --body-file /tmp/comment.md
+gh issue view <n> --repo owenb321/MiSTer_DVD --json body -q .body   # read before editing
+```
+
+If the follow-up includes a repro bundle the user has saved locally, verify it before
+trusting it — `python3 tools/dvd_report.py info <zip>` prints the manifest, and
+`unpack` turns it into something the nav tools read. See
+[`docs/bug_reports.md`](../../../docs/bug_reports.md).

--- a/.claude/skills/field-report/SKILL.md
+++ b/.claude/skills/field-report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: field-report
-description: Turn a field report pasted from Discord (or anywhere else) into a tracked GitHub issue on owenb321/MiSTer_DVD, plus a ready-to-paste reply asking for whatever is missing. Use when the user pastes a user's bug report and wants it filed, tracked, or turned into an issue.
+description: Turn a field report from Discord — pasted text or a screenshot of a thread — into a tracked GitHub issue on owenb321/MiSTer_DVD, plus a ready-to-paste reply asking for whatever is missing. Use when the user shares a user's bug report and wants it filed, tracked, or turned into an issue.
 ---
 
 # Filing a field report as an issue
@@ -41,6 +41,36 @@ that the draft looks good.
 **Check for duplicates first.** Discord reports repeat, and the same disc surfaces
 repeatedly. Search before drafting, and if something matches, propose commenting on the
 existing issue instead of opening a new one.
+
+## Screenshots of a thread
+
+A screenshot works as well as pasted text — drag it into the terminal, or give the file
+path and read it. It is often the *easier* thing for the user to produce, so expect it.
+Three things change, and they matter more than they look:
+
+**Never guess an illegible character.** Reading a screenshot is transcription, and the
+highest-value fields are the most digit-dense and therefore the easiest to get wrong: the
+version line (`v0.3.0 260901`), the number in `LINK FAIL 12`, a chapter or title number. A
+misread version sends the maintainer to the wrong build and, unlike a blank, nobody ever
+notices it was wrong. If a character is ambiguous, it is **Not stated** — then ask for it
+as text in the Discord reply. Transcribing `v0.3.0` as `v0.3.6` is worse than not having
+it.
+
+**Never attach the screenshot to the issue.** It is a picture of a chat window: handles,
+display names, avatars, the server and channel in the sidebar, and other people's messages.
+Transcribe what is relevant and leave the image on the local machine. This is the same rule
+as stripping handles from text, but it is much easier to violate by accident — dragging the
+image straight into `gh issue create` publishes every one of those at once.
+
+**Read the whole thread, not just the reporter.** A screenshot usually catches several
+messages. Someone else in the thread may have supplied the version line, or asked the
+question that produced the useful detail — take those. Ignore unrelated chatter, and if two
+different people are describing two different problems, treat it as the "several unrelated
+problems" case below rather than blending them.
+
+If the screenshot is cropped so the useful part is missing — a version line half cut off, a
+message continuing past the edge — say so rather than working around it. Asking for one
+more screenshot is cheap.
 
 ## Step 1 — classify
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: release
+description: Cut and publish a GitHub release of the MiSTer DVD core — build the timing-clean .rbf and the MiSTer_DVDcss Main, assemble the ready-to-extract zip, gather release notes from every PR merged since the previous release, publish with the right assets, and bump CORE_VERSION. Use when the user asks to cut, make, or publish a release.
+---
+
+# Cutting a DVD core release
+
+Publishes a GitHub release for `owenb321/MiSTer_DVD`. Two build outputs (FPGA `.rbf` via
+Quartus, `MiSTer_DVDcss` Main via the ARM toolchain) plus a packaged zip, with notes drawn
+from the PRs merged since the last release.
+
+## Versioning — semver, with one hard exception
+
+- **`CORE_VERSION` in `dvd/emu.sv` = semver `MAJOR.MINOR.PATCH`** (e.g. `0.2.0`). Shown in
+  the OSD as `` v`CORE_VERSION` `BUILD_DATE` ``. Bump it the **moment a release publishes**,
+  so no dev build ever advertises a version that already exists on the releases page.
+- **Release tag = `v<semver>`** (e.g. `v0.2.0`); title = `v<semver> — <headline>`.
+  (This replaces the older `v<version>-<yyyymmdd>` tag format — pure semver now.)
+- **Zip = `MiSTer_DVD_v<semver>.zip`** (produced by `tools/package_release.sh`).
+- **★ The `.rbf` filename stays `DVD_YYYYMMDD.rbf` — date only, NEVER a version.** This is
+  required, not stylistic: MiSTer's core browser and update scripts parse the `YYYYMMDD`
+  out of the filename to decide which build is newest. A semver there breaks update
+  detection. `build_release.sh --release` already produces this name. Date and semver never
+  collide: date lives in the filename (for MiSTer), semver lives in the tag/zip/OSD (for
+  humans).
+- `BUILD_DATE` (`yymmdd`) is regenerated per compile; do not extend it — it is part of
+  `CONF_STR`, so any change re-rolls the fitter seed lottery.
+
+## Preconditions
+
+- On `main`, clean tree, and every feature branch intended for this release is already
+  merged (use the `merge` command for any that aren't).
+- **The manual matches what is shipping.** `python3 tools/docs_check.py` and
+  `mkdocs build --strict` both pass. If a release note would claim something the manual
+  does not say, fix the manual first — it is the published contract.
+- `CORE_VERSION` is AHEAD of the latest published tag (`gh release list`). If it still
+  equals a published version, bump it first and commit.
+
+## gh auth
+
+`gh` is not authenticated by default here — pull the token from git credential (see the
+`gh-cli-not-authenticated` memory):
+
+```bash
+export GH_TOKEN=$(printf "host=github.com\nprotocol=https\n\n" | git credential fill | sed -n 's/^password=//p')
+```
+
+## Steps
+
+1. **Build the core (timing-clean).** Quartus, in the pinned container:
+   ```bash
+   USE_DOCKER=1 ./build_release.sh --release --compile   # -> releases/DVD_YYYYMMDD.rbf
+   ```
+   The `--release` gate refuses to pack a timing-marginal netlist. **Never ship a
+   `_MARGINAL_` .rbf.** If it comes back marginal, re-roll the seed (`tools/seed_sweep.sh`)
+   until clean. (Long compile — run in the background and report the result.)
+
+2. **Build the Main:**
+   ```bash
+   USE_DOCKER=1 ./main/build_main.sh                      # -> main/.build/MiSTer_DVDcss
+   ```
+
+3. **Assemble the package:**
+   ```bash
+   ./tools/package_release.sh                             # -> releases/MiSTer_DVD_v<ver>.zip
+   ```
+   It picks the newest non-MARGINAL `DVD_*.rbf` (or pass `--rbf`), bundles the Main and
+   both `Scripts/` tools (`install_dvdcss.sh`, `set_dvd_region.sh`), and **prints the exact
+   files to attach**.
+
+4. **Draft release notes from the PRs since the last release** (see the section below).
+
+4b. **Reconcile the manual against the notes.** You have just read every PR in the range,
+   so this is nearly free. Invoke the `docs-sweep` skill over `<prev_tag>..HEAD`. For each
+   PR ask: does it change controls, an OSD option, an on-screen message, install steps, or
+   compatibility? Confirm the owning page in `site/content/` is current.
+
+   Then, in the same commit:
+   - Update `extra.released_version` in `mkdocs.yml` to the version being cut — it drives
+     the "latest release is vX.Y.Z" banner on every page.
+   - Update the "Current as of **vX.Y.Z**" line in `site/content/reference/compatibility.md`.
+   - Sweep out `!!! info "Unreleased"` admonitions for anything this release ships.
+
+   **Commit these to `main` BEFORE tagging.** The Pages deploy is triggered by that push,
+   so the manual goes live as the release is announced rather than after it.
+
+5. **Publish** (attach the zip AND the bare components — most users want only the `.rbf`):
+   ```bash
+   gh release create v<semver> \
+     --title "v<semver> — <headline>" \
+     --notes-file /tmp/relnotes.md \
+     releases/MiSTer_DVD_v<semver>.zip \
+     releases/DVD_YYYYMMDD.rbf \
+     main/.build/MiSTer_DVDcss \
+     main/Scripts/install_dvdcss.sh \
+     main/Scripts/set_dvd_region.sh
+   ```
+   The `/releases/latest` URL the README links to updates automatically — no README edit
+   needed per release.
+
+6. **Bump `CORE_VERSION`** in `dvd/emu.sv` to the next planned version and commit (so the
+   next dev build's OSD line is already distinct from what you just shipped).
+
+## Release assets (attach all five)
+
+| Asset | For |
+|---|---|
+| `MiSTer_DVD_v<semver>.zip` | Complete install — extracts to SD root, drops the installer into the Scripts menu |
+| `DVD_YYYYMMDD.rbf` | Core only — ISO-only users (physical disc is opt-in); most people want just this |
+| `MiSTer_DVDcss` | Custom Main only — physical discs + encrypted ISOs; needs `[DVD] main=MiSTer_DVDcss` |
+| `install_dvdcss.sh` | libdvdcss installer (also inside the zip's `Scripts/`) |
+| `set_dvd_region.sh` | DVD drive-region tool — physical-disc users (also inside the zip's `Scripts/`). Documented in `site/content/formats/physical-discs.md`; keep it that way — it shipped as an asset for a release before it appeared in any prose. |
+
+## Release notes from every PR since the previous release
+
+Gather them mechanically so nothing is missed, then organize into human notes:
+
+```bash
+# publish time of the current latest release
+PREV=$(gh release view --json publishedAt -q .publishedAt)
+# every PR merged into main since then, oldest first
+gh pr list --state merged --base main --limit 300 \
+  --json number,title,mergedAt,author \
+  --jq "[.[] | select(.mergedAt > \"$PREV\")] | sort_by(.mergedAt) | .[] | \"- #\(.number) \(.title)\""
+```
+
+If a PR spans branches or the boundary is fuzzy, cross-check against merge commits:
+`git log <prev_tag>..HEAD --merges --format='%h %s'`.
+
+Turn that list into notes: a one-line **headline** for the title, then group the PRs by
+area (e.g. Playback / Navigation / Physical disc / Analog-CRT / Build) with a short
+human sentence each — not just the raw PR titles. Call out anything user-visible (new
+formats, new OSD options, new controls, fixed limitations) and anything that changes
+install steps. Write to `/tmp/relnotes.md` for `--notes-file`.
+
+## Notes
+
+- Physical-disc/encrypted-ISO support ships as part of the release now (the `MiSTer_DVDcss`
+  Main + the installer), but stays **opt-in** — the bare `.rbf` alone plays decrypted ISOs.
+- Historical `fj#NN` PR references are Forgejo numbers with no GitHub equivalent — leave
+  them; new PRs use plain `#NN`.
+- Link the manual in the release notes footer:
+  <https://owenb321.github.io/MiSTer_DVD/>. It is the place to send anyone whose report
+  turns out to be a setup question.

--- a/.github/ISSUE_TEMPLATE/01-navigation.yml
+++ b/.github/ISSUE_TEMPLATE/01-navigation.yml
@@ -1,0 +1,103 @@
+name: Navigation, menus or titles
+description: Menus that misbehave, LINK FAIL, the wrong title playing, chapters wrong
+labels: ["bug", "area:navigation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A disc's navigation lives in small `.IFO` files — well under 100 KB on a typical
+        disc — and they are all that is needed to reproduce this class of problem without
+        the disc itself.
+
+        If you have a decrypted rip on a PC, please attach a repro bundle. It takes a
+        minute and it is usually the difference between "I'll look when I find that disc"
+        and a fix:
+
+        ```bash
+        python3 dvd_report.py MY_DISC.iso
+        ```
+
+        [`dvd_report.py`](https://github.com/owenb321/MiSTer_DVD/blob/main/tools/dvd_report.py)
+        · [what it does and what it contains](https://owenb321.github.io/MiSTer_DVD/reference/reporting-a-bug/)
+
+  - type: input
+    id: version
+    attributes:
+      label: Core version
+      description: The line at the top of the OSD. It is the only thing that identifies a build.
+      placeholder: v0.3.0 260901
+    validations:
+      required: true
+
+  - type: input
+    id: disc
+    attributes:
+      label: Disc title and region
+      placeholder: The Matrix, region 1 NTSC
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happens
+      description: Where it goes wrong — does it boot, reach a menu, start the feature? What did you press?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should happen instead
+    validations:
+      required: false
+
+  - type: input
+    id: message
+    attributes:
+      label: On-screen message, if any
+      description: For example `LINK FAIL 12`. Copy the number too — it identifies the failing jump.
+      placeholder: LINK FAIL 12
+    validations:
+      required: false
+
+  - type: dropdown
+    id: source
+    attributes:
+      label: What are you playing from?
+      options:
+        - Decrypted image
+        - Encrypted image (with MiSTer_DVDcss)
+        - Physical disc
+    validations:
+      required: true
+
+  - type: dropdown
+    id: menus
+    attributes:
+      label: Is `Disc Menus` on?
+      options:
+        - "On (the default)"
+        - "Off"
+        - "Don't know"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Did this work in an earlier version?
+      options:
+        - "Don't know / never tried it before"
+        - "No — this is the first version I have tried"
+        - "Yes — it worked in an earlier version"
+    validations:
+      required: false
+
+  - type: textarea
+    id: bundle
+    attributes:
+      label: Repro bundle
+      description: Drag the `dvdreport-*.zip` here. If you cannot make one, say so — the report is still useful.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/01-navigation.yml
+++ b/.github/ISSUE_TEMPLATE/01-navigation.yml
@@ -9,9 +9,9 @@ body:
         disc — and they are all that is needed to reproduce this class of problem without
         the disc itself.
 
-        If you have a decrypted rip on a PC, please attach a repro bundle. It takes a
-        minute and it is usually the difference between "I'll look when I find that disc"
-        and a fix:
+        If you have a rip of the disc on a PC — encrypted or decrypted, either works —
+        please attach a repro bundle. It takes a minute and it is usually the difference
+        between "I'll look when I find that disc" and a fix:
 
         ```bash
         python3 dvd_report.py MY_DISC.iso

--- a/.github/ISSUE_TEMPLATE/02-audio.yml
+++ b/.github/ISSUE_TEMPLATE/02-audio.yml
@@ -1,0 +1,105 @@
+name: Audio — silent, wrong track, or unsupported
+description: No sound on a track, the wrong language, or AUDIO UNSUPPORTED
+labels: ["bug", "area:audio"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Which track maps to which soundtrack is decided in the disc's `.IFO` navigation
+        tables — so a silent or wrong-language track is reproducible from a repro bundle,
+        even though it presents as an audio problem. If you have a decrypted rip on a PC:
+
+        ```bash
+        python3 dvd_report.py MY_DISC.iso
+        ```
+
+        [`dvd_report.py`](https://github.com/owenb321/MiSTer_DVD/blob/main/tools/dvd_report.py)
+        · [more](https://owenb321.github.io/MiSTer_DVD/reference/reporting-a-bug/)
+
+        Before filing: **`Audio Out = Passthru` is silent on an ordinary television**, and
+        LPCM and MP2 have no bitstream form, so they are silent in that mode too. See
+        [No sound](https://owenb321.github.io/MiSTer_DVD/reference/troubleshooting/#no-sound).
+
+  - type: input
+    id: version
+    attributes:
+      label: Core version
+      placeholder: v0.3.0 260901
+    validations:
+      required: true
+
+  - type: input
+    id: disc
+    attributes:
+      label: Disc title and region
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: What is silent?
+      options:
+        - One track only — other tracks play
+        - Every track on this disc
+        - Every track on every disc
+        - Not silent — the wrong language or channel layout plays
+        - Only in menus
+    validations:
+      required: true
+
+  - type: dropdown
+    id: audioout
+    attributes:
+      label: "`Audio Out` setting"
+      options:
+        - Decode PCM
+        - Passthru (S/PDIF or HDMI bitstream)
+        - "Don't know"
+    validations:
+      required: true
+
+  - type: input
+    id: track
+    attributes:
+      label: What the track popup says
+      description: Press B7 to cycle tracks; the popup names the track and language, e.g. `AUD 2/4 FR`.
+      placeholder: AUD 2/4 FR
+    validations:
+      required: false
+
+  - type: input
+    id: format
+    attributes:
+      label: Track format, if you know it
+      description: Dolby Digital / DTS / LPCM / MP2, and the channel layout (2.0, 5.1, mono…).
+      placeholder: Dolby Digital 1.0 mono
+    validations:
+      required: false
+
+  - type: textarea
+    id: what
+    attributes:
+      label: Anything else
+      description: Whether a message appeared, whether it is the whole disc or one title, what you have tried.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Did this work in an earlier version?
+      options:
+        - "Don't know / never tried it before"
+        - "No — this is the first version I have tried"
+        - "Yes — it worked in an earlier version"
+    validations:
+      required: false
+
+  - type: textarea
+    id: bundle
+    attributes:
+      label: Repro bundle
+      description: Drag the `dvdreport-*.zip` here if you were able to make one.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02-audio.yml
+++ b/.github/ISSUE_TEMPLATE/02-audio.yml
@@ -7,7 +7,8 @@ body:
       value: |
         Which track maps to which soundtrack is decided in the disc's `.IFO` navigation
         tables — so a silent or wrong-language track is reproducible from a repro bundle,
-        even though it presents as an audio problem. If you have a decrypted rip on a PC:
+        even though it presents as an audio problem. If you have a rip of the disc on a PC
+        (encrypted or decrypted — either works):
 
         ```bash
         python3 dvd_report.py MY_DISC.iso

--- a/.github/ISSUE_TEMPLATE/03-wont-load.yml
+++ b/.github/ISSUE_TEMPLATE/03-wont-load.yml
@@ -1,0 +1,93 @@
+name: A disc or image will not load
+description: Black screen, nothing happens, CSS ENCRYPTED, or UNSUPPORTED IMAGE
+labels: ["bug", "area:loading"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Start with the message on screen — it usually is the answer.**
+
+        - **`CSS ENCRYPTED`** — the image is an encrypted rip and nothing available can
+          decrypt it. Install `MiSTer_DVDcss` + libdvdcss, or use a decrypted rip.
+        - **`UNSUPPORTED IMAGE`** — the core read the file and could not play it. A
+          UDF-only image will do this; ISO9660 is required.
+        - **No message at all** — the core never received the file. The usual cause is a
+          **network share mounted read-only**: the framework opens images read-write, so a
+          read-only mount fails silently.
+
+        [Nothing plays →](https://owenb321.github.io/MiSTer_DVD/reference/troubleshooting/#nothing-plays)
+
+        If none of those fit, please carry on.
+
+  - type: input
+    id: version
+    attributes:
+      label: Core version
+      placeholder: v0.3.0 260901
+    validations:
+      required: true
+
+  - type: dropdown
+    id: message
+    attributes:
+      label: What appears on screen?
+      options:
+        - Nothing — black screen, no message
+        - "`UNSUPPORTED IMAGE`"
+        - "`CSS ENCRYPTED`"
+        - The idle logo keeps bouncing, as if nothing was loaded
+        - Something else (describe below)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: source
+    attributes:
+      label: What are you loading?
+      options:
+        - Decrypted image (.iso)
+        - Encrypted image (.iso)
+        - Physical disc
+        - VCD / SVCD (.bin)
+        - Bare .VOB / .mpg / .m2v
+    validations:
+      required: true
+
+  - type: input
+    id: ripped
+    attributes:
+      label: How was it made?
+      description: MakeMKV Backup, dvdbackup, ImgBurn, downloaded, unknown…
+    validations:
+      required: false
+
+  - type: dropdown
+    id: media
+    attributes:
+      label: Where does the file live?
+      options:
+        - SD card
+        - USB storage
+        - Network share (CIFS/SMB or NFS)
+        - "Not applicable — physical disc"
+    validations:
+      required: true
+
+  - type: input
+    id: disc
+    attributes:
+      label: Disc title, if it is one specific disc
+      description: Leave blank if nothing loads at all.
+    validations:
+      required: false
+
+  - type: textarea
+    id: what
+    attributes:
+      label: Anything else
+      description: |
+        If you have the image on a PC, `python3 tools/css_scan.py MY_DISC.iso` reports
+        whether it is still encrypted — pasting that output here answers the question
+        outright.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/04-playback.yml
+++ b/.github/ISSUE_TEMPLATE/04-playback.yml
@@ -1,0 +1,122 @@
+name: Picture or sound during playback
+description: Stutter, artefacts, wrong colours, lip sync, subtitles, captions
+labels: ["bug", "area:playback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        These live in the video stream itself, which is far too large to share — so words
+        are the right tool here, and detail pays off.
+
+        **Two questions separate whole classes of cause.** Please answer both below: does
+        it happen from a cold load or only after playing a while, and does a chapter skip
+        clear it?
+
+        For lip sync, a **phone video with sound** is genuinely useful — the offset can be
+        measured from it. Drag it in at the bottom.
+
+  - type: input
+    id: version
+    attributes:
+      label: Core version
+      placeholder: v0.3.0 260901
+    validations:
+      required: true
+
+  - type: input
+    id: disc
+    attributes:
+      label: Disc title and region
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of problem?
+      options:
+        - Stutter or judder
+        - Lip sync — audio and video out of step
+        - Artefacts, blockiness, or tearing
+        - Wrong colours
+        - Subtitles
+        - Closed captions
+        - Picture geometry — stretched, squashed, cropped
+        - Something else
+    validations:
+      required: true
+
+  - type: dropdown
+    id: output
+    attributes:
+      label: Which output are you watching?
+      options:
+        - HDMI
+        - Analog — CRT
+        - Analog — other display
+        - HDMI and analog, both affected
+    validations:
+      required: true
+
+  - type: dropdown
+    id: onset
+    attributes:
+      label: When does it happen?
+      options:
+        - From the moment it starts playing, on a cold load
+        - Only after playing for a while
+        - Only after loading a new disc mid-play
+        - Only after seeking or a chapter skip
+        - Only in menus
+        - At one specific point in the film
+    validations:
+      required: true
+
+  - type: dropdown
+    id: chapterskip
+    attributes:
+      label: Does a chapter skip clear it?
+      options:
+        - "Yes — it comes good after a skip"
+        - "No — it survives a skip"
+        - "Haven't tried"
+        - "Not applicable"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: Describe it
+      description: What you see or hear, and roughly where in the film. Busy scene or calm one?
+    validations:
+      required: true
+
+  - type: textarea
+    id: settings
+    attributes:
+      label: Relevant settings
+      description: |
+        `Film 24p Out`, `A/V Offset`, `Interlaced Out`, `Video Standard`, `Audio Out` —
+        whichever you have changed from the defaults.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Did this work in an earlier version?
+      options:
+        - "Don't know / never tried it before"
+        - "No — this is the first version I have tried"
+        - "Yes — it worked in an earlier version"
+    validations:
+      required: false
+
+  - type: textarea
+    id: media
+    attributes:
+      label: Photo or video
+      description: Drag it here. For lip sync, video with sound is worth far more than a description.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/05-analog-crt.yml
+++ b/.github/ISSUE_TEMPLATE/05-analog-crt.yml
@@ -1,0 +1,79 @@
+name: Analog or CRT output
+description: No analog picture, wrong geometry, sync problems, scanline or field issues
+labels: ["bug", "area:analog"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The analog path engages from `MiSTer.ini` like any other core — there is no OSD
+        switch for it. If there is no analog picture at all, check `vga_scaler=0` and a
+        sync mode (`composite_sync=1`, `ypbpr=1`, or sync-on-green) are actually set.
+
+        [Analog and CRT output →](https://owenb321.github.io/MiSTer_DVD/video/analog-crt/)
+
+        **PAL on an analog CRT is unconfirmed** — no PAL CRT was available to test it, so
+        reports of that specifically are wanted.
+
+  - type: input
+    id: version
+    attributes:
+      label: Core version
+      placeholder: v0.3.0 260901
+    validations:
+      required: true
+
+  - type: textarea
+    id: ini
+    attributes:
+      label: Your MiSTer.ini video lines
+      description: The `vga_scaler`, `composite_sync`, `ypbpr`, `direct_video` and any `[DVD]` section lines.
+      render: ini
+    validations:
+      required: true
+
+  - type: dropdown
+    id: analogout
+    attributes:
+      label: "`Analog Out` setting"
+      options:
+        - "Auto (the default)"
+        - Interlaced
+        - Progressive
+        - Native Fields
+    validations:
+      required: true
+
+  - type: input
+    id: display
+    attributes:
+      label: What is it plugged into?
+      description: The display, and how — CRT over RGB SCART, component, VGA, an upscaler, a capture card…
+    validations:
+      required: true
+
+  - type: input
+    id: board
+    attributes:
+      label: Which I/O board?
+      description: Analog I/O board revision, HDMI-to-DAC, YC/composite encoder…
+    validations:
+      required: false
+
+  - type: dropdown
+    id: standard
+    attributes:
+      label: NTSC or PAL content?
+      options:
+        - NTSC
+        - PAL
+        - Both, and both are affected
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happens
+      description: No picture, rolling, wrong size or position, combing, flicker — and whether HDMI is fine at the same time.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/06-physical-disc.yml
+++ b/.github/ISSUE_TEMPLATE/06-physical-disc.yml
@@ -1,0 +1,81 @@
+name: Physical discs, MiSTer_DVDcss or libdvdcss
+description: The custom Main, drive detection, CSS decryption, region, install script
+labels: ["bug", "area:physical-disc"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This covers the optional add-on: the `MiSTer_DVDcss` Main, the `install_dvdcss`
+        script, drive detection and CSS decryption. The bare `.rbf` plays decrypted images
+        without any of it.
+
+        **`/tmp/dvdcss.log` on the MiSTer records every mount decision** and is the single
+        most useful thing you can attach here.
+
+        [Physical discs and encrypted ISOs →](https://owenb321.github.io/MiSTer_DVD/formats/physical-discs/)
+
+  - type: input
+    id: version
+    attributes:
+      label: Core version
+      placeholder: v0.3.0 260901
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What is going wrong?
+      options:
+        - The drive is not detected, or a disc does nothing
+        - An encrypted image will not decrypt
+        - Decryption is very slow every time
+        - "`install_dvdcss` fails"
+        - The core does not use MiSTer_DVDcss at all
+        - Region setting
+        - Something else
+    validations:
+      required: true
+
+  - type: dropdown
+    id: installed
+    attributes:
+      label: Is the custom Main actually in use?
+      description: "`MiSTer_DVDcss` must be at the SD card root, with `main=MiSTer_DVDcss` under `[DVD]` in MiSTer.ini."
+      options:
+        - "Yes — both the file and the MiSTer.ini line are in place"
+        - "No, or not sure"
+    validations:
+      required: true
+
+  - type: input
+    id: drive
+    attributes:
+      label: Drive make and model
+      description: For a physical-disc problem. How is it connected and powered?
+    validations:
+      required: false
+
+  - type: input
+    id: disc
+    attributes:
+      label: Disc title and region
+    validations:
+      required: false
+
+  - type: textarea
+    id: log
+    attributes:
+      label: "`/tmp/dvdcss.log`"
+      description: Paste it, or drag the file in. It is written fresh on every boot.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: what
+    attributes:
+      label: What happens
+      description: Any on-screen message, how long it waits, and what you have already tried.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Read the manual first
+    url: https://owenb321.github.io/MiSTer_DVD/reference/troubleshooting/
+    about: Troubleshooting covers most problems, including several that look like bugs.
+  - name: Is this disc supported?
+    url: https://owenb321.github.io/MiSTer_DVD/reference/compatibility/
+    about: What plays, what does not, and what is known-incomplete.
+  # Add the Discord invite here so people have a low-friction route:
+  # - name: Ask on Discord
+  #   url: https://discord.gg/<invite>
+  #   about: Questions and quick reports. Anything that needs tracking gets an issue.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 nul
-.claude/
+# .claude/: the shared agent config (skills, commands, project settings) IS tracked --
+# it is part of how this project is built, and the release/merge/docs workflows live
+# there. Only per-machine and runtime state stays out.
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/**/*.local.*
 Template_MiSTer-master/
 CDi_MiSTer-main/
 mpeg2fpga-orig/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1376,7 +1376,12 @@ the MANUAL page `site/content/reference/reporting-a-bug.md` (Reference → Repor
 bug) — NOT the README, which is a landing page. Design: **`docs/bug_reports.md`**.
 
 **★ AND FROM THE PLAYER ITSELF — a gamepad chord (2026-09-01, `MiSTer_DVDcss`;
-⏳ HW-confirm pending).** Hold **Audio + Subtitle 2 s** and the Main writes a bundle
+✅ HW-CONFIRMED 2026-09-02, and on the hardest case first — a PHYSICAL DISC:
+77 KB off a 7.22 GB disc, audit clean, full nav walk + VM boot chain on the
+reconstruction, and ★ the playhead landed 2,064 sectors into the feature, which is
+the fact a reporter can never supply. ★★ Reading `/dev/srN` while `dvd_css` holds
+the drive WORKS — the thing flagged as likeliest to misbehave.)** Hold
+**Audio + Subtitle 2 s** and the Main writes a bundle
 for whatever is mounted — image OR optical drive — to `/media/fat/DVD_reports/`.
 ★ **The Main SHELLS OUT to `tools/dvd_report.py`, it does not reimplement the
 collector** (python3 is on stock MiSTer; a C++ copy would drift, audit and
@@ -1396,7 +1401,10 @@ own `InfoMessage()`, so no RTL change was needed for it either. Uniquely capture
 from memory. ⚠ **The DE10-Nano has NO battery-backed RTC** — an on-player bundle
 from a never-networked MiSTer carries an epoch date in its filename AND
 `created_utc`; unique per session, not trustworthy as a sequence
-(`player.generated_on == "mister"` marks them). Integration steps 22–25.
+(`player.generated_on == "mister"` marks them). Integration steps 22–25. The **core version needs no new plumbing**: `CONF_STR`'s
+`V,` line is appended to the OSD core name at init, so `OsdCoreNameGet()` reads back
+`"DVD v0.4.0 260901"` — everything after the first space (no space ⇒ record nothing,
+never pass the bare core name off as a version).
 ⚠ **`main/build_main.sh` used to copy the overlay as a HAND-MAINTAINED FILE LIST**
 and silently omitted the new module — it now globs `support/dvd/*`; the failure
 surfaced far away as a missing-header error in `user_io.cpp`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1336,6 +1336,30 @@ or letters** — so interactive means a cursor menu, never a typed prompt. A reg
 Tested by `tools/test_set_dvd_region.py` (fakes the drive, drives the menus through a pty);
 the ioctl itself is the HW gate. Design + ioctl details: `docs/physical_disc.md`.
 
+### User bug reports arrive as sparse-sector nav bundles, not ISOs
+
+**`tools/dvd_report.py` (2026-08-31) — the answer to "the disc that breaks it is
+one I don't own".** A nav bug needs the IFO tables and nothing else, and those are
+~0.005% of an image (104 KB of a 4.47 GB rip), so a reporter builds a **36–100 KB
+zip** from their own rip on their PC. The bundle stores `{LBA → sector}` pairs at
+their **original disc addresses**; `unpack` writes them into a **sparse** image of
+the original size (6.77 GB apparent, 480 KB on disk). ★ **That is why no tool
+needed changing** — `IsoNav` asserts `CD001` at sector 16 and follows absolute
+LBAs, so the reconstruction simply *is* an ISO; it is also the `*_meta.hex`
+testbench idiom, so a submission is already shaped like a regression fixture.
+Validated 23/23 discs across the library: `iso_nav_check.py` output byte-identical
+between original and reconstruction (up to 9,143 lines), plus `dvd_vm_ref.py`
+boot/menu, `dvd_census.py`, `nav_extract.py`. Every bundle **self-checks by
+rebuilding itself** before it is handed over (a bundle that cannot be walked is
+worse than none — the reporter is gone by the time anyone opens it).
+⚠ Two traps recorded in `docs/bug_reports.md`: NAV-pack detection is **not**
+`0x000001BF` at offset 14 (a **system header** pushes PCI to `0x26`; the fixed
+offset found ZERO packs and reported success), and the tool is **deliberately
+self-contained** — a reporter downloads one file, not a checkout, so it duplicates
+a small ISO9660 walk instead of importing `IsoNav`. Scope is nav only; video-side
+bugs (subpicture, CC, cadence, lip-sync) report in prose. User-facing entry:
+README "Reporting a navigation bug". Design: **`docs/bug_reports.md`**.
+
 ### No USB DVD-ROM drive support
 MiSTer's custom Linux kernel almost certainly lacks `sr_mod` (`CONFIG_BLK_DEV_SR`).
 Recompiling the kernel is out of scope. Workflow: rip disc to ISO on PC, copy to SD card,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1375,6 +1375,33 @@ bugs (subpicture, CC, cadence, lip-sync) report in prose. User-facing entry:
 the MANUAL page `site/content/reference/reporting-a-bug.md` (Reference → Reporting a
 bug) — NOT the README, which is a landing page. Design: **`docs/bug_reports.md`**.
 
+**★ AND FROM THE PLAYER ITSELF — a gamepad chord (2026-09-01, `MiSTer_DVDcss`;
+⏳ HW-confirm pending).** Hold **Audio + Subtitle 2 s** and the Main writes a bundle
+for whatever is mounted — image OR optical drive — to `/media/fat/DVD_reports/`.
+★ **The Main SHELLS OUT to `tools/dvd_report.py`, it does not reimplement the
+collector** (python3 is on stock MiSTer; a C++ copy would drift, audit and
+self-check included) — and that is also what DISSOLVED the old Scripts-menu
+blocker: "no arguments, gamepad gives only arrows/Enter" stops mattering when the
+Main already knows what is mounted and passes it as an argument. ★★ **A chord, not
+an OSD row, because a `CONF_STR` entry changes the netlist and RE-ROLLS THE PINNED
+FITTER SEED** — a one-line menu addition is not a one-line change in this project.
+⚠ `dvd_report_joy()` **observes `map` and never modifies it**: masking the chord
+bits would mean a detection bug could stop buttons working, and would swallow a
+fast double-press — the accepted cost is that the chord also steps audio/subtitle
+once each (why B7/B8, not the transport buttons, where a stray seek would linger).
+⚠ **The work FORKS** — `dvd_report_tick()` shares the poll loop with SD block
+service, so inline work would starve the core mid-playback; feedback rides Main's
+own `InfoMessage()`, so no RTL change was needed for it either. Uniquely captures
+`buffer_lba` = **where playback actually was**, which a reporter can never state
+from memory. ⚠ **The DE10-Nano has NO battery-backed RTC** — an on-player bundle
+from a never-networked MiSTer carries an epoch date in its filename AND
+`created_utc`; unique per session, not trustworthy as a sequence
+(`player.generated_on == "mister"` marks them). Integration steps 22–25.
+⚠ **`main/build_main.sh` used to copy the overlay as a HAND-MAINTAINED FILE LIST**
+and silently omitted the new module — it now globs `support/dvd/*`; the failure
+surfaced far away as a missing-header error in `user_io.cpp`.
+Design: **`docs/support_bundle_hps.md`**.
+
 ### No USB DVD-ROM drive support
 MiSTer's custom Linux kernel almost certainly lacks `sr_mod` (`CONFIG_BLK_DEV_SR`).
 Recompiling the kernel is out of scope. Workflow: rip disc to ISO on PC, copy to SD card,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1352,6 +1352,20 @@ between original and reconstruction (up to 9,143 lines), plus `dvd_vm_ref.py`
 boot/menu, `dvd_census.py`, `nav_extract.py`. Every bundle **self-checks by
 rebuilding itself** before it is handed over (a bundle that cannot be walked is
 worse than none — the reporter is gone by the time anyone opens it).
+★ **The bundle contains ONLY unencrypted navigation structures — no picture, no
+sound, no keys — and that is ENFORCED, not promised.** `audit()` refuses to write
+a bundle if any gathered sector parses as an MPEG-PS pack containing anything but
+a system header, padding or `private_stream_2`; proven RED against a real title
+sector (`0xE0`) and green on a real NAV pack. It cannot carry key material even in
+principle (title keys live in scrambled sector headers, the disc key block in the
+lead-in, which is not in an ISO image at all) — and the IFO/NAV data it DOES carry
+is capturable precisely because CSS never scrambles it (our own
+`main/support/dvd/dvd_css.cpp:341,393` says so). ⚠ **Never relax this to accept
+VOB payload "just for one bug"** — the guarantee is why a stranger can hand a
+bundle over without thinking, and it is the same line as
+`css-key-cache-never-ship`. ⛔ A `--from-drive` mode was considered and REJECTED
+(2026-08-31, user decision): it points users at their optical drive, and a
+reporter who has already ripped their own ISO is a better reporter.
 ⚠ Two traps recorded in `docs/bug_reports.md`: NAV-pack detection is **not**
 `0x000001BF` at offset 14 (a **system header** pushes PCI to `0x26`; the fixed
 offset found ZERO packs and reported success), and the tool is **deliberately

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1372,7 +1372,8 @@ offset found ZERO packs and reported success), and the tool is **deliberately
 self-contained** — a reporter downloads one file, not a checkout, so it duplicates
 a small ISO9660 walk instead of importing `IsoNav`. Scope is nav only; video-side
 bugs (subpicture, CC, cadence, lip-sync) report in prose. User-facing entry:
-README "Reporting a navigation bug". Design: **`docs/bug_reports.md`**.
+the MANUAL page `site/content/reference/reporting-a-bug.md` (Reference → Reporting a
+bug) — NOT the README, which is a landing page. Design: **`docs/bug_reports.md`**.
 
 ### No USB DVD-ROM drive support
 MiSTer's custom Linux kernel almost certainly lacks `sr_mod` (`CONFIG_BLK_DEV_SR`).

--- a/docs/bug_reports.md
+++ b/docs/bug_reports.md
@@ -170,6 +170,27 @@ That disc is also the argument for the whole feature: it is a 5 MB image
 assembled by hand to investigate a remote Blade Runner report, and the bundle
 reproduces it at 46 KB automatically.
 
+### An encrypted rip produces the same bundle
+
+**Verified on a real CSS-encrypted disc** (`interactive/FAIRYTOPIA.iso`, 7.99 GB,
+78 of 417 sampled title-VOB packs scrambled — about 19%, the raw-rip case that
+motivated the `CSS ENCRYPTED` detection). It builds a 188 KB bundle, self-check
+and content audit both pass, and the reconstruction gives **byte-identical output
+to the encrypted original** on `iso_nav_check.py` (747 lines), `dvd_vm_ref.py
+boot`, and `dvd_vm_ref.py menu`.
+
+This is the practical half of "CSS never scrambles the nav tables": every sector
+the collector reads is one CSS leaves alone, so encryption is invisible to it.
+It matters for **who can file a report** — a reporter needs a rip, but not a
+*decrypted* one, and asking for a bundle therefore never asks anyone to decrypt
+anything. The user-facing wording was corrected accordingly (it had said
+"decrypted rip" in the manual and two issue forms).
+
+⚠ A simulation ran first — 2,920 synthetic scrambled packs written into a
+reconstruction's VOB regions, bundle byte-identical — and was **superseded** by
+the real disc. Keep the real-disc result as the citation; a simulation of CSS
+proves only that the collector skips sectors *it* marked, which is circular.
+
 ## Notes for future work on this file
 
 - **`tools/dvd_report.py` is deliberately self-contained** — it duplicates a

--- a/docs/bug_reports.md
+++ b/docs/bug_reports.md
@@ -1,7 +1,9 @@
 # Navigation bug reports — the sparse-sector repro bundle
 
 **Status: ✅ implemented (`tools/dvd_report.py`), validated across 23 library discs.
-User-facing entry point is the README's "Reporting a navigation bug" section.**
+User-facing entry point is the manual page `site/content/reference/reporting-a-bug.md`
+(Reference → Reporting a bug); the README is a landing page and deliberately does not
+carry this.**
 
 ## Why this exists
 

--- a/docs/bug_reports.md
+++ b/docs/bug_reports.md
@@ -1,0 +1,160 @@
+# Navigation bug reports — the sparse-sector repro bundle
+
+**Status: ✅ implemented (`tools/dvd_report.py`), validated across 23 library discs.
+User-facing entry point is the README's "Reporting a navigation bug" section.**
+
+## Why this exists
+
+The core is public, and the discs that break it are overwhelmingly discs the
+maintainer does not own. Every nav bug in this project's history arrived as a
+sentence — *"link failure on every menu option"*, *"picks Play All whatever you
+choose"*, *"the floor maze starts the player in the wrong position"* — with no
+way to get at the disc. A DVD-Video ISO is 4–8 GB; nobody is uploading that to
+an issue tracker, and asking them to is what makes a report never happen.
+
+But a navigation bug does not need the disc. It needs the **nav tables**, which
+are the IFO files, and those are minuscule. Measured on a real 4.47 GB rip:
+
+| | Size | vs image |
+|---|---|---|
+| `VIDEO_TS.IFO` + `VTS_01_0.IFO` | 104 KB | 0.0023% |
+| Typical finished bundle (compressed) | **36–100 KB** | ~0.005% |
+
+Every host-side nav tool in `tools/` — `iso_nav_check.py`, `dvd_vm_ref.py`,
+`dvd_census.py` — reads *only* those tables plus the ISO9660 directory records
+that locate them. So the bug is fully reproducible from about a hundred
+kilobytes, and always was; there just was no way for a reporter to produce it.
+
+## Why sparse sectors rather than "just send the IFO files"
+
+Loose IFO files are not usable by anything we have. The tools take an **image**:
+`IsoNav` (`tools/dvd_vm_ref.py:324`) asserts `CD001` at sector 16 and then
+follows absolute LBAs everywhere. Accepting loose files would mean rewriting
+every tool, and would throw away the LBAs — which the RTL reader consumes too.
+
+So the bundle stores `{LBA → 2048-byte sector}` pairs **at their original disc
+addresses**, and `unpack` writes them back into a **sparse** file of the original
+image's size. Every captured sector sits at its true offset; everything else
+reads as zero. Consequences, all of which are the point:
+
+- **No tool needed changing.** Not one. The reconstruction is an ISO as far as
+  anything is concerned.
+- **The filesystem stores only the real bytes.** A 6.77 GB reconstruction
+  occupies 480 KB on disk.
+- **It matches the existing testbench idiom.** The committed `*_meta.hex`
+  fixtures are the same thing in `$readmemh` form —
+  `bench/dvd/iso_reader_atmos_tb.sv` reproduces a real title-selection bug on an
+  8.26 GB disc from 16 sectors, its header noting "everything else reads as zero
+  in the TB". A received bundle is therefore already in the shape a regression
+  fixture wants, rather than being a one-off debugging session.
+
+## What is captured
+
+1. The volume descriptor set (sector 16 to the terminator).
+2. The root directory extent, and the `VIDEO_TS` directory extent.
+3. **Every `.IFO` file, whole.** Not a computed subset of tables — taking them
+   entire costs tens of KB and removes any chance of a bundle that is missing
+   the one table the bug turns on.
+4. With `--nav-packs`: NAV packs (PCI/HLI — the button rectangles) from the menu
+   VOBs, for menu-highlight bugs. Off by default; it is the only part that scans
+   VOB payload, and it is bounded by `--nav-scan-mb` (default 512).
+
+Deliberately **not** captured: title VOB payload. Subpicture, closed-caption,
+film-cadence and A/V-sync evidence all live in the elementary stream, which is
+megabytes and a different problem — those report better in prose.
+
+## The bundle
+
+A plain `.zip` — **not** a custom extension, because GitHub only accepts a fixed
+set of attachment types on issues and a `.dvdrep` would simply be rejected.
+
+```
+manifest.json   schema, tool version, core version as typed by the reporter,
+                symptom/expected/steps, disc identity, extent list
+sectors.bin     the captured sectors, concatenated in extent order
+README.txt      what this is, for whoever opens it without context
+```
+
+Disc identity is the **fingerprint** `v1:<sha1>` — SHA-1 over `VIDEO_TS.IFO`,
+capped at 1 MiB and at its own `vmgi_last_sector`. Same construction the ripper
+tooling uses, chosen because the IFO area is never CSS-scrambled and so reads
+identically from a drive and from a finished ISO. It makes reports de-duplicate
+by disc, and answers "do I already own this one?" against the local library
+without opening anything.
+
+## Working a received bundle
+
+```bash
+python3 tools/dvd_report.py info   dvdreport-FOO-1a2b3c4d.zip
+python3 tools/dvd_report.py unpack dvdreport-FOO-1a2b3c4d.zip -o repro.iso
+python3 tools/iso_nav_check.py repro.iso
+python3 tools/dvd_vm_ref.py boot repro.iso
+python3 tools/dvd_vm_ref.py menu repro.iso
+python3 tools/dvd_census.py repro.iso
+python3 tools/nav_extract.py repro.iso --vts N --cmds   # needs --nav-packs
+```
+
+⚠ **Playback of a reconstruction is not expected to work** — the video is not
+there. It is an analysis artifact. (It will still *mount*, and the nav decisions
+it drives are real, so loading one on hardware to watch which PGC the reader
+lands on is legitimate; the picture will not be.)
+
+## Validation
+
+Correctness here means one thing: **the tools must produce byte-identical output
+on the reconstruction and on the original disc.** That is checked two ways.
+
+**Per bundle, automatically.** `dvd_report.py` rebuilds every bundle it writes
+into a temporary sparse image, re-walks it, and compares the IFO bytes against
+the source before reporting `self-check: PASS`. A bundle that cannot be walked is
+worse than no bundle, because the reporter has moved on by the time anyone opens
+it — so this is not optional and not a flag.
+
+**Across the library, once.** A sweep over 23 discs sampled from every category
+(`bugs/`, `interactive/`, `pal/`, `tv/`, `film/`, `concert/`) built a bundle,
+unpacked it, and diffed `iso_nav_check.py` output against the original: **23/23
+identical**, up to 9,143 lines of nav analysis per disc, bundles 36–705 KB (the
+two largest are DVD game discs with many VTS). Spot-checked further on
+`dvd_vm_ref.py boot`/`menu`, `dvd_census.py`, and — for a `--nav-packs` bundle —
+`nav_extract.py`, all identical. The sweep included the three discs named in
+this project's own bug history (Scooby-Doo 2, Dinosaur, The Residents).
+
+One disc, `bugs/br.iso`, fails `iso_nav_check.py` **on the original as well**: it
+is a hand-made metadata-only extract with no title VOBs at all, and
+`iso_nav_check.py:294` does `max()` over an empty VOB group list. Unrelated to
+bundles (a bundle preserves the directory records, so the VOB entries still
+exist), but worth knowing before it is mistaken for a bundle defect. Its VM
+traces are identical between original and reconstruction.
+
+That disc is also the argument for the whole feature: it is a 5 MB image
+assembled by hand to investigate a remote Blade Runner report, and the bundle
+reproduces it at 46 KB automatically.
+
+## Notes for future work on this file
+
+- **`tools/dvd_report.py` is deliberately self-contained** — it duplicates a
+  small ISO9660 walk instead of importing `IsoNav`. A bug reporter downloads
+  *one file* from the repository and runs it; they have no checkout. Keep it
+  that way, and keep it dependency-free (standard library only). If the walk
+  ever diverges from `IsoNav`, the per-bundle self-check is what catches it.
+- ⚠ **NAV pack detection is not "`0x000001BF` at offset 14".** Real discs put a
+  **system header** (`0x000001BB`) between the pack header and the PCI packet,
+  which lands the PCI start code at `0x26` and its payload at `0x2D`. The first
+  version of `is_nav_pack()` used the fixed offset, found **zero** nav packs on
+  the first disc tried, and reported success while doing nothing — the same
+  silent-miss that cost an earlier NAV scan in this project (see CLAUDE.md,
+  forced-select). It now walks the packets by length.
+- The manifest carries the raw `DVD_v1.CFG` bytes when the reporter passes
+  `--cfg`, **undecoded on purpose**. The `O[..]` bit layout moves with almost
+  every feature, so a decoder embedded in a file that users download and keep
+  would go stale silently and mislead. The raw status word never does.
+
+## Not done (deliberate)
+
+- **No GitHub issue template.** Would raise report quality further and is
+  independent of this tool.
+- **No on-device generation.** A `Scripts/dvd_report.sh` on the MiSTer itself
+  would remove the PC from the loop, but MiSTer scripts take no arguments and
+  the gamepad injects only arrow keys and Enter, so disc/timestamp selection
+  would need a cursor menu with no precedent anywhere in this tree.
+- **No decoder-side (video) evidence.** See scope above.

--- a/docs/bug_reports.md
+++ b/docs/bug_reports.md
@@ -63,6 +63,44 @@ Deliberately **not** captured: title VOB payload. Subpicture, closed-caption,
 film-cadence and A/V-sync evidence all live in the elementary stream, which is
 megabytes and a different problem — those report better in prose.
 
+## The content guarantee, and why it is structural
+
+A bundle contains **only unencrypted navigation structures: no picture, no
+sound, no decryption keys.** That is worth being able to say plainly, so it is
+enforced by `audit()` rather than left as an intention.
+
+Before anything is written, `audit()` walks every gathered sector and applies one
+total rule: *if a sector parses as an MPEG program-stream pack at all, every
+packet in it must be a system header, padding, or `private_stream_2`* — the only
+stream ids that carry no elementary stream data. Anything else aborts the run
+with no bundle produced. Because it runs over the **final** captured set, it also
+catches a mistake upstream of the nav-pack scanner (an IFO extent length spilling
+into a VOB, say), not merely a bad nav-pack verdict. The counts land in the
+manifest as `content_audit` and are printed as `content audit: PASS`.
+
+Proven RED, not merely observed green: pointed at a real title-VOB sector from
+`Dinosaur` (stream id `0xE0`) it refuses, and passes a real NAV pack from the
+same disc. Then re-swept across the library with `--nav-packs` on — every disc
+audits clean, bundles 38–596 KB.
+
+The **no keys** half needs no enforcement, because a bundle cannot carry key
+material even in principle: CSS title keys live in the headers of scrambled
+sectors, which are never captured, and the disc key block lives in the lead-in
+control area, which is not part of an ISO filesystem image at all.
+
+This is also why the IFO tables and NAV packs are capturable in the first place.
+CSS cannot scramble them — every player has to read them to navigate — which
+this project's own CSS implementation states outright:
+`main/support/dvd/dvd_css.cpp:341` ("a filesystem/IFO sector (never scrambled ->
+must be read raw)") and `:393` ("The NAV pack (VOBU sector 0) is never
+scrambled"). A bundle is, by construction, exactly the part of a DVD that is
+already in the clear.
+
+⚠ **Never relax this to accept VOB payload "just for one bug".** The guarantee is
+the whole reason the bundle is something a stranger can hand over without
+thinking about it, and it is what keeps the tool clearly distinct from the CSS
+key cache, which must never be shared (see the `css-key-cache-never-ship` rule).
+
 ## The bundle
 
 A plain `.zip` — **not** a custom extension, because GitHub only accepts a fixed
@@ -158,3 +196,10 @@ reproduces it at 46 KB automatically.
   the gamepad injects only arrow keys and Enter, so disc/timestamp selection
   would need a cursor menu with no precedent anywhere in this tree.
 - **No decoder-side (video) evidence.** See scope above.
+- **No `--from-drive` mode.** Reading the IFOs straight off `/dev/sr0` would
+  work — they are unscrambled, so no decryption is involved — and would mean a
+  reporter never needed a rip at all. Rejected 2026-08-31 by user decision, for
+  two reasons: it asks users to point a tool at their optical drive, and a report
+  from someone who has already ripped and decrypted their own ISO is a better
+  report — they can answer follow-up questions and re-run tools against the disc.
+  The target reporter is a capable one, and the workflow should assume that.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,20 +5,26 @@
 
 > **How to read the checklists.** This file is mostly a **record of work already
 > done** — phase-by-phase, with the root causes and the theories that turned out
-> wrong — rather than a live plan. Three markers, and they are kept honest because
+> wrong — rather than a live plan. Four markers, and they are kept honest because
 > a stale one misdirects a cold session as surely as a wrong comment:
 >
 > - `- [x]` — done. Some carry a note where the outcome differed from the plan.
 > - `- ⛔ **[superseded — why]**` — the item is no longer wanted *as written*,
 >   because the approach changed under it. Kept, not deleted: the reason it was
 >   dropped is usually more useful than the item was.
-> - `- [ ]` — genuinely still open. **There are 9 of them**, and that is the whole
->   forward-looking content of this file.
+> - `- ⛔ **[dropped — why]**` — reviewed and decided against. Not the same as
+>   superseded: nothing changed underneath it, it simply is not wanted.
+> - `- [ ]` — genuinely still open. **There are none left.**
 >
-> Reconciled 2026-09-01: 23 items were ticked and 15 marked superseded in one pass.
-> Most of the stale ones were Phase-0 setup tasks ("fork the repo", "install
-> Quartus") left unticked for 890 commits, which read as though the project had
-> never started.
+> Reconciled 2026-09-01. First pass: 23 ticked, 15 marked superseded — most of the
+> stale ones were Phase-0 setup tasks ("fork the repo", "install Quartus") left
+> unticked for 890 commits, which read as though the project had never started.
+> Second pass: the 9 remaining open items were reviewed one by one and all closed —
+> several were already answered by work that had shipped, two by their own bodies,
+> and the rest dropped by decision.
+>
+> **So this file no longer carries any forward plan, and should not be read as one.**
+> It is the development record. New work is tracked on GitHub.
 
 ## Guiding Principles
 
@@ -281,12 +287,12 @@ DVD VOB (program stream with audio + nav packs) has not been tested end-to-end. 
      Covered by `bench/dvd/ps_demux_nav_tb.sv` (embeds a fake `00 00 01 E0` inside
      a nav payload and proves only the real video PES reaches the output); the
      real-Matrix-VOB `ps_chain_tb` still passes byte-for-byte (50,395 bytes).
-   - [ ] **Multi-sequence / repeated sequence headers.** Each VOB cell can carry
+   - ⛔ **[superseded — the symptom (repeated resolution change) was root-caused elsewhere — the mb-padded picture split + the VERT_RES off-by-one, both fixed 2026-06-24]** **Multi-sequence / repeated sequence headers.** Each VOB cell can carry
      its own sequence header; the repeated resolution change suggests the decoder
      is re-initialising per cell or on corrupted headers. Confirm the demuxed
      video ES is a clean, continuous elementary stream (dump `vid_byte` to SD /
      UART and compare against a known-good `.m2v` extracted with `ffmpeg`).
-   - [ ] **Unbounded video PES (`PES_packet_length == 0`).** Documented
+   - ⛔ **[superseded — ISO 13818-1 §2.4.3.7 permits length 0 only for video PES inside TRANSPORT streams; DVD is a Program Stream, so it cannot legally occur. Measured 0 of 3,395 video PES headers across 13 discs. ⚠ If it ever did occur the 16-bit counter would WRAP and eat ~64 KB — noted in ps_demux.sv]** **Unbounded video PES (`PES_packet_length == 0`).** Documented
      limitation in `ps_demux` — rare in VOBs but verify the test file doesn't use
      it; add the start-code-hunt fallback if needed.
 
@@ -560,7 +566,7 @@ motion-comp starvation that caused the misses (keep Frame Drop On as a safety ne
   (a strict consecutive-run counter never locked through menu/VM-path cadence hiccups).
 
 **Remaining follow-ups:**
-- [ ] **Motion-comp throughput rewrite (high-motion / PAL stutter)** — staged attack on the
+- ⛔ **[superseded — the item's own body retracts it: Matrix was a SOURCE-FILE defect (reproduces in VLC), and both genuine cases were fixed without a datapath rewrite — MiB act 3 by the Stage-1 reference prefetch, PAL BBB by the frame-drop governor]** **Motion-comp throughput rewrite (high-motion / PAL stutter)** — staged attack on the
   compute/feed-bound stutter; see `docs/motcomp_throughput.md`. **⚠️ Motivation revisited
   (2026-07-09):** the Matrix opening — long cited as *the* canonical worst case — is a
   SOURCE-FILE defect (its stutter reproduces in VLC on a PC, USER-CONFIRMED), so it is NOT
@@ -611,7 +617,7 @@ motion-comp starvation that caused the misses (keep Frame Drop On as a safety ne
   0xFF = 2 MB now; the `vbuf_healthy` hysteresis thresholds stay fractional (25 %/12.5 %),
   so the guard now demands an 8× fatter absolute cushion — the conservative direction.
   Files: `dvd/mem_override/mem_codes.v`, `rtl/mpeg2/framestore_request.v` (tap width).
-- [ ] **PAL high-motion stutter** — addressed by the frame-drop governor above (decode-load bound,
+- [x] **PAL high-motion stutter** — addressed by the frame-drop governor above (decode-load bound,  *(addressed by the frame-drop governor above (decode-load bound, not PAL-specific))*
   not PAL-specific).
 - [x] **PAL interlaced (576i @ 50) — HDMI/ascal — ✅ HW-CONFIRMED + MERGED (PR fj#132)**.
   Mirrors the NTSC-480i per-field modeline (pixel_repetition doubling): new
@@ -629,7 +635,7 @@ motion-comp starvation that caused the misses (keep Frame Drop On as a safety ne
   pixrep `h_pos` map + `spu_decode`/`crt_ov_map` `.interlaced` following `il_eff`,
   shipped as a prerequisite of `Analog Out = Native Fields`.
   See `docs/interlaced_auto.md`.
-- [ ] **Film 3:2 / PAL-25-from-24** `SHOW_N` cadence handling (separate from the above).
+- ⛔ **[dropped — not needed (2026-09-01, user decision) — Film 24p and 25p both shipped and are HW-confirmed; what this line added beyond them was never established]** **Film 3:2 / PAL-25-from-24** `SHOW_N` cadence handling (separate from the above).
 
 ### Composite / Interlaced Analog Output for CRT (primary end goal)
 
@@ -734,7 +740,7 @@ half-line, weave workaround, 1440-wide pixel repetition) is the
     `bench/dvd/crt_ov_map_tb.sv`); `spu_decode` row-base adder generalized for the skipping
     line walks; CRT Auto aspect now menu-aware (`ar_wide_auto_eff`, matches HDMI). Detail +
     HW-gate checklist: `docs/crt_anamorphic.md` §9.
-- [ ] **HDMI 4:3 output follows the same Fit / Letterbox / Crop setting as the analog CRT.**
+- ⛔ **[dropped — not needed (2026-09-01, user decision) — a want rather than a defect, for the narrow case of 16:9 anamorphic content on a 4:3 HDMI display]** **HDMI 4:3 output follows the same Fit / Letterbox / Crop setting as the analog CRT.**
   Today `O[4:3] CRT Aspect` (Fit/Letterbox/Crop, `docs/crt_anamorphic.md`) is gated on
   `crt_eff` (analog CRT mode only); HDMI instead gets its aspect from ascal via
   `O[20:19] Aspect Ratio` → `VIDEO_ARX/ARY`. Goal: when a **4:3 HDMI display** shows 16:9
@@ -883,7 +889,7 @@ Levers, cheapest/lowest-risk first:
   still pinned per-netlist for reproducibility, but sweeps should rarely be needed; a fit
   under the 86.0 gate now means the netlist degraded — measure (`tools/timing_paths.sh`) and
   fix, don't re-roll. (`FITTER_AGGRESSIVE_ROUTABILITY_OPTIMIZATION` remains `ALWAYS`.)
-- [ ] **Floorplan / LogicLock the hotspot (last resort, heavy effort).** If the logic cuts
+- ⛔ **[dropped — not needed (2026-09-01, user decision) — it was always the last resort, and the design fits at 88% ALM with clk_dec closing on the pinned seed's first roll. Kept as a note in case congestion returns; it is not pending work]** **Floorplan / LogicLock the hotspot (last resort, heavy effort).** If the logic cuts
   above aren't enough, constrain placement of the framestore/decoder→overlay region (or give
   the overlay/output path its own region) so the router isn't forced to cram it into
   X33_Y11–X44_Y22. High effort and brittle to design changes — only after the cheaper levers.
@@ -1013,7 +1019,7 @@ order. Detail lives in `docs/av_sync.md` "Open follow-ups".
   Deferred in PR fj#36 — the 16-row 4-bit-addressed `debug_overlay` is fragile to expand.
   The debug nets are already wired in `emu.sv`; add a row (or repurpose one) to read
   drift on HW. Needed to *measure* lip-sync rather than eyeball it.
-- [ ] **Per-sample PTS through the AC-3 pipeline.** Only if HW shows a residual phase
+- ⛔ **[superseded — its own precondition never fired — the drift saga closed at round 12 with vid_err flat and lips constant, so LEAD_TARGET absorbs what there is]** **Per-sample PTS through the AC-3 pipeline.** Only if HW shows a residual phase
   error `LEAD_TARGET` can't absorb: carry the frame PTS through decode and subtract the
   live `pcm_out` FIFO occupancy so the loop references the PTS of the sample actually
   *leaving* the speaker, not the one entering the decoder.
@@ -1423,7 +1429,7 @@ coordinates — NOT text. Needs a decoder + a video-overlay blend.
   menu highlights render with the disc's authored colours. SET_CONTR alpha honoured.
   Hardened for seeks by the `pgc-palette-seek-reset-bug` fix (palette on `reset_n`, not the
   per-seek pipe reset). The earlier "v1 uses a fixed high-contrast palette" note was stale.
-- [ ] **Follow-ups (minor):** HDMI-480i (O9) subtitle (needs the pixrep `q_x` halving — CRT
+- ⛔ **[partly shipped — the HDMI-480i (O9) subtitle q_x halving SHIPPED with the overlay pixrep fix 2026-08-22; CHG_COLCON and per-disc subtitle-track enumeration dropped as not needed (2026-09-01, user decision)]** **Follow-ups (minor):** HDMI-480i (O9) subtitle (needs the pixrep `q_x` halving — CRT
   is native width so it was addressed first); CHG_COLCON; per-disc subtitle-track
   enumeration (needs IFO — folds into the Phase-10 audio/subp attribute parse); HW
   confirmation on a subtitle disc (progressive + CRT 480i).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,6 +3,23 @@
 > Speculative "might-be-interesting" ideas that are **not** committed here live in
 > [`docs/experiments.md`](experiments.md). Move an item over once it's decided.
 
+> **How to read the checklists.** This file is mostly a **record of work already
+> done** — phase-by-phase, with the root causes and the theories that turned out
+> wrong — rather than a live plan. Three markers, and they are kept honest because
+> a stale one misdirects a cold session as surely as a wrong comment:
+>
+> - `- [x]` — done. Some carry a note where the outcome differed from the plan.
+> - `- ⛔ **[superseded — why]**` — the item is no longer wanted *as written*,
+>   because the approach changed under it. Kept, not deleted: the reason it was
+>   dropped is usually more useful than the item was.
+> - `- [ ]` — genuinely still open. **There are 9 of them**, and that is the whole
+>   forward-looking content of this file.
+>
+> Reconciled 2026-09-01: 23 items were ticked and 15 marked superseded in one pass.
+> Most of the stale ones were Phase-0 setup tasks ("fork the repo", "install
+> Quartus") left unticked for 890 commits, which read as though the project had
+> never started.
+
 ## Guiding Principles
 
 - **★ Self-contained `.rbf` — NO HPS-side daemon (project owner's hard requirement).**
@@ -28,16 +45,16 @@
 **Goal:** Working build environment, upstream core running on hardware.
 
 ### Tasks
-- [ ] Fork `mrchrisster/MiSTer_MPEG2` → your GitHub account as `MiSTer_DVD`
-- [ ] Add upstream as remote: `git remote add upstream https://github.com/mrchrisster/MiSTer_MPEG2.git`
-- [ ] Install Quartus **17.0.2** with Cyclone V device support
-- [ ] Install VS Code extensions: `mshr-h.verilog`, `teros-technology.teroshdl`, `ms-vscode.cpptools`
-- [ ] Set up `.vscode/settings.json` (see CLAUDE.md)
+- [x] Fork `mrchrisster/MiSTer_MPEG2` → your GitHub account as `MiSTer_DVD`
+- [x] Add upstream as remote: `git remote add upstream https://github.com/mrchrisster/MiSTer_MPEG2.git`
+- [x] Install Quartus **17.0.2** with Cyclone V device support
+- [x] Install VS Code extensions: `mshr-h.verilog`, `teros-technology.teroshdl`, `ms-vscode.cpptools`
+- [x] Set up `.vscode/settings.json` (see CLAUDE.md)
 - [x] Rename `.qpf` / `.qsf` / `.qdf` revision from `mpeg2fpga` → `DVD` (done)
-- [ ] Compile in Quartus — verify bitstream generates without errors
-- [ ] Load on DE10-Nano via USB Blaster, test with a sample `.mpg` file
-- [ ] Create directory structure: `dvd/`, `hps/`, `bench/dvd/`
-- [ ] Verify lsmod / kernel: `find /lib/modules -name 'sr_mod.ko'` (expect: not found — confirm ISO-only strategy)
+- [x] Compile in Quartus — verify bitstream generates without errors
+- [x] Load on DE10-Nano via USB Blaster, test with a sample `.mpg` file
+- [x] Create directory structure: `dvd/`, `hps/`, `bench/dvd/`
+- [x] Verify lsmod / kernel: `find /lib/modules -name 'sr_mod.ko'` (expect: not found — confirm ISO-only strategy)  *(answered — sr_mod IS present; physical discs play via /dev/srN)*
 
 **Checkpoint:** Upstream MPEG-2 player works on hardware. You can see video from a `.mpg` file.
 
@@ -71,8 +88,8 @@ interleaved in packets. The demuxer separates them.
   held handshake). Compiles in Quartus, configures on hardware, OSD reached.
 
 ### HPS Tasks
-- [ ] Modify `hps/main.cpp` to open an ISO instead of a raw `.mpg` file
-- [ ] Stub out audio ring buffer read loop (just log audio frame type/size for now)
+- ⛔ **[superseded — the HPS daemon was retired 2026-06-27; playback is all in fabric]** Modify `hps/main.cpp` to open an ISO instead of a raw `.mpg` file
+- ⛔ **[superseded — as above — audio_ring is read in fabric, not by an HPS loop]** Stub out audio ring buffer read loop (just log audio frame type/size for now)
 
 **Checkpoint:** Video still plays correctly (same quality as Phase 0). Console log
 shows audio frames being correctly identified as AC-3/DTS/LPCM with correct sizes.
@@ -301,9 +318,9 @@ LPCM is the easiest codec (no decode needed) so it's the right first audio targe
     `frames_available`, `bytes_available`, `overflow_count`.
   - See CLAUDE.md → "audio_ring.sv — Status & design decisions" for the full
     rationale and the length-deferred-finalize limitation.
-- [ ] **Next:** wire `audio_ring` into `dvd/emu.sv` (replace the `aud_ready=1'b1`
+- [x] **Next:** wire `audio_ring` into `dvd/emu.sv` (replace the `aud_ready=1'b1`
   park) and expose its status on `status`/debug-overlay bits.
-- [ ] **Next:** add the HPS read path — `ioctl_upload` wiring in the `hps_io`
+- ⛔ **[superseded — no HPS read path exists; dvd_audio_decode consumes the ring in fabric]** **Next:** add the HPS read path — `ioctl_upload` wiring in the `hps_io`
   instance + an HPS-side reader.
   - ~~Read port: Avalon-MM slave, accessible by HPS via `f2sdram` bridge~~
     (superseded — ioctl_upload chosen instead).
@@ -317,7 +334,7 @@ LPCM is the easiest codec (no decode needed) so it's the right first audio targe
   dispatch + ALSA. LPCM implemented (sub-header already stripped by `ps_demux`, so
   just big-endian→little-endian + write). AC-3/DTS behind `HAVE_A52`/`HAVE_DCA`.
   `hps/Makefile` + `hps/README.md`. Host-compiles clean; **not yet run on hardware**.
-- [ ] **Bring-up:** `./dvd_audio --probe` on HW → magic "DVDA" + write_seq climbing;
+- ⛔ **[superseded — the dvd_audio daemon was deleted in the pre-release cleanup]** **Bring-up:** `./dvd_audio --probe` on HW → magic "DVDA" + write_seq climbing;
   then `./dvd_audio` for LPCM playback on an LPCM disc.
 
 **Checkpoint:** DVDs with LPCM audio (find test discs with LPCM track) play with
@@ -335,11 +352,11 @@ synchronised audio and video on HDMI. Use a movie with stereo LPCM to test.
 This covers the vast majority of commercial DVD releases.
 
 ### HPS Tasks
-- [ ] Cross-compile or build liba52 for ARM (or find it in MiSTer's Linux environment)
-- [ ] Write AC-3 decode path in `hps/audio_decode.c` (see audio.md for code)
-- [ ] Test: `a52dec` command-line tool on MiSTer to verify liba52 works before integrating
-- [ ] Integrate into ring buffer read loop
-- [ ] Basic A/V sync: dual frame counter approach (see architecture.md)
+- ⛔ **[superseded — AC-3 decodes in fabric (dvd/ac3/*); no liba52 on the ARM]** Cross-compile or build liba52 for ARM (or find it in MiSTer's Linux environment)
+- ⛔ **[superseded — replaced by dvd/ac3/* + dvd/dvd_audio_decode.sv]** Write AC-3 decode path in `hps/audio_decode.c` (see audio.md for code)
+- ⛔ **[superseded — no liba52 dependency to verify]** Test: `a52dec` command-line tool on MiSTer to verify liba52 works before integrating
+- ⛔ **[superseded — the ring is consumed in fabric]** Integrate into ring buffer read loop
+- ⛔ **[superseded — replaced by the PTS-driven STC in dvd/av_sync.sv]** Basic A/V sync: dual frame counter approach (see architecture.md)
 
 ### Testing
 - Most commercial DVDs are AC-3 2.0 or 5.1 — choose a simple 2.0 disc first
@@ -389,9 +406,9 @@ ifo_handle_t *vmgi = ifoOpen(dvd, 0);    // VIDEO_TS.IFO
 
 **Option B: Write minimal UDF parser**
 If you want more control or can't build libdvdread for MiSTer's ARM:
-- [ ] `hps/udf.c` — parse UDF Volume Descriptor Sequences
-- [ ] Find `VIDEO_TS/` directory, enumerate `.IFO` and `.VOB` files
-- [ ] `hps/ifo_parse.c` — parse title structure
+- ⛔ **[superseded — UDF is still unsupported, but it would be parsed in fabric, not in hps/udf.c]** `hps/udf.c` — parse UDF Volume Descriptor Sequences
+- [x] Find `VIDEO_TS/` directory, enumerate `.IFO` and `.VOB` files
+- ⛔ **[superseded — IFO parsing lives in dvd/dvd_iso_reader.sv + dvd/dvd_vm.sv]** `hps/ifo_parse.c` — parse title structure
   - Read `VIDEO_TS.IFO` → find main title set
   - Read `VTS_XX_0.IFO` → find main PGC (longest = main feature heuristic)
   - Get ordered list of VOB cell addresses
@@ -399,9 +416,9 @@ If you want more control or can't build libdvdread for MiSTer's ARM:
 **For v1:** Skip menu navigation. Use "longest PGC = main feature" heuristic.
 
 ### CSS Encryption Integration
-- [ ] Link libdvdcss into HPS program
-- [ ] Replace `open()`/`read()` with `dvdcss_open()`/`dvdcss_read(DVDCSS_READ_DECRYPT)`
-- [ ] Test with both unencrypted ISOs and CSS-encrypted rips
+- [x] Link libdvdcss into HPS program
+- [x] Replace `open()`/`read()` with `dvdcss_open()`/`dvdcss_read(DVDCSS_READ_DECRYPT)`
+- [x] Test with both unencrypted ISOs and CSS-encrypted rips
 
 **Checkpoint:** Drop an ISO of any commercial DVD onto the SD card. Core automatically
 finds the main feature, navigates to it, and plays from start.
@@ -427,7 +444,7 @@ finds the main feature, navigates to it, and plays from start.
 - [x] HPS half: `main/support/dvd/dvd_hdmi_audio.cpp` (EDID Short Audio Descriptors +
   `hdmi_config_set_audio()`), gated by a `cfg[14]` ack so **stock Main is safe by
   construction** — no ack, no bitstream, no noise.
-- [ ] **HW gate:** receiver names DD/DTS and plays 5.1; locks at startup without a chapter
+- [x] **HW gate:** receiver names DD/DTS and plays 5.1; locks at startup without a chapter
   skip; a plain TV stays silent, never noisy; stock Main unchanged.
 - Design + the open preamble-nibble assumption: **`docs/hdmi_bitstream.md`**.
 
@@ -449,7 +466,7 @@ av_sync). Fixed by slaving the burst release to the video STC (`head_delta ≥ 0
   `frame_len` from the sync gap (contiguous frames). Verified on a real T2 DTS track.
 - [x] iec61937_wrap: Pc=`0x000B` for DTS; LPCM/unknown → silence guard. Burst period = 512
   (T2-correct; NBLKS-snoop deferred, see docs/iec61937.md).
-- [ ] **HW gate:** DTS VOB → receiver shows "DTS", plays clean + in sync. (Concert DVDs —
+- [x] **HW gate:** DTS VOB → receiver shows "DTS", plays clean + in sync. (Concert DVDs —
   many have DTS as the primary track. T2 is a known DTS disc.)
 
 ---
@@ -898,7 +915,7 @@ blocks); the fixed-rate fabric output removed that safety net. Tiered plan:
   AC-3 ~43 ms. Absorbs bursty delivery; sufficient for short clips / near-zero drift.
   A buffer only *delays* drift, it doesn't cure it — a feature-length movie exposes
   even a ~0.05 % mismatch.
-- [ ] **Tier 2 — sample drop/duplicate at watermarks (recommended near-term).** Keep
+- ⛔ **[superseded — superseded by Tier 3 PTS genlock below, on which the drift saga closed]** **Tier 2 — sample drop/duplicate at watermarks (recommended near-term).** Keep
   the clean fixed 48 kHz output but drop one sample on over-fill / repeat one on
   under-fill. One sample every ~second is inaudible, ~20 lines of RTL, no pitch-wobble
   risk; makes long playback robust regardless of small drift. Cheap insurance.
@@ -911,7 +928,7 @@ blocks); the fixed-rate fabric output removed that safety net. Tiered plan:
   `ps_demux.aud_frame_pts → audio_ring → dvd_audio_decode.dispatch_pts → av_sync`.
   Full design: `docs/av_sync.md`. (Tier 2 sample drop/dup is now subsumed; the bare
   adaptive-NCO stepping stone is moot.)
-- [ ] **Flush on load/seek.** Flush all audio buffers + reset decoders on a new
+- [x] **Flush on load/seek.** Flush all audio buffers + reset decoders on a new
   disc/clip or a seek, so stale audio never plays out or lags video. Cheap, and
   required for seeking (Phase 8). av_sync already re-anchors on a PTS discontinuity;
   this adds the buffer flush so the resync is clean rather than draining stale audio.
@@ -984,7 +1001,7 @@ order. Detail lives in `docs/av_sync.md` "Open follow-ups".
   residual ≈100 ms audio-EARLY (A/V Offset +100 nulls it). Small follow-ups
   in lipsync_pickup.md round 12: shipping offset default (verify Matrix/PAL),
   overlay cleanup debt, why-4-lates/s churn (secondary).
-- [ ] **Loop-gain tuning (`KP_SHIFT`/`KI_SHIFT`).** If audio audibly speeds/slows
+- ⛔ **[superseded — the NCO trim was retired — same-crystal rate lock, nothing to tune]** **Loop-gain tuning (`KP_SHIFT`/`KI_SHIFT`).** If audio audibly speeds/slows
   ("hunting"), soften `KP` and lean on the integrator. Sim convergence currently uses
   `KP_SHIFT=1`, `KI_SHIFT=9`.
 - [x] **PAL / 25 fps (manual toggle).** Done 2026-06-30 (`feature/hres-offbyone-pal`):
@@ -992,7 +1009,7 @@ order. Detail lives in `docs/av_sync.md` "Open follow-ups".
   already gives 25 fps at 50 Hz. **Remaining:** drive it from `frame_rate_code` so
   25/50 Hz content syncs *automatically* (no manual toggle) — see "PAL/NTSC Framerate
   Sync" above. Shared TODO with `docs/frame_rate_governor.md`.
-- [ ] **Overlay surfacing of drift/trim** (`av_drift`/`av_nco_trim`/`reanchor_count`).
+- ⛔ **[superseded — the drift instrument rows were built, used and then retired; the overlay is compiled out of release builds]** **Overlay surfacing of drift/trim** (`av_drift`/`av_nco_trim`/`reanchor_count`).
   Deferred in PR fj#36 — the 16-row 4-bit-addressed `debug_overlay` is fragile to expand.
   The debug nets are already wired in `emu.sv`; add a row (or repurpose one) to read
   drift on HW. Needed to *measure* lip-sync rather than eyeball it.
@@ -1000,7 +1017,7 @@ order. Detail lives in `docs/av_sync.md` "Open follow-ups".
   error `LEAD_TARGET` can't absorb: carry the frame PTS through decode and subtract the
   live `pcm_out` FIFO occupancy so the loop references the PTS of the sample actually
   *leaving* the speaker, not the one entering the decoder.
-- [ ] **Static-*pop* drop fix (related, separate effort).** `audio_ring` drops PES-sized
+- [x] **Static-*pop* drop fix (related, separate effort).** `audio_ring` drops PES-sized
   chunks, not AC-3 frames, so an overflow drop misaligns the AC-3 stream → `err` →
   self-heal reset → audible pop. PTS pacing reduces drop *frequency* but can't silence a
   drop. Fix: AC-3-frame-aligned drop in `audio_ring`, or graceful mute-and-resync in
@@ -1014,11 +1031,11 @@ refresh; see `docs/frame_rate_governor.md`. Tier 3 PTS genlock above replaced it
 Optical out is not Digital-board-exclusive: the framework's `spdif` net feeds both
 `AUDIO_SPDIF` (Digital TOSLINK) and `SDCD_SPDIF`/`PIN_AH7` (Analog board combo-jack
 mini-TOSLINK). The blocker is format, not connector — `audio_out` emits PCM only.
-- [ ] Complete `dvd/iec61937_wrap.sv` (frame undecoded AC-3/DTS from `ps_demux`/`audio_ring`;
+- [x] Complete `dvd/iec61937_wrap.sv` (frame undecoded AC-3/DTS from `ps_demux`/`audio_ring`;
       set the IEC 60958 non-PCM channel-status bit)
-- [ ] Bypass MiSTer framework's PCM `audio_out` for bitstream output
-- [ ] Drive the S/PDIF pin directly (`AUDIO_SPDIF` and/or `SDCD_SPDIF`)
-- [ ] Test with AV receiver via optical (confirm the board revision populates the TOSLINK TX)
+- [x] Bypass MiSTer framework's PCM `audio_out` for bitstream output
+- [x] Drive the S/PDIF pin directly (`AUDIO_SPDIF` and/or `SDCD_SPDIF`)
+- [x] Test with AV receiver via optical (confirm the board revision populates the TOSLINK TX)
 
 ### DVD Menu Navigation (stretch goal)
 - Parse DVD navigation packets (NAV packs embedded in VOB data)
@@ -1227,7 +1244,7 @@ chapter, and accurate-seek features need that data **parsed** instead of discard
   chapters / PTT (Phase 6)". **Deferred (documented):** cross-PGC user chapter-skip +
   PTT-based current-chapter `n` (would rewrite the HW-confirmed `chap_st`, and only affects
   multi-PGC game discs — no observable movie benefit).
-- [ ] **`program_map_offset` seekable timeline** (presentation time ⇄ disc sector) — the
+- ⛔ **[superseded — Phase-8b TMAP was retired by user decision 2026-07-10]** **`program_map_offset` seekable timeline** (presentation time ⇄ disc sector) — the
   PGC `palette`@164 and cell category word are already handled (Phases 3/9); the exact
   time↔sector map beyond the DSI ±10 s scrub is unbuilt (Phase-8b TMAP was retired).
 
@@ -1376,7 +1393,7 @@ of each via `aud_track`/`sp_track`. What was missing was knowing how many exist.
 - [x] **HW-CONFIRMED on MiB VTS_21** (2026-07-10): audio 4-track cycle audible, subtitle
   4-track+off visible, no out-of-range garbage, audio switch stays in sync with no video
   corruption.
-- [ ] **(Phase 11) On-screen track/language popup** — part of the custom graphic OSD (the
+- [x] **(Phase 11) On-screen track/language popup** — part of the custom graphic OSD (the
   piece the MiSTer OSD can't do); uses the `attr_*` readout + the subpicture blend.
 
 ### Subtitle (subpicture) selection

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1790,6 +1790,39 @@ every one of them — the trail is worth more than the clone size. Note the larg
 
 **Remaining: the final soak** (film + TV + one game disc on shipping defaults), then tag.
 
+## User bug reports — repro bundles (2026-09-01) — ⏳ HW-confirm pending (chord only)
+
+**Branch `feature/bug-report-bundle`; design in `docs/bug_reports.md` +
+`docs/support_bundle_hps.md`; user-facing page `site/content/reference/reporting-a-bug.md`.**
+
+The project is public and the discs that break it are discs we do not own. A nav bug
+needs only the IFO tables — ~0.005% of an image — so `tools/dvd_report.py` packages
+them into a 36–100 KB zip that reconstructs to a **sparse ISO at the original LBAs**,
+which every existing nav tool reads unmodified and which matches the `*_meta.hex`
+testbench idiom (so a submission is already fixture-shaped).
+
+- ✅ **PC route** — validated 23/23 discs across the library: `iso_nav_check.py` output
+  byte-identical between original and reconstruction (up to 9,143 lines), plus
+  `dvd_vm_ref.py boot`/`menu`, `dvd_census.py`, `nav_extract.py`.
+- ✅ **Works on an ENCRYPTED rip** — verified on a real CSS disc (FAIRYTOPIA, ~19% of
+  sampled packs scrambled): identical nav output, so asking a user for a bundle never
+  asks them to decrypt anything.
+- ✅ **Content guarantee is enforced, not promised** — `audit()` refuses to write a
+  bundle if any gathered sector carries elementary stream data; proven RED against a
+  real title-VOB sector (`0xE0`).
+- ⏳ **On-player route** — Audio + Subtitle held 2 s makes `MiSTer_DVDcss` build a bundle
+  from whatever is mounted (image or drive) into `/media/fat/DVD_reports/`. Uniquely
+  captures `buffer_lba`, i.e. where playback actually was. Integration steps 22–25.
+  **Not hardware-confirmed:** chord timing, `InfoMessage` during playback,
+  fork-under-load, and reading `/dev/srN` while `dvd_css` holds the drive.
+- ✅ **Intake** — six GitHub issue forms split by the evidence a report needs, and a
+  `field-report` skill that turns a pasted/screenshotted Discord report into a tracked
+  issue (most users will never open one themselves).
+
+Next: the HW gate on the chord, then decide whether the audio-silence route is pulling
+its weight — the acmod census says 11 discs have an unsupported DEFAULT track, so that
+form should see traffic early.
+
 ## Test Media Recommendations
 
 > **✅ HW-CONFIRMED 2026-08-18 (PR fj#165): authored cell duration ("real-player cell

--- a/docs/support_bundle_hps.md
+++ b/docs/support_bundle_hps.md
@@ -117,9 +117,29 @@ space is the version. ⚠ If there is no space the core published no `V` line, a
 the bundle records nothing rather than passing the bare core name off as a
 version.
 
-## Integration steps 22–25
+## ⚠ Where the mounted image's path comes from
 
-Four anchored edits in `main/integration/apply_integration.py`; all verified to
+Nothing in stock Main keeps it. `fileTYPE::name` is the **basename only**
+(`FileOpenEx` stores `p + 1`), and `fileTYPE::path` is populated **solely** in the
+pre-create branch of `user_io_file_mount()` (`if (!ret && pre)`). So a normally
+mounted ISO has neither, and the first version of `find_source()` — which tested
+`f->path[0]` — reported **"Load a disc or image first" with a disc plainly
+loaded**. A physical disc worked throughout, because that path resolves through
+`dvd_phys_device()` instead, which is exactly why the bug survived the first
+hardware round.
+
+Fixed by capturing the path at mount time (step 26) rather than trying to recover
+it afterwards.
+
+⚠ **And it must be made absolute.** Mount paths are relative to `getRootDir()`
+unless they begin with `/` — `make_fullpath()` does that expansion, and every
+in-Main consumer goes through it. This one does not: it is handed to a separate
+process with its own working directory, so a relative path would simply not be
+found. The `*DVD_PHYS*` sentinel is filtered out too; it is not a file.
+
+## Integration steps 22–26
+
+Five anchored edits in `main/integration/apply_integration.py`; all verified to
 apply and re-apply idempotently against the current stock tree.
 
 | # | File | What |
@@ -128,6 +148,7 @@ apply and re-apply idempotently against the current stock tree.
 | 23 | `user_io.cpp` | `dvd_report_tick()` at the step-7 tick site |
 | 24 | `user_io.cpp` | `dvd_report_joy(map)` at the top of `user_io_digital_joystick()` |
 | 25 | `user_io.cpp` + `.h` | `user_io_last_lba(int)` — `buffer_lba[]` is file-static |
+| 26 | `user_io.cpp` | `dvd_report_note_mount(name)` in `user_io_file_mount()` |
 
 Step 25 is anchored on the **end of the `buffer_lba[16]` initialiser**, not on the
 following function, so the accessor lands beside the data it exposes and

--- a/docs/support_bundle_hps.md
+++ b/docs/support_bundle_hps.md
@@ -15,6 +15,12 @@ It recorded sector **52673**; VTS_01's title VOB starts at **50609**, so it caug
 the user 2,064 sectors (4.2 MB) into the feature. That is the one fact a reporter
 can never supply from memory.
 
+**Both source routes confirmed.** A second bundle, from a *mounted ISO*
+(`dvdreport-20260902-035310.zip`, THE_MATRIX, 8.39 GB): 131 sectors → 99 KB, audit
+clean, `core version v0.4.0 260901` captured automatically, playhead at sector
+619898 — and `iso_nav_check.py` output is **byte-identical (526 lines) to the
+original ISO** held locally, which is the strongest form this check takes.
+
 ★★ **Reading `/dev/srN` while `dvd_css` holds the drive WORKS** — this was flagged
 as the likeliest thing to misbehave (two readers seeking one optical device) and it
 did not.

--- a/docs/support_bundle_hps.md
+++ b/docs/support_bundle_hps.md
@@ -83,7 +83,8 @@ edge-triggered single steps with on-screen feedback and both are trivially undon
 ```
 chord held 2 s
   └─ dvd_report_tick()          (poll loop, self-gates on is_dvd())
-       ├─ source: dvd_phys_device() if a disc is mounted, else get_image(0)->path
+       ├─ source: dvd_phys_device() if a disc is mounted, else mounted_path
+       │           (captured at mount time -- see below; NOT get_image()->path)
        ├─ playhead: user_io_last_lba(0)
        ├─ settings: newest /media/fat/config/DVD*.CFG
        ├─ core version: OsdCoreNameGet() after the first space

--- a/docs/support_bundle_hps.md
+++ b/docs/support_bundle_hps.md
@@ -1,8 +1,23 @@
 # On-player support bundles — the gamepad chord
 
-**Status: 🔧 implemented (2026-09-01), sim/host-verified; ⏳ HW-confirm pending.**
-Ships in `MiSTer_DVDcss`, so it needs a Main rebuild and a board test.
-See [`bug_reports.md`](bug_reports.md) for the bundle format itself.
+**Status: ✅ HW-CONFIRMED 2026-09-02 — and on the hardest case first, a PHYSICAL
+DISC.** See [`bug_reports.md`](bug_reports.md) for the bundle format itself.
+
+The confirming artifact (`dvdreport-20260902-030608.zip`, NCIS_S1_D4 on `sr0`,
+7.22 GB disc): 76 sectors → **77 KB**, content audit clean (76 nav-table sectors,
+0 carrying A/V), reconstructs to a 7.22 GB sparse image occupying 160 KB, and
+`iso_nav_check.py` walks it fully — 5 titles, TT_SRPT, the First Play PGC and its
+13 pre-commands — while `dvd_vm_ref.py boot` executes the boot chain to
+`JumpTT 5` → VTS 2 PGCN 1.
+
+★ **The playhead is the part that justifies building this into the Main at all.**
+It recorded sector **52673**; VTS_01's title VOB starts at **50609**, so it caught
+the user 2,064 sectors (4.2 MB) into the feature. That is the one fact a reporter
+can never supply from memory.
+
+★★ **Reading `/dev/srN` while `dvd_css` holds the drive WORKS** — this was flagged
+as the likeliest thing to misbehave (two readers seeking one optical device) and it
+did not.
 
 ## Why put this in the Main at all
 
@@ -65,6 +80,7 @@ chord held 2 s
        ├─ source: dvd_phys_device() if a disc is mounted, else get_image(0)->path
        ├─ playhead: user_io_last_lba(0)
        ├─ settings: newest /media/fat/config/DVD*.CFG
+       ├─ core version: OsdCoreNameGet() after the first space
        ├─ fork + execvp python3 dvd_report.py <src> --lba N --cfg F
        │                          --generated-on mister -o DVD_reports/<ts>.zip
        └─ reap in a later tick -> InfoMessage("written to ...") or ("FAILED, see log")
@@ -86,6 +102,20 @@ never scrambles — proven on a real encrypted disc, see
 [`bug_reports.md`](bug_reports.md) "An encrypted rip produces the same bundle" —
 so no libdvdcss handle, no keys, and no circumvention. `dvd_phys.cpp` gained
 `dvd_phys_device()` to export the mounted node.
+
+## The core version comes for free
+
+The first hardware bundle read `core version (not stated)`, which matters more on
+this route than on the PC one: there is no reporter in the loop to type it, and
+CLAUDE.md is emphatic that the OSD version line is the only thing that identifies
+a build.
+
+No new plumbing was needed. `CONF_STR`'s `V,v0.4.0 260901` line is appended to the
+OSD core name at init (`user_io.cpp`, the `p[0] == 'V'` arm), so
+`OsdCoreNameGet()` reads back `"DVD v0.4.0 260901"` and everything after the first
+space is the version. ⚠ If there is no space the core published no `V` line, and
+the bundle records nothing rather than passing the bare core name off as a
+version.
 
 ## Integration steps 22–25
 
@@ -128,7 +158,4 @@ say, not by their timestamps. A bundle made on a PC has a real clock behind it;
 - **No HUD confirmation.** `InfoMessage()` is Main's overlay, not the core's, so
   the message is not part of the recorded video if someone films the screen. Good
   enough, and free.
-- **Not hardware-confirmed.** The chord timing, the `InfoMessage` behaviour during
-  playback, fork-under-load, and reading `/dev/srN` while `dvd_css` holds the
-  drive are all untested on a board. That last one is the likeliest to surprise:
-  two readers seeking the same optical device.
+- ~~Not hardware-confirmed.~~ Confirmed 2026-09-02 — see the status block above.

--- a/docs/support_bundle_hps.md
+++ b/docs/support_bundle_hps.md
@@ -1,0 +1,122 @@
+# On-player support bundles — the gamepad chord
+
+**Status: 🔧 implemented (2026-09-01), sim/host-verified; ⏳ HW-confirm pending.**
+Ships in `MiSTer_DVDcss`, so it needs a Main rebuild and a board test.
+See [`bug_reports.md`](bug_reports.md) for the bundle format itself.
+
+## Why put this in the Main at all
+
+`tools/dvd_report.py` already lets a reporter package a disc's navigation tables
+on a PC. That covers most cases. Two things it cannot do:
+
+- **It does not know where playback was.** A report says "somewhere in the
+  menus"; the Main knows the exact sector being served when the user hit the
+  chord. That is the single most useful fact a nav report can carry, and the one
+  a reporter can never supply from memory.
+- **It needs a PC.** Plenty of users have a MiSTer, a disc and Discord, and
+  nothing else.
+
+So: hold a gamepad chord while the DVD core is running and the Main writes a
+bundle to `/media/fat/DVD_reports/`, built from whatever is currently mounted —
+an image file *or* the optical drive.
+
+## The shape, and why
+
+**The Main shells out to `tools/dvd_report.py`.** It does not reimplement the
+collector in C++. python3 is on a stock MiSTer (`install_dvdcss.sh` already
+depends on it), the tool is stdlib-only and needs 3.7+, and a second
+implementation would drift from the first — the audit and self-check would have
+to be duplicated too, and a divergence there is exactly the kind of thing nobody
+notices until a bundle turns out to be wrong.
+
+It also dissolves the constraint that killed the earlier Scripts-menu idea. "A
+Scripts entry gets no arguments, and the gamepad injects only arrows and Enter"
+stops mattering when **the Main already knows what is mounted** and passes it as
+an argument. No cursor menu, no typing, no `dialog` dependency.
+
+`dvd_report.py` ships in the release zip at `Scripts/dvd_report.py`
+(`tools/package_release.sh`), which is also the first place
+`dvd_report.cpp` looks for it.
+
+## The trigger: a chord, not an OSD row
+
+**An OSD row would have cost a fitter seed re-roll.** Adding a `CONF_STR` entry
+changes the string, which changes the netlist, which invalidates the pinned SEED
+— the thing the `DVD.qsf` ledger exists to track. A one-line menu addition is not
+a one-line change in this project.
+
+A chord costs nothing in fabric: **Audio (B7) + Subtitle (B8), held 2 seconds**,
+detected in `user_io_digital_joystick()`.
+
+⚠ **The chord's own buttons still do their normal thing** — one audio-track step
+and one subtitle step. That is deliberate. Masking the two bits on their way to
+the core was considered and rejected twice over: it would mean *editing* the map,
+so a detection bug could stop buttons working entirely, and it would swallow a
+legitimate fast double-press. `dvd_report_joy()` only reads `map`, so it cannot
+break anything that works today. B7/B8 were chosen because both are
+edge-triggered single steps with on-screen feedback and both are trivially undone
+— a chord on the transport buttons could leave a stray seek or pause.
+
+## Flow
+
+```
+chord held 2 s
+  └─ dvd_report_tick()          (poll loop, self-gates on is_dvd())
+       ├─ source: dvd_phys_device() if a disc is mounted, else get_image(0)->path
+       ├─ playhead: user_io_last_lba(0)
+       ├─ settings: newest /media/fat/config/DVD*.CFG
+       ├─ fork + execvp python3 dvd_report.py <src> --lba N --cfg F
+       │                          --generated-on mister -o DVD_reports/<ts>.zip
+       └─ reap in a later tick -> InfoMessage("written to ...") or ("FAILED, see log")
+```
+
+⚠ **The work must not run inline.** `dvd_report_tick()` shares the poll loop with
+SD block service; a bundle takes long enough that blocking there would starve the
+core mid-playback. Hence fork, with the child reaped by a later tick and the
+result surfaced through `InfoMessage()` — Main's own facility, so **no RTL change
+is needed for feedback either**.
+
+The child runs **without `--nav-packs`**: that scans menu VOBs, which is seconds
+of I/O on SD media. Nav tables only, which is what almost every nav bug needs.
+
+## Physical discs work, and no decryption is involved
+
+The source may be `/dev/srN` directly. Every sector the tool reads is one CSS
+never scrambles — proven on a real encrypted disc, see
+[`bug_reports.md`](bug_reports.md) "An encrypted rip produces the same bundle" —
+so no libdvdcss handle, no keys, and no circumvention. `dvd_phys.cpp` gained
+`dvd_phys_device()` to export the mounted node.
+
+## Integration steps 22–25
+
+Four anchored edits in `main/integration/apply_integration.py`; all verified to
+apply and re-apply idempotently against the current stock tree.
+
+| # | File | What |
+|---|---|---|
+| 22 | `user_io.cpp` | include `dvd_report.h` |
+| 23 | `user_io.cpp` | `dvd_report_tick()` at the step-7 tick site |
+| 24 | `user_io.cpp` | `dvd_report_joy(map)` at the top of `user_io_digital_joystick()` |
+| 25 | `user_io.cpp` + `.h` | `user_io_last_lba(int)` — `buffer_lba[]` is file-static |
+
+Step 25 is anchored on the **end of the `buffer_lba[16]` initialiser**, not on the
+following function, so the accessor lands beside the data it exposes and
+`insert_after` controls the spacing exactly (`insert_before` strips a trailing
+blank line and would have jammed it against the next function).
+
+No `Makefile` change: `$(wildcard ./support/*/*.cpp)` already picks up the new
+file.
+
+## What is not done
+
+- **The live status word is not captured.** `user_io_status_get()` reads at most
+  two bytes of `cur_status[]`, so the full 128-bit word would need its own
+  accessor. The saved `DVD*.CFG` is passed instead — the same settings, one save
+  behind. Revisit only if a report ever turns on an unsaved toggle.
+- **No HUD confirmation.** `InfoMessage()` is Main's overlay, not the core's, so
+  the message is not part of the recorded video if someone films the screen. Good
+  enough, and free.
+- **Not hardware-confirmed.** The chord timing, the `InfoMessage` behaviour during
+  playback, fork-under-load, and reading `/dev/srN` while `dvd_css` holds the
+  drive are all untested on a board. That last one is the likeliest to surprise:
+  two readers seeking the same optical device.

--- a/docs/support_bundle_hps.md
+++ b/docs/support_bundle_hps.md
@@ -107,6 +107,18 @@ blank line and would have jammed it against the next function).
 No `Makefile` change: `$(wildcard ./support/*/*.cpp)` already picks up the new
 file.
 
+## ⚠ Do not trust the clock on an on-player bundle
+
+The DE10-Nano has **no battery-backed RTC**. A networked MiSTer gets the time by
+NTP; one that has never been online does not, so both the bundle's filename
+(`dvdreport-YYYYMMDD-HHMMSS.zip`) and the manifest's `created_utc` can be
+arbitrarily wrong — an epoch date rather than today's.
+
+They stay *unique* within a session either way, which is all the filename needs.
+But when ordering two bundles from the same reporter, sequence them by what they
+say, not by their timestamps. A bundle made on a PC has a real clock behind it;
+`player.generated_on == "mister"` marks the ones that may not.
+
 ## What is not done
 
 - **The live status word is not captured.** `user_io_status_get()` reads at most

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -525,7 +525,7 @@ assign CE_PIXEL = 1'b1;
 // builds: it is part of CONF_STR = part of the netlist, so every compile would
 // become a new netlist and re-roll the fitter seed lottery (DVD.qsf's ledger).
 // Same-day dev builds are identified by their build_release.sh --name filename.
-`define CORE_VERSION "0.3.1"
+`define CORE_VERSION "0.4.0"
 
 parameter CONF_STR = {
     "DVD;;",

--- a/dvd/ps_demux.sv
+++ b/dvd/ps_demux.sv
@@ -520,6 +520,20 @@ always_ff @(posedge clk or negedge rst_n) begin
             end
 
             // ---- PES packet length ----
+            // NOTE: PES_packet_length == 0 ("unbounded", run to the next start
+            // code) is NOT handled, and would not fail gracefully: pes_length is
+            // a 16-bit down-counter compared against 1, so loading 0 wraps to
+            // 0xFFFF on the first decrement and ~64 KB of following stream --
+            // pack headers, NAV packs, audio -- gets consumed as video payload
+            // before S_HUNT resyncs.
+            //
+            // This is deliberate, not an oversight. ISO 13818-1 §2.4.3.7 permits
+            // length 0 ONLY for video PES carried in TRANSPORT streams; DVD is a
+            // Program Stream, where the field must always be set. Measured 0 of
+            // 3,395 video PES headers across 13 library discs. The roadmap item
+            // for it was closed 2026-09-01 on those two grounds; if a
+            // non-compliant muxer ever produces one, this comment is the reason
+            // the picture breaks, and the fix is a start-code-hunt fallback.
             S_PES_LEN_HI: begin pes_len_hi <= in_byte; state <= S_PES_LEN_LO; end
             S_PES_LEN_LO: begin
                 pes_length <= {pes_len_hi, in_byte};

--- a/main/build_main.sh
+++ b/main/build_main.sh
@@ -61,10 +61,11 @@ fi
 # 2. Copy the self-contained overlay (Makefile auto-globs support/*/*.cpp).
 echo "-- applying overlay"
 mkdir -p "$STOCK/support/dvd" "$STOCK/Scripts"
-cp "$HERE"/support/dvd/dvd_css.cpp  "$HERE"/support/dvd/dvd_css.h  "$STOCK/support/dvd/"
-cp "$HERE"/support/dvd/dvd_detect.cpp "$HERE"/support/dvd/dvd_detect.h "$STOCK/support/dvd/"
-cp "$HERE"/support/dvd/dvd_phys.cpp "$HERE"/support/dvd/dvd_phys.h "$STOCK/support/dvd/"
-cp "$HERE"/support/dvd/dvd_hdmi_audio.cpp "$HERE"/support/dvd/dvd_hdmi_audio.h "$STOCK/support/dvd/"
+# Copy the WHOLE overlay dir, not a hand-maintained file list. The list form
+# silently omitted dvd_report.* when it was added, and the failure surfaces far
+# away as "user_io.cpp: support/dvd/dvd_report.h: No such file or directory" --
+# everything under main/support/dvd/ is ours and belongs in the build.
+cp "$HERE"/support/dvd/*.cpp "$HERE"/support/dvd/*.h "$STOCK/support/dvd/"
 cp "$HERE"/Scripts/install_dvdcss.sh "$STOCK/Scripts/"
 
 # 3. Patch user_io.cpp / user_io.h / Makefile.

--- a/main/integration/INTEGRATION.md
+++ b/main/integration/INTEGRATION.md
@@ -186,7 +186,7 @@ main=MiSTer_DVDcss
 dvd_hdmi_bitstream=0
 ```
 
-## Steps 22-25 — on-player support bundle
+## Steps 22-26 — on-player support bundle
 
 `main/support/dvd/dvd_report.{h,cpp}`. A gamepad chord (Audio + Subtitle, held
 2 s) makes the Main build a navigation support bundle from whatever is mounted
@@ -199,6 +199,7 @@ rejected: `MiSTer_DVD/docs/support_bundle_hps.md`.
 | 23 | `user_io.cpp` | `dvd_report_tick()` at the step-7 tick site |
 | 24 | `user_io.cpp` | `dvd_report_joy(map)` at the top of `user_io_digital_joystick()` |
 | 25 | `user_io.cpp` + `user_io.h` | `user_io_last_lba(int index)` accessor |
+| 26 | `user_io.cpp` | `dvd_report_note_mount(name)` inside `user_io_file_mount()` |
 
 Notes that matter on a `MAIN_MISTER_REF` bump:
 
@@ -211,6 +212,10 @@ Notes that matter on a `MAIN_MISTER_REF` bump:
   line `ULLONG_MAX,ULLONG_MAX,ULLONG_MAX,ULLONG_MAX };`. If stock reformats that
   array the anchor breaks loudly, which is correct — the accessor must sit after
   the declaration it reads.
+- **Step 26 exists because nothing else keeps the mounted path.** `fileTYPE::name`
+  is the basename only and `fileTYPE::path` is filled only in this function's
+  pre-create branch, so a normal mount has neither. It observes `name` and never
+  modifies it.
 - **No Makefile edit is needed.** `CPP_SRC` already has
   `$(wildcard ./support/*/*.cpp)`.
 - The work forks; it must never run inline in the poll loop, which also services

--- a/main/integration/INTEGRATION.md
+++ b/main/integration/INTEGRATION.md
@@ -185,3 +185,33 @@ main=MiSTer_DVDcss
 ;   2 = force engage regardless of EDID (sinks do mis-report, especially over ARC)
 dvd_hdmi_bitstream=0
 ```
+
+## Steps 22-25 — on-player support bundle
+
+`main/support/dvd/dvd_report.{h,cpp}`. A gamepad chord (Audio + Subtitle, held
+2 s) makes the Main build a navigation support bundle from whatever is mounted
+and write it to `/media/fat/DVD_reports/`. Design, and the alternatives that were
+rejected: `MiSTer_DVD/docs/support_bundle_hps.md`.
+
+| # | File | Edit |
+|---|---|---|
+| 22 | `user_io.cpp` | include `support/dvd/dvd_report.h` |
+| 23 | `user_io.cpp` | `dvd_report_tick()` at the step-7 tick site |
+| 24 | `user_io.cpp` | `dvd_report_joy(map)` at the top of `user_io_digital_joystick()` |
+| 25 | `user_io.cpp` + `user_io.h` | `user_io_last_lba(int index)` accessor |
+
+Notes that matter on a `MAIN_MISTER_REF` bump:
+
+- **Step 24 observes only.** It reads `map` and never writes it, so the chord's
+  buttons still reach the core and a bug here cannot stop a button working. Do
+  not "improve" it into masking the chord bits — that trades a harmless
+  double-action for the risk of breaking input outright, and it would swallow a
+  legitimate fast double-press.
+- **Step 25 is anchored on the end of the `buffer_lba[16]` initialiser**, i.e. the
+  line `ULLONG_MAX,ULLONG_MAX,ULLONG_MAX,ULLONG_MAX };`. If stock reformats that
+  array the anchor breaks loudly, which is correct — the accessor must sit after
+  the declaration it reads.
+- **No Makefile edit is needed.** `CPP_SRC` already has
+  `$(wildcard ./support/*/*.cpp)`.
+- The work forks; it must never run inline in the poll loop, which also services
+  SD blocks for the core.

--- a/main/integration/apply_integration.py
+++ b/main/integration/apply_integration.py
@@ -402,6 +402,15 @@ u = insert_after(u,
     '}\n',
     25, 'user_io_last_lba')
 
+# 26. capture the mounted image's full path. Nothing in stock Main keeps it:
+# fileTYPE::name is the basename only, and fileTYPE::path is filled ONLY in the
+# pre-create branch of this same function -- so a normally-mounted ISO has
+# neither, which made the support-bundle chord report "Load a disc or image
+# first" with a disc plainly loaded. Observes only; it never touches `name`.
+u = insert_after(u, '\tint len = strlen(name);',
+    '\tdvd_report_note_mount(name);   // dvd:report — observe only\n',
+    26, 'dvd_report_note_mount(name)')
+
 write(uio_path, u)
 print("[integration] user_io.cpp patched (support bundle)")
 

--- a/main/integration/apply_integration.py
+++ b/main/integration/apply_integration.py
@@ -382,7 +382,11 @@ u = insert_after(u, 'dvd_hdmi_audio_tick();  // ADV7513 non-PCM mode + the cfg[1
 # 24. observe the gamepad for the chord. Placed at the TOP of the function, and
 # it only reads `map` - the map is passed to the core unchanged, so a bug here
 # cannot stop a button working.
-u = insert_after(u, 'void user_io_digital_joystick(unsigned char joystick, uint32_t map, int newdir)\n{',
+# NOTE the anchor is the function's FIRST BODY LINE, not its signature.
+# insert_after() splits on the first newline AFTER the anchor, so a two-line
+# 'signature\n{' anchor lands the call BETWEEN the signature and its brace --
+# which compiles as "expected initializer before 'dvd_report_joy'".
+u = insert_after(u, '\tuint8_t joy = (joystick>1 || !joyswap) ? joystick : joystick ^ 1;',
     '\tdvd_report_joy(map);   // dvd:report — observe only, never modifies map\n',
     24, 'dvd_report_joy(map)')
 

--- a/main/integration/apply_integration.py
+++ b/main/integration/apply_integration.py
@@ -362,4 +362,50 @@ cc = insert_after(cc, '{ "HDMI_AUDIO_96K", (void*)(&(cfg.hdmi_audio_96k)), UINT8
 write(cfgc_path, cc)
 print("[integration] cfg.h/cfg.cpp patched")
 
+# =============================================================================
+# On-player support bundle (steps 22-25). See INTEGRATION.md and
+# MiSTer_DVD/docs/support_bundle_hps.md.
+# =============================================================================
+
+u = read(uio_path)
+
+# 22. include
+u = insert_after(u, '#include "support/dvd/dvd_hdmi_audio.h"',
+    '#include "support/dvd/dvd_report.h"\n',
+    22, 'support/dvd/dvd_report.h')
+
+# 23. poll tick (reuses the step-7 tick site)
+u = insert_after(u, 'dvd_hdmi_audio_tick();  // ADV7513 non-PCM mode + the cfg[14] ack',
+    '\tdvd_report_tick();      // support-bundle chord: fire + reap\n',
+    23, 'dvd_report_tick();')
+
+# 24. observe the gamepad for the chord. Placed at the TOP of the function, and
+# it only reads `map` - the map is passed to the core unchanged, so a bug here
+# cannot stop a button working.
+u = insert_after(u, 'void user_io_digital_joystick(unsigned char joystick, uint32_t map, int newdir)\n{',
+    '\tdvd_report_joy(map);   // dvd:report — observe only, never modifies map\n',
+    24, 'dvd_report_joy(map)')
+
+# 25. expose the last-served sector. buffer_lba[] is file-static, and it is the
+# one thing the on-player bundle knows that a reporter cannot state from memory:
+# where playback actually was when the problem was seen.
+u = insert_after(u,
+    '\t\t\t\t\t\t\t\t   ULLONG_MAX,ULLONG_MAX,ULLONG_MAX,ULLONG_MAX };',
+    '\nuint64_t user_io_last_lba(int index)   // dvd:report\n'
+    '{\n'
+    '\tif (index < 0 || index >= 16) return (uint64_t)-1;\n'
+    '\treturn buffer_lba[index];\n'
+    '}\n',
+    25, 'user_io_last_lba')
+
+write(uio_path, u)
+print("[integration] user_io.cpp patched (support bundle)")
+
+h = read(h_path)
+h = insert_after(h, 'char is_dvd();',
+    'uint64_t user_io_last_lba(int index);   // dvd:report\n',
+    25, 'user_io_last_lba')
+write(h_path, h)
+print("[integration] user_io.h patched (support bundle)")
+
 print("[integration] done")

--- a/main/support/dvd/dvd_phys.cpp
+++ b/main/support/dvd/dvd_phys.cpp
@@ -25,6 +25,7 @@
 #define DVD_PHYS_SCAN_PERIOD_S 1
 
 static int    mounted = 0;         // 1 while a DVD-Video disc is mounted into the core
+static char   mounted_dev[16] = {0};  // its /dev/srN, exported by dvd_phys_device()
 static time_t last_scan = 0;
 static time_t reset_release_at = 0; // >0 while an eject reset pulse is being held
 
@@ -80,6 +81,7 @@ void dvd_phys_tick(void)
 			printf("DVD_PHYS: disc removed, unmounting + reset to idle\n");
 			user_io_file_mount("", 0);
 			dvd_css_close();
+			mounted_dev[0] = 0;
 			user_io_status_set("[0]", 1);   // OSD-reset: unload + VM reset -> idle logo
 			reset_release_at = now + 1;      // release after ~1 s (see the tick top)
 			mounted = 0;
@@ -100,5 +102,14 @@ void dvd_phys_tick(void)
 	// (see the SD_TYPE_DVDCSS handling in user_io.cpp). dvd_css_open() inside it
 	// re-scans for the drive and runs the CSS handshake; a failure there (no
 	// libdvdcss on an encrypted disc) surfaces the on-screen install prompt.
-	if (user_io_file_mount(DVD_PHYS_SENTINEL, 0)) mounted = 1;
+	if (user_io_file_mount(DVD_PHYS_SENTINEL, 0))
+	{
+		mounted = 1;
+		snprintf(mounted_dev, sizeof(mounted_dev), "%s", dev);
+	}
+}
+
+const char *dvd_phys_device(void)
+{
+	return mounted_dev[0] ? mounted_dev : 0;
 }

--- a/main/support/dvd/dvd_phys.h
+++ b/main/support/dvd/dvd_phys.h
@@ -26,4 +26,10 @@
 // No-op on non-DVD cores and while nothing changes.
 void dvd_phys_tick(void);
 
+// The /dev/srN node of the disc currently mounted by this module, or NULL when
+// nothing is mounted. Exported for dvd_report.cpp, which hands it to
+// tools/dvd_report.py: every sector that tool reads is one CSS never scrambles,
+// so a support bundle can be built straight off the drive with no decryption.
+const char *dvd_phys_device(void);
+
 #endif

--- a/main/support/dvd/dvd_report.cpp
+++ b/main/support/dvd/dvd_report.cpp
@@ -148,7 +148,20 @@ static void start(void)
 	const char *src = find_source();
 	if (!src)
 	{
-		InfoMessage("Load a disc or image first", 3000, "DVD");
+		// Say what was actually seen, not just that nothing was found. The
+		// three inputs fail for different reasons -- an old Main with no
+		// step-26 hook looks identical to a genuinely empty slot otherwise,
+		// and one screenshot should tell them apart.
+		char msg[220];
+		const char *dev = dvd_phys_device();
+		snprintf(msg, sizeof(msg),
+		         "Nothing to bundle\n\ncss active: %d\ndrive: %s\nmounted: %s",
+		         dvd_css_active(), dev ? dev : "(none)",
+		         mounted_path[0] ? mounted_path : "(not captured)");
+		InfoMessage(msg, 8000, "DVD");
+		printf("DVD_REPORT: no source (css=%d dev=%s mount=%s)\n",
+		       dvd_css_active(), dev ? dev : "-",
+		       mounted_path[0] ? mounted_path : "-");
 		return;
 	}
 

--- a/main/support/dvd/dvd_report.cpp
+++ b/main/support/dvd/dvd_report.cpp
@@ -1,0 +1,237 @@
+// dvd_report.cpp — generate a navigation support bundle from the player itself.
+// See dvd_report.h and MiSTer_DVD/docs/support_bundle_hps.md.
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <time.h>
+#include <errno.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include "../../user_io.h"
+#include "../../menu.h"
+#include "../../file_io.h"
+#include "dvd_report.h"
+#include "dvd_css.h"
+#include "dvd_phys.h"
+
+// ---------------------------------------------------------------------------
+// The trigger
+// ---------------------------------------------------------------------------
+// J1 on this core is fully populated (13 buttons), so any chord also performs
+// its own actions. Audio (B7) + Subtitle (B8) is chosen because both are
+// edge-triggered single steps with on-screen feedback and both are trivially
+// undone — a chord on the transport buttons could leave a seek or a pause.
+//
+// Suppressing the two bits while the chord is held was considered and rejected:
+// it would mean editing the map on its way to the core, so a detection bug would
+// make buttons stop working, and it would swallow a legitimate fast double-press.
+// Observing only cannot break anything that was working.
+//
+// JOY_BTN1 is bit 4 (JOY_BTN_SHIFT), so button N is bit (3 + N).
+#define BTN_BIT(n)   (1u << (3 + (n)))
+#define CHORD_MASK   (BTN_BIT(7) | BTN_BIT(8))
+#define HOLD_MS      2000
+
+#define OUT_DIR      "/media/fat/DVD_reports"
+
+static const char *SCRIPT_PATHS[] = {
+	"/media/fat/Scripts/dvd_report.py",
+	"/media/fat/dvd_report.py",
+	"/media/fat/Scripts/.dvd/dvd_report.py",
+	0
+};
+
+static uint32_t chord_since = 0;   // 0 = chord not currently held
+static int      fired       = 0;   // one bundle per press-and-hold
+static pid_t    child       = -1;
+static char     out_path[320];
+
+static uint32_t now_ms(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint32_t)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
+}
+
+static const char *find_script(void)
+{
+	for (int i = 0; SCRIPT_PATHS[i]; i++)
+	{
+		struct stat st;
+		if (!stat(SCRIPT_PATHS[i], &st) && S_ISREG(st.st_mode)) return SCRIPT_PATHS[i];
+	}
+	return 0;
+}
+
+// The saved-settings file carries the user's OSD options. Its name embeds the
+// CONF_STR config version ("v,1;" -> DVD_v1.CFG), which is bumped on any
+// incompatible option relayout — so glob rather than hardcoding v1, and fall
+// back to the unversioned name. Passing the file beats reading the live status
+// word: user_io_status_get() spans only two bytes of cur_status[], so the full
+// 128-bit word would need its own accessor for a marginal gain.
+static const char *find_cfg(char *buf, size_t len)
+{
+	DIR *d = opendir("/media/fat/config");
+	if (!d) return 0;
+
+	char best[64] = {0};
+	struct dirent *e;
+	while ((e = readdir(d)))
+	{
+		if (strncasecmp(e->d_name, "DVD", 3)) continue;
+		size_t n = strlen(e->d_name);
+		if (n < 5 || strcasecmp(e->d_name + n - 4, ".CFG")) continue;
+		// "DVD.CFG" or "DVD_v<N>.CFG" only — never another core's file.
+		if (e->d_name[3] != '.' && strncasecmp(e->d_name + 3, "_v", 2)) continue;
+		if (strcmp(e->d_name, best) > 0) snprintf(best, sizeof(best), "%s", e->d_name);
+	}
+	closedir(d);
+	if (!best[0]) return 0;
+	snprintf(buf, len, "/media/fat/config/%s", best);
+	return buf;
+}
+
+// What is the core reading from right now? An image file gives its path; a
+// physical disc gives the drive node, which is safe to hand to the tool because
+// every sector it reads is unscrambled (see docs/bug_reports.md).
+static const char *find_source(void)
+{
+	if (dvd_css_active())
+	{
+		const char *dev = dvd_phys_device();
+		if (dev && *dev) return dev;
+	}
+	fileTYPE *f = get_image(0);
+	if (f && f->path[0]) return f->path;
+	return 0;
+}
+
+static void start(void)
+{
+	const char *script = find_script();
+	if (!script)
+	{
+		InfoMessage("Support bundle needs dvd_report.py\n"
+		            "in /media/fat/Scripts/", 4000, "DVD");
+		return;
+	}
+
+	const char *src = find_source();
+	if (!src)
+	{
+		InfoMessage("Load a disc or image first", 3000, "DVD");
+		return;
+	}
+
+	mkdir(OUT_DIR, 0777);
+
+	time_t t = time(0);
+	struct tm tm;
+	localtime_r(&t, &tm);
+	snprintf(out_path, sizeof(out_path), OUT_DIR "/dvdreport-%04d%02d%02d-%02d%02d%02d.zip",
+	         tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+	         tm.tm_hour, tm.tm_min, tm.tm_sec);
+
+	char lba[24] = {0};
+	uint64_t l = user_io_last_lba(0);
+	int have_lba = (l != (uint64_t)-1);
+	if (have_lba) snprintf(lba, sizeof(lba), "%llu", (unsigned long long)l);
+
+	char cfgbuf[128];
+	const char *cfg = find_cfg(cfgbuf, sizeof(cfgbuf));
+
+	printf("DVD_REPORT: %s -> %s (lba %s)\n", src, out_path, have_lba ? lba : "n/a");
+
+	pid_t p = fork();
+	if (p < 0)
+	{
+		InfoMessage("Could not start bundle generation", 3000, "DVD");
+		return;
+	}
+	if (!p)
+	{
+		// Child. Nav-tables only: no --nav-packs, because that scans menu VOBs
+		// and this should finish in seconds on SD-card media.
+		const char *argv[16];
+		int i = 0;
+		argv[i++] = "python3";
+		argv[i++] = script;
+		argv[i++] = src;
+		argv[i++] = "--no-prompt";
+		argv[i++] = "--generated-on";
+		argv[i++] = "mister";
+		argv[i++] = "-o";
+		argv[i++] = out_path;
+		if (have_lba) { argv[i++] = "--lba"; argv[i++] = lba; }
+		if (cfg)      { argv[i++] = "--cfg"; argv[i++] = cfg; }
+		argv[i] = 0;
+
+		freopen("/tmp/dvd_report.log", "w", stdout);
+		dup2(fileno(stdout), fileno(stderr));
+		execvp("python3", (char * const *)argv);
+		_exit(127);
+	}
+
+	child = p;
+	InfoMessage("Generating support bundle...", 2000, "DVD");
+}
+
+static void reap(void)
+{
+	if (child < 0) return;
+
+	int st = 0;
+	pid_t r = waitpid(child, &st, WNOHANG);
+	if (r != child) return;
+	child = -1;
+
+	if (WIFEXITED(st) && !WEXITSTATUS(st))
+	{
+		const char *name = strrchr(out_path, '/');
+		char msg[256];
+		snprintf(msg, sizeof(msg),
+		         "Support bundle written to\nDVD_reports/%s\n\nAttach it to a GitHub issue.",
+		         name ? name + 1 : out_path);
+		InfoMessage(msg, 6000, "DVD");
+	}
+	else
+	{
+		// python3 missing, an unreadable disc, or a tool error. The child's
+		// output is in /tmp/dvd_report.log — say so rather than swallowing it.
+		InfoMessage("Support bundle FAILED\nsee /tmp/dvd_report.log", 5000, "DVD");
+	}
+}
+
+void dvd_report_joy(uint32_t map)
+{
+	if (!is_dvd()) return;
+
+	if ((map & CHORD_MASK) == CHORD_MASK)
+	{
+		if (!chord_since) chord_since = now_ms();
+	}
+	else
+	{
+		chord_since = 0;
+		fired = 0;               // re-arm only after the chord is released
+	}
+}
+
+void dvd_report_tick(void)
+{
+	if (!is_dvd()) return;
+
+	reap();
+
+	if (chord_since && !fired && child < 0 && (now_ms() - chord_since) >= HOLD_MS)
+	{
+		fired = 1;
+		start();
+	}
+}

--- a/main/support/dvd/dvd_report.cpp
+++ b/main/support/dvd/dvd_report.cpp
@@ -15,6 +15,7 @@
 
 #include "../../user_io.h"
 #include "../../menu.h"
+#include "../../osd.h"
 #include "../../file_io.h"
 #include "dvd_report.h"
 #include "dvd_css.h"
@@ -146,7 +147,24 @@ static void start(void)
 	char cfgbuf[128];
 	const char *cfg = find_cfg(cfgbuf, sizeof(cfgbuf));
 
-	printf("DVD_REPORT: %s -> %s (lba %s)\n", src, out_path, have_lba ? lba : "n/a");
+	// The core version, without a human having to read it off the OSD and type
+	// it. CONF_STR's "V,v0.4.0 260901" line is appended to the OSD core name at
+	// init (user_io.cpp, the p[0]=='V' arm), so OsdCoreNameGet() reads back
+	// "DVD v0.4.0 260901" and everything after the first space is the version.
+	// This matters more here than on the PC route: there is no reporter in the
+	// loop to supply it, and it is the only thing that identifies a build.
+	const char *ver = 0;
+	const char *osdname = OsdCoreNameGet();
+	if (osdname)
+	{
+		const char *sp = strchr(osdname, ' ');
+		// No space means no V line was parsed -- pass nothing rather than
+		// recording the bare core name as if it were a version.
+		if (sp && sp[1]) ver = sp + 1;
+	}
+
+	printf("DVD_REPORT: %s -> %s (lba %s, ver %s)\n",
+	       src, out_path, have_lba ? lba : "n/a", ver ? ver : "n/a");
 
 	pid_t p = fork();
 	if (p < 0)
@@ -158,7 +176,7 @@ static void start(void)
 	{
 		// Child. Nav-tables only: no --nav-packs, because that scans menu VOBs
 		// and this should finish in seconds on SD-card media.
-		const char *argv[16];
+		const char *argv[20];
 		int i = 0;
 		argv[i++] = "python3";
 		argv[i++] = script;
@@ -170,6 +188,7 @@ static void start(void)
 		argv[i++] = out_path;
 		if (have_lba) { argv[i++] = "--lba"; argv[i++] = lba; }
 		if (cfg)      { argv[i++] = "--cfg"; argv[i++] = cfg; }
+		if (ver)      { argv[i++] = "--core-version"; argv[i++] = ver; }
 		argv[i] = 0;
 
 		freopen("/tmp/dvd_report.log", "w", stdout);

--- a/main/support/dvd/dvd_report.cpp
+++ b/main/support/dvd/dvd_report.cpp
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdarg.h>
 #include <time.h>
 #include <errno.h>
 #include <dirent.h>
@@ -53,6 +54,35 @@ static uint32_t chord_since = 0;   // 0 = chord not currently held
 static int      fired       = 0;   // one bundle per press-and-hold
 static pid_t    child       = -1;
 static char     out_path[320];
+
+// Append-only trace. The OSD popup is timed and has to be transcribed by hand,
+// which cost several debugging rounds; this can just be cat'd.
+static void rep_log(const char *fmt, ...)
+{
+	va_list ap;
+	static int stamped = 0;
+	FILE *f = fopen("/tmp/dvd_report.log", "a");
+	if (f)
+	{
+		// Which binary is actually running? Several debugging rounds were lost
+		// to a stale copy that was indistinguishable by size, so the log says
+		// for itself rather than relying on an md5 taken at another time.
+		if (!stamped)
+		{
+			stamped = 1;
+			fprintf(f, "--- dvd_report built " __DATE__ " " __TIME__ " ---\n");
+		}
+		va_start(ap, fmt);
+		vfprintf(f, fmt, ap);
+		va_end(ap);
+		fputc('\n', f);
+		fclose(f);
+	}
+	va_start(ap, fmt);
+	vprintf(fmt, ap);
+	va_end(ap);
+	printf("\n");
+}
 
 static uint32_t now_ms(void)
 {
@@ -104,8 +134,18 @@ static const char *find_cfg(char *buf, size_t len)
 // every sector it reads is unscrambled (see docs/bug_reports.md).
 void dvd_report_note_mount(const char *path)
 {
-	if (!path || !path[0]) { mounted_path[0] = 0; return; }         // unmount
-	if (!strcmp(path, DVD_PHYS_SENTINEL)) { mounted_path[0] = 0; return; }
+	if (!path || !path[0])
+	{
+		rep_log("DVD_REPORT: mount hook: (empty) -> cleared");
+		mounted_path[0] = 0;
+		return;
+	}
+	if (!strcmp(path, DVD_PHYS_SENTINEL))
+	{
+		rep_log("DVD_REPORT: mount hook: sentinel -> cleared");
+		mounted_path[0] = 0;
+		return;
+	}
 
 	// ⚠ Mount paths are RELATIVE to getRootDir() unless they start with '/' --
 	// make_fullpath() in file_io.cpp does this expansion, and everything inside
@@ -116,6 +156,7 @@ void dvd_report_note_mount(const char *path)
 		snprintf(mounted_path, sizeof(mounted_path), "%s", path);
 	else
 		snprintf(mounted_path, sizeof(mounted_path), "%s/%s", getRootDir(), path);
+	rep_log("DVD_REPORT: mount hook: %s -> %s", path, mounted_path);
 }
 
 static const char *find_source(void)
@@ -159,9 +200,9 @@ static void start(void)
 		         dvd_css_active(), dev ? dev : "(none)",
 		         mounted_path[0] ? mounted_path : "(not captured)");
 		InfoMessage(msg, 8000, "DVD");
-		printf("DVD_REPORT: no source (css=%d dev=%s mount=%s)\n",
-		       dvd_css_active(), dev ? dev : "-",
-		       mounted_path[0] ? mounted_path : "-");
+		rep_log("DVD_REPORT: NO SOURCE (css=%d dev=%s mount=%s)",
+		        dvd_css_active(), dev ? dev : "-",
+		        mounted_path[0] ? mounted_path : "-");
 		return;
 	}
 
@@ -198,8 +239,8 @@ static void start(void)
 		if (sp && sp[1]) ver = sp + 1;
 	}
 
-	printf("DVD_REPORT: %s -> %s (lba %s, ver %s)\n",
-	       src, out_path, have_lba ? lba : "n/a", ver ? ver : "n/a");
+	rep_log("DVD_REPORT: src=%s out=%s lba=%s ver=%s",
+	        src, out_path, have_lba ? lba : "n/a", ver ? ver : "n/a");
 
 	pid_t p = fork();
 	if (p < 0)
@@ -226,7 +267,7 @@ static void start(void)
 		if (ver)      { argv[i++] = "--core-version"; argv[i++] = ver; }
 		argv[i] = 0;
 
-		freopen("/tmp/dvd_report.log", "w", stdout);
+		freopen("/tmp/dvd_report_run.log", "w", stdout);
 		dup2(fileno(stdout), fileno(stderr));
 		execvp("python3", (char * const *)argv);
 		_exit(127);
@@ -258,7 +299,7 @@ static void reap(void)
 	{
 		// python3 missing, an unreadable disc, or a tool error. The child's
 		// output is in /tmp/dvd_report.log — say so rather than swallowing it.
-		InfoMessage("Support bundle FAILED\nsee /tmp/dvd_report.log", 5000, "DVD");
+		InfoMessage("Support bundle FAILED\nsee /tmp/dvd_report_run.log", 5000, "DVD");
 	}
 }
 

--- a/main/support/dvd/dvd_report.cpp
+++ b/main/support/dvd/dvd_report.cpp
@@ -48,6 +48,7 @@ static const char *SCRIPT_PATHS[] = {
 	0
 };
 
+static char     mounted_path[1024] = {0};   // full path of the mounted image
 static uint32_t chord_since = 0;   // 0 = chord not currently held
 static int      fired       = 0;   // one bundle per press-and-hold
 static pid_t    child       = -1;
@@ -101,15 +102,36 @@ static const char *find_cfg(char *buf, size_t len)
 // What is the core reading from right now? An image file gives its path; a
 // physical disc gives the drive node, which is safe to hand to the tool because
 // every sector it reads is unscrambled (see docs/bug_reports.md).
+void dvd_report_note_mount(const char *path)
+{
+	if (!path || !path[0]) { mounted_path[0] = 0; return; }         // unmount
+	if (!strcmp(path, DVD_PHYS_SENTINEL)) { mounted_path[0] = 0; return; }
+
+	// ⚠ Mount paths are RELATIVE to getRootDir() unless they start with '/' --
+	// make_fullpath() in file_io.cpp does this expansion, and everything inside
+	// Main goes through it. We hand this path to a separate process with its own
+	// working directory, so it has to be absolute or python3 simply will not
+	// find the file.
+	if (path[0] == '/')
+		snprintf(mounted_path, sizeof(mounted_path), "%s", path);
+	else
+		snprintf(mounted_path, sizeof(mounted_path), "%s/%s", getRootDir(), path);
+}
+
 static const char *find_source(void)
 {
+	// A physical disc first: dvd_phys owns the drive and its node is what the
+	// tool should read (every sector it touches is unscrambled).
 	if (dvd_css_active())
 	{
 		const char *dev = dvd_phys_device();
 		if (dev && *dev) return dev;
 	}
-	fileTYPE *f = get_image(0);
-	if (f && f->path[0]) return f->path;
+	// Otherwise the mounted image, captured at mount time. Do NOT use
+	// fileTYPE::path here -- user_io.cpp only fills it in the pre-create branch
+	// (`if (!ret && pre)`), so a normally-mounted ISO leaves it empty and this
+	// reported "Load a disc or image first" with a disc plainly loaded.
+	if (mounted_path[0]) return mounted_path;
 	return 0;
 }
 

--- a/main/support/dvd/dvd_report.h
+++ b/main/support/dvd/dvd_report.h
@@ -37,4 +37,11 @@ void dvd_report_joy(uint32_t map);
 // starve the core mid-playback.
 void dvd_report_tick(void);
 
+// Call from user_io_file_mount() with the path it was handed. Nothing else in
+// Main keeps the full path of a mounted image: fileTYPE::name is the basename
+// only, and fileTYPE::path is populated solely in the pre-create branch -- so a
+// normally-mounted ISO has neither, and the bundle had nothing to work from.
+// Observes only; the empty string (an unmount) clears it.
+void dvd_report_note_mount(const char *path);
+
 #endif

--- a/main/support/dvd/dvd_report.h
+++ b/main/support/dvd/dvd_report.h
@@ -1,0 +1,40 @@
+// dvd_report.h — generate a navigation support bundle from the player itself.
+//
+// A DVD navigation bug is reproducible from the disc's IFO tables alone, which
+// are tiny and unencrypted (see MiSTer_DVD/docs/bug_reports.md). tools/dvd_report.py
+// packages them; normally a reporter runs it on a PC against their own rip.
+//
+// This module offers the same thing without a PC: hold a gamepad chord while the
+// DVD core is running and the Main builds a bundle from whatever is currently
+// mounted — an image file or the optical drive — and writes it to
+// /media/fat/DVD_reports/ for the user to attach to an issue.
+//
+// It is worth having in the Main rather than only as a PC step for one reason
+// beyond convenience: the Main knows the SECTOR BEING SERVED at the moment the
+// user hit the chord, which is the one thing a reporter cannot state from memory.
+// A bug reported as "somewhere in the menus" arrives with the exact cell.
+//
+// Design, and the alternatives that were rejected (an OSD row costs a fitter seed
+// re-roll; a C++ collector would drift from the Python one):
+// MiSTer_DVD/docs/support_bundle_hps.md.
+
+#ifndef MISTER_DVD_REPORT_H
+#define MISTER_DVD_REPORT_H
+
+#include <stdint.h>
+
+// Call from user_io_digital_joystick() with the button map, before it is sent on
+// to the core. Observes only — the map is not modified, so the chord's own
+// buttons still do their normal thing (one audio-track step and one subtitle
+// step, both visible and both trivially undone).
+void dvd_report_joy(uint32_t map);
+
+// Call every user_io_poll. Fires the deferred generation once the chord has been
+// held long enough, and reaps the child. Self-gates on is_dvd(); no-op otherwise.
+//
+// The work runs in a FORKED CHILD, never inline: this tick shares the poll loop
+// with SD block service, and a bundle takes long enough that blocking here would
+// starve the core mid-playback.
+void dvd_report_tick(void);
+
+#endif

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,7 @@ nav:
   - Reference:
       - Compatibility: reference/compatibility.md
       - Troubleshooting: reference/troubleshooting.md
+      - Reporting a bug: reference/reporting-a-bug.md
   - About:
       - Building from source: about/building.md
       - Acknowledgements: about/acknowledgements.md

--- a/site/content/getting-started/install.md
+++ b/site/content/getting-started/install.md
@@ -53,7 +53,8 @@ what each piece does.
 ├── MiSTer_DVDcss               optional custom Main (physical discs, encrypted ISOs)
 ├── Scripts/
 │   ├── install_dvdcss.sh       fetches libdvdcss
-│   └── set_dvd_region.sh       reads/sets a USB drive's region
+│   ├── set_dvd_region.sh       reads/sets a USB drive's region
+│   └── dvd_report.py           builds a bug-report bundle (unreleased)
 └── DVD_INSTALL.txt             the same instructions, on the card
 ```
 

--- a/site/content/getting-started/what-you-need.md
+++ b/site/content/getting-started/what-you-need.md
@@ -18,6 +18,7 @@ that when something does not play, you can tell which piece is missing.
 | **Physical disc — CSS-encrypted** *(most commercial discs)* | — | — | ✓ |
 | **CSS-encrypted ISO** — *no optical drive needed* | — | — | ✓ |
 | Recovered-key caching (slow only on first play) | — | — | ✓ |
+| Support bundle from the player itself *(unreleased)* | — | ✓ | ✓ |
 
 ## The three pieces
 

--- a/site/content/playback/controls.md
+++ b/site/content/playback/controls.md
@@ -62,6 +62,17 @@ naming what you switched to, with the language where the disc provides one — `
     Switching the audio track while a disc menu is open silences the menu's own audio until
     you leave the menu. Menu audio otherwise plays normally on the default track.
 
+## Support bundle chord
+
+!!! info "Unreleased"
+    Available in development builds; not in v0.3.0. Needs `MiSTer_DVDcss`.
+
+**Audio + Subtitle held together for two seconds** writes a navigation support bundle for
+the disc you are playing to `/media/fat/DVD_reports/` — a small file that makes a menu or
+navigation bug reproducible without the disc. See
+[Reporting a bug](../reference/reporting-a-bug.md). It also steps the audio and subtitle
+tracks once each, which you can simply step back.
+
 ## D-pad seek
 
 During plain playback the D-pad does nothing unless you turn on

--- a/site/content/playback/on-screen-messages.md
+++ b/site/content/playback/on-screen-messages.md
@@ -24,6 +24,23 @@ themselves; the ones that persist are describing a condition, not an event.
     means it read the file and could not play it. See
     [Troubleshooting](../reference/troubleshooting.md#nothing-plays).
 
+## Support bundle
+
+!!! info "Unreleased"
+    Available in development builds; not in v0.3.0. Needs `MiSTer_DVDcss`.
+
+Shown when you hold **Audio + Subtitle** for two seconds to write a
+[support bundle](../reference/reporting-a-bug.md#or-make-one-on-the-mister-itself).
+
+| Message | Meaning |
+|---|---|
+| `Generating support bundle...` | Started. It runs in the background, so playback carries on. |
+| `Support bundle written to DVD_reports/…` | Done — that is the file to attach to an issue. |
+| `Nothing to bundle` | No image or disc was found. The lines beneath say what was seen; `mounted: (not captured)` with a disc playing is a bug worth reporting. |
+| `Support bundle needs dvd_report.py` | Put `dvd_report.py` in `/media/fat/Scripts/` — the release zip does this for you. |
+| `Support bundle FAILED` | The collector errored. `/tmp/dvd_report_run.log` says why; the usual cause is a missing or very old python3. |
+| `Could not start bundle generation` | The player could not spawn the collector at all. |
+
 ## Transport popups
 
 These appear briefly when you change something, and are not errors:

--- a/site/content/reference/compatibility.md
+++ b/site/content/reference/compatibility.md
@@ -100,13 +100,13 @@ the receiver re-acquires in under a second when audio returns.
 
 ## Reporting a disc that does not work
 
-[Open an issue](https://github.com/owenb321/MiSTer_DVD/issues) with:
+[Open an issue](https://github.com/owenb321/MiSTer_DVD/issues) with the core version from
+the OSD, the disc title and region, what happens and where, and any
+[on-screen message](../playback/on-screen-messages.md).
 
-- The **core version** from the OSD — the `v0.3.0 260901` line
-- The disc title and region
-- What happens, and where — does it boot, reach a menu, start the feature?
-- Any [on-screen message](../playback/on-screen-messages.md)
-- Whether it is a physical disc, a decrypted image, or an encrypted image
+If the trouble is with **menus, titles or audio tracks**, you can also send the disc's
+navigation tables as a sub-100 KB file, which makes the problem reproducible without the
+disc — see [Reporting a bug](reporting-a-bug.md).
 
 Interactive/game discs are known-incomplete, so those reports are useful but expected. A
 **film or TV disc** that does not play properly is the more surprising case and worth

--- a/site/content/reference/reporting-a-bug.md
+++ b/site/content/reference/reporting-a-bug.md
@@ -63,6 +63,22 @@ python3 dvd_report.py MY_DISC.iso --nav-packs
     path from your computer. `python3 dvd_report.py info <zip>` prints back everything a
     bundle holds, any time.
 
+### Or make one on the MiSTer itself
+
+!!! info "Unreleased"
+    Available in development builds; not in v0.3.0. Needs `MiSTer_DVDcss`.
+
+While a disc is playing, **hold Audio + Subtitle together for two seconds**. The player
+writes a bundle to `/media/fat/DVD_reports/` and tells you the filename on screen. Copy it
+off the SD card and attach it to the issue.
+
+This works for **physical discs** as well as images, and it needs no PC. It also records
+something the PC route cannot: the exact point on the disc you were at when you pressed it,
+which for a menu problem is usually the whole answer.
+
+Holding those two buttons also steps the audio track and the subtitle track once each —
+that is expected, and pressing them again puts things back.
+
 The bundle is built from an image file, so this path needs a rip on a PC — encrypted or
 decrypted, either works. If you only ever play physical discs, describe the problem
 instead; that is still a useful report.

--- a/site/content/reference/reporting-a-bug.md
+++ b/site/content/reference/reporting-a-bug.md
@@ -63,6 +63,9 @@ python3 dvd_report.py MY_DISC.iso --nav-packs
     path from your computer. `python3 dvd_report.py info <zip>` prints back everything a
     bundle holds, any time.
 
+This route needs a rip on a PC — encrypted or decrypted, either works. If you only ever
+play physical discs, the next section is for you.
+
 ### Or make one on the MiSTer itself
 
 !!! info "Unreleased"
@@ -79,9 +82,10 @@ which for a menu problem is usually the whole answer.
 Holding those two buttons also steps the audio track and the subtitle track once each —
 that is expected, and pressing them again puts things back.
 
-The bundle is built from an image file, so this path needs a rip on a PC — encrypted or
-decrypted, either works. If you only ever play physical discs, describe the problem
-instead; that is still a useful report.
+The bundle it writes also records two things the PC route cannot: the **core version**,
+so you never have to read it off the OSD, and the **exact point on the disc** you were at
+when you pressed the chord.
+
 
 ## Everything else: describe it
 

--- a/site/content/reference/reporting-a-bug.md
+++ b/site/content/reference/reporting-a-bug.md
@@ -31,7 +31,9 @@ typical disc they come to well under 100 KB, and they are all that is needed to 
 - chapters that are missing or in the wrong place
 
 Download **[`dvd_report.py`](https://github.com/owenb321/MiSTer_DVD/blob/main/tools/dvd_report.py)**
-and run it on a PC against your own decrypted rip. It needs Python 3 and nothing else:
+and run it on a PC against your own rip of the disc. It needs Python 3 and nothing else,
+and it works on an **encrypted rip too** — the navigation tables are never encrypted, so
+no decryption step is involved:
 
 ```bash
 python3 dvd_report.py MY_DISC.iso
@@ -61,8 +63,9 @@ python3 dvd_report.py MY_DISC.iso --nav-packs
     path from your computer. `python3 dvd_report.py info <zip>` prints back everything a
     bundle holds, any time.
 
-The bundle is built from an image, so this path needs a decrypted rip on a PC. If you only
-ever play physical discs, describe the problem instead — that is still a useful report.
+The bundle is built from an image file, so this path needs a rip on a PC — encrypted or
+decrypted, either works. If you only ever play physical discs, describe the problem
+instead; that is still a useful report.
 
 ## Everything else: describe it
 

--- a/site/content/reference/reporting-a-bug.md
+++ b/site/content/reference/reporting-a-bug.md
@@ -1,0 +1,91 @@
+# Reporting a bug
+
+Most problems are disc-specific, and the disc is usually one nobody else has. What makes a
+report actionable is saying **which build**, **which disc**, and **what happened** — and,
+for anything to do with menus or audio tracks, attaching a small file that lets the
+problem be reproduced without the disc.
+
+[Open an issue →](https://github.com/owenb321/MiSTer_DVD/issues)
+
+## Always include
+
+- The **core version** from the OSD — the `v0.3.0 260901` line. It is the only thing that
+  identifies a build.
+- The **disc title and region**.
+- **What happens, and where** — does it boot, reach a menu, start the feature?
+- Any [on-screen message](../playback/on-screen-messages.md).
+- Whether it is a **physical disc, a decrypted image, or an encrypted image**.
+- If it used to work, **which version it last worked in**.
+
+## Menus, titles and audio tracks: send a repro bundle
+
+A DVD keeps its navigation — every menu, button, title, chapter and audio-track
+assignment — in a handful of small `.IFO` files, separate from the film itself. On a
+typical disc they come to well under 100 KB, and they are all that is needed to reproduce:
+
+- menus that do nothing, jump somewhere wrong, or show `LINK FAIL nn`
+- the wrong title playing, or the disc not reaching the feature
+- **a track that is silent, or the wrong language playing** — which track maps to which
+  soundtrack is decided in those same tables, so this is a navigation question even though
+  it sounds like an audio one
+- chapters that are missing or in the wrong place
+
+Download **[`dvd_report.py`](https://github.com/owenb321/MiSTer_DVD/blob/main/tools/dvd_report.py)**
+and run it on a PC against your own decrypted rip. It needs Python 3 and nothing else:
+
+```bash
+python3 dvd_report.py MY_DISC.iso
+```
+
+It asks a few optional questions, writes a `dvdreport-*.zip` of around 40–100 KB, and
+verifies the bundle actually reproduces before telling you it is done. Attach that zip to
+the issue.
+
+If the problem is specifically about **menu buttons or highlights** — the wrong button
+lit, the highlight in the wrong place, a press doing nothing — add `--nav-packs` so the
+button positions are captured too:
+
+```bash
+python3 dvd_report.py MY_DISC.iso --nav-packs
+```
+
+!!! note "What is in the bundle, and what is not"
+    Only the disc's **unencrypted navigation structures**: the directory records, the
+    `.IFO` navigation tables, optionally the data describing menu buttons, and your
+    answers. **No video, no audio, and no decryption keys.** It is not a copy of the film
+    and cannot be used to watch anything.
+
+    That is enforced, not just intended — the tool checks every sector it has gathered and
+    refuses to write a bundle if any of them carries picture or sound, reporting
+    `content audit: PASS` when it finishes. It stores your image's filename but no other
+    path from your computer. `python3 dvd_report.py info <zip>` prints back everything a
+    bundle holds, any time.
+
+The bundle is built from an image, so this path needs a decrypted rip on a PC. If you only
+ever play physical discs, describe the problem instead — that is still a useful report.
+
+## Everything else: describe it
+
+Picture and sound problems live in the video stream itself, which is far too large to
+share, so words are the right tool. What helps most:
+
+| Problem | Worth saying |
+|---|---|
+| Stutter or judder | Whether it is a busy scene, and whether it is [film or video content](../video/film-24p.md) |
+| Lip sync out | Whether it is wrong from the start or drifts; whether a **chapter skip fixes it**; your `A/V Offset` setting |
+| Artefacts or wrong colours | Whether it is constant or occasional, and which output — HDMI, analog, CRT |
+| Analog or CRT trouble | Your `MiSTer.ini` video lines, `Analog Out` mode, and what the display is |
+| Passthrough or receiver trouble | The receiver model, the codec, and whether optical or HDMI |
+
+Two questions are worth answering for almost any playback problem, because they separate
+whole classes of cause: **does it happen from a cold load, or only after playing a while?**
+And **does a chapter skip clear it?**
+
+For lip sync in particular, a **phone video with sound** is genuinely useful — the offset
+can be measured from it directly.
+
+## What is expected to be broken
+
+Interactive DVD **games** are known-incomplete, so reports about them are welcome but
+unsurprising. A **film or TV disc** that misbehaves is the more valuable report. See
+[Compatibility](compatibility.md) for what is known not to work.

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -197,6 +197,26 @@ The auto-selection picks the largest title set, which is not always right. `Titl
 and `Title VTS Units` on the Debug page force a specific one. The core shows `TITLE VTS nn`
 to say what it picked.
 
+## Support bundles
+
+### The chord does nothing
+
+Hold **Audio + Subtitle together** for a full two seconds. Both buttons must be down at
+once, and the timer only starts when the second one goes down. It also needs
+`MiSTer_DVDcss` — on the stock Main nothing is listening, and there is no message.
+
+### `Nothing to bundle` with a disc playing
+
+The message lists what the player could see. `mounted: (not captured)` means it did not
+record the mount, which should not happen — that one is worth
+[reporting](reporting-a-bug.md). `css active: 0` with `drive: (none)` while a physical
+disc is playing points the same way.
+
+### `Support bundle FAILED`
+
+Read `/tmp/dvd_report_run.log`. Most often python3 is missing or too old — the collector
+needs 3.7 or newer.
+
 ## After an update
 
 ### All my settings reset

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -71,6 +71,11 @@ Press **B7** to cycle audio tracks. The disc's default may be:
 
 `AUDIO UNSUPPORTED` on screen means exactly this.
 
+If none of those fit — a track is silent with no message, or cycling lands on the wrong
+language — the fault is likely in how the disc maps tracks to soundtracks, which lives in
+its navigation tables. A [repro bundle](reporting-a-bug.md) captures those, so that report
+can be reproduced without the disc.
+
 ### Menu audio went silent
 
 You changed the audio track while the menu was open. It comes back when you leave the menu.
@@ -173,8 +178,10 @@ with zero contrast, which is intentional on their part.
 working menu. Occasional occurrences are harmless.
 
 If a disc is consistently unnavigable, it is worth
-[reporting](compatibility.md#reporting-a-disc-that-does-not-work) — especially a film or TV
-disc, since interactive games are known-incomplete.
+[reporting](reporting-a-bug.md) — especially a film or TV disc, since interactive games are
+known-incomplete. A menu problem can be reproduced from the disc's navigation tables
+alone, so a [repro bundle](reporting-a-bug.md#menus-titles-and-audio-tracks-send-a-repro-bundle)
+makes that report actionable without the disc.
 
 **Workaround:** set **`Disc Menus` = `Off`** to skip navigation and auto-play the main
 feature.

--- a/tools/dvd_report.py
+++ b/tools/dvd_report.py
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+# =============================================================================
+# dvd_report.py -- build a tiny, shareable repro bundle for a DVD NAVIGATION bug
+# =============================================================================
+# THE PROBLEM THIS SOLVES
+#
+# Nearly every navigation bug reported against this core happens on a disc the
+# maintainer does not own: "LINK FAIL 12", "it plays the wrong title", "the menu
+# button does nothing", "no audio in this one VTS". Diagnosing those needs the
+# disc's nav tables -- and nothing else. But a DVD-Video ISO is 4-8 GB, which
+# nobody can attach to an issue.
+#
+# The nav tables are the IFO files, and they are TINY. Measured on a real 4.47 GB
+# rip: VIDEO_TS.IFO + VTS_01_0.IFO together are 104 KB -- 0.0023% of the image,
+# about 43,000x smaller. Every host-side nav tool in tools/ (iso_nav_check.py,
+# dvd_vm_ref.py, dvd_census.py) reads ONLY those tables plus the ISO9660
+# directory records that locate them. So a nav bug is fully reproducible from
+# roughly a hundred kilobytes.
+#
+# WHY A SPARSE-SECTOR BUNDLE AND NOT "JUST SEND THE IFO FILES"
+#
+# The tools do not take loose IFO files -- they take an ISO, and IsoNav starts by
+# asserting 'CD001' at sector 16 and then follows absolute LBAs. Loose IFOs would
+# mean rewriting every tool, and the LBAs (which the RTL reader also consumes)
+# would be lost.
+#
+# So this bundle stores {LBA -> 2048-byte sector} pairs at their ORIGINAL disc
+# addresses. `unpack` writes them back into a SPARSE file of the original image
+# size: every captured sector sits at its true offset and everything else reads
+# as zero. The filesystem stores only the real bytes (a 4.47 GB reconstruction
+# occupies ~100 KB on disk), and:
+#
+#   * every existing tool works UNMODIFIED -- no tool needed changing for this,
+#   * the RTL testbenches already use exactly this idiom (see the *_meta.hex
+#     fixtures and bench/dvd/iso_reader_atmos_tb.sv, whose header notes
+#     "everything else reads as zero in the TB"), so a submission can become a
+#     regression fixture rather than a one-off debugging session.
+#
+# SCOPE -- deliberately navigation only
+#
+# Subpicture, closed-caption, film-cadence and A/V-sync bugs need real VOB
+# payload bytes (the evidence lives in the elementary stream, not in any nav
+# table), which is megabytes and a different problem. Those are better reported
+# in prose. This tool does not try to cover them. The one exception is the
+# optional --nav-packs flag, which captures menu NAV packs (PCI/HLI button
+# rectangles) for menu-highlight bugs -- still nav-domain data.
+#
+# PRIVACY -- bundles are meant to be attached to PUBLIC issues
+#
+# The manifest records the image's BASENAME only, never a full path, and no
+# username, hostname or directory layout. The bundle is summarised on stdout
+# after it is written so the reporter can see exactly what they are sharing.
+#
+# This file is deliberately SELF-CONTAINED (it duplicates a small ISO9660 walk
+# rather than importing dvd_vm_ref.IsoNav) because a bug reporter downloads this
+# ONE file from the repository and runs it -- they do not have a checkout.
+#
+# Usage (reporter, on a PC, with their own decrypted rip):
+#   python3 dvd_report.py disc.iso
+#   python3 dvd_report.py disc.iso --nav-packs        # menu highlight bugs
+#   python3 dvd_report.py disc.iso --core-version "0.3.0 260830" --no-prompt
+#
+# Usage (maintainer, on a received bundle):
+#   python3 tools/dvd_report.py info    dvdreport-*.zip
+#   python3 tools/dvd_report.py unpack  dvdreport-*.zip -o repro.iso
+#   python3 tools/iso_nav_check.py repro.iso
+#   python3 tools/dvd_vm_ref.py boot repro.iso
+# =============================================================================
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import re
+import struct
+import sys
+import tempfile
+import zipfile
+
+SEC = 2048
+SCHEMA = 1
+TOOL_VERSION = "1"
+
+# GitHub only accepts a fixed set of attachment extensions on issues, and a
+# custom one (.dvdrep) is not among them -- so the bundle is a plain .zip.
+BUNDLE_EXT = ".zip"
+
+BUNDLE_README = """\
+MiSTer DVD core -- navigation bug repro bundle
+=============================================
+
+This archive contains the ISO9660 directory records and the DVD-Video IFO
+(navigation table) sectors of a DVD, stored at their original disc addresses.
+It contains NO video and NO audio -- only the disc's navigation metadata.
+
+To use it (from a MiSTer_DVD checkout):
+
+    python3 tools/dvd_report.py info   <this-file>
+    python3 tools/dvd_report.py unpack <this-file> -o repro.iso
+    python3 tools/iso_nav_check.py repro.iso
+    python3 tools/dvd_vm_ref.py boot repro.iso
+
+`unpack` writes a sparse image of the original disc's size: the captured
+sectors sit at their true offsets and every other sector reads as zero, so the
+existing navigation tools work on it unmodified. Playback of the reconstructed
+image is NOT expected to work -- the video is not here.
+"""
+
+
+# ---------------------------------------------------------------- ISO9660 walk
+
+class IsoWalk(object):
+    """Minimal ISO9660 reader: volume descriptors, root, VIDEO_TS.
+
+    Mirrors the walk in tools/dvd_vm_ref.py IsoNav._walk, but records the LBA
+    *spans* it visits so they can be captured, and is standalone so this file
+    can be downloaded and run on its own.
+    """
+
+    def __init__(self, path):
+        self.path = path
+        self.f = open(path, "rb")
+        self.file_size = os.path.getsize(path)
+        self.vd_lbas = []        # volume descriptor sectors
+        self.dir_spans = []      # (lba, nsec) for root + VIDEO_TS
+        self.ifo = {}            # NAME -> (lba, length)
+        self.menu_vob = {}       # vts -> (lba, length); 0 = VIDEO_TS.VOB
+        self.title_vob = {}      # vts -> [(lba, length), ...]
+        self._walk()
+
+    def sec(self, n):
+        self.f.seek(n * SEC)
+        d = self.f.read(SEC)
+        return d + b"\0" * (SEC - len(d)) if len(d) < SEC else d
+
+    def close(self):
+        self.f.close()
+
+    def _dir(self, dlba, dlen):
+        nsec = (dlen + SEC - 1) // SEC
+        self.dir_spans.append((dlba, nsec))
+        buf = b"".join(self.sec(dlba + i) for i in range(nsec))
+        out = []
+        for s in range(nsec):
+            p = s * SEC
+            end = p + SEC
+            while p < end:
+                rl = buf[p]
+                if rl == 0:
+                    break
+                ext = struct.unpack("<I", buf[p + 2:p + 6])[0]
+                dl = struct.unpack("<I", buf[p + 10:p + 14])[0]
+                fl = buf[p + 25]
+                nl = buf[p + 32]
+                nm = buf[p + 33:p + 33 + nl]
+                out.append((nm.upper(), ext, dl, fl))
+                p += rl
+        return out
+
+    def _walk(self):
+        lba = 16
+        pvd = None
+        while lba < 16 + 32:
+            d = self.sec(lba)
+            if d[1:6] != b"CD001":
+                raise SystemExit(
+                    "%s is not an ISO9660 image (no CD001 at sector %d).\n"
+                    "This tool needs a decrypted DVD-Video .iso rip."
+                    % (os.path.basename(self.path), lba))
+            self.vd_lbas.append(lba)
+            if d[0] == 1 and pvd is None:
+                pvd = d
+            if d[0] == 255:
+                break
+            lba += 1
+        if pvd is None:
+            raise SystemExit("no Primary Volume Descriptor found")
+
+        self.volume_label = pvd[40:72].decode("latin-1").strip() or "(unnamed)"
+        self.volume_sectors = struct.unpack("<I", pvd[80:84])[0]
+        root_lba = struct.unpack("<I", pvd[158:162])[0]
+        root_len = struct.unpack("<I", pvd[166:170])[0]
+
+        vts_dir = None
+        for nm, ext, dl, fl in self._dir(root_lba, root_len):
+            if nm.startswith(b"VIDEO_TS") and (fl & 2):
+                vts_dir = (ext, dl)
+        if not vts_dir:
+            raise SystemExit(
+                "no VIDEO_TS directory -- this is not a DVD-Video image.\n"
+                "(UDF-only images are not supported by this tool, and are not\n"
+                "supported by the core either.)")
+
+        for nm, ext, dl, fl in self._dir(*vts_dir):
+            base = nm.split(b";")[0]
+            if base.endswith(b".IFO"):
+                self.ifo[base.decode("latin-1")] = (ext, dl)
+            elif base == b"VIDEO_TS.VOB":
+                self.menu_vob[0] = (ext, dl)
+            elif base.startswith(b"VTS_") and base.endswith(b".VOB"):
+                try:
+                    vn = int(base[4:6])
+                    part = int(base[7:8])
+                except ValueError:
+                    continue
+                if part == 0:
+                    self.menu_vob[vn] = (ext, dl)
+                else:
+                    self.title_vob.setdefault(vn, []).append((ext, dl))
+
+        if "VIDEO_TS.IFO" not in self.ifo:
+            raise SystemExit("no VIDEO_TS.IFO -- image is not a DVD-Video disc")
+
+    # -- summary numbers for the manifest (cheap, IFO-only) -------------------
+
+    def summary(self):
+        vmgi_lba = self.ifo["VIDEO_TS.IFO"][0]
+        mat = self.sec(vmgi_lba)
+        tsp = struct.unpack(">I", mat[196:200])[0]
+        n_titles = 0
+        if 0 < tsp <= 0xFFFFF:
+            n_titles = struct.unpack(">H", self.sec(vmgi_lba + tsp)[0:2])[0]
+        return {
+            "volume_label": self.volume_label,
+            "volume_sectors": self.volume_sectors,
+            "n_vts": len([k for k in self.ifo if k.startswith("VTS_")]),
+            "n_titles": n_titles,
+            "ifo_files": sorted(self.ifo),
+        }
+
+    def fingerprint(self):
+        """SHA-1 over VIDEO_TS.IFO, capped at 1 MiB and at its own length.
+
+        Same construction as the disc fingerprint used by the ripper tooling:
+        the IFO area is never CSS-scrambled, so it reads identically from a
+        drive and from a finished ISO, which makes it a stable disc identity
+        for de-duplicating reports.
+        """
+        lba, _ = self.ifo["VIDEO_TS.IFO"]
+        mat = self.sec(lba)
+        vmgi_last = struct.unpack(">I", mat[28:32])[0]
+        cap = 1 << 20
+        length = min((vmgi_last + 1) * SEC, cap) if vmgi_last else cap
+        self.f.seek(lba * SEC)
+        return "v1:" + hashlib.sha1(self.f.read(length)).hexdigest()
+
+
+# ------------------------------------------------------------ sector selection
+
+def merge(lbas):
+    """Sorted unique LBAs -> list of [start, count] runs."""
+    out = []
+    for l in sorted(set(lbas)):
+        if out and l == out[-1][0] + out[-1][1]:
+            out[-1][1] += 1
+        else:
+            out.append([l, 1])
+    return out
+
+
+def is_nav_pack(d):
+    """True if this sector is a DVD NAV pack (pack header + PCI).
+
+    ⚠ Do NOT shortcut this as "0x000001BF at offset 14". Real discs put a
+    SYSTEM HEADER (0x000001BB) between the pack header and the PCI packet, so
+    the PCI start code lands at 0x26 and its payload at 0x2D. A fixed-offset
+    check finds ZERO nav packs on such a disc and reports success while doing
+    nothing -- the same silent-miss that cost a NAV scan elsewhere in this
+    project (see CLAUDE.md, forced-select fix). Walk the packets by length.
+    """
+    if d[0:4] != b"\x00\x00\x01\xba":
+        return False
+    p = 14 + (d[13] & 7)                      # pack header + stuffing
+    if d[p:p + 4] == b"\x00\x00\x01\xbb":     # optional system header
+        p += 6 + struct.unpack(">H", d[p + 4:p + 6])[0]
+    # private_stream_2 carries no PES optional header: payload starts at p+6,
+    # and its first byte is the substream id (0x00 = PCI, 0x01 = DSI).
+    return d[p:p + 4] == b"\x00\x00\x01\xbf" and d[p + 6:p + 7] == b"\x00"
+
+
+def collect(iso, nav_packs=False, nav_scan_mb=512, verbose=True):
+    lbas = list(iso.vd_lbas)
+    for lba, nsec in iso.dir_spans:
+        lbas.extend(range(lba, lba + nsec))
+    for name, (lba, dl) in sorted(iso.ifo.items()):
+        lbas.extend(range(lba, lba + (dl + SEC - 1) // SEC))
+
+    if nav_packs:
+        budget = (nav_scan_mb * 1024 * 1024) // SEC
+        found = 0
+        for vts, (lba, dl) in sorted(iso.menu_vob.items()):
+            n = min((dl + SEC - 1) // SEC, budget)
+            if n <= 0:
+                break
+            for i in range(n):
+                if is_nav_pack(iso.sec(lba + i)):
+                    lbas.append(lba + i)
+                    found += 1
+            budget -= n
+        if verbose:
+            print("  menu NAV packs captured: %d" % found)
+    return merge(lbas)
+
+
+# ------------------------------------------------------------------- bundling
+
+def read_cfg(path):
+    if not path:
+        return None
+    with open(path, "rb") as f:
+        raw = f.read(64)
+    return {"file": os.path.basename(path), "hex": raw.hex()}
+
+
+def prompt(label, default=""):
+    try:
+        v = input("%s: " % label).strip()
+    except EOFError:
+        return default
+    return v or default
+
+
+def safe_slug(s):
+    s = re.sub(r"[^A-Za-z0-9._-]+", "_", s).strip("_")
+    return s[:40] or "disc"
+
+
+def cmd_make(args):
+    iso = IsoWalk(args.iso)
+    summ = iso.summary()
+    fp = iso.fingerprint()
+
+    print("Disc: %s  (%d VTS, %d titles)"
+          % (summ["volume_label"], summ["n_vts"], summ["n_titles"]))
+    print("Fingerprint: %s" % fp)
+
+    core_version = args.core_version
+    symptom = args.symptom
+    expected = args.expected
+    steps = args.steps
+    if not args.no_prompt and sys.stdin.isatty():
+        print()
+        print("A few questions -- all optional, press Enter to skip.")
+        print("(Everything you type here goes into the bundle, which is meant")
+        print(" to be attached to a public issue. Do not include personal info.)")
+        print()
+        if not core_version:
+            core_version = prompt(
+                "Core version, exactly as shown in the OSD (e.g. 0.3.0 260830)")
+        if not symptom:
+            symptom = prompt("What happened")
+        if not expected:
+            expected = prompt("What you expected instead")
+        if not steps:
+            steps = prompt("Steps (e.g. 'boot disc, press Menu, choose Scenes')")
+        print()
+
+    extents = collect(iso, args.nav_packs, args.nav_scan_mb)
+    n_sec = sum(c for _, c in extents)
+
+    blob = bytearray()
+    for lba, count in extents:
+        for i in range(count):
+            blob += iso.sec(lba + i)
+
+    image_bytes = max(iso.file_size, iso.volume_sectors * SEC)
+    manifest = {
+        "schema": SCHEMA,
+        "tool": "dvd_report.py",
+        "tool_version": TOOL_VERSION,
+        "created_utc": datetime.datetime.now(
+            datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "core_version": core_version or None,
+        "symptom": symptom or None,
+        "expected": expected or None,
+        "steps": steps or None,
+        "disc": {
+            "image_name": os.path.basename(args.iso),
+            "image_bytes": image_bytes,
+            "fingerprint": fp,
+            **{k: v for k, v in summ.items() if k != "volume_sectors"},
+        },
+        "settings_cfg": read_cfg(args.cfg),
+        "includes_nav_packs": bool(args.nav_packs),
+        "sector_count": n_sec,
+        "extents": extents,
+    }
+
+    out = args.out or ("dvdreport-%s-%s%s"
+                       % (safe_slug(summ["volume_label"]),
+                          fp[3:11], BUNDLE_EXT))
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED, compresslevel=9) as z:
+        z.writestr("manifest.json", json.dumps(manifest, indent=2) + "\n")
+        z.writestr("sectors.bin", bytes(blob))
+        z.writestr("README.txt", BUNDLE_README)
+    iso.close()
+
+    ok = verify(out, args.iso)
+
+    size = os.path.getsize(out)
+    print()
+    print("Wrote %s" % out)
+    print("  %d sectors (%.1f KB of disc data) -> %.1f KB compressed"
+          % (n_sec, len(blob) / 1024.0, size / 1024.0))
+    print("  %.5f%% of the original %.2f GB image"
+          % (100.0 * len(blob) / image_bytes, image_bytes / 1e9))
+    print("  self-check: %s" % ("PASS" if ok else "FAILED -- please report this"))
+    print()
+    print("This bundle contains: ISO9660 directory records, the IFO navigation")
+    print("tables%s, and what you typed above."
+          % (", menu NAV packs" if args.nav_packs else ""))
+    print("It contains NO video and NO audio, and no file paths from this machine.")
+    print("Attach it to a GitHub issue.")
+    return 0 if ok else 1
+
+
+def verify(bundle, original):
+    """Rebuild to a temp sparse image, re-walk it, and compare IFO bytes.
+
+    A bundle that cannot be walked is worse than no bundle -- the reporter has
+    moved on by the time anyone opens it -- so this runs unconditionally.
+    """
+    tmp = tempfile.NamedTemporaryFile(prefix="dvdrepro-", suffix=".iso",
+                                      delete=False)
+    tmp.close()
+    try:
+        unpack_to(bundle, tmp.name)
+        a = IsoWalk(tmp.name)
+        b = IsoWalk(original)
+        for name, (lba, dl) in sorted(b.ifo.items()):
+            n = (dl + SEC - 1) // SEC
+            for i in range(n):
+                if a.sec(lba + i) != b.sec(lba + i):
+                    a.close(); b.close()
+                    return False
+        a.summary()
+        a.close(); b.close()
+        return True
+    except Exception as e:
+        print("  self-check error: %s" % e)
+        return False
+    finally:
+        os.unlink(tmp.name)
+
+
+# ------------------------------------------------------------------ unpacking
+
+def unpack_to(bundle, out):
+    with zipfile.ZipFile(bundle) as z:
+        man = json.loads(z.read("manifest.json"))
+        if man.get("schema") != SCHEMA:
+            raise SystemExit("unsupported bundle schema %r (this tool: %d)"
+                             % (man.get("schema"), SCHEMA))
+        blob = z.read("sectors.bin")
+    need = man["sector_count"] * SEC
+    if len(blob) != need:
+        raise SystemExit("bundle is truncated: sectors.bin is %d bytes, "
+                         "manifest declares %d" % (len(blob), need))
+    with open(out, "wb") as f:
+        f.truncate(man["disc"]["image_bytes"])   # sparse: costs no disk
+        pos = 0
+        for lba, count in man["extents"]:
+            f.seek(lba * SEC)
+            f.write(blob[pos:pos + count * SEC])
+            pos += count * SEC
+    return man
+
+
+def cmd_unpack(args):
+    out = args.out or "repro.iso"
+    man = unpack_to(args.bundle, out)
+    du = os.stat(out).st_blocks * 512
+    print("Wrote %s -- %.2f GB sparse image, %.1f KB actually on disk"
+          % (out, man["disc"]["image_bytes"] / 1e9, du / 1024.0))
+    print()
+    print("Next:")
+    print("  python3 tools/iso_nav_check.py %s" % out)
+    print("  python3 tools/dvd_vm_ref.py boot %s" % out)
+    print("  python3 tools/dvd_census.py %s" % out)
+    return 0
+
+
+def cmd_info(args):
+    with zipfile.ZipFile(args.bundle) as z:
+        man = json.loads(z.read("manifest.json"))
+    d = man["disc"]
+    print("bundle       %s" % os.path.basename(args.bundle))
+    print("created      %s  (tool v%s, schema %s)"
+          % (man["created_utc"], man["tool_version"], man["schema"]))
+    print("core version %s" % (man.get("core_version") or "(not stated)"))
+    print("disc         %s  [%s]" % (d["volume_label"], d["image_name"]))
+    print("fingerprint  %s" % d["fingerprint"])
+    print("size         %.2f GB, %d VTS, %d titles"
+          % (d["image_bytes"] / 1e9, d["n_vts"], d["n_titles"]))
+    print("captured     %d sectors, nav packs: %s"
+          % (man["sector_count"], "yes" if man["includes_nav_packs"] else "no"))
+    if man.get("settings_cfg"):
+        print("settings     %s = %s"
+              % (man["settings_cfg"]["file"], man["settings_cfg"]["hex"]))
+    for k in ("symptom", "expected", "steps"):
+        if man.get(k):
+            print("%-12s %s" % (k, man[k]))
+    return 0
+
+
+# ----------------------------------------------------------------------- main
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Build a small, shareable repro bundle for a DVD "
+                    "navigation bug in the MiSTer DVD core.",
+        epilog="Run with just an .iso path to build a bundle.")
+    sub = ap.add_subparsers(dest="cmd")
+
+    def add_make(p):
+        p.add_argument("iso", help="decrypted DVD-Video .iso rip")
+        p.add_argument("-o", "--out", help="output .zip (default: auto-named)")
+        p.add_argument("--core-version",
+                       help="core version line from the OSD, e.g. '0.3.0 260830'")
+        p.add_argument("--symptom", help="what happened")
+        p.add_argument("--expected", help="what you expected")
+        p.add_argument("--steps", help="how to reach it")
+        p.add_argument("--cfg", help="path to config/DVD_v1.CFG from the SD card")
+        p.add_argument("--nav-packs", action="store_true",
+                       help="also capture menu NAV packs (PCI/HLI button "
+                            "rectangles) -- add this for menu HIGHLIGHT bugs")
+        p.add_argument("--nav-scan-mb", type=int, default=512,
+                       help="cap on menu VOB bytes scanned for NAV packs "
+                            "(default 512)")
+        p.add_argument("--no-prompt", action="store_true",
+                       help="do not ask any questions")
+
+    pm = sub.add_parser("make", help="build a bundle from an ISO")
+    add_make(pm)
+    pm.set_defaults(func=cmd_make)
+
+    pu = sub.add_parser("unpack", help="rebuild a sparse ISO from a bundle")
+    pu.add_argument("bundle")
+    pu.add_argument("-o", "--out", help="output image (default repro.iso)")
+    pu.set_defaults(func=cmd_unpack)
+
+    pi = sub.add_parser("info", help="print a bundle's manifest")
+    pi.add_argument("bundle")
+    pi.set_defaults(func=cmd_info)
+
+    # Bare `dvd_report.py disc.iso` is the reporter's path -- no subcommand.
+    argv = sys.argv[1:]
+    if argv and argv[0] not in ("make", "unpack", "info", "-h", "--help"):
+        argv = ["make"] + argv
+    args = ap.parse_args(argv)
+    if not getattr(args, "func", None):
+        ap.print_help()
+        return 2
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/dvd_report.py
+++ b/tools/dvd_report.py
@@ -147,13 +147,32 @@ class IsoWalk(object):
     def __init__(self, path):
         self.path = path
         self.f = open(path, "rb")
-        self.file_size = os.path.getsize(path)
+        self.file_size = self._size(path)
         self.vd_lbas = []        # volume descriptor sectors
         self.dir_spans = []      # (lba, nsec) for root + VIDEO_TS
         self.ifo = {}            # NAME -> (lba, length)
         self.menu_vob = {}       # vts -> (lba, length); 0 = VIDEO_TS.VOB
         self.title_vob = {}      # vts -> [(lba, length), ...]
         self._walk()
+
+    def _size(self, path):
+        """Byte size of an image file OR a block device (/dev/sr0).
+
+        os.path.getsize() returns 0 for a device node, which would poison
+        image_bytes and so the size of the reconstruction. Seek to the end
+        instead; if even that fails, the caller falls back to the PVD's own
+        volume_space_size, which is the disc's true size anyway.
+        """
+        try:
+            n = os.path.getsize(path)
+            if n:
+                return n
+        except OSError:
+            pass
+        try:
+            return self.f.seek(0, os.SEEK_END) or 0
+        except OSError:
+            return 0
 
     def sec(self, n):
         self.f.seek(n * SEC)
@@ -464,6 +483,16 @@ def cmd_make(args):
             **{k: v for k, v in summ.items() if k != "volume_sectors"},
         },
         "settings_cfg": read_cfg(args.cfg),
+        # Present only when the bundle was generated on the player itself,
+        # where the Main knows things a reporter cannot state from memory:
+        # the exact sector being served when the problem was seen, and the
+        # live status word (= the OSD settings, without hunting for the CFG).
+        "player": None if not (args.lba is not None or args.status
+                               or args.generated_on) else {
+            "generated_on": args.generated_on,
+            "lba": args.lba,
+            "status_hex": args.status,
+        },
         "includes_nav_packs": bool(args.nav_packs),
         "sector_count": n_sec,
         "content_audit": {
@@ -594,6 +623,13 @@ def cmd_info(args):
     if man.get("settings_cfg"):
         print("settings     %s = %s"
               % (man["settings_cfg"]["file"], man["settings_cfg"]["hex"]))
+    pl = man.get("player")
+    if pl:
+        print("generated on %s" % (pl.get("generated_on") or "?"))
+        if pl.get("lba") is not None:
+            print("playhead     sector %d" % pl["lba"])
+        if pl.get("status_hex"):
+            print("status word  %s  (live OSD settings)" % pl["status_hex"])
     for k in ("symptom", "expected", "steps"):
         if man.get(k):
             print("%-12s %s" % (k, man[k]))
@@ -626,6 +662,14 @@ def main():
                             "(default 512)")
         p.add_argument("--no-prompt", action="store_true",
                        help="do not ask any questions")
+        # Set by MiSTer_DVDcss when it generates a bundle on the player; see
+        # main/support/dvd/dvd_report.cpp and docs/support_bundle_hps.md.
+        p.add_argument("--lba", type=int,
+                       help="sector being served when the problem was seen")
+        p.add_argument("--status",
+                       help="core status word as hex (the live OSD settings)")
+        p.add_argument("--generated-on",
+                       help="where this was generated, e.g. 'mister'")
 
     pm = sub.add_parser("make", help="build a bundle from an ISO")
     add_make(pm)
@@ -644,6 +688,23 @@ def main():
     argv = sys.argv[1:]
     if argv and argv[0] not in ("make", "unpack", "info", "-h", "--help"):
         argv = ["make"] + argv
+    if not argv:
+        # Reached with no arguments -- most likely picked from the MiSTer
+        # Scripts menu, where a script gets no arguments at all. An argparse
+        # usage dump is useless there, so say what this is and how it is used.
+        print("MiSTer DVD -- support bundle builder")
+        print()
+        print("This packages a disc's navigation tables (no video, no audio) so a")
+        print("navigation bug can be reproduced without the disc.")
+        print()
+        print("On the MiSTer: hold Audio + Subtitle for 2 seconds while a disc is")
+        print("playing. The bundle is written to /media/fat/DVD_reports/.")
+        print()
+        print("On a PC:  python3 dvd_report.py MY_DISC.iso")
+        print()
+        print("https://owenb321.github.io/MiSTer_DVD/reference/reporting-a-bug/")
+        return 0
+
     args = ap.parse_args(argv)
     if not getattr(args, "func", None):
         ap.print_help()

--- a/tools/dvd_report.py
+++ b/tools/dvd_report.py
@@ -45,6 +45,19 @@
 # optional --nav-packs flag, which captures menu NAV packs (PCI/HLI button
 # rectangles) for menu-highlight bugs -- still nav-domain data.
 #
+# That scope line is ENFORCED, not merely intended. audit() runs over the final
+# captured set before anything is written, and refuses to produce a bundle if
+# any captured sector that parses as an MPEG-PS pack contains a packet other
+# than a system header, padding or private_stream_2. A bundle therefore cannot
+# carry picture or sound even if the collector is wrong.
+#
+# It also cannot carry decryption keys, and not by choice: CSS title keys live
+# in the headers of scrambled sectors (which are never captured), and the disc
+# key block lives in the lead-in control area, which is not part of an ISO
+# filesystem image at all. The IFO tables and NAV packs a bundle does contain
+# are the parts of a DVD that CSS leaves in the clear by design, because every
+# player must read them to navigate -- see main/support/dvd/dvd_css.cpp:341,393.
+#
 # PRIVACY -- bundles are meant to be attached to PUBLIC issues
 #
 # The manifest records the image's BASENAME only, never a full path, and no
@@ -90,9 +103,16 @@ BUNDLE_README = """\
 MiSTer DVD core -- navigation bug repro bundle
 =============================================
 
-This archive contains the ISO9660 directory records and the DVD-Video IFO
-(navigation table) sectors of a DVD, stored at their original disc addresses.
-It contains NO video and NO audio -- only the disc's navigation metadata.
+This archive contains only the UNENCRYPTED NAVIGATION STRUCTURES of a DVD --
+the ISO9660 directory records, the IFO navigation tables, and optionally the
+NAV packs that describe menu buttons -- stored at their original disc
+addresses.
+
+It contains NO video, NO audio and NO decryption keys, and it cannot be used
+to watch anything. Every sector was checked before the archive was written:
+any sector that parses as an MPEG program-stream pack carries navigation
+packets only (system header, padding, private_stream_2), never picture or
+sound. See "content_audit" in manifest.json.
 
 To use it (from a MiSTer_DVD checkout):
 
@@ -259,8 +279,35 @@ def merge(lbas):
     return out
 
 
+# The only PES stream ids that carry NO elementary stream data: system header,
+# padding, and private_stream_2 (which on a DVD is PCI/DSI navigation only).
+# A sector built exclusively from these cannot contain picture or sound.
+NAV_ONLY_IDS = {0xBB, 0xBE, 0xBF}
+
+
+def pack_packets(d):
+    """Walk a 2048-byte MPEG-PS pack. -> [(stream_id, payload_off)] or None."""
+    if d[0:4] != b"\x00\x00\x01\xba":
+        return None
+    p = 14 + (d[13] & 7)                      # pack header + stuffing
+    out = []
+    while p + 6 <= len(d) and d[p:p + 3] == b"\x00\x00\x01":
+        ln = struct.unpack(">H", d[p + 4:p + 6])[0]
+        out.append((d[p + 3], p + 6))
+        if ln == 0:
+            break
+        p += 6 + ln
+    return out
+
+
 def is_nav_pack(d):
-    """True if this sector is a DVD NAV pack (pack header + PCI).
+    """True iff this sector is a DVD NAV pack AND carries nothing else.
+
+    Both halves matter. The second is what makes "no audiovisual content" a
+    property of the code rather than an intention: a sector is only ever taken
+    from a VOB if EVERY packet in it is a system header, padding or
+    private_stream_2, and one of those is a PCI. Proven by walking the packet
+    lengths -- not assumed from the layout.
 
     ⚠ Do NOT shortcut this as "0x000001BF at offset 14". Real discs put a
     SYSTEM HEADER (0x000001BB) between the pack header and the PCI packet, so
@@ -269,14 +316,42 @@ def is_nav_pack(d):
     nothing -- the same silent-miss that cost a NAV scan elsewhere in this
     project (see CLAUDE.md, forced-select fix). Walk the packets by length.
     """
-    if d[0:4] != b"\x00\x00\x01\xba":
+    pkts = pack_packets(d)
+    if not pkts:
         return False
-    p = 14 + (d[13] & 7)                      # pack header + stuffing
-    if d[p:p + 4] == b"\x00\x00\x01\xbb":     # optional system header
-        p += 6 + struct.unpack(">H", d[p + 4:p + 6])[0]
-    # private_stream_2 carries no PES optional header: payload starts at p+6,
-    # and its first byte is the substream id (0x00 = PCI, 0x01 = DSI).
-    return d[p:p + 4] == b"\x00\x00\x01\xbf" and d[p + 6:p + 7] == b"\x00"
+    if any(sid not in NAV_ONLY_IDS for sid, _ in pkts):
+        return False
+    # private_stream_2 carries no PES optional header: its payload starts
+    # immediately, and the first byte is the substream id (0x00 = PCI).
+    return any(sid == 0xBF and d[off:off + 1] == b"\x00" for sid, off in pkts)
+
+
+def audit(iso, extents):
+    """Prove that no captured sector carries elementary stream data.
+
+    This is the structural form of the promise the bundle makes: it contains
+    only unencrypted navigation structures, never picture or sound. Rather than
+    trusting the collector's intent, it runs over the FINAL captured set --
+    filesystem and IFO sectors included, so it also catches a mistake upstream
+    of the nav-pack scanner (a bad extent length spilling into a VOB, say).
+
+    The rule is total and simple: if a captured sector parses as an MPEG-PS pack
+    at all, every packet in it must be nav-only.
+    """
+    meta = navp = 0
+    for lba, count in extents:
+        for i in range(count):
+            d = iso.sec(lba + i)
+            if pack_packets(d) is None:
+                meta += 1                     # not a media pack: PVD/dir/IFO
+            elif is_nav_pack(d):
+                navp += 1
+            else:
+                raise SystemExit(
+                    "INTERNAL ERROR: sector %d carries elementary stream data, "
+                    "so no bundle was written.\nPlease report this -- it is a "
+                    "bug in this tool, not in your disc." % (lba + i))
+    return meta, navp
 
 
 def collect(iso, nav_packs=False, nav_scan_mb=512, verbose=True):
@@ -358,6 +433,7 @@ def cmd_make(args):
 
     extents = collect(iso, args.nav_packs, args.nav_scan_mb)
     n_sec = sum(c for _, c in extents)
+    n_meta, n_nav = audit(iso, extents)
 
     blob = bytearray()
     for lba, count in extents:
@@ -384,6 +460,11 @@ def cmd_make(args):
         "settings_cfg": read_cfg(args.cfg),
         "includes_nav_packs": bool(args.nav_packs),
         "sector_count": n_sec,
+        "content_audit": {
+            "metadata_sectors": n_meta,
+            "nav_pack_sectors": n_nav,
+            "elementary_stream_sectors": 0,   # enforced by audit(), not asserted
+        },
         "extents": extents,
     }
 
@@ -405,12 +486,16 @@ def cmd_make(args):
           % (n_sec, len(blob) / 1024.0, size / 1024.0))
     print("  %.5f%% of the original %.2f GB image"
           % (100.0 * len(blob) / image_bytes, image_bytes / 1e9))
-    print("  self-check: %s" % ("PASS" if ok else "FAILED -- please report this"))
+    print("  self-check:    %s" % ("PASS" if ok else "FAILED -- please report this"))
+    print("  content audit: PASS -- %d navigation-table sectors, %d NAV packs,"
+          % (n_meta, n_nav))
+    print("                 0 sectors carrying picture or sound data")
     print()
-    print("This bundle contains: ISO9660 directory records, the IFO navigation")
-    print("tables%s, and what you typed above."
+    print("This bundle contains only the UNENCRYPTED NAVIGATION STRUCTURES of the")
+    print("disc: ISO9660 directory records, the IFO tables%s,"
           % (", menu NAV packs" if args.nav_packs else ""))
-    print("It contains NO video and NO audio, and no file paths from this machine.")
+    print("and what you typed above. No video, no audio, no decryption keys, and")
+    print("no file paths from this machine. It cannot be used to watch anything.")
     print("Attach it to a GitHub issue.")
     return 0 if ok else 1
 
@@ -495,6 +580,11 @@ def cmd_info(args):
           % (d["image_bytes"] / 1e9, d["n_vts"], d["n_titles"]))
     print("captured     %d sectors, nav packs: %s"
           % (man["sector_count"], "yes" if man["includes_nav_packs"] else "no"))
+    ca = man.get("content_audit")
+    if ca:
+        print("audit        %d nav-table sectors, %d NAV packs, %d carrying A/V"
+              % (ca["metadata_sectors"], ca["nav_pack_sectors"],
+                 ca["elementary_stream_sectors"]))
     if man.get("settings_cfg"):
         print("settings     %s = %s"
               % (man["settings_cfg"]["file"], man["settings_cfg"]["hex"]))

--- a/tools/dvd_report.py
+++ b/tools/dvd_report.py
@@ -58,6 +58,12 @@
 # are the parts of a DVD that CSS leaves in the clear by design, because every
 # player must read them to navigate -- see main/support/dvd/dvd_css.cpp:341,393.
 #
+# The corollary matters for who can file a report: a bundle built from an
+# ENCRYPTED rip is byte-identical to one built from the decrypted disc, because
+# every sector this reads is one CSS never touches. So asking a user for a bundle
+# never asks them to decrypt anything. Verified on a real CSS disc, not argued
+# from the spec -- see docs/bug_reports.md "Validation".
+#
 # PRIVACY -- bundles are meant to be attached to PUBLIC issues
 #
 # The manifest records the image's BASENAME only, never a full path, and no
@@ -68,7 +74,7 @@
 # rather than importing dvd_vm_ref.IsoNav) because a bug reporter downloads this
 # ONE file from the repository and runs it -- they do not have a checkout.
 #
-# Usage (reporter, on a PC, with their own decrypted rip):
+# Usage (reporter, on a PC, with their own rip -- encrypted or decrypted):
 #   python3 dvd_report.py disc.iso
 #   python3 dvd_report.py disc.iso --nav-packs        # menu highlight bugs
 #   python3 dvd_report.py disc.iso --core-version "0.3.0 260830" --no-prompt
@@ -186,7 +192,7 @@ class IsoWalk(object):
             if d[1:6] != b"CD001":
                 raise SystemExit(
                     "%s is not an ISO9660 image (no CD001 at sector %d).\n"
-                    "This tool needs a decrypted DVD-Video .iso rip."
+                    "This tool needs a DVD-Video .iso rip (encrypted is fine)."
                     % (os.path.basename(self.path), lba))
             self.vd_lbas.append(lba)
             if d[0] == 1 and pvd is None:
@@ -604,7 +610,7 @@ def main():
     sub = ap.add_subparsers(dest="cmd")
 
     def add_make(p):
-        p.add_argument("iso", help="decrypted DVD-Video .iso rip")
+        p.add_argument("iso", help="DVD-Video .iso rip (encrypted or decrypted)")
         p.add_argument("-o", "--out", help="output .zip (default: auto-named)")
         p.add_argument("--core-version",
                        help="core version line from the OSD, e.g. '0.3.0 260830'")

--- a/tools/dvd_report.py
+++ b/tools/dvd_report.py
@@ -503,9 +503,14 @@ def cmd_make(args):
         "extents": extents,
     }
 
-    out = args.out or ("dvdreport-%s-%s%s"
-                       % (safe_slug(summ["volume_label"]),
-                          fp[3:11], BUNDLE_EXT))
+    # Auto-name carries BOTH the disc identity and a timestamp: the identity so
+    # two discs never collide and the maintainer can see what it is without
+    # opening it, the timestamp so a second run on the SAME disc -- a follow-up
+    # after a fix, or a second bug -- does not silently overwrite the first.
+    out = args.out or ("dvdreport-%s-%s-%s%s"
+                       % (safe_slug(summ["volume_label"]), fp[3:11],
+                          datetime.datetime.now().strftime("%Y%m%d-%H%M%S"),
+                          BUNDLE_EXT))
     with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED, compresslevel=9) as z:
         z.writestr("manifest.json", json.dumps(manifest, indent=2) + "\n")
         z.writestr("sectors.bin", bytes(blob))

--- a/tools/package_release.sh
+++ b/tools/package_release.sh
@@ -84,6 +84,11 @@ cp "$INSTALLER" "$STAGE/Scripts/install_dvdcss.sh"
 chmod +x "$STAGE/Scripts/install_dvdcss.sh"
 cp "$REGIONTOOL" "$STAGE/Scripts/set_dvd_region.sh"
 chmod +x "$STAGE/Scripts/set_dvd_region.sh"
+# dvd_report.py rides along so the support-bundle chord works out of the box:
+# MiSTer_DVDcss shells out to it (main/support/dvd/dvd_report.cpp searches
+# Scripts/ first). It is also the tool a reporter runs on a PC.
+cp "$REPO/tools/dvd_report.py" "$STAGE/Scripts/dvd_report.py"
+chmod +x "$STAGE/Scripts/dvd_report.py"
 
 RBF_SHOWN="${RBF_DIR:+$RBF_DIR/}$(basename "$RBF")"
 cat > "$STAGE/DVD_INSTALL.txt" <<EOF
@@ -95,6 +100,7 @@ MiSTer DVD Player v${VER}
      MiSTer_DVDcss         - custom Main (physical discs + encrypted ISOs); keep at the root
      Scripts/install_dvdcss.sh
      Scripts/set_dvd_region.sh
+     Scripts/dvd_report.py
 
 2. To play PHYSICAL discs or ENCRYPTED ISOs, add to /media/fat/MiSTer.ini
    (add the section; do NOT replace the file):


### PR DESCRIPTION
## Why

The project is public and the discs that break it are discs we do not own. Reports arrive as a sentence — *"LINK FAIL on every menu option"* — with no way to get at the disc, because a DVD-Video ISO is 4–8 GB.

But a navigation bug does not need the disc. It needs the IFO nav tables, which are **~0.005% of an image** (104 KB of a 4.47 GB rip), and every host-side nav tool already reads only those plus the ISO9660 directory records that locate them.

## What this adds

**`tools/dvd_report.py`** packages exactly that into a 36–100 KB zip. Sectors are stored at their **original disc addresses**, and `unpack` writes them into a **sparse** image of the original size (6.77 GB apparent, 480 KB on disk) — so the reconstruction simply *is* an ISO. No tool needed changing, and it matches the `*_meta.hex` testbench idiom, so a submission is already fixture-shaped.

**A gamepad chord** (Audio + Subtitle, 2 s) makes `MiSTer_DVDcss` build one from whatever is mounted — image *or* optical drive — with no PC at all. It uniquely captures **where playback actually was**, and the core version, neither of which a reporter can supply.

**Six GitHub issue forms**, split by the evidence a report needs rather than by subsystem, plus a `field-report` skill that turns a pasted or screenshotted Discord report into a tracked issue — most users will never open one themselves.

## The content guarantee is enforced, not promised

A bundle contains only unencrypted navigation structures: **no picture, no sound, no keys**. `audit()` refuses to write a bundle if any gathered sector parses as an MPEG-PS pack containing anything but a system header, padding or `private_stream_2`.

It also works on an **encrypted rip** — verified on a real CSS disc — so asking a user for a bundle never asks them to decrypt anything.

## Test plan

- [x] 23/23 library discs: `iso_nav_check.py` byte-identical between original and reconstruction (up to 9,143 lines)
- [x] Spot-checked `dvd_vm_ref.py boot`/`menu`, `dvd_census.py`, `nav_extract.py`
- [x] Content audit proven **RED** against a real title-VOB sector (`0xE0`), green on a real NAV pack
- [x] Encrypted rip (FAIRYTOPIA, ~19% packs scrambled) → identical nav output
- [x] **HW: physical disc** — NCIS on `sr0`, 77 KB off 7.22 GB, playhead 2,064 sectors into the feature
- [x] **HW: mounted ISO** — THE_MATRIX, 99 KB off 8.39 GB, `iso_nav_check.py` **byte-identical to the original ISO** (526 lines)
- [x] `MiSTer_DVDcss` cross-compiles clean; integration steps 22–26 re-apply idempotently
- [x] Core builds timing-clean: SEED 5 first roll, clk_dec 96.08/91.69 MHz (gate 86.0), ALM 88%
- [x] `docs_check.py` OK; `mkdocs build --strict` clean

## Also in here

- `CORE_VERSION` → **0.4.0** (a new user-visible capability is a minor bump)
- `docs/roadmap.md` reconciled: 47 stale checkboxes resolved individually; the file now carries **no open items** and says plainly that it is a record, not a plan
- `.claude/` is tracked now — the skills encode how this project is released, merged and documented; `settings.local.json` stays out
- Two `build_main.sh`/integration bugs that `-fsyntax-only` structurally could not catch
