### PR TITLE
Video Output consolidation + CRT field-parity fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/04-playback.yml
+++ b/.github/ISSUE_TEMPLATE/04-playback.yml
@@ -97,7 +97,7 @@ body:
     attributes:
       label: Relevant settings
       description: |
-        `Film 24p Out`, `A/V Offset`, `Interlaced Out`, `Video Standard`, `Audio Out` —
+        `Film 24p Out`, `A/V Offset`, `Video Output`, `Video Standard`, `Audio Out` —
         whichever you have changed from the defaults.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/05-analog-crt.yml
+++ b/.github/ISSUE_TEMPLATE/05-analog-crt.yml
@@ -34,12 +34,12 @@ body:
   - type: dropdown
     id: analogout
     attributes:
-      label: "`Analog Out` setting"
+      label: "`Video Output` setting (`Analog Out` on v0.3.0 and earlier)"
       options:
         - "Auto (the default)"
         - Interlaced
         - Progressive
-        - Native Fields
+        - "Native Fields (v0.3.0 and earlier)"
     validations:
       required: true
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,44 @@ worse maintenance burden than targeted in-place edits. So:
 
 ## Hardware status (THIS fork, verified 2026-06-21)
 
+- 🔧 **VIDEO OUTPUT CONSOLIDATION + FIELD-PARITY RE-ENGAGE FIX (2026-09-02, branch
+  `feature/video-output-consolidation`) — sim-proven (RED/GREEN), ⏳ HW-confirm pending
+  (gate = the two CRT field reports below reproduce clean).** Two CRT field reports
+  (SuperStationOne→YPbPr→Sony CRT; a second user on The Shining) exposed (a) the weave
+  analog path "extremely wobbly" = the known caveat-2 pairing defect, and (b) Native
+  Fields going "super aliased" after chapter skip/FF/aspect changes, healed only by
+  toggling the mode 3–4 times = a 50/50 parity roll. **(1) THE PARITY BUG — root-caused
+  and FIXED (`docs/field_parity.md`):** the mixer's relaxed frame-top matcher (the
+  3:2/drop black-fields fix) accepts either raster parity slot, and nothing carried
+  raster parity back to `resample_addrgen`'s pickup — one odd perturbation (seek tff,
+  raster restart, cold start) flipped content-field↔raster-field phase PERMANENTLY
+  (invisible under HDMI Bob, glaring on fieldpass/Weave). Fix = feed-forward
+  `alt_break` (schedule head would repeat the last field's parity) + feedback `par_fb`
+  (new `mixer.frame_top_par_err` → sync_reg → addrgen), inserting ONE held-frame field
+  and deferring the pickup one refresh (`pickup_go`), with a `frame_late` pulse so the
+  drop ledger reclaims it. ★ **The triggers compose by XOR and the inserted field's
+  TYPE depends on the trigger** (alt_break: OPPOSITE field; par_fb: SAME field; both at
+  once: insert NOTHING — the break itself lands aligned): "insert opposite on either"
+  livelocks — alt_break un-fixes every par_fb insertion. Suite
+  `bench/dvd/run_field_parity.sh` — the checker reads the mixer's frame-top acceptance
+  hierarchically (what the SCREEN gets); proven RED on pre-fix RTL (a break's
+  misalignment persists 16/16 tops and survives a CLEAN seek = the toggle-ritual
+  mechanism) and GREEN post-fix (feed-forward arms: zero wrong fields ever displayed;
+  feedback arm: ≤2). ⚠ `gov_field_late_tb` needed a stimulus fix, not an expectation
+  fix: real discs TOGGLE tff after an rff picture; holding it constant is an authored
+  cadence break the corrector now rightly heals. **(2) SETTINGS CONSOLIDATED (user
+  decision, reversing the 2026-08-23 "all four modes stay" review — see
+  `docs/roadmap.md`):** `O[10:9] Interlaced Out` (+ its `det_video` Auto detector) and
+  the 4-value `O[27:26] Analog Out` are REPLACED by ONE option **`O[10:9] Video Output
+  = Auto/Interlaced/Progressive`** (`Interlaced` = the old Native Fields renamed —
+  authored fields session-wide, fieldpass analog raster, HDMI 480i via ascal Bob/Weave;
+  `Auto` = ini-driven `analog_want`, boot-static; `Progressive` keeps Film 24p and
+  serves 480p-analog displays). `re_interlace.sv` is FIELDPASS-ONLY (weave/derive
+  deleted — CRT-480i-plus-progressive-HDMI simultaneity deliberately dropped:
+  pick-your-output); `analog_eff`/`il_eff` collapse into one `interlaced_eff`; config
+  layout `"v,1"`→`"v,2"` (all saved settings reset once). O[27:26] left dead/reserved.
+  Detail: `docs/field_parity.md`, superseded headers in `docs/interlaced_auto.md` +
+  `docs/analog_dual_raster.md`.
 - ✅ **MID-PLAY LOAD A/V DESYNC — FIXED IN FABRIC; ✅ HW-CONFIRMED 2026-08-28 (user
   report: mid-play loads across VOB/mpg/ISO/VCD cut to black, start clean, hold sync;
   T2 logo chain clean; seeks/menus/cold mount unregressed; build
@@ -760,7 +798,10 @@ worse maintenance burden than targeted in-place edits. So:
   (needs downscale). *(Interlaced ~half-speed field-cadence is addressed by native 480i/576i
   fields output — see the `Interlaced Out: Auto` note below.)*
 - ✅ **Interlaced Out (Off/Auto/On) — native 480i/576i fields to ascal — HW-CONFIRMED +
-  MERGED (PR fj#132, 2026-07-27).** `O[10:9] Interlaced Out` is 3-way **Off/Auto/On**,
+  MERGED (PR fj#132, 2026-07-27). ⛔ OPTION RETIRED 2026-09-02 — the fields raster it
+  built still ships as `Video Output = Interlaced`; the separate option and the
+  `det_video` Auto detector are deleted (see the consolidation bullet at the top).**
+  `O[10:9] Interlaced Out` is 3-way **Off/Auto/On**,
   **default Off** (reverted from Auto 2026-07-27 — see below). `On` gives native interlaced
   fields (NTSC 480i **and** the newly-added **PAL 576i**: `il_eff` no longer forced low under
   PAL; new `pal_prev & il_prev` modeline branch, 312 lines/field ≈ 50 Hz) and plays
@@ -838,7 +879,11 @@ worse maintenance burden than targeted in-place edits. So:
   (clean); SEED 3 closed the pre-round-2 netlist (90.9/90.2). **HW gate (round 3 =
   C1 decode): `docs/closed_captions.md` §0 + §6.**
 - ✅ **DUAL-RASTER ANALOG OUTPUT (2026-07-29, HW-CONFIRMED + MERGED PR fj#146,
-  2026-07-30) — SUPERSEDES the O[14] whole-core CRT mode below.** User-confirmed
+  2026-07-30) — SUPERSEDES the O[14] whole-core CRT mode below. ⛔ PARTLY RETIRED
+  2026-09-02: the DERIVE (weave) modes and the 4-value Analog Out enum are gone —
+  `re_interlace` is fieldpass-only under `Video Output = Interlaced` (see the
+  consolidation bullet at the top). The VGA2 plumbing, ini engagement rule, fieldpass
+  re-timer and CC injection below all still ship.** User-confirmed
   working on real hardware (analog engages from ini alone, HDMI stays progressive
   simultaneously). ⚠️ The exact PAL 576i timing numbers and the field-dominance
   caveat (see `docs/analog_dual_raster.md`) were not specifically re-verified by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,11 @@ worse maintenance burden than targeted in-place edits. So:
   partial application; the OSD-toggle control passes un-fixed — why no prior HW round
   ever saw it). ⚠ Lesson: any emu-side logic writing decoder REGISTERS around reset
   must gate on `sync_rst_out`, not `reset_n` — the walk was the only such writer.
+  ★ HW round 2 (`DVD_videoout2`, user report): a MID-TITLE switch to Interlaced now
+  works cleanly — indirect HW evidence for the parity corrector (pre-fix that exact
+  raster restart was a coin-flip perturbation, the source of the old "set it before
+  loading" advice; the manual now says the switch works with a chapter-seek-style
+  interruption).
 - ✅ **MID-PLAY LOAD A/V DESYNC — FIXED IN FABRIC; ✅ HW-CONFIRMED 2026-08-28 (user
   report: mid-play loads across VOB/mpg/ISO/VCD cut to black, start clean, hold sync;
   T2 logo chain clean; seeks/menus/cold mount unregressed; build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,6 +280,22 @@ worse maintenance burden than targeted in-place edits. So:
   layout `"v,1"`→`"v,2"` (all saved settings reset once). O[27:26] left dead/reserved.
   Detail: `docs/field_parity.md`, superseded headers in `docs/interlaced_auto.md` +
   `docs/analog_dual_raster.md`.
+  ★ **HW ROUND 1 (2026-09-02) found a LATENT BOOT RACE the consolidation was first to
+  arm: Interlaced-at-boot showed "719x...i @ 31.48 kHz" + dead CRT — the modeline walk
+  keys on RAW reset_n while the decoder synchronizes its resets INTERNALLY
+  (reset.v cascaded 5-FF stages), so hard_rst (gating every regfile modeline register)
+  deasserts ~5-10 clk_dec cycles later and the boot walk's writes were SILENTLY
+  SWALLOWED — progressive raster + VGA_F1 toggling, and il_prev latched so nothing
+  retried.** Invisible since the walk was built: il_eff was always 0 at boot (a
+  swallowed walk wrote the reset defaults anyway) and every change came via OSD with
+  the decoder alive — `Auto` from the ini bits is the first boot-time walk that
+  matters. FIX = `dec_ready` gate (kicks wait for `core_sync_rst` = the decoder's own
+  `sync_rst_out`, the LAST reset to deassert, observed high 8 cycles). Proven
+  RED/GREEN by `bench/dvd/modeline_boot_tb.sv` over the REAL `reset.v` + `regfile.v`
+  (RED reproduced BOTH failure shapes: total swallow = the exact HW symptom, and
+  partial application; the OSD-toggle control passes un-fixed — why no prior HW round
+  ever saw it). ⚠ Lesson: any emu-side logic writing decoder REGISTERS around reset
+  must gate on `sync_rst_out`, not `reset_n` — the walk was the only such writer.
 - ✅ **MID-PLAY LOAD A/V DESYNC — FIXED IN FABRIC; ✅ HW-CONFIRMED 2026-08-28 (user
   report: mid-play loads across VOB/mpg/ISO/VCD cut to black, start clean, hold sync;
   T2 logo chain clean; seeks/menus/cold mount unregressed; build

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -705,4 +705,9 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # "deleting a mode" freed almost nothing). The 88%->89% step vs the previous
 # entry is the four intervening merged branches + packing noise, not this one.
 # Fifth consecutive first-roll fit. Build DVD_videoout_20260902_1146.rbf.
+# 2026-09-02b (same branch + the boot-time modeline-walk reset-race fix -- the
+# dec_ready gate, a 3-bit counter): SEED 5 held FIRST roll again -- clk_dec
+# 93.28 @100C / 89.91 @-40C at 88% ALM (37,078). The 97.73 of the previous roll
+# confirming itself as fit variance. Sixth consecutive first-roll fit. Build
+# DVD_videoout2_20260902_1312.rbf.
 set_global_assignment -name SEED 5

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -692,4 +692,17 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # across both: the serializer is a shift register and counters, so it inferred no
 # memory, which was the design prediction. Fourth consecutive first-roll fit since
 # the mem_shim reclaim -- the sub-86 rule continues to hold.
+# 2026-09-02 (feature/video-output-consolidation netlist: the field-parity
+# corrector added ~small logic in mixer/mpeg2video/addrgen, while the
+# consolidation DELETED the det_video detector, the re_interlace derive
+# constants/muxes, and the il_want/analog_mode resolve -- CONF_STR relayout to
+# "Video Output" + "v,2"): pinned SEED 5 held on the FIRST roll -- clk_dec
+# 97.73 @100C / 93.11 @-40C at 89% ALM (37,100), RAM 64%, DSP 92 -- the best
+# clk_dec corner pair in this ledger, though that is fit variance on a fresh
+# netlist, not the logic delta: the branch is roughly ALM-NEUTRAL (deleted
+# det_video + the weave muxes + il_want ~ a few dozen ALMs, added the parity
+# corrector ~ the same; weave shared all of re_interlace's real structure, so
+# "deleting a mode" freed almost nothing). The 88%->89% step vs the previous
+# entry is the four intervening merged branches + packing noise, not this one.
+# Fifth consecutive first-roll fit. Build DVD_videoout_20260902_1146.rbf.
 set_global_assignment -name SEED 5

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ know. It is not an endorsement of the approach — draw your own conclusions.
   [entirely in fabric](https://owenb321.github.io/MiSTer_DVD/audio/formats/); AC-3 and DTS as
   [IEC 61937 bitstream](https://owenb321.github.io/MiSTer_DVD/audio/passthrough/) to a receiver — over optical S/PDIF,
   or over HDMI with the custom Main, so 5.1 needs no add-on board.
-- **Analog / CRT** — a native 15 kHz 480i/576i raster alongside the progressive one, so
-  [a CRT and HDMI work at once](https://owenb321.github.io/MiSTer_DVD/video/analog-crt/). Engages from `MiSTer.ini`
-  like any other core.
+- **Analog / CRT** — a native 15 kHz 480i/576i raster built from the disc's
+  [authored fields](https://owenb321.github.io/MiSTer_DVD/video/analog-crt/), the presentation a set-top player
+  feeds a TV. Engages from `MiSTer.ini` like any other core.
 - **[Closed captions](https://owenb321.github.io/MiSTer_DVD/video/closed-captions/)** re-modulated onto line 21 of the
   analog output for your television to decode, exactly as a real player does.
 - **[Video CD / SVCD](https://owenb321.github.io/MiSTer_DVD/formats/vcd-svcd/)** — bin/cue rips play directly.

--- a/bench/dvd/cadence_slip_tb.sv
+++ b/bench/dvd/cadence_slip_tb.sv
@@ -73,7 +73,7 @@ module cadence_slip_tb;
     .det_video(det_video),
     .video_live(), .pickup_hold(1'b0), .pause(1'b0),
     .refresh_tick_dbg(refresh_tick_w),
-    .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(film24));
+    .raster_par_err(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(film24));
 
   always #5 clk = ~clk;
 

--- a/bench/dvd/cadence_slip_tb.sv
+++ b/bench/dvd/cadence_slip_tb.sv
@@ -48,7 +48,7 @@ module cadence_slip_tb;
   reg         disp_wr_addr_almost_full = 0, resample_wr_almost_full = 0;
   wire        busy;
   wire        frame_late;
-  wire        film_det_ntsc, film_det_pal, det_video;
+  wire        film_det_ntsc, film_det_pal;
   wire        refresh_tick_w;
   reg         film24 = 1'b1;
 
@@ -70,7 +70,6 @@ module cadence_slip_tb;
     .disp_wr_addr_almost_full(disp_wr_addr_almost_full), .resample_wr_almost_full(resample_wr_almost_full),
     .busy(busy), .frame_late(frame_late),
     .film_det_ntsc(film_det_ntsc), .film_det_pal(film_det_pal),
-    .det_video(det_video),
     .video_live(), .pickup_hold(1'b0), .pause(1'b0),
     .refresh_tick_dbg(refresh_tick_w),
     .raster_par_err(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(film24));

--- a/bench/dvd/cc_e2e_tb.sv
+++ b/bench/dvd/cc_e2e_tb.sv
@@ -10,8 +10,9 @@
  * chain went dead on hardware — and every bench still passed. The wiring BETWEEN
  * the proven pieces was the only untested thing, and it was the thing that broke.
  *
- * So this bench treats re_interlace exactly as the analog chain does: synthetic
- * progressive NTSC main raster in, caption pairs injected on a separate producer
+ * So this bench treats re_interlace exactly as the analog chain does: the synthetic
+ * pixrep NTSC fields main raster in (fieldpass-only since the 2026-09-02 Video
+ * Output consolidation), caption pairs injected on a separate producer
  * clock, and the ONLY signals observed are out_r/out_hs/out_vs/out_de/out_ce —
  * the pins. The checker is a TV model:
  *
@@ -54,7 +55,7 @@ module cc_e2e_tb;
 
   re_interlace dut (
     .clk(clk), .rst_n(rst_n), .ce2(ce2),
-    .enable(1'b1), .pal(1'b0), .fieldpass(1'b0),
+    .enable(1'b1), .pal(1'b0),
     .in_r(in_r), .in_g(in_g), .in_b(in_b), .in_de(in_de),
     .in_hpos(in_hpos), .in_vpos(in_vpos),
     .out_r(out_r), .out_g(out_g), .out_b(out_b),
@@ -65,18 +66,29 @@ module cc_e2e_tb;
     .cc_pair_field(dec_pair_field), .cc_active(cc_active)
   );
 
-  // ------------------------------------------- synthetic NTSC main raster
-  integer g_h = 0, g_v = 0;
+  // -------------------------- synthetic NTSC fields main raster (pixrep 480i)
+  // The interlaced main raster the decoder emits under Video Output = Interlaced:
+  // 1716-dot lines, fields alternating 262/263 lines, active 1440 dots (each source
+  // pixel sent twice) x 240 lines/field; v_pos = the absolute frame line
+  // (2*v_cntr + field). This is the only source raster the fieldpass-only
+  // re_interlace accepts (the progressive model this TB used pre-consolidation no
+  // longer locks). Flat active video — the caption checker only reads the VBI.
+  integer g_h = 0, g_vc = 0, g_fld = 0;
   always @(posedge clk) begin
-    if (g_h >= 857) begin
+    if (g_h >= 1715) begin
       g_h <= 0;
-      g_v <= (g_v >= 524) ? 0 : g_v + 1;
+      if (g_vc >= (g_fld ? 262 : 261)) begin
+        g_vc  <= 0;
+        g_fld <= 1 - g_fld;
+      end else g_vc <= g_vc + 1;
     end else g_h <= g_h + 1;
   end
+  integer g_absline;
   always @(*) begin
+    g_absline = 2*g_vc + g_fld;
     in_hpos = g_h[11:0];
-    in_vpos = g_v[11:0];
-    in_de   = (g_h < 720) && (g_v < 480);
+    in_vpos = g_absline[11:0];
+    in_de   = (g_h < 1440) && (g_vc < 240);
     in_r    = 8'h20; in_g = 8'h30; in_b = 8'h40;   // flat active video
   end
 

--- a/bench/dvd/crt_ov_map_tb.sv
+++ b/bench/dvd/crt_ov_map_tb.sv
@@ -610,7 +610,7 @@ module crt_ov_map_tb;
             end
         end
 
-        // (b) 480i (Native Fields raster), both fields: parity-preserving inverse
+        // (b) 480i (the Video Output = Interlaced fields raster), both fields: parity-preserving inverse
         interlaced = 1;
         for (f = 0; f < 2; f = f + 1) begin
             v_pos_in = 12'hFFF; repeat (4) @(negedge clk);

--- a/bench/dvd/crt_syncgen_tb.sv
+++ b/bench/dvd/crt_syncgen_tb.sv
@@ -215,7 +215,7 @@ module crt_syncgen_tb;
 
     track_fields = 0;
     // =======================================================================
-    // PHASE 2 — HDMI Interlaced Out (O[10:9]) 480i, EXACT-RATE check.
+    // PHASE 2 — HDMI fields 480i (Video Output = Interlaced; was Interlaced Out O[10:9]), EXACT-RATE check.
     //
     // Driven with the values syncgen ACTUALLY sees in this mode, i.e. AFTER
     // syncgen_intf's pixel-repetition doubling (`x -> {x[10:0],1'b1}` = 2x+1,

--- a/bench/dvd/field_parity_tb.sv
+++ b/bench/dvd/field_parity_tb.sv
@@ -1,0 +1,333 @@
+`timescale 1ns/1ps
+//
+// field_parity_tb.sv — prove (and then guard) the FIELD-PARITY RE-ENGAGE defect
+// and its corrector (docs/field_parity.md).
+//
+// THE DEFECT (field reports, 2026-09-02: "super aliased after chapter skip /
+// FF / aspect change, fix by toggling the output mode 3-4 times"): on an
+// interlaced display the mixer consumes one field image per raster field, and
+// its frame-top matcher deliberately accepts EITHER parity slot (mixer.v
+// display_first_pixel — the 3:2/drop "black fields" fix). The emitted field
+// sequence normally alternates TOP/BOTTOM, so content parity and raster parity
+// stay locked — but ONE odd perturbation (a seek released on an arbitrary tff,
+// a raster restart, cold-start luck) flips the phase PERMANENTLY: every TOP
+// image scans out during a bottom raster field and vice versa. Toggling the
+// output mode merely re-rolls the coin.
+//
+// THE CHAIN UNDER TEST is the real display path: resample (addrgen + dta +
+// bilinear) -> framestore_reader + behavioural memory -> pixel_queue ->
+// mixer <- sync_gen (interlaced raster). disp_vscale/disp_hstretch are
+// bypassed pass-throughs in this scenario and are left out of the build.
+//
+// THE CHECK reads the wire the defect lives on, hierarchically into the
+// UNMODIFIED mixer: at every accepted frame-top (STATE_WAIT ->
+// STATE_FIRST_PIXEL with a ROW_0/ROW_1 head) the content field type
+// (position_in_0) must match the raster field parity (v_pos 0 = top field
+// line 0, v_pos 1 = bottom field line 1). A register-peek of the corrector
+// would prove nothing — this asserts what the SCREEN gets.
+//
+// SCENARIOS (one run; +phase=0 / +phase=1 shifts the cold-start supply by one
+// field period so BOTH landing parities are exercised across the two runs):
+//   [1] cold start          — feedback-path case: nothing schedule-visible is
+//                             wrong, but one +phase arm lands misaligned.
+//   [2] seek released on a SAME-parity tff (alternation break) — feed-forward
+//                             case; the classic chapter-skip coin flip.
+//   [3] seek released on the OPPOSITE (clean) tff — control, must not insert.
+//   [4] second alternation-break seek (flip back).
+//   [5] soft-telecine film (rff=1, tff toggling per picture, the authored
+//                             T,B,T | B,T,B cadence) — alternation is intact
+//                             by authoring; the corrector must stay silent.
+// After each perturbation a settle window of SETTLE frame-tops absorbs the
+// (bounded) correction latency; the CHECK window after it requires EVERY
+// frame-top aligned. PRE-FIX EXPECTATION (build with -DNO_PARITY_FIX against
+// the pre-fix RTL): each +phase arm fails at least one window — a
+// misalignment, once entered, PERSISTS (that is the proven coin flip).
+// POST-FIX: all windows pass in both arms, and the settle windows observe at
+// most 2 misaligned tops each (the feedback latency bound).
+//
+// Build (GREEN, current RTL):
+//   iverilog -g2012 -D__IVERILOG__ -I rtl/mpeg2 -o bench/dvd/field_parity_sim \
+//     rtl/mpeg2/resample.v dvd/resample_addrgen.v rtl/mpeg2/resample_dta.v \
+//     rtl/mpeg2/resample_bilinear.v rtl/mpeg2/mem_addr.v rtl/mpeg2/mixer.v \
+//     rtl/mpeg2/pixel_queue.v rtl/mpeg2/syncgen.v rtl/mpeg2/read_write.v \
+//     rtl/mpeg2/wrappers.v rtl/mpeg2/fwft.v rtl/mpeg2/xilinx_fifo_dc.v \
+//     rtl/mpeg2/xfifo_sc.v bench/dvd/field_parity_tb.sv
+//   vvp bench/dvd/field_parity_sim +phase=0
+//   vvp bench/dvd/field_parity_sim +phase=1
+// Or: bash bench/dvd/run_field_parity.sh
+// (RED capture: same build with -DNO_PARITY_FIX against the pre-fix
+//  resample.v/resample_addrgen.v/mixer.v — see run_field_parity.sh --red.)
+//
+module field_parity_tb;
+
+`include "resample_codes.v"
+
+  // ---- narrow/fast interlaced geometry (resample_chain_tb's narrow modeline,
+  //      il variant: content 64x256 -> 128-line fields) ----
+  localparam [7:0]  MB_WIDTH        = 8'd4;
+  localparam [7:0]  MB_HEIGHT       = 8'd16;
+  localparam [13:0] HORIZONTAL_SIZE = 14'd64;
+  localparam [13:0] VERTICAL_SIZE   = 14'd256;
+  localparam [11:0] H_RES = 12'd64,  H_SS = 12'd70,  H_SE = 12'd78,  H_LEN = 12'd84;
+  // Shortened vertical raster (content-woven 256 lines + small blanking) — the
+  // resample_chain_tb narrow modeline's 505-line vertical made a full 5-window run
+  // take ~10 min of wall time for no extra coverage; v_sync verified toggling and
+  // all windows behave identically at this height.
+  localparam [11:0] V_RES = 12'd260, V_SS = 12'd268, V_SE = 12'd271, V_LEN = 12'd280;
+
+  // ---- clocks (2:1 like HW clk_dec 54 / dot_clk 27) ----
+  reg clk = 0;      always #5  clk = ~clk;
+  reg dot_clk = 0;  always #10 dot_clk = ~dot_clk;
+  reg rst = 0;
+
+  // ---- stimulus ----
+  reg  [2:0] output_frame = 3'd2;
+  reg        output_frame_valid = 0;
+  wire       output_frame_rd;
+  reg        progressive_sequence = 0;       // DVD coding: interlaced sequence
+  reg        progressive_frame = 0;          // [1]-[4]: true video; [5]: film
+  reg        top_field_first = 1;
+  reg        repeat_first_field = 0;
+  reg        film_mode = 0;                  // [5]: tff toggles per consumed picture
+  always @(posedge clk)
+    if (rst && film_mode && output_frame_rd) top_field_first <= ~top_field_first;
+
+  // ---- resample <-> framestore_reader ----
+  wire        disp_wr_addr_full, disp_wr_addr_almost_full;
+  wire        disp_wr_addr_en, disp_wr_addr_ack;
+  wire [21:0] disp_wr_addr;
+  wire        disp_rd_dta_empty, disp_rd_dta_almost_empty;
+  wire        disp_rd_dta_en, disp_rd_dta_valid;
+  wire [63:0] disp_rd_dta;
+  wire        resample_wr_overflow;
+
+  // ---- resample -> pixel_queue -> mixer ----
+  wire [7:0]  px_y, px_u, px_v, px_osd;
+  wire [2:0]  px_position;
+  wire        px_wr_en, pq_wr_almost_full;
+  wire [7:0]  mx_y, mx_u, mx_v, mx_osd;
+  wire [2:0]  mx_position;
+  wire        mx_rd_en, mx_rd_empty, mx_rd_valid, mx_rd_underflow;
+
+  // ---- sync_gen -> mixer ----
+  wire [11:0] h_pos, v_pos;
+  wire        h_sync, v_sync, pixel_en;
+  wire [7:0]  y_out, u_out, v_out, osd_out;
+  wire        h_sync_out, v_sync_out, pixel_en_out;
+
+  // ---- the parity feedback loop (mpeg2video's sync_reg CDC, replicated) ----
+`ifndef NO_PARITY_FIX
+  wire mixer_par_err;
+  reg  pe_s1 = 0, pe_s2 = 0;
+  always @(posedge clk) begin pe_s1 <= mixer_par_err; pe_s2 <= pe_s1; end
+  wire par_err_sync = pe_s2;
+`endif
+
+  resample resample (
+    .clk(clk), .rst(rst),
+    .output_frame(output_frame), .output_frame_valid(output_frame_valid),
+    .output_frame_rd(output_frame_rd),
+    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame),
+    .informative(1'b1),
+    .top_field_first(top_field_first), .repeat_first_field(repeat_first_field),
+    .mb_width(MB_WIDTH), .mb_height(MB_HEIGHT),
+    .horizontal_size(HORIZONTAL_SIZE), .vertical_size(VERTICAL_SIZE),
+    .resample_wr_overflow(resample_wr_overflow),
+    .disp_wr_addr_full(disp_wr_addr_full), .disp_wr_addr_almost_full(disp_wr_addr_almost_full),
+    .disp_wr_addr_en(disp_wr_addr_en), .disp_wr_addr_ack(disp_wr_addr_ack), .disp_wr_addr(disp_wr_addr),
+    .disp_rd_dta_empty(disp_rd_dta_empty), .disp_rd_dta_en(disp_rd_dta_en),
+    .disp_rd_dta_valid(disp_rd_dta_valid), .disp_rd_dta(disp_rd_dta),
+    .pixel_wr_almost_full(pq_wr_almost_full),
+    .interlaced(1'b1), .deinterlace(1'b0),       // native fields display path
+    .persistence(1'b1), .repeat_frame(5'd0),
+    .y(px_y), .u(px_u), .v(px_v), .osd_out(px_osd),
+    .position_out(px_position), .pixel_wr_en(px_wr_en),
+    .video_live(), .pickup_hold(1'b0), .pause(1'b0),
+`ifndef NO_PARITY_FIX
+    .raster_par_err(par_err_sync),
+`endif
+    .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0)
+  );
+
+  // framestore_reader + full-rate behavioural memory (constant non-black word)
+  wire        rd_addr_empty, rd_addr_valid;
+  wire [21:0] rd_addr;
+  wire        wr_dta_full, wr_dta_almost_full, wr_dta_ack, wr_dta_overflow;
+  reg         wr_dta_en;
+  wire        rd_addr_en = ~rd_addr_empty && ~wr_dta_almost_full;
+  framestore_reader #(
+    .fifo_addr_depth(9'd8), .fifo_dta_depth(9'd8),
+    .fifo_addr_threshold(9'd32), .fifo_dta_threshold(9'd64))
+  disp_reader (
+    .rst(rst), .clk(clk),
+    .wr_addr_clk_en(1'b1),
+    .wr_addr_full(disp_wr_addr_full), .wr_addr_almost_full(disp_wr_addr_almost_full),
+    .wr_addr_en(disp_wr_addr_en), .wr_addr_ack(disp_wr_addr_ack),
+    .wr_addr_overflow(), .wr_addr(disp_wr_addr),
+    .rd_dta_clk_en(1'b1),
+    .rd_dta_almost_empty(disp_rd_dta_almost_empty), .rd_dta_empty(disp_rd_dta_empty),
+    .rd_dta_en(disp_rd_dta_en), .rd_dta_valid(disp_rd_dta_valid), .rd_dta(disp_rd_dta),
+    .rd_addr_empty(rd_addr_empty), .rd_addr_en(rd_addr_en),
+    .rd_addr(rd_addr), .rd_addr_valid(rd_addr_valid),
+    .wr_dta_full(wr_dta_full), .wr_dta_almost_full(wr_dta_almost_full),
+    .wr_dta_en(wr_dta_en), .wr_dta_ack(wr_dta_ack), .wr_dta_overflow(wr_dta_overflow),
+    .wr_dta(64'h4040_4040_4040_4040)
+  );
+  always @(posedge clk)
+    if (~rst) wr_dta_en <= 1'b0;
+    else      wr_dta_en <= rd_addr_valid;
+
+  pixel_queue pixel_queue (
+    .clk_in(clk), .clk_in_en(1'b1), .rst(rst),
+    .y_in(px_y), .u_in(px_u), .v_in(px_v), .osd_in(px_osd), .position_in(px_position),
+    .pixel_wr_en(px_wr_en), .pixel_wr_almost_full(pq_wr_almost_full),
+    .pixel_wr_full(), .pixel_wr_overflow(),
+    .clk_out(dot_clk), .clk_out_en(1'b1),
+    .y_out(mx_y), .u_out(mx_u), .v_out(mx_v), .osd_out(mx_osd), .position_out(mx_position),
+    .pixel_rd_en(mx_rd_en), .pixel_rd_empty(mx_rd_empty),
+    .pixel_rd_valid(mx_rd_valid), .pixel_rd_underflow(mx_rd_underflow)
+  );
+
+  sync_gen sync_gen (
+    .clk(dot_clk), .clk_en(1'b1), .rst(rst),
+    .horizontal_size(HORIZONTAL_SIZE), .vertical_size(VERTICAL_SIZE),
+    .display_horizontal_size(14'd0), .display_vertical_size(14'd0),
+    .horizontal_resolution(H_RES), .horizontal_sync_start(H_SS),
+    .horizontal_sync_end(H_SE), .horizontal_length(H_LEN),
+    .vertical_resolution(V_RES), .vertical_sync_start(V_SS),
+    .vertical_sync_end(V_SE), .horizontal_halfline(12'd0), .vertical_length(V_LEN),
+    .interlaced(1'b1), .clip_display_size(1'b0),
+    .h_pos(h_pos), .v_pos(v_pos), .pixel_en(pixel_en),
+    .h_sync(h_sync), .v_sync(v_sync), .c_sync(), .h_blank(), .v_blank()
+  );
+
+  mixer mixer (
+    .clk(dot_clk), .clk_en(1'b1), .rst(rst),
+    .pixel_repetition(1'b0),
+    .y_in(mx_y), .u_in(mx_u), .v_in(mx_v), .osd_in(mx_osd), .position_in(mx_position),
+    .pixel_rd_en(mx_rd_en), .pixel_rd_valid(mx_rd_valid), .pixel_rd_underflow(mx_rd_underflow),
+    .h_pos(h_pos), .v_pos(v_pos), .h_sync_in(h_sync), .v_sync_in(v_sync), .pixel_en_in(pixel_en),
+    .y_out(y_out), .u_out(u_out), .v_out(v_out), .osd_out(osd_out),
+    .h_sync_out(h_sync_out), .v_sync_out(v_sync_out), .pixel_en_out(pixel_en_out),
+`ifndef NO_PARITY_FIX
+    .frame_top_par_err(mixer_par_err),
+`endif
+    .disp_v_offset(12'd0)
+  );
+
+  // ====================================================================
+  // The parity check — hierarchical into the (unmodified) mixer: every
+  // accepted frame-top's content field type vs the raster field parity.
+  // ====================================================================
+  wire ft_evt     = (mixer.state == mixer.STATE_WAIT) &&
+                    (mixer.next  == mixer.STATE_FIRST_PIXEL) &&
+                    mixer.is_frame_top;
+  wire ft_aligned = (mixer.position_in_0 == ROW_0_COL_0) ? (v_pos == 12'd0)
+                                                         : (v_pos == 12'd1);
+
+  integer ft_seen = 0;
+  integer mis_seen = 0;        // misaligned tops inside the current CHECK window
+  integer settle_mis = 0;      // misaligned tops inside the current SETTLE window
+  reg     checking = 0, settling = 0;
+  always @(posedge dot_clk)
+    if (rst && ft_evt) begin
+      ft_seen = ft_seen + 1;
+      if (!ft_aligned) begin
+        if (checking) begin
+          mis_seen = mis_seen + 1;
+          $display("  [%0t] MISALIGNED frame-top in CHECK window: %s field at v_pos=%0d",
+                   $time, (mixer.position_in_0 == ROW_0_COL_0) ? "TOP" : "BOTTOM", v_pos);
+        end
+        if (settling) settle_mis = settle_mis + 1;
+      end
+    end
+
+  task wait_fts(input integer n);
+    integer t0;
+    begin t0 = ft_seen; wait (ft_seen >= t0 + n); @(posedge dot_clk); end
+  endtask
+
+  localparam SETTLE = 6;       // frame-tops allowed for the correction to land
+  localparam NCHK   = 16;      // frame-tops that must ALL be aligned after it
+  integer errors = 0;
+  integer settle_worst = 0;
+
+  task check_window(input [8*40-1:0] name);
+    begin
+      settling = 1; settle_mis = 0;
+      wait_fts(SETTLE);
+      settling = 0;
+      if (settle_mis > settle_worst) settle_worst = settle_mis;
+      checking = 1; mis_seen = 0;
+      wait_fts(NCHK);
+      checking = 0;
+      if (mis_seen == 0)
+        $display("[%0s] PASS: %0d/%0d frame-tops aligned (settle saw %0d misaligned)",
+                 name, NCHK, NCHK, settle_mis);
+      else begin
+        errors = errors + 1;
+        $display("[%0s] FAIL: %0d of %0d frame-tops MISALIGNED (settle saw %0d)",
+                 name, mis_seen, NCHK, settle_mis);
+      end
+    end
+  endtask
+
+  integer phase = 0;
+
+  initial begin
+    void'($value$plusargs("phase=%d", phase));
+    $display("\n==== field_parity_tb  +phase=%0d ====", phase);
+
+    rst = 0; output_frame_valid = 0;
+    repeat (8) @(posedge clk);
+    rst = 1;
+
+    // [1] COLD START at the +phase-selected raster field parity (feedback case)
+    repeat (2) @(negedge v_sync);
+    repeat (phase) @(negedge v_sync);          // one field period shifts landing parity
+    output_frame_valid = 1;
+    check_window("1-cold-start");
+
+    // [2] SEEK released on a SAME-parity tff (alternation break; the chapter skip)
+    output_frame_valid = 0;
+    repeat (5) @(negedge v_sync);              // persistence re-scans the held frame
+    top_field_first = 0;                       // last shown field was BOTTOM (tff=1 tail);
+                                               // tff=0 heads BOTTOM again = the break
+    output_frame_valid = 1;
+    check_window("2-seek-break");
+
+    // [3] SEEK released on the clean tff (control: alternation intact, no insertion)
+    output_frame_valid = 0;
+    repeat (4) @(negedge v_sync);
+    // tff stays 0: held tail is TOP, new head is BOTTOM — clean junction
+    output_frame_valid = 1;
+    check_window("3-seek-clean");
+
+    // [4] second alternation-break seek (flip back to tff=1)
+    output_frame_valid = 0;
+    repeat (3) @(negedge v_sync);
+    top_field_first = 1;                       // held tail TOP, head TOP = break again
+    output_frame_valid = 1;
+    check_window("4-seek-break-2");
+
+    // [5] soft-telecine film: rff=1, tff toggling per picture (authored T,B,T|B,T,B
+    // cadence keeps strict alternation) — the corrector must stay silent
+    progressive_frame = 1; repeat_first_field = 1; film_mode = 1;
+    check_window("5-film-3:2");
+
+    if (errors == 0) begin
+      $display("\n==== PASS (+phase=%0d): all windows aligned; worst settle window saw %0d misaligned top(s) ====",
+               phase, settle_worst);
+      $finish;
+    end else
+      $fatal(1, "==== FAIL (+phase=%0d): %0d window(s) with persistent misalignment ====",
+             phase, errors);
+  end
+
+  // global watchdog: the raster must keep producing frame-tops
+  initial begin
+    #400_000_000;  // 400 ms sim time
+    $fatal(1, "TIMEOUT: frame-top flow stalled (ft_seen=%0d)", ft_seen);
+  end
+
+endmodule

--- a/bench/dvd/film_detect_tb.sv
+++ b/bench/dvd/film_detect_tb.sv
@@ -44,7 +44,6 @@ module film_detect_tb;
   wire        busy;
   wire        frame_late;
   wire        film_det_ntsc, film_det_pal;
-  wire        det_video;                    // DVD-FORK (Interlaced Out auto): true-interlaced verdict
 
   // decoder-supply model: keep a few frames buffered so pickups keep flowing
   integer     supplied = 0, consumed = 0;
@@ -65,7 +64,6 @@ module film_detect_tb;
     .disp_wr_addr_almost_full(disp_wr_addr_almost_full), .resample_wr_almost_full(resample_wr_almost_full),
     .busy(busy), .frame_late(frame_late),
     .film_det_ntsc(film_det_ntsc), .film_det_pal(film_det_pal),
-    .det_video(det_video),
     .video_live(), .pickup_hold(1'b0), .pause(1'b0),
     .raster_par_err(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0));
 
@@ -117,15 +115,8 @@ module film_detect_tb;
     if (!cond) begin $display("  FAIL: %0s", msg); errors = errors + 1; end
   endtask
 
-  // MUTUAL EXCLUSIVITY: the true-interlaced verdict (progressive_frame==0) and the film
-  // verdicts (progressive_frame==1) can never co-assert — they key on opposite senses of
-  // the same flag. Continuously guard it (a co-assert would let emu pick two output modes).
-  always @(posedge clk)
-    if (rst && det_video && (film_det_ntsc || film_det_pal)) begin
-      $display("  FAIL: det_video co-asserted with a film verdict (n=%b p=%b v=%b)",
-               film_det_ntsc, film_det_pal, det_video);
-      errors = errors + 1;
-    end
+  // (The det_video true-interlaced verdict and its mutual-exclusion guard were removed
+  // with the Interlaced Out option — Video Output consolidation, 2026-09-02.)
 
   // run until `n` more pickups have completed
   task run_pickups(input integer n);
@@ -148,9 +139,8 @@ module film_detect_tb;
     run_pickups(40);   // > ENGAGE_N (48) clean film frames total
     chk(film_det_ntsc, "det_ntsc did NOT engage on sustained 3:2 film");
     chk(film_det_pal,  "det_pal did NOT engage on progressive film");
-    chk(!det_video,    "det_video FALSELY engaged on progressive film (must stay 0)");
-    $display("  [1] NTSC film: det_ntsc=%b det_pal=%b det_video=%b after sustained 3:2 (expect 1/1/0)",
-             film_det_ntsc, film_det_pal, det_video);
+    $display("  [1] NTSC film: det_ntsc=%b det_pal=%b after sustained 3:2 (expect 1/1)",
+             film_det_ntsc, film_det_pal);
 
     // ===== 2. transition to 30fps progressive VIDEO (pf=1, rff=0) =====
     // det_ntsc must RELEASE (rff no longer toggles) but det_pal must HOLD
@@ -164,9 +154,8 @@ module film_detect_tb;
     run_pickups(60);
     chk(!film_det_ntsc, "det_ntsc did NOT release on sustained 30fps progressive video");
     chk(film_det_pal,   "det_pal wrongly released on progressive video");
-    chk(!det_video,     "det_video FALSELY engaged on 30fps progressive video");
-    $display("  [2] 30fps video: det_ntsc=%b det_pal=%b det_video=%b (expect 0/1/0)",
-             film_det_ntsc, film_det_pal, det_video);
+    $display("  [2] 30fps video: det_ntsc=%b det_pal=%b (expect 0/1)",
+             film_det_ntsc, film_det_pal);
 
     // ===== G. THE EVIDENCE GATE (informative=0 pickups) =====
     // The whole point of the gate: on a fade to black the encoder stops
@@ -184,17 +173,15 @@ module film_detect_tb;
     mode = 2;                       // pf=0, exactly what a black picture carries
     run_pickups(80);                // far longer than the ~13 pickups that release
     chk(film_det_ntsc, "[G1] film lock dropped on an UNINFORMATIVE interlaced run (the APOLLO_13 bug)");
-    chk(!det_video,    "[G1] det_video engaged on uninformative pickups");
-    $display("  [G1] 80 uninformative pf=0 pickups: det_ntsc=%b det_video=%b (expect 1/0)",
-             film_det_ntsc, det_video);
+    $display("  [G1] 80 uninformative pf=0 pickups: det_ntsc=%b (expect 1)",
+             film_det_ntsc);
 
     // G2: the same run, now INFORMATIVE = a real film->video change. Must follow it.
     tb_informative = 1'b1;
     run_pickups(80);
     chk(!film_det_ntsc, "[G2] film lock did NOT release on a genuine interlaced video run");
-    chk(det_video,      "[G2] det_video did not engage on genuine interlaced video");
-    $display("  [G2] 80 informative pf=0 pickups: det_ntsc=%b det_video=%b (expect 0/1)",
-             film_det_ntsc, det_video);
+    $display("  [G2] 80 informative pf=0 pickups: det_ntsc=%b (expect 0)",
+             film_det_ntsc);
 
     // G3: gated pickups must not disturb the 3:2 toggle test either -- the run
     // resumes across the gap rather than seeing a false rff edge.
@@ -209,17 +196,15 @@ module film_detect_tb;
     $display("  [G3] film survives a 40-pickup gated gap: det_ntsc=%b (expect 1)", film_det_ntsc);
 
     // ===== 3. transition to 60i/50i interlaced VIDEO (pf=0) =====
-    // Both film verdicts release AND the true-interlaced verdict must ENGAGE — this is
-    // the signal that drives Interlaced Out Auto to the native fields path (480i/576i).
+    // Both film verdicts must release. (The det_video engage half of this test
+    // left with the Interlaced Out Auto detector, 2026-09-02.)
     mode = 2;
     run_pickups(30);
     chk(!film_det_ntsc, "det_ntsc engaged on interlaced video");
     chk(!film_det_pal,  "det_pal did NOT release on interlaced video");
-    chk(!det_video,     "det_video engaged too early (< ENGAGE_TH interlaced frames)");
-    run_pickups(30);    // > ENGAGE_TH (120 / UP_STEP 3 = 40) sustained interlaced frames
-    chk(det_video,      "det_video did NOT engage on sustained interlaced video");
-    $display("  [3] 60i video: det_ntsc=%b det_pal=%b det_video=%b (expect 0/0/1)",
-             film_det_ntsc, film_det_pal, det_video);
+    run_pickups(30);
+    $display("  [3] 60i video: det_ntsc=%b det_pal=%b (expect 0/0)",
+             film_det_ntsc, film_det_pal);
 
     // ===== 4. false-positive guard: START on 30fps progressive video and run a
     //          LONG time — det_ntsc must NEVER engage (only det_pal). =====
@@ -227,9 +212,8 @@ module film_detect_tb;
     run_pickups(120);
     chk(!film_det_ntsc, "det_ntsc FALSELY engaged on a long 30fps-video run (REGRESSION)");
     chk(film_det_pal,   "det_pal did not hold on long progressive video");
-    chk(!det_video,     "det_video did NOT release on sustained progressive video");
-    $display("  [4] long 30fps video: det_ntsc=%b det_video=%b (expect 0/0 — false-positive guards)",
-             film_det_ntsc, det_video);
+    $display("  [4] long 30fps video: det_ntsc=%b (expect 0 — false-positive guard)",
+             film_det_ntsc);
 
     // ===== 4b. ISSUE-1 REGRESSION: film reached via a menu = periodic cadence
     //          hiccups (every 8th frame breaks the rff alternation). Starting from

--- a/bench/dvd/film_detect_tb.sv
+++ b/bench/dvd/film_detect_tb.sv
@@ -67,7 +67,7 @@ module film_detect_tb;
     .film_det_ntsc(film_det_ntsc), .film_det_pal(film_det_pal),
     .det_video(det_video),
     .video_live(), .pickup_hold(1'b0), .pause(1'b0),
-    .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0));
+    .raster_par_err(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0));
 
   always #5 clk = ~clk;
 

--- a/bench/dvd/gov_field_late_tb.sv
+++ b/bench/dvd/gov_field_late_tb.sv
@@ -77,7 +77,7 @@ module gov_field_late_tb;
     .resample_wr_dta(resample_wr_dta), .resample_wr_en(resample_wr_en),
     .disp_wr_addr_almost_full(disp_wr_addr_almost_full), .resample_wr_almost_full(resample_wr_almost_full),
     .busy(busy), .frame_late(frame_late), .video_live(), .pickup_hold(pickup_hold), .pause(1'b0),
-    .cur_show_out(cur_show_w), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0));
+    .cur_show_out(cur_show_w), .raster_par_err(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0));
 
   always #5 clk = ~clk;
 
@@ -138,7 +138,12 @@ module gov_field_late_tb;
     refreshes = 0;
     waitclk(4);
     film_show = cur_show_w;
-    progressive_frame = 1'b0; repeat_first_field = 1'b0;   // NEXT frame = plain video
+    // NEXT frame = plain video. tff TOGGLES after an rff picture on a real disc
+    // (the 3-field T,B,T show ends on TOP, so the next picture starts BOTTOM to
+    // keep strict field alternation). Holding tff=1 here would be an authored-
+    // cadence break, and the field-parity corrector (2026-09-02) now rightly
+    // inserts a re-align field for it — which this measurement must not count.
+    progressive_frame = 1'b0; repeat_first_field = 1'b0; top_field_first = 1'b0;
     supply;
     @(posedge output_frame_rd);
     film_scans = refreshes;

--- a/bench/dvd/menu_ff_tb.sv
+++ b/bench/dvd/menu_ff_tb.sv
@@ -54,7 +54,7 @@ module menu_ff_tb;
     .resample_wr_dta(resample_wr_dta), .resample_wr_en(resample_wr_en),
     .disp_wr_addr_almost_full(disp_wr_addr_almost_full), .resample_wr_almost_full(resample_wr_almost_full),
     .busy(busy), .frame_late(frame_late), .video_live(video_live), .pickup_hold(1'b0), .pause(1'b0),
-    .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(menu_ff), .film24(1'b0));
+    .raster_par_err(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(menu_ff), .film24(1'b0));
 
   always #5 clk = ~clk;
 

--- a/bench/dvd/modeline_boot_tb.sv
+++ b/bench/dvd/modeline_boot_tb.sv
@@ -1,0 +1,230 @@
+`timescale 1ns/1ps
+//
+// modeline_boot_tb.sv — the BOOT-TIME MODELINE WALK RESET RACE (2026-09-02 HW
+// report: `Video Output = Auto` with analog ini bits shows 719x...i @ 31.48 kHz
+// and a dead CRT — il_eff asserted, raster still progressive).
+//
+// THE RACE: emu.sv's modeline-walk sequencer keys on RAW reset_n and fires its
+// six regfile writes starting the very next clk_dec cycle, but the decoder's
+// resets are SYNCHRONIZED INSIDE mpeg2video (reset.v: 5-FF sync_reset stages,
+// cascaded) — hard_rst, which gates every modeline register in regfile.v,
+// deasserts ~5-10 clk cycles AFTER reset_n rises. Writes landing inside that
+// window are silently discarded while the registers re-default to the
+// PROGRESSIVE modeline; the walk latches il_prev anyway, so no edge remains to
+// retry, and the core runs a progressive raster with VGA_F1 toggling forever.
+//
+// The race existed since the walk was built, but was INVISIBLE: il_eff was 0
+// at boot (the swallowed init walk wrote the progressive values the registers
+// were resetting to anyway), and every mode change arrived later via OSD with
+// the decoder long out of reset. `Video Output = Auto` from the MiSTer.ini
+// bits is the first time the boot-time walk writes something DIFFERENT from
+// the reset defaults.
+//
+// This bench instantiates the REAL reset.v + regfile.v (wired exactly as
+// mpeg2video wires them) and drives them with a VERBATIM
+// copy of emu.sv's walk sequencer, il_out=1 from t0 (the Auto-with-analog-ini
+// boot). It then reads the regfile modeline hierarchically:
+//   RED  (+holdoff=0): some/all interlaced-mode registers still hold their
+//                      progressive reset defaults — the swallowed walk.
+//   GREEN(+holdoff=1): the fix — kicks gated on sync_rst_out having been
+//                      deasserted for a few cycles — lands every register.
+// A control phase toggles il_out with the decoder long alive (the historical
+// OSD path) and must apply in both variants.
+//
+// Build:
+//   iverilog -g2012 -I rtl/mpeg2 -o bench/dvd/modeline_boot_sim \
+//     rtl/mpeg2/reset.v rtl/mpeg2/synchronizer.v rtl/mpeg2/regfile.v \
+//     bench/dvd/modeline_boot_tb.sv
+//   vvp bench/dvd/modeline_boot_sim +holdoff=0   (RED pre-fix)
+//   vvp bench/dvd/modeline_boot_sim +holdoff=1   (GREEN)
+// Or: bash bench/dvd/run_modeline_boot.sh
+//
+module modeline_boot_tb;
+
+  // clocks (ratios roughly like HW: clk_dec 81 / mem 90 / dot 27)
+  reg clk = 0;      always #6  clk = ~clk;
+  reg mem_clk = 0;  always #5  mem_clk = ~mem_clk;
+  reg dot_clk = 0;  always #18 dot_clk = ~dot_clk;
+
+  reg rst = 0;      // emu reset_n equivalent (raw, as the walk sees it)
+
+  // ---- walk -> decoder register bus ----
+  localparam [3:0] REG_WR_HOR      = 4'h1;
+  localparam [3:0] REG_WR_HOR_SYNC = 4'h2;
+  localparam [3:0] REG_WR_VER      = 4'h3;
+  localparam [3:0] REG_WR_VER_SYNC = 4'h4;
+  localparam [3:0] REG_WR_VID_MODE = 4'h5;
+  localparam [3:0] REG_WR_TRICK    = 4'hb;
+
+  reg  il_out = 1'b1;               // Video Output = Auto + analog ini: fields from boot
+  wire pal_out = 1'b0, filmp_out = 1'b0;
+
+  reg  il_s1, il_s2, il_prev, il_init;
+  reg  pal_s1, pal_s2, pal_prev;
+  reg  filmp_s1, filmp_s2, filmp_prev;
+  reg  seq_run;
+  reg  [2:0] seq_step;
+
+  wire sync_rst_out;
+  integer holdoff = 0;
+
+  // ---- the FIX under test: only allow kicks once the decoder's synchronized
+  // reset has been observed deasserted for a few cycles (regfile writable) ----
+  reg [2:0] dec_rdy_cnt;
+  always @(posedge clk)
+    if (!rst || !sync_rst_out) dec_rdy_cnt <= 3'd0;
+    else if (dec_rdy_cnt != 3'd7) dec_rdy_cnt <= dec_rdy_cnt + 3'd1;
+  wire dec_ready = (holdoff == 0) || (dec_rdy_cnt == 3'd7);
+
+  // ---- VERBATIM emu.sv walk sequencer (modulo the dec_ready gate) ----
+  always @(posedge clk) begin
+    if (!rst) begin
+        il_s1 <= 1'b0; il_s2 <= 1'b0; il_prev <= 1'b0;
+        pal_s1 <= 1'b0; pal_s2 <= 1'b0; pal_prev <= 1'b0;
+        filmp_s1 <= 1'b0; filmp_s2 <= 1'b0; filmp_prev <= 1'b0;
+        il_init <= 1'b0; seq_run <= 1'b0; seq_step <= 3'd0;
+    end else begin
+        il_s1  <= il_out;
+        il_s2  <= il_s1;
+        pal_s1 <= pal_out;
+        pal_s2 <= pal_s1;
+        filmp_s1 <= filmp_out;
+        filmp_s2 <= filmp_s1;
+        if (seq_run) begin
+            if (seq_step == 3'd5) seq_run <= 1'b0;
+            seq_step <= seq_step + 3'd1;
+        end else if (dec_ready &&
+                     (!il_init || (il_s2 != il_prev) || (pal_s2 != pal_prev) || (filmp_s2 != filmp_prev))) begin
+            il_prev  <= il_s2;
+            pal_prev <= pal_s2;
+            filmp_prev <= filmp_s2;
+            il_init  <= 1'b1;
+            seq_run  <= 1'b1;
+            seq_step <= 3'd0;
+        end
+    end
+  end
+
+  wire [10:0] trick_w = { il_prev ? 1'b0 : 1'b1, 5'b00000, 1'b1, 3'b000, 1'b0 };
+  reg  [3:0]  wr_addr;
+  reg  [31:0] wr_data;
+  always @(*) begin
+    case (seq_step)
+        3'd0: begin wr_addr = REG_WR_HOR;
+                    wr_data = pal_prev ? {4'b0, 12'd720, 4'b0, 12'd863}
+                                       : {4'b0, 12'd720, 4'b0, 12'd857}; end
+        3'd1: begin wr_addr = REG_WR_HOR_SYNC;
+                    wr_data = {4'b0, 12'd735, 4'b0, 12'd797}; end
+        3'd2: begin wr_addr = REG_WR_VER;
+                    wr_data = il_prev ? {4'b0, 12'd479, 4'b0, 12'd261}
+                                      : {4'b0, 12'd480, 4'b0, 12'd524}; end
+        3'd3: begin wr_addr = REG_WR_VER_SYNC;
+                    wr_data = il_prev ? {4'b0, 12'd244, 4'b0, 12'd247}
+                                      : {4'b0, 12'd488, 4'b0, 12'd494}; end
+        3'd4: begin wr_addr = REG_WR_VID_MODE;
+                    wr_data = il_prev ? {4'b0, 12'd0, 13'b0, 3'b011}
+                                      : {4'b0, 12'd0, 13'b0, 3'b000}; end
+        default: begin wr_addr = REG_WR_TRICK;
+                    wr_data = {21'b0, trick_w}; end
+    endcase
+  end
+
+  // ---- the real reset synchronizer + register file, wired EXACTLY as
+  //      mpeg2video wires them (reset.v -> clk_rst/hard_rst; regfile on
+  //      hard_rst + rst=sync_rst). The whole race lives in these two modules
+  //      plus the walk above; the rest of the decoder is irrelevant to it
+  //      (and mpeg2video.v's declaration ordering trips iverilog anyway). ----
+  wire sync_rst_w, mem_rst_w, dot_rst_w, hard_rst_w;
+  reset u_reset (
+    .clk(clk), .mem_clk(mem_clk), .dot_clk(dot_clk),
+    .async_rst(rst),
+    .watchdog_rst(1'b1),        // never expires here
+    .soft_rst_n(1'b1),
+    .clk_rst(sync_rst_w), .mem_rst(mem_rst_w), .dot_rst(dot_rst_w),
+    .hard_rst(hard_rst_w)
+  );
+  assign sync_rst_out = sync_rst_w;   // what emu's core_sync_rst tap reads
+
+  regfile regfile (
+    .clk(clk), .clk_en(1'b1),
+    .hard_rst(hard_rst_w),
+    .rst(sync_rst_w),
+    .reg_addr(seq_run ? wr_addr : 4'b0),
+    .reg_wr_en(seq_run),
+    .reg_dta_in(wr_data),
+    .reg_rd_en(1'b0),
+    .vld_err(1'b0), .v_sync(1'b0),
+    .progressive_sequence(1'b0),
+    .horizontal_size(14'd0), .vertical_size(14'd0),
+    .display_horizontal_size(14'd0), .display_vertical_size(14'd0),
+    .frame_rate_code(4'd0), .frame_rate_extension_n(2'd0), .frame_rate_extension_d(5'd0),
+    .aspect_ratio_information(4'd0), .mb_width(8'd0),
+    .update_picture_buffers(1'b0),
+    .watchdog_status(1'b1),
+    .osd_wr_full(1'b0), .osd_wr_ack(1'b0),
+    .testpoint(34'd0)
+  );
+
+  integer errors = 0;
+  task chk(input cond, input [8*64-1:0] msg);
+    if (!cond) begin errors = errors + 1; $display("  FAIL: %0s", msg); end
+  endtask
+
+  task check_interlaced_modeline(input [8*16-1:0] phase);
+    begin
+      $display("[%0s] regfile: hlen=%0d vres=%0d vlen=%0d vss=%0d ilace=%b pixrep=%b deint=%b",
+               phase,
+               regfile.horizontal_length, regfile.vertical_resolution,
+               regfile.vertical_length, regfile.vertical_sync_start,
+               regfile.interlaced, regfile.pixel_repetition, regfile.deinterlace);
+      chk(regfile.horizontal_length    == 12'd857, "horizontal_length not applied");
+      chk(regfile.vertical_resolution  == 12'd479, "vertical_resolution not applied (per-field)");
+      chk(regfile.vertical_length      == 12'd261, "vertical_length not applied (per-field)");
+      chk(regfile.vertical_sync_start  == 12'd244, "vertical_sync_start not applied (per-field)");
+      chk(regfile.interlaced           == 1'b1,    "VID_MODE interlaced not applied");
+      chk(regfile.pixel_repetition     == 1'b1,    "VID_MODE pixel_repetition not applied");
+      chk(regfile.deinterlace          == 1'b0,    "TRICK deinterlace=0 not applied");
+    end
+  endtask
+
+  initial begin
+    void'($value$plusargs("holdoff=%d", holdoff));
+    $display("\n==== modeline_boot_tb  holdoff=%0d ====", holdoff);
+    rst = 0;
+    repeat (20) @(posedge clk);
+    rst = 1;                                  // reset_n release; il_out already 1 (the Auto boot)
+
+    // [1] BOOT: give it far longer than any synchronizer + walk needs
+    repeat (2000) @(posedge clk);
+    check_interlaced_modeline("1-boot");
+
+    // [2] control: the historical OSD path — flip to progressive and back with
+    // the decoder long alive; must apply in BOTH variants.
+    il_out = 0;
+    repeat (500) @(posedge clk);
+    chk(regfile.interlaced == 1'b0, "control: progressive OSD toggle not applied");
+    il_out = 1;
+    repeat (500) @(posedge clk);
+    check_interlaced_modeline("2-osd-toggle");
+
+    // [3] a SECOND reset pulse with il_out still 1 (core reload with the ini
+    // bits set) — the same boot race again.
+    rst = 0;
+    repeat (20) @(posedge clk);
+    rst = 1;
+    repeat (2000) @(posedge clk);
+    check_interlaced_modeline("3-reload");
+
+    if (errors == 0) begin
+      $display("\n==== PASS (holdoff=%0d) ====", holdoff);
+      $finish;
+    end else
+      $fatal(1, "==== FAIL (holdoff=%0d): %0d error(s) ====", holdoff, errors);
+  end
+
+  initial begin
+    #4_000_000;
+    $fatal(1, "TIMEOUT");
+  end
+
+endmodule

--- a/bench/dvd/pickup_hold_tb.sv
+++ b/bench/dvd/pickup_hold_tb.sv
@@ -65,7 +65,7 @@ module pickup_hold_tb;
     .resample_wr_dta(resample_wr_dta), .resample_wr_en(resample_wr_en),
     .disp_wr_addr_almost_full(disp_wr_addr_almost_full), .resample_wr_almost_full(resample_wr_almost_full),
     .busy(busy), .frame_late(frame_late),
-    .video_live(video_live), .pickup_hold(pickup_hold), .pause(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0));
+    .video_live(video_live), .pickup_hold(pickup_hold), .pause(1'b0), .raster_par_err(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0));
 
   always #5 clk = ~clk;
 

--- a/bench/dvd/re_interlace_tb.sv
+++ b/bench/dvd/re_interlace_tb.sv
@@ -1,10 +1,13 @@
 `timescale 1ns/1ps
 //
-// re_interlace_tb.sv — verify dvd/re_interlace.sv (dual-raster analog output).
+// re_interlace_tb.sv — verify dvd/re_interlace.sv (the analog fields re-timer;
+// fieldpass-only since the 2026-09-02 Video Output consolidation).
 //
-// The DUT converts the main progressive raster (720x480p/576p, 27 MHz CE=1)
-// into a native 15 kHz 2:1-interlaced raster (NTSC 858x262/263 half-line 429;
-// PAL 864x312/313 half-line 432) through a 4-line BRAM + a second sync_gen.
+// The DUT re-times the pixel-repeated interlaced main raster (Video Output =
+// Interlaced, il_eff) onto a native 15 kHz half-line raster (NTSC 858x262/263
+// half-line 429; PAL 864x312/313 half-line 432) through a 4-line BRAM + a
+// second sync_gen. The old progressive-DERIVE (weave) mode is deleted; the
+// progressive raster is now a REJECT stimulus (the il_switch mode-walk guard).
 //
 // Invariants proven here:
 //   A (lock):    consecutive out_vs rising edges are EXACTLY 225225 13.5 MHz
@@ -15,10 +18,12 @@
 //                with the RIGHT line parity per field (A=even, B=odd), lines
 //                stepping +2, x stepping +1 from 0..719, 240 (288) active
 //                lines per field, and ONE consistent source-frame tag per
-//                field that increments by exactly 1 each field — the direct
-//                proof of the SKEW window math (a read/write race shows up as
-//                a mixed or wrong frame tag).
-//   C (health):  a non-standard main raster (Film-24p length) never locks;
+//                field advancing +1 every TWO fields (both fields of a source
+//                frame carry that frame's own tag) — the direct proof of the
+//                SKEW_FP math (a read/write race shows up as a mixed or wrong
+//                frame tag).
+//   C (health):  non-fieldpass rasters (the PROGRESSIVE main raster during an
+//                il_switch mode walk; the Film-24p raster) never lock;
 //                enable-drop and NTSC->PAL geometry switches re-lock cleanly.
 //
 // Build:
@@ -43,8 +48,7 @@ module re_interlace_tb;
   reg         rst_n  = 0;
   reg         enable = 0;
   reg         pal    = 0;
-  reg         fieldpass = 0;   // DUT mode: 1 = re-time the interlaced pixrep raster 1:1
-  reg         src_fp    = 0;   // stimulus select (kept separate so a MISMATCH is testable)
+  reg         src_fp    = 1;   // stimulus select: 1 = fields raster, 0 = progressive (reject tests)
   reg  [7:0]  in_r, in_g, in_b;
   reg         in_de;
   reg  [11:0] in_hpos, in_vpos;
@@ -53,7 +57,7 @@ module re_interlace_tb;
 
   re_interlace dut (
     .clk(clk), .rst_n(rst_n), .ce2(ce2),
-    .enable(enable), .pal(pal), .fieldpass(fieldpass),
+    .enable(enable), .pal(pal),
     .in_r(in_r), .in_g(in_g), .in_b(in_b), .in_de(in_de),
     .in_hpos(in_hpos), .in_vpos(in_vpos),
     .out_r(out_r), .out_g(out_g), .out_b(out_b),
@@ -87,7 +91,7 @@ module re_interlace_tb;
     end else g_h <= g_h + 1;
   end
 
-  // ------------------------------- fieldpass source raster model (scenario [6])
+  // --------------------------------------- fields source raster model (primary)
   // The pixel-repeated INTERLACED main raster the decoder emits under il_eff:
   //   line   = 1716 clk27 (NTSC) / 1728 (PAL)  -- same duration as our output line
   //   field A = 262 (312) lines, EVEN absolute v_pos; field B = 263 (313), ODD
@@ -186,20 +190,14 @@ module re_interlace_tb;
         if (lines_in_field != exp_lines_per_field)
           fail($sformatf("field had %0d active lines (expected %0d)",
                          lines_in_field, exp_lines_per_field));
-        // Expected tag progression differs by MODE, and that difference is the
-        // whole point of fieldpass:
-        //   derive   : field A reads main frame N, field B frame N+1 -> +1 EVERY field
-        //   fieldpass: both fields of a source frame are that frame's own authored
-        //              fields -> the tag repeats on field B (odd lines) and advances
-        //              on field A (even lines), i.e. +1 every TWO fields.
-        // field_parity holds the parity of the field being closed here.
-        exp_field_tag = (fieldpass && (field_parity == 1))
-                        ? prev_field_tag
-                        : ((prev_field_tag + 1) % 16);
+        // Both fields of a source frame carry that frame's own authored tag ->
+        // the tag repeats on field B (odd lines) and advances on field A (even
+        // lines), i.e. +1 every TWO fields. field_parity = the field closing here.
+        exp_field_tag = (field_parity == 1) ? prev_field_tag
+                                            : ((prev_field_tag + 1) % 16);
         if (have_prev_field_tag && (cur_frame_tag != exp_field_tag))
-          fail($sformatf("field frame tag %0d after %0d (expected %0d, %0s)",
-                         cur_frame_tag, prev_field_tag, exp_field_tag,
-                         fieldpass ? "fieldpass" : "derive"));
+          fail($sformatf("field frame tag %0d after %0d (expected %0d)",
+                         cur_frame_tag, prev_field_tag, exp_field_tag));
         prev_field_tag = cur_frame_tag;
         have_prev_field_tag = 1;
       end
@@ -270,22 +268,25 @@ module re_interlace_tb;
 
   integer t0;
   initial begin
-    $display("re_interlace_tb: start");
+    $display("re_interlace_tb: start (fieldpass-only)");
     repeat (10) @(posedge clk);
     rst_n = 1;
 
     // ------------------------------------------------ [1] NTSC lock + run
+    // Source = the interlaced pixrep fields raster; the module re-times authored
+    // fields 1:1. Each field carries its OWN source frame's tag -> the tag
+    // advances every TWO fields (see the checker).
     enable = 1;
     t0 = $time;
-    while (!locked && ($time - t0) < 40_000_000) @(posedge clk);
-    if (!locked) fail("[1] no lock on NTSC main raster");
+    while (!locked && ($time - t0) < 80_000_000) @(posedge clk);
+    if (!locked) fail("[1] no lock on the fieldpass NTSC raster");
     // let the first (possibly partial-checked) field pass, then arm checks
     wait_fields(2);
     reset_checker;
     check_arm = 1;
     wait_fields(8);
-    if (!locked) fail("[1] lost lock during NTSC run");
-    $display("[1] NTSC: 8 checked fields OK (spacing %0d)", exp_field_dots);
+    if (!locked) fail("[1] lost lock during the NTSC run");
+    $display("[1] fieldpass NTSC: 8 checked fields OK (spacing %0d)", exp_field_dots);
 
     // ------------------------------------------------ [2] enable drop / re-lock
     check_arm = 0;
@@ -296,7 +297,7 @@ module re_interlace_tb;
       fail("[2] outputs not quiet while disabled");
     enable = 1;
     t0 = $time;
-    while (!locked && ($time - t0) < 40_000_000) @(posedge clk);
+    while (!locked && ($time - t0) < 80_000_000) @(posedge clk);
     if (!locked) fail("[2] no re-lock after enable");
     wait_fields(2);
     reset_checker; check_arm = 1;
@@ -307,27 +308,27 @@ module re_interlace_tb;
     check_arm = 0;
     // geometry and pal flag change together (as the modeline walk would)
     pal = 1;
-    g_hlen = 864; g_vlen = 625; g_vact = 576;
+    f_hlen = 1728; f_vlenA = 312; f_vlenB = 313; f_hact = 1440; f_vact = 288;
     exp_field_dots = 270000;
     exp_lines_per_field = 288;
     t0 = $time;
     // must drop lock (wrong period detected), then re-lock on PAL
-    while (locked && ($time - t0) < 40_000_000) @(posedge clk);
+    while (locked && ($time - t0) < 80_000_000) @(posedge clk);
     if (locked) fail("[3] never dropped lock on geometry change");
     t0 = $time;
-    while (!locked && ($time - t0) < 60_000_000) @(posedge clk);
-    if (!locked) fail("[3] no lock on PAL raster");
+    while (!locked && ($time - t0) < 100_000_000) @(posedge clk);
+    if (!locked) fail("[3] no lock on the fieldpass PAL raster");
     wait_fields(2);
     reset_checker; check_arm = 1;
     wait_fields(8);
-    if (!locked) fail("[3] lost lock during PAL run");
-    $display("[3] PAL: 8 checked fields OK (spacing %0d)", exp_field_dots);
+    if (!locked) fail("[3] lost lock during the PAL run");
+    $display("[3] fieldpass PAL: 8 checked fields OK (spacing %0d)", exp_field_dots);
 
     // ------------------------------------------------ [4] film raster never locks
     check_arm = 0;
     enable = 0;
     repeat (20) @(posedge clk);
-    pal = 0;
+    pal = 0; src_fp = 0;
     g_hlen = 875; g_vlen = 1287; g_vact = 480;   // Film-24p NTSC frame (875x1287 exact-rate, PR #158)
     enable = 1;
     // wait ~3 film frames
@@ -335,93 +336,36 @@ module re_interlace_tb;
     if (locked) fail("[4] locked onto a Film-24p raster (period check broken)");
     $display("[4] film raster correctly rejected");
 
-    // ------------------------------------------------ [5] back to NTSC
-    // BOTH axes must be restored: the Film-24p raster is 875 dots/line (not 858 —
-    // an odd htotal is what makes 24000/1001 exact, PR #158), so restoring only
-    // g_vlen would leave 875 x 525 = 459,375 != 450,450 and re_interlace would
-    // correctly refuse to lock. (Caught exactly that way when the film numbers were
-    // updated — an incidental confirmation that the period check covers h as well.)
-    g_hlen = 858; g_vlen = 525;
-    exp_field_dots = 225225;
-    exp_lines_per_field = 240;
-    t0 = $time;
-    while (!locked && ($time - t0) < 40_000_000) @(posedge clk);
-    if (!locked) fail("[5] no re-lock after film -> NTSC");
-    wait_fields(2);
-    reset_checker; check_arm = 1;
-    wait_fields(4);
-    $display("[5] film -> NTSC re-lock OK");
-
-    // ------------------------------------------------ [6] fieldpass NTSC
-    // Native Fields: the source is already the interlaced pixrep raster, so the
-    // module re-times authored fields 1:1 instead of splitting a weave. Same output
-    // raster (invariant A unchanged), but each field now carries its OWN source
-    // frame's tag -> the tag advances every TWO fields (see the checker).
+    // ------------------------------------------------ [5] progressive raster never locks
+    // The re-timer expects a 900900-clk27 (NTSC) frame period. The PROGRESSIVE
+    // main raster (450450) must be rejected by the same period check — this is
+    // the il_switch mode-walk backstop: while Video Output flips and the modeline
+    // walks, the analog output stays silent rather than showing a torn picture.
     check_arm = 0;
     enable = 0;
     repeat (20) @(posedge clk);
-    pal = 0; fieldpass = 1; src_fp = 1;
+    g_hlen = 858; g_vlen = 525; g_hact = 720; g_vact = 480;
+    enable = 1;
+    repeat (3 * 858 * 525) @(posedge clk);
+    if (locked) fail("[5] locked onto the progressive raster (mode-walk guard broken)");
+    $display("[5] progressive raster correctly rejected");
+
+    // ------------------------------------------------ [6] back to fieldpass NTSC
+    check_arm = 0;
+    enable = 0;
+    repeat (20) @(posedge clk);
+    src_fp = 1;
     f_hlen = 1716; f_vlenA = 262; f_vlenB = 263; f_hact = 1440; f_vact = 240;
     exp_field_dots = 225225;
     exp_lines_per_field = 240;
     enable = 1;
     t0 = $time;
     while (!locked && ($time - t0) < 80_000_000) @(posedge clk);
-    if (!locked) fail("[6] no lock on the fieldpass NTSC raster");
-    wait_fields(2);
-    reset_checker; check_arm = 1;
-    wait_fields(8);
-    if (!locked) fail("[6] lost lock during the fieldpass NTSC run");
-    $display("[6] fieldpass NTSC: 8 checked fields OK (spacing %0d)", exp_field_dots);
-
-    // ------------------------------------------------ [7] fieldpass PAL
-    check_arm = 0;
-    enable = 0;
-    repeat (20) @(posedge clk);
-    pal = 1;
-    f_hlen = 1728; f_vlenA = 312; f_vlenB = 313; f_hact = 1440; f_vact = 288;
-    exp_field_dots = 270000;
-    exp_lines_per_field = 288;
-    enable = 1;
-    t0 = $time;
-    while (!locked && ($time - t0) < 100_000_000) @(posedge clk);
-    if (!locked) fail("[7] no lock on the fieldpass PAL raster");
-    wait_fields(2);
-    reset_checker; check_arm = 1;
-    wait_fields(8);
-    if (!locked) fail("[7] lost lock during the fieldpass PAL run");
-    $display("[7] fieldpass PAL: 8 checked fields OK (spacing %0d)", exp_field_dots);
-
-    // ------------------------------------------------ [8] mode/source mismatch
-    // fieldpass expects a 900900-clk27 (NTSC) frame period. Feeding it the
-    // PROGRESSIVE raster (450450) must be rejected by the period check, exactly
-    // as the film raster is in [4] — the backstop that keeps a mis-set mode silent
-    // rather than showing a torn picture.
-    check_arm = 0;
-    enable = 0;
-    repeat (20) @(posedge clk);
-    pal = 0; fieldpass = 1; src_fp = 0;
-    g_hlen = 858; g_vlen = 525; g_hact = 720; g_vact = 480;
-    enable = 1;
-    repeat (3 * 858 * 525) @(posedge clk);
-    if (locked) fail("[8] locked onto a progressive raster while fieldpass=1");
-    $display("[8] fieldpass correctly rejects the progressive raster");
-
-    // ------------------------------------------------ [9] back to derive mode
-    check_arm = 0;
-    enable = 0;
-    repeat (20) @(posedge clk);
-    fieldpass = 0; src_fp = 0;
-    exp_field_dots = 225225;
-    exp_lines_per_field = 240;
-    enable = 1;
-    t0 = $time;
-    while (!locked && ($time - t0) < 40_000_000) @(posedge clk);
-    if (!locked) fail("[9] no re-lock after returning to derive mode");
+    if (!locked) fail("[6] no re-lock on return to the fieldpass NTSC raster");
     wait_fields(2);
     reset_checker; check_arm = 1;
     wait_fields(4);
-    $display("[9] fieldpass -> derive re-lock OK");
+    $display("[6] progressive -> fieldpass re-lock OK");
 
     if (errors == 0) begin
       $display("re_interlace_tb: PASS");

--- a/bench/dvd/resample_addr_realstride_tb.sv
+++ b/bench/dvd/resample_addr_realstride_tb.sv
@@ -58,7 +58,7 @@ module resample_addr_realstride_tb;
     .disp_wr_addr_ack(disp_wr_addr_ack), .disp_wr_addr(disp_wr_addr),
     .resample_wr_dta(resample_wr_dta), .resample_wr_en(resample_wr_en),
     .disp_wr_addr_almost_full(disp_wr_addr_almost_full), .resample_wr_almost_full(resample_wr_almost_full),
-    .busy(busy), .video_live(), .pickup_hold(1'b0), .pause(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0));
+    .busy(busy), .video_live(), .pickup_hold(1'b0), .pause(1'b0), .raster_par_err(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0));
 
   always #5 clk = ~clk;
 

--- a/bench/dvd/resample_cadence_rate_tb.sv
+++ b/bench/dvd/resample_cadence_rate_tb.sv
@@ -57,7 +57,7 @@ module resample_cadence_rate_tb;
     .disp_wr_addr_ack(disp_wr_addr_ack), .disp_wr_addr(disp_wr_addr),
     .resample_wr_dta(resample_wr_dta), .resample_wr_en(resample_wr_en),
     .disp_wr_addr_almost_full(disp_wr_addr_almost_full), .resample_wr_almost_full(resample_wr_almost_full),
-    .busy(busy), .frame_late(frame_late), .video_live(), .pickup_hold(1'b0), .pause(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0));
+    .busy(busy), .frame_late(frame_late), .video_live(), .pickup_hold(1'b0), .pause(1'b0), .raster_par_err(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0));
 
   always #5 clk = ~clk;
 

--- a/bench/dvd/resample_cadence_tb.sv
+++ b/bench/dvd/resample_cadence_tb.sv
@@ -70,7 +70,7 @@ module resample_cadence_tb;
     .disp_wr_addr_ack(disp_wr_addr_ack), .disp_wr_addr(disp_wr_addr),
     .resample_wr_dta(resample_wr_dta), .resample_wr_en(resample_wr_en),
     .disp_wr_addr_almost_full(disp_wr_addr_almost_full), .resample_wr_almost_full(resample_wr_almost_full),
-    .busy(busy), .frame_late(frame_late), .video_live(), .pickup_hold(1'b0), .pause(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0));
+    .busy(busy), .frame_late(frame_late), .video_live(), .pickup_hold(1'b0), .pause(1'b0), .raster_par_err(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0));
 
   always #5 clk = ~clk;
 

--- a/bench/dvd/resample_chain_tb.sv
+++ b/bench/dvd/resample_chain_tb.sv
@@ -224,7 +224,7 @@ module resample_chain_tb;
     .y(px_y), .u(px_u), .v(px_v), .osd_out(px_osd),
     .position_out(px_position), .pixel_wr_en(px_wr_en),
     .video_live(), .pickup_hold(1'b0), .pause(1'b0),
-    .vscale_mode(rs_vscale_mode),              // DVD-FORK (CRT anamorphic vscale: letterbox)
+    .raster_par_err(1'b0), .vscale_mode(rs_vscale_mode),              // DVD-FORK (CRT anamorphic vscale: letterbox)
     .hcrop_en(rs_hcrop_en),                    // DVD-FORK (CRT anamorphic horizontal crop)
     .menu_ff(1'b0),                            // DVD-FORK (menu VBUF-lag §5): not exercised here
     .film24(1'b0)                              // DVD-FORK (Film 24p Out): not exercised here

--- a/bench/dvd/resample_persist_tb.sv
+++ b/bench/dvd/resample_persist_tb.sv
@@ -47,7 +47,7 @@ module resample_persist_tb;
     .disp_wr_addr_ack(disp_wr_addr_ack), .disp_wr_addr(disp_wr_addr),
     .resample_wr_dta(resample_wr_dta), .resample_wr_en(resample_wr_en),
     .disp_wr_addr_almost_full(disp_wr_addr_almost_full), .resample_wr_almost_full(resample_wr_almost_full),
-    .busy(busy), .video_live(), .pickup_hold(1'b0), .pause(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0));
+    .busy(busy), .video_live(), .pickup_hold(1'b0), .pause(1'b0), .raster_par_err(1'b0), .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0));
 
   always #5 clk = ~clk;
 

--- a/bench/dvd/run_field_parity.sh
+++ b/bench/dvd/run_field_parity.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# run_field_parity.sh — build & run the field-parity re-engage suite
+# (bench/dvd/field_parity_tb.sv; design + RED evidence: docs/field_parity.md).
+#
+# Default: build against the CURRENT RTL and run both raster-phase arms —
+# every window must pass in both.
+#
+# --red <dir>: reproduce the historical RED capture — build with
+# -DNO_PARITY_FIX against PRE-FIX copies of resample.v, resample_addrgen.v and
+# mixer.v placed in <dir> (e.g. extracted with `git show <pre-fix-rev>:<path>`).
+# Expected result: each +phase arm FAILS at least one window — the misalignment,
+# once entered, persists (the proven coin flip the fix removes).
+#
+set -e
+cd "$(dirname "$0")/../.."
+
+RS=rtl/mpeg2/resample.v
+AG=dvd/resample_addrgen.v
+MX=rtl/mpeg2/mixer.v
+DEFS=""
+OUT=bench/dvd/field_parity_sim
+
+if [ "$1" = "--red" ]; then
+  BD="$2"
+  [ -n "$BD" ] || { echo "usage: $0 [--red <baseline-dir>]"; exit 1; }
+  RS="$BD/resample.v"; AG="$BD/resample_addrgen.v"; MX="$BD/mixer.v"
+  DEFS="-DNO_PARITY_FIX"
+  OUT=bench/dvd/field_parity_sim_red
+  echo "### RED build (pre-fix RTL from $BD, -DNO_PARITY_FIX) — failures EXPECTED"
+fi
+
+iverilog -g2012 -D__IVERILOG__ $DEFS -I rtl/mpeg2 -o "$OUT" \
+  "$RS" "$AG" rtl/mpeg2/resample_dta.v rtl/mpeg2/resample_bilinear.v \
+  rtl/mpeg2/mem_addr.v "$MX" rtl/mpeg2/pixel_queue.v rtl/mpeg2/syncgen.v \
+  rtl/mpeg2/read_write.v rtl/mpeg2/wrappers.v rtl/mpeg2/fwft.v \
+  rtl/mpeg2/xilinx_fifo_dc.v rtl/mpeg2/xfifo_sc.v \
+  bench/dvd/field_parity_tb.sv
+
+fail=0
+for p in 0 1; do
+  echo
+  echo "============ +phase=$p ============"
+  vvp "$OUT" +phase=$p | grep -vE '^\s*$' || fail=1
+done
+exit $fail

--- a/bench/dvd/run_modeline_boot.sh
+++ b/bench/dvd/run_modeline_boot.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# run_modeline_boot.sh — the boot-time modeline-walk reset race
+# (bench/dvd/modeline_boot_tb.sv; found on HW round 1 of the Video Output
+# consolidation: `Auto` + analog ini bits booted a progressive raster with
+# VGA_F1 toggling and a dead CRT).
+#
+# Runs the GREEN variant (+holdoff=1, matching the emu.sv dec_ready gate).
+# +holdoff=0 reproduces the pre-fix swallow (expected FAIL) for reference.
+set -e
+cd "$(dirname "$0")/../.."
+iverilog -g2012 -I rtl/mpeg2 -o bench/dvd/modeline_boot_sim \
+  rtl/mpeg2/reset.v rtl/mpeg2/synchronizer.v rtl/mpeg2/regfile.v \
+  rtl/mpeg2/mem_addr.v bench/dvd/modeline_boot_tb.sv
+vvp bench/dvd/modeline_boot_sim +holdoff=1

--- a/docs/analog_dual_raster.md
+++ b/docs/analog_dual_raster.md
@@ -1,6 +1,24 @@
 # Dual-Raster Analog Output — CRT 480i/576i from MiSTer.ini alone
 
-**Status: ✅ HW-CONFIRMED + MERGED (PR fj#146, 2026-07-30).** User-confirmed working on real
+**★ STATUS UPDATE 2026-09-02 (branch `feature/video-output-consolidation`): the DERIVE
+(weave) modes are REMOVED — fieldpass is now the ONLY analog delivery, under the single
+`O[10:9] Video Output = Auto/Interlaced/Progressive` control (`Interlaced` = the old
+Native Fields; `Auto` = the ini rule below resolving to Interlaced/Progressive; the old
+4-value `O[27:26] Analog Out` enum and `O[10:9] Interlaced Out` are gone, config layout
+bumped to `v,2`).** Why reversed (this doc's caveat 2 was the decisive evidence): two
+field reports — the derive path's pairing wobble seen in the wild ("extremely wobbly,
+not how interlace normally looks"), and the Native Fields post-seek "super aliased /
+toggle 3-4 times" defect, root-caused as a separate field-parity re-engage coin flip and
+FIXED (`docs/field_parity.md`). With fieldpass immune to caveat 2 by construction and the
+parity corrector closing the re-engage hole, the derive machinery's only remaining value
+was CRT-480i-plus-progressive-HDMI simultaneity, which the maintainer chose to drop
+(pick-your-output). `re_interlace.sv` keeps only the fieldpass timing (PERIOD_FP_*/
+SKEW_FP); the `fieldpass` port, the derive PERIOD/SKEW constants and the derive arming
+are deleted; `analog_eff`/`il_eff` collapsed into one `interlaced_eff`. The raster
+generator, phase lock, BRAM, CC injection and `VGA2_*` plumbing below all still ship.
+The rest of this doc is kept as design history; "caveat 2" is CLOSED.
+
+*(Historical status:)* ✅ HW-CONFIRMED + MERGED (PR fj#146, 2026-07-30). User-confirmed working on real
 hardware: the analog output engages from MiSTer.ini alone (no OSD step) with HDMI staying
 simultaneously progressive. Sim-verified: `bench/dvd/re_interlace_tb.sv` green (NTSC + PAL +
 re-lock + film-reject), all display-path regressions green. Supersedes the O[14] whole-core

--- a/docs/field_parity.md
+++ b/docs/field_parity.md
@@ -1,0 +1,181 @@
+# Field-parity re-engage corrector (2026-09-02)
+
+**Status: ✅ sim-proven (RED pre-fix / GREEN post-fix, `bench/dvd/field_parity_tb.sv`);
+⏳ HW-confirm pending — the gate is the two field reports below (chapter skip / FF /
+Analog Aspect change on a CRT in Native Fields no longer needs mode-toggling to fix).**
+
+## The field reports
+
+Two independent CRT users (SuperStationOne + SuperDock → YPbPr → Sony KV-25FS120; a
+second user playing The Shining), both on `Analog Out = Native Fields`:
+
+1. *"If you skip a chapter, back or fastforward, the image becomes super aliased; you
+   need to change the Analog Output option to another setting and then return, but
+   sometimes you need to do it 3 or 4 times in order to work. This also happens …
+   simply while watching the movie (I suspect at the beginning of each new chapter)."*
+2. *"If I change analog aspect it can become jittery, almost like a screen door type
+   effect. If I flip back through the aspects quickly it might fix itself again."*
+
+"Toggle repeatedly until it fixes itself" is the signature of a **50/50 parity roll**:
+each toggle re-rolls a coin and it lands right about half the time.
+
+## Root cause
+
+On an interlaced display the chain is: `dvd/resample_addrgen.v` emits one field image
+(TOP/BOTTOM) per refresh → `pixel_queue` → `rtl/mpeg2/mixer.v` maps each image onto the
+next raster field. Two facts combine into the defect:
+
+1. **The mixer's frame-top matcher deliberately accepts either parity slot**
+   (`display_first_pixel`, mixer.v — the fork's 3:2/drop "black fields" fix). A field's
+   first line carries `ROW_0_COL_0` (TOP) or `ROW_1_COL_0` (BOTTOM); upstream only
+   started a picture when that code matched the free-running raster parity (`v_pos==0`
+   top / `v_pos==1` bottom), which emitted a black field at every 3:2/drop alternation
+   break. The relaxed matcher displays every field — at whichever slot comes next. Its
+   cost note ("offset ≤1 line, irrelevant for bob") predates the fieldpass CRT path.
+2. **Nothing carried the raster's field parity back to the pickup decision.** The
+   addrgen's schedule (`image_0..image_5`, ordered by `top_field_first`) is consumed
+   one entry per refresh; authored cadence and the `STATE_REPEAT` persistence re-scan
+   both preserve strict TOP/BOTTOM alternation, so in steady state content parity and
+   raster parity stay locked — but **one odd perturbation flips the phase permanently**:
+   every TOP image then scans out during a bottom raster field and vice versa. The whole
+   picture sits one scan-line set off — "super aliased" on a field display (fieldpass
+   CRT, ascal Weave), nearly invisible under ascal **Bob** (HDMI's default), which is
+   why it shipped unseen.
+
+Observed odd perturbations: a seek/flush released on an arbitrary first `tff` (the new
+GOP's field order is a coin flip vs the held frame's tail — chapter skips, and natural
+cell boundaries whose first GOP happens to break alternation), the `il_switch` raster
+restart, an Analog Aspect walk's syncgen restart, a mixer underflow, and cold-start
+luck. Toggling `Analog Out` fires the full il_switch flush = another coin flip —
+exactly the users' "3–4 tries".
+
+`re_interlace` was ruled out: in fieldpass its lock is period-based and the raster
+free-runs straight through a seek — it never re-arms there and has no opportunity to
+mislock.
+
+## The fix
+
+Closed-loop parity feedback plus a feed-forward alternation guard. Progressive display
+is bit-identical by construction (every new term is qualified by `interlaced`).
+
+- **`mixer.v`**: new output `frame_top_par_err` — a field-rate LEVEL latched at each
+  accepted frame-top: 1 if the picture's first line began on the wrong raster parity.
+  The relaxed matcher itself is untouched (it must stay — mid-stream 3:2/drop breaks
+  still need to display).
+- **`mpeg2video.v`**: gates it with `dot_interlaced` and syncs dot→clk with the
+  existing `sync_reg` pattern → `raster_par_err` → through `resample.v` → addrgen.
+- **`dvd/resample_addrgen.v`** — the corrector, at the pickup decision (`STATE_INIT`):
+  - **Feed-forward `alt_break`**: the pending picture's first field would repeat the
+    parity of the last displayed field (schedule head == `last_image`). Catches a
+    seek-released tff break *before a single wrong field displays*.
+  - **Feedback `par_fb`**: the mixer reports a misaligned frame-top. Catches what the
+    schedule cannot see (cold start, raster restarts, underflow slips). `par_armed`
+    hysteresis (one insertion per error assertion, re-armed when the level clears,
+    plus a 4-refresh liveness timeout) absorbs the ~1–2-field + CDC feedback latency
+    so one error causes exactly one insertion.
+  - **On a trigger, defer the pickup one refresh and insert ONE field of the HELD
+    frame** (persistence-style — the screen shows real content; worst cost one refresh,
+    16.7 ms). Every pickup-conditioned latch rides a new `pickup_go` qualifier so the
+    pending frame stays unconsumed and its schedule intact; the FSM still scans the
+    inserted field.
+  - A `frame_late` pulse hands the inserted refresh to the frame-drop ledger (the
+    `cad_late_r` pattern); a B-drop removes an even field count on video content, so
+    the reclaim can never re-break parity.
+
+### ★ The triggers compose by XOR, and the inserted field's type depends on the trigger
+
+This was the subtle part — the first design ("insert the opposite field on either
+trigger") **livelocks on the feedback path**. Slot arithmetic (fields land on strictly
+alternating raster slots; a frame-top is accepted at whichever slot comes next):
+
+| situation | raster | content | action |
+|---|---|---|---|
+| `alt_break` only | aligned | breaks alternation | insert the **OPPOSITE** field — fills the slot the break would have skipped; stream stays alternating |
+| `par_fb` only | misaligned | intact | re-show the **SAME** field — it lands aligned on the next slot; one junction break, absorbed by the relaxed matcher |
+| both at once | misaligned | breaks alternation | **insert nothing** — two wrongs make a right: the break itself lands the new head aligned |
+
+Hence `par_ins = alt_break ^ par_fb`. Inserting "opposite" on a `par_fb` would keep the
+misalignment *and* manufacture a new alternation break for `alt_break` to un-fix on the
+next pickup — an oscillation that never converges.
+
+### Rejected alternatives
+
+- **Strict mixer matching** (revert the relaxed matcher): re-introduces the black-field
+  regression on every legitimate 3:2/drop alternation break.
+- **A flush-driven discontinuity flag** (arm the corrector from `vbuf_flush` /
+  `mode_switch`): misses the Analog Aspect walk (no flush is issued) and mixer
+  underflow slips, and cannot see cold-start luck. The alternation break and the
+  observed parity error *are* the discontinuity detectors.
+- **Deriving `VGA_F1` from content instead of raster parity**: fixes only ascal's view;
+  the CRT's half-line sequence is fixed alternating and cannot follow content — the
+  alignment must happen at the source.
+
+## Proof — `bench/dvd/field_parity_tb.sv` (`bash bench/dvd/run_field_parity.sh`)
+
+The real display chain (resample + addrgen → framestore model → pixel_queue → mixer ←
+interlaced sync_gen) with the parity feedback loop closed exactly as in `mpeg2video.v`.
+The checker reads **the wire the defect lives on**, hierarchically into the unmodified
+mixer: at every accepted frame-top, content field type (`position_in_0`) must match
+raster parity (`v_pos`) — it asserts what the screen gets, not a corrector register.
+Five windows per run: cold start (at a `+phase`-selected raster parity), two
+alternation-break seeks (the chapter-skip model), a clean-seek control, and soft-telecine
+film with authored tff toggling (the corrector must stay silent). Both `+phase` arms run.
+
+**RED (pre-fix RTL, `--red`; captured 2026-09-02 against pre-fix
+`resample.v`/`resample_addrgen.v`/`mixer.v` extracted from main)** — the coin flip,
+verbatim:
+
+```
++phase=0  [1-cold-start]  PASS  16/16 aligned        (lucky landing)
+          [2-seek-break]  FAIL  16/16 MISALIGNED     (the break flips the phase...)
+          [3-seek-clean]  FAIL  16/16 MISALIGNED     (...and it PERSISTS through a clean seek)
+          [4-seek-break-2]PASS  16/16 aligned        (only another break flips it back)
+          [5-film-3:2]    PASS  16/16 aligned
++phase=1  [1-cold-start]  FAIL  16/16 MISALIGNED     (unlucky landing — the feedback-only case)
+          [2-seek-break]  PASS  16/16 aligned        (two wrongs make a right)
+          [3-seek-clean]  PASS  16/16 aligned
+          [4-seek-break-2]FAIL  16/16 MISALIGNED
+          [5-film-3:2]    FAIL  16/16 MISALIGNED     (stays broken indefinitely)
+```
+
+Misalignment is a persistent STATE that perturbations toggle — which is precisely why
+the users' "change the setting and change it back, sometimes 3–4 times" ritual worked:
+each toggle re-rolled the coin.
+
+**GREEN (fixed RTL)**:
+
+```
++phase=0: all 5 windows 16/16 aligned; worst settle window 0 misaligned tops
+          (feed-forward: not a single wrong field ever displayed)
++phase=1: all 5 windows 16/16 aligned; worst settle window 2 misaligned tops
+          (the misaligned cold start — feedback corrects within its designed
+           ~2-field latency bound, then stays aligned)
+```
+
+Also green after the change: `run_prefetch_chain.sh` (progressive chain unchanged),
+`gov_field_late_tb` (its stimulus needed a real-disc fix: tff must toggle after an rff
+picture — holding it constant is an authored-cadence break the corrector now rightly
+handles), `resample_cadence(_rate)_tb`, `pickup_hold_tb`, `menu_ff_tb`,
+`cadence_slip_tb`, `resample_persist_tb`, `resample_addr_realstride_tb`,
+`run_film_evidence.sh`.
+
+## Consequences for the HW symptom
+
+- Chapter skip / FF / seek: the feed-forward guard aligns the first field of the new
+  GOP before it displays — no aliasing window at all.
+- Aspect changes, underflow, cold start: the feedback path heals within ~2 fields
+  (~33 ms) of the first misaligned frame-top.
+- The "toggle Analog Out 3–4 times" ritual is obsolete; a mode toggle still works but
+  is never needed.
+
+## Files
+
+- `rtl/mpeg2/mixer.v` — `frame_top_par_err` output (verdict register only; matcher
+  untouched)
+- `rtl/mpeg2/mpeg2video.v` — gate + `sync_reg` CDC + routing
+- `rtl/mpeg2/resample.v` — pass-through
+- `dvd/resample_addrgen.v` — the corrector (`alt_break` / `par_fb` / `par_armed` /
+  `pickup_go` / the insertion branch)
+- `bench/dvd/field_parity_tb.sv`, `bench/dvd/run_field_parity.sh` — the suite
+- Every TB that instantiates `resample`/`resample_addrgen` directly ties
+  `.raster_par_err(1'b0)` (an unconnected input would read X into the interlaced arms)

--- a/docs/film_24p_plan.md
+++ b/docs/film_24p_plan.md
@@ -419,7 +419,8 @@ Active scan (720 × 480 at 27 MHz) is bit-for-bit unchanged; only blanking moves
 60 → 77 dots, vblank 833 → 807 lines). hsync goes 31.47 → 30.86 kHz. Nothing downstream cares:
 ascal takes DE/HS/VS + `CE_PIXEL≡1` and rescales the active window, the HDMI output modeline is
 the framework's own, and the 858-assuming `dvd/re_interlace.sv` is unreachable here (film is
-force-disabled under `analog_eff`). PAL 25p is already exact and is untouched.
+force-disabled under `analog_eff` — since the 2026-09-02 Video Output consolidation, the
+equivalent gate is `interlaced_eff`). PAL 25p is already exact and is untouched.
 
 `dvd/av_sync.sv` needs **no change**: `REFRESH_MHZ_FILM = 23976` was always the *correct*
 constant — it was the raster that didn't match it. Now they agree.

--- a/docs/history.md
+++ b/docs/history.md
@@ -416,3 +416,38 @@ dual-raster headline — CRT 480i with simultaneously-progressive HDMI — no lo
 with a CRT active, HDMI shows 480i. Reversal rationale recorded at the (retained)
 original decision block in `docs/roadmap.md`; superseded headers in
 `docs/interlaced_auto.md` and `docs/analog_dual_raster.md`.
+
+### §12 addendum — HW round 1: the boot-time modeline-walk reset race (2026-09-02)
+
+The first hardware round of the consolidation build (`DVD_videoout_20260902_1146`)
+failed immediately: with the analog ini bits set, the core booted reporting
+"719x5i", a disc load showed "719x1035123i @ 31.48 kHz", and the composite CRT was
+dead — while the Progressive path was fine. The reading: 31.48 kHz is the
+PROGRESSIVE line rate and the "i" flag means `VGA_F1` was toggling, so `il_eff`
+was asserted but the modeline never switched (Main's geometry measurement returns
+garbage line counts when F1 toggles against a progressive raster), and
+`re_interlace`'s period check therefore correctly refused to lock — dead analog.
+
+Root cause: a latent race the consolidation was the first to arm. The emu modeline
+walk keys on RAW `reset_n` and fires its six regfile writes starting the next
+clk_dec cycle, but `mpeg2video` synchronizes its resets internally (`reset.v`,
+cascaded 5-FF `sync_reset` stages) — `hard_rst`, which gates every modeline
+register in `regfile.v`, deasserts ~5–10 cycles AFTER `reset_n` rises. Writes in
+that window are silently discarded while the registers re-default to the
+progressive modeline, and the walk latches `il_prev` anyway, so no edge remains to
+retry. Invisible since the walk was built (2026-07): `il_eff` was always 0 at boot,
+so a swallowed init walk wrote the values the registers were resetting to anyway,
+and every later mode change came from the OSD with the decoder long alive.
+`Video Output = Auto` driving `il_eff` from the ini bits is the first boot-time
+walk that ever wrote something different from the reset defaults.
+
+Fix: a `dec_ready` gate — walk kicks wait until `core_sync_rst` (the decoder's own
+`sync_rst_out`, the last reset in the cascade to deassert, same clk_dec domain)
+has been observed high for 8 consecutive cycles. Proven by
+`bench/dvd/modeline_boot_tb.sv` (`run_modeline_boot.sh`), which drives the REAL
+`reset.v` + `regfile.v` with a verbatim copy of the walk: pre-fix it reproduces
+both failure shapes (total swallow — the exact HW symptom — and partial
+application, timing-dependent, matching "very broken"), while the OSD-toggle
+control passes even un-fixed, which is why no earlier HW round could have caught
+it. The walk is the only emu-side writer of decoder registers; any future one must
+gate on `sync_rst_out`, not `reset_n`.

--- a/docs/history.md
+++ b/docs/history.md
@@ -387,3 +387,32 @@ this is the shear-fix module and sim cannot prove hit-rate-under-real-traffic. S
 `releases/DVD_shimreclaim_20260828_0259.rbf`: the entire MiB movie played through plus
 menu/seek actions — no video issues, no shearing, no artifacting. Merged as PR #18
 (no release cut yet — rides with the next one; `` `CORE_VERSION `` 0.1e stays open).
+
+## 12. The video-output settings consolidation + the field-parity coin flip (2026-09-02)
+
+Two CRT field reports arrived within days of each other: the derive/weave analog path
+looked "extremely wobbly — not how an interlaced signal normally looks on a CRT" (the
+long-documented caveat-2 pairing defect, now seen in the wild), and `Analog Out = Native
+Fields` came back from any chapter skip / fast-forward / Analog Aspect change "super
+aliased", healed only by toggling the mode away and back "3 or 4 times". The
+repeat-until-fixed ritual was the tell: a 50/50 parity roll.
+
+The parity bug was root-caused to the junction of two individually-correct decisions: the
+mixer's relaxed frame-top matcher (the 3:2/drop black-fields fix) accepts a field at
+either raster parity slot, and nothing carried the raster's field parity back to
+`resample_addrgen`'s pickup — so one odd perturbation flipped content-field↔raster-field
+phase permanently (invisible under HDMI Bob, which is why it shipped unseen). Fixed with
+a feed-forward alternation guard plus a mixer→addrgen parity feedback loop that inserts
+exactly one held-frame field; the two triggers compose by XOR and the inserted field's
+type depends on which fired. Full design, the livelock the first draft had, and the
+RED/GREEN testbench evidence: `docs/field_parity.md`.
+
+With fieldpass immune to the wobble by construction and the re-engage hole closed, the
+user reversed the 2026-08-23 "all four Analog Out modes stay" decision and collapsed the
+surface to one option: `O[10:9] Video Output = Auto/Interlaced/Progressive` (Interlaced =
+Native Fields renamed; the derive modes, `Interlaced Out`, and the `det_video` detector
+deleted; `re_interlace` fieldpass-only; config layout `v,2`). The deliberate cost: the
+dual-raster headline — CRT 480i with simultaneously-progressive HDMI — no longer exists;
+with a CRT active, HDMI shows 480i. Reversal rationale recorded at the (retained)
+original decision block in `docs/roadmap.md`; superseded headers in
+`docs/interlaced_auto.md` and `docs/analog_dual_raster.md`.

--- a/docs/interlaced_auto.md
+++ b/docs/interlaced_auto.md
@@ -1,6 +1,19 @@
 # Interlaced Out: Auto — native 480i/576i fields for true-interlaced video
 
-**Status: ✅ HW-CONFIRMED + MERGED (PR fj#132, 2026-07-27) — `On`/`Off` ship; `Auto` parked opt-in.**
+**Status: ⛔ SUPERSEDED (2026-09-02, branch `feature/video-output-consolidation`) — the
+`O[10:9] Interlaced Out` option and its `det_video` auto-detector are REMOVED.** The
+settings surface collapsed to one `O[10:9] Video Output = Auto/Interlaced/Progressive`
+control: `Interlaced` is the old "Native Fields" behavior (authored fields session-wide;
+HDMI 480i via ascal — the same picture Interlaced Out=On gave an HDMI rig), `Auto` is
+ini-driven and boot-static, and the mid-title `Auto` content detector died with its known
+audio-skew problem. The fields RASTER this doc designed (the il_eff modeline branch,
+syncgen behavior, VGA_F1/ascal handling, the mid-stream `il_switch` flush) **still ships
+unchanged** and is what Video Output=Interlaced engages — only the option surface and the
+detector are gone. Rationale + field reports: `docs/field_parity.md`,
+`docs/analog_dual_raster.md` status, roadmap "Video Output consolidation". The body below
+is kept as the engineering history of the raster design.
+
+*(Historical status at supersession:)* ✅ HW-CONFIRMED + MERGED (PR fj#132, 2026-07-27) — `On`/`Off` shipped; `Auto` parked opt-in.
 Sim-verified: `bench/dvd/film_detect_tb.sv` (extended with `det_video` cases). HW round 1–2
 (2026-07-26/27): interlaced detection + mode switching work, and **`On`/`Off` both play with
 correct A/V sync (HW-confirmed)** — but **`Auto`'s mid-title switch still leaves audio

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -630,11 +630,15 @@ motion-comp starvation that caused the misses (keep Frame Drop On as a safety ne
   in `dvd/resample_addrgen.v` (sustained `progressive_frame==0`) drives **Auto**
   (auto-engage for true-interlaced video; mid-title switch via a full seek-style flush).
   **⚠️ Auto PARKED as opt-in — its mid-title switch still leaves audio slightly out of
-  sync on HW; default is Off.** Open follow-up: the residual Auto-switch audio skew.
+  sync on HW; default is Off.**
   The **overlay/OSD horizontal squish in interlaced mode is ✅ FIXED (2026-08-22)** —
   pixrep `h_pos` map + `spu_decode`/`crt_ov_map` `.interlaced` following `il_eff`,
   shipped as a prerequisite of `Analog Out = Native Fields`.
-  See `docs/interlaced_auto.md`.
+  **⛔ OPTION RETIRED 2026-09-02** (`feature/video-output-consolidation`): the fields
+  raster it built still ships as `Video Output = Interlaced`; the separate option, the
+  `det_video` detector, and the Auto-switch audio-skew follow-up are all deleted with
+  the consolidation. See `docs/interlaced_auto.md` (superseded header) +
+  `docs/field_parity.md`.
 - ⛔ **[dropped — not needed (2026-09-01, user decision) — Film 24p and 25p both shipped and are HW-confirmed; what this line added beyond them was never established]** **Film 3:2 / PAL-25-from-24** `SHOW_N` cadence handling (separate from the above).
 
 ### Composite / Interlaced Analog Output for CRT (primary end goal)
@@ -1598,7 +1602,9 @@ falls back to the largest-VTS heuristic, which is documented to pick the wrong t
 some discs. Every other default audited and left as-is (Aspect Auto, Audio On, Audio Out
 Decode HDMI, Player Language English, Interlaced Out Off, Analog Out Auto, Analog Aspect
 Auto, Video Standard Auto, Frame Drop On, Audio Genlock On, Film 24p Auto, A/V Offset
-+100 ms, Debug Overlay Off, Title VTS Auto).
++100 ms, Debug Overlay Off, Title VTS Auto). *(2026-09-02: Interlaced Out + Analog Out
+have since been consolidated into `Video Output`, default Auto — see the reversal note
+further down.)*
 
 **⚠ The saved-status hazard (applies to every future default flip).** A MiSTer
 `CONF_STR` value list is positional — status value 0 is the FIRST label — and the
@@ -1761,7 +1767,23 @@ status; rip instructions with `tools/css_scan.py` as pre-flight; a settings refe
 covering every OSD option — including the `Analog Out` mode table below and a prominent
 **Frame Drop must stay On** warning; `MiSTer.ini` lines for analog/CRT output.
 
-**`Analog Out` — why all four modes stay (2026-08-23 review).** `Native Fields` and
+**`Analog Out` — why all four modes stay (2026-08-23 review). ⛔ REVERSED 2026-09-02
+(branch `feature/video-output-consolidation`, user decision).** The 2026-08-23 reasoning
+below was correct about the mechanics but its keep-them-all conclusion did not survive
+contact with the field: (1) the derive path's field-pairing wobble (this doc's
+"re-randomised several times a second") was REPORTED FROM THE WILD as "extremely wobbly,
+not how an interlaced signal normally looks on a CRT"; (2) Native Fields shipped with a
+separate field-parity re-engage coin flip ("super aliased after a chapter skip, toggle
+the mode 3-4 times to fix") — root-caused and FIXED (`docs/field_parity.md`); (3) with
+that fixed, fieldpass strictly dominates derive on the CRT side, and the maintainer chose
+to drop the one thing derive still bought (CRT 480i + progressive HDMI simultaneously —
+pick-your-output instead). The surface collapsed to **one option, `O[10:9] Video Output
+= Auto/Interlaced/Progressive`** (`Interlaced` = the old Native Fields renamed; `Auto` =
+the ini rule, boot-static; `O[27:26]` freed/dead; `Interlaced Out` + its `det_video`
+Auto detector deleted; config layout `v,2`). The persistence analysis in the last
+paragraph below still applies verbatim to the new option.
+
+*(Historical, pre-reversal:)* `Native Fields` and
 `Interlaced` are NOT redundant. Both force the analog raster on, but `Native Fields`
 also forces `il_eff`, which makes the MAIN raster interlaced ⇒ HDMI drops to 480i via
 ascal for the session, and ascal is not cadence-aware ⇒ **film regresses on HDMI**.
@@ -1776,8 +1798,9 @@ mid-title (Native Fields fires the `il_switch` flush).
 | CRT **and** HDMI simultaneously | **Auto / Interlaced** — Native Fields costs HDMI |
 | 15 kHz RGBHV rig the ini can't identify | **Interlaced** |
 
-**OSD overrides always beat the ini, and they persist.** `analog_eff` takes the ini
-(`analog_want`) only under `analog_mode == 2'd0` (Auto); `Progressive` (mode 2) matches
+**OSD overrides always beat the ini, and they persist.** `analog_eff` (now
+`interlaced_eff`) takes the ini
+(`analog_want`) only under mode Auto; `Progressive` matches
 none of the OR terms so it is unconditionally off. `emu.sv` never drives
 `status_set`/`status_in`, so nothing in fabric clobbers a restored selection — picking
 `Progressive` with `composite_sync=1` still in MiSTer.ini survives every reload.

--- a/dvd/crt_ov_map.sv
+++ b/dvd/crt_ov_map.sv
@@ -66,7 +66,7 @@ module crt_ov_map (
     /* DVD-FORK FIX (SIF analog fill): invert the addrgen 2x line repeat (vscale_mode==2).
      * The forward walk (resample_addrgen, v_step=128, rounded) maps output line i to
      * source line min(floor((i+1)/2), v_src_max) on the progressive path; on the
-     * interlaced (Native Fields) path each field walks its own parity:
+     * interlaced (Video Output = Interlaced) path each field walks its own parity:
      * field line i, parity p -> min(p + 2*floor((i+1)/2), v_src_max). This stage
      * post-maps the letterbox mux's candidate (letterbox output is a line in DOUBLED
      * space — the 2x repeat happens upstream of disp_vscale — so the two inverses

--- a/dvd/disp_vscale.sv
+++ b/dvd/disp_vscale.sv
@@ -16,7 +16,7 @@
  * mirrors dvd/disp_hstretch.sv (the horizontal Crop stretcher) but on the vertical axis.
  *
  * FIELD PATH (480i): when the decoder is in NATIVE-FIELDS mode (`interlaced=1`, i.e. O[10:9]
- * Interlaced Out, or Analog Out = Native Fields) resample_addrgen emits a whole field's lines
+ * Video Output = Interlaced; was Interlaced Out / Native Fields) resample_addrgen emits a whole field's lines
  * contiguously (all one parity), so "adjacent stream lines" are adjacent SAME-FIELD source
  * lines — blending them is parity-safe (no inter-field comb / twitter) for both film (rff 3:2)
  * and true-interlaced content. Each field is an independent resampling pass, re-armed on its
@@ -32,7 +32,7 @@
  *   - true-interlaced content: the blend genuinely CROSS-FADES two time instants. It is not a
  *     deinterlacer and not a correctness bug (it softens rather than combs), but it is real.
  * Only Letterbox (disp_vscale_en = analog_letterbox, i.e. Auto-on-16:9 or manual) reaches this;
- * Fit and Crop never blend vertically. Analog Out = Native Fields restores the parity-safe
+ * Fit and Crop never blend vertically. Video Output = Interlaced restores the parity-safe
  * premise, because it puts the decoder back on the field path. See docs/analog_dual_raster.md.
  *
  * BARS: unchanged. This module just emits the 360 / 180 CONTENT lines (carrying the scan's

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -3298,6 +3298,31 @@ always @(*) begin
     endcase
 end
 
+// DVD-FORK FIX (boot-time walk reset race, 2026-09-02 — HW round 1 of the Video
+// Output consolidation): this block keys on RAW reset_n, but the decoder
+// synchronizes its resets INTERNALLY (rtl/mpeg2/reset.v: cascaded 5-FF
+// sync_reset stages), so hard_rst — which gates every modeline register in
+// regfile.v — deasserts ~5-10 clk_dec cycles AFTER reset_n rises. A walk kicked
+// in that window has its writes silently discarded while the registers
+// re-default to the PROGRESSIVE modeline, and il_prev latches anyway, so
+// nothing retries: the core then runs a progressive raster (31.47 kHz) with
+// VGA_F1 toggling — the HW report's "719x...i @ 31.48kHz", dead CRT. The race
+// was here since the walk was built but INVISIBLE: il_eff was always 0 at boot
+// (a swallowed init walk wrote the reset defaults anyway) and every change came
+// later via OSD with the decoder long alive. `Video Output = Auto` driving
+// il_eff from the MiSTer.ini bits is the first boot-time walk that matters.
+// FIX: gate every kick on the decoder's own synchronized reset (core_sync_rst =
+// mpeg2video.sync_rst_out, clk_dec domain, the LAST reset to deassert) having
+// been observed high for 8 consecutive cycles. Pending changes are simply
+// applied by the first post-ready walk — il_s2/pal_s2/filmp_s2 keep tracking.
+// Proven RED (swallowed walk, both partial and total) / GREEN by
+// bench/dvd/modeline_boot_tb.sv over the REAL reset.v + regfile.v.
+reg [2:0] dec_rdy_cnt = 3'd0;
+always @(posedge clk_dec)
+    if (!reset_n || !core_sync_rst) dec_rdy_cnt <= 3'd0;
+    else if (dec_rdy_cnt != 3'd7)   dec_rdy_cnt <= dec_rdy_cnt + 3'd1;
+wire dec_ready = (dec_rdy_cnt == 3'd7);   // decoder regfile writable (with margin)
+
 always @(posedge clk_dec) begin
     if (!reset_n) begin
         il_s1 <= 1'b0; il_s2 <= 1'b0; il_prev <= 1'b0;
@@ -3314,7 +3339,8 @@ always @(posedge clk_dec) begin
         if (seq_run) begin
             if (seq_step == 3'd5) seq_run <= 1'b0;
             seq_step <= seq_step + 3'd1;
-        end else if (!il_init || (il_s2 != il_prev) || (pal_s2 != pal_prev) || (filmp_s2 != filmp_prev)) begin
+        end else if (dec_ready &&
+                     (!il_init || (il_s2 != il_prev) || (pal_s2 != pal_prev) || (filmp_s2 != filmp_prev))) begin
             il_prev  <= il_s2;                   // latch the values being applied
             pal_prev <= pal_s2;
             filmp_prev <= filmp_s2;

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -155,40 +155,38 @@ assign VIDEO_ARY    = (analog_letterbox | analog_crop) ? 13'd3 : (ar_wide_eff | 
 // pal_eff: resolved PAL/50Hz flag (Auto-detected or forced via O[17:16]); assigned
 // near the decoder instance once core_vertical_size / pal_det_s2 exist.
 wire pal_eff;
-// DVD-FORK (dual-raster analog output, supersedes the O[14] whole-core CRT mode):
-// the native 15 kHz CRT raster is now a SECOND, simultaneous output
-// (dvd/re_interlace.sv -> VGA2_*) instead of a whole-core mode switch — HDMI keeps
-// the progressive main raster while the analog pins get broadcast 480i/576i
-// (PAL included). It auto-engages from the MiSTer.ini video bits like any other
-// MiSTer core: vga_scaler=0 plus an analog-TV signal type configured
-// (composite_sync / ypbpr / vga_sog), or direct_video (HDMI DAC -> CRT; the
-// direct-video tap sits on the muxed analog chain in sys_top). forced_scandoubler
-// vetoes Auto (a 31 kHz VGA rig). O[27:26] "Analog Out" overrides:
-//   Auto (default) = the ini rule above;
-//   Interlaced     = force the 480i raster (15 kHz RGBHV rigs none of the ini
-//                    bits identify);
-//   Progressive    = force it off (component/VGA displays that want 480p, and
-//                    dev A/B testing — the analog pins then carry the main
-//                    progressive raster through the stock bit-identical path);
-//   Native Fields  = force the 480i raster AND put the decoder in native-fields
-//                    mode, so the re-interlacer re-times AUTHORED fields 1:1
-//                    instead of splitting a woven progressive frame. This is the
-//                    structural fix for the field-pairing defect (caveat 2): a
-//                    governor late costs an ODD +1 refresh on the progressive
-//                    path, flipping the pairing parity ~4x/s, but an EVEN +2 on
-//                    the field path. Opt-in because it makes the MAIN raster
-//                    interlaced too, so HDMI drops to 480i via ascal bob/weave
-//                    for the session (ascal is not cadence-aware => film
-//                    regresses on HDMI). SET IT BEFORE LOADING A DISC: changing
-//                    it mid-title toggles il_eff and therefore fires the full
-//                    seek-equivalent il_switch flush.
-// See docs/analog_dual_raster.md.
+// DVD-FORK (Video Output consolidation, 2026-09-02 — replaces the O[10:9]
+// "Interlaced Out" + O[27:26] "Analog Out" pair):
+// ONE output-mode choice, O[10:9] "Video Output" = Auto / Interlaced / Progressive.
+//   Interlaced  = the old "Analog Out = Native Fields", renamed: the decoder runs in
+//                 native-fields mode (il_eff — the MAIN raster is the pixrep 480i/576i
+//                 fields raster), dvd/re_interlace.sv re-times the AUTHORED fields 1:1
+//                 onto the 15 kHz half-line analog raster (VGA2_*), and HDMI gets 480i
+//                 via ascal (OB Bob/Weave). Structurally immune to the derive path's
+//                 field-pairing defect (a governor late re-scans a field PAIR = even),
+//                 and the field-parity corrector (docs/field_parity.md) keeps
+//                 content-field <-> raster-field alignment through seeks/restarts.
+//   Progressive = the progressive main raster: full HDMI quality, Film 24p available,
+//                 and the analog pins carry the progressive raster through the stock
+//                 path (480p/576p-capable analog displays).
+//   Auto        = ini-driven, boot-static: an analog TV configured in MiSTer.ini
+//                 (vga_scaler=0 plus composite_sync / ypbpr / vga_sog, or direct_video;
+//                 forced_scandoubler vetoes = a 31 kHz VGA rig) resolves to Interlaced,
+//                 else Progressive — the same ini workflow as every other core.
+// The 2026-07 dual-raster DERIVE (weave) modes — CRT 480i built from the progressive
+// raster, HDMI simultaneously progressive — are DELETED (field-reported "extremely
+// wobbly": the pairing parity flips on every governor late, ~4/s; the simultaneity was
+// deliberately traded away — pick-your-output). SET THE MODE BEFORE LOADING A DISC:
+// changing it mid-title toggles il_eff and fires the full seek-equivalent il_switch
+// flush (the parity corrector heals the field phase, but the flush itself restarts
+// playback). See docs/analog_dual_raster.md (history + fieldpass design),
+// docs/interlaced_auto.md (superseded), docs/field_parity.md.
 wire direct_video;                        // hps_io cfg[10] (declared early for the gating here)
 wire forced_scandoubler;                  // hps_io cfg[4]
 wire ini_vga_scaler, ini_csync, ini_ypbpr, ini_sog;  // hps_io MiSTer.ini exports (DVD-FORK)
 wire hdmi_bs_ack;                                    // cfg[14] HPS ack (DVD-FORK, HDMI bitstream)
 wire bs_stb_w;                                       // 48 kHz pair strobe from iec61937_wrap
-wire [1:0] analog_mode = status[27:26];   // 0=Auto 1=Interlaced 2=Progressive 3=Native Fields
+wire [1:0] video_out_mode = status[10:9]; // 0=Auto 1=Interlaced 2=Progressive (O[27:26] left dead — old Analog Out)
 // Debug "Title VTS" override (P1, two BCD digits -> VTS 1..99; 0 = Auto).
 // See the CONF_STR note at the retired O[31:28] slot.
 wire [3:0] dbg_tv_tens  = status[35:32];
@@ -218,10 +216,12 @@ always @(*) case (status[43:40])
 endcase
 wire       analog_want = ((ini_csync | ini_ypbpr | ini_sog) & ~ini_vga_scaler & ~forced_scandoubler)
                        | direct_video;
-// Native Fields: session flag driving BOTH the analog raster and the decoder mode.
-wire       analog_fields = (analog_mode == 2'd3);
-wire       analog_eff  = (analog_mode == 2'd1) | analog_fields
-                       | ((analog_mode == 2'd0) & analog_want);
+// The ONE resolved output mode. Session flag: drives the decoder fields mode (il_eff),
+// the analog 15 kHz raster (re_interlace/VGA2), and every analog-only nicety (SIF fill,
+// Analog Aspect, line-21 CC). analog_want is latched from the HPS cfg word at core boot,
+// so Auto is boot-static — interlaced_eff only ever changes on an OSD edit (il_switch).
+wire       interlaced_eff = (video_out_mode == 2'd1)
+                          | ((video_out_mode == 2'd0) & analog_want);
 // Analog Aspect resolves near the decoder (needs ar_wide_auto_eff); forward-declared
 // like ar_wide_eff/pal_eff so VIDEO_ARX/ARY above can reference them.
 wire analog_letterbox, analog_crop;
@@ -239,41 +239,26 @@ wire analog_letterbox, analog_crop;
 //   telecine, PAL = sustained progressive = native 25p). CRT can't do 24/25 Hz on the
 //   analog pins, so forced off there. See docs/film_24p_plan.md §9.
 wire        film_det_ntsc_sync, film_det_pal_sync;   // driven near the decoder instance
-wire        il_det_sync;                             // DVD-FORK (Interlaced Out auto): true-interlaced verdict, clk_sys (driven near the decoder instance)
 // Enum ORDER makes AUTO the power-on default: MiSTer status bits reset to 0, and
 // index 0 = "Auto" in the CONF_STR below, so an unconfigured core film-detects.
 wire [1:0]  film_mode  = status[25:24];              // 0=Auto 1=Off 2=On
 wire        film_det   = pal_eff ? film_det_pal_sync : film_det_ntsc_sync;
 wire        film_want  = (film_mode == 2'b10) | ((film_mode == 2'b00) & film_det);
-// DVD-FORK (dual-raster): the 23.976/25 Hz film raster cannot feed the analog
-// re-interlacer (no frame store for the rate conversion), so an active analog
-// output suppresses it — HDMI falls back to the in-core 3:2 at 59.94p (today's
-// default quality), the CRT keeps its fields. ini-driven, boot-static.
-wire        filmp_eff  = film_want & ~analog_eff;    // progressive-film raster wanted
+// The 23.976/25 Hz film raster is a PROGRESSIVE-mode feature: it cannot carry fields
+// (and cannot feed the analog re-timer — no frame store for the rate conversion), so
+// Interlaced mode suppresses it. Film on the CRT then plays with its normal 3:2 field
+// cadence — exactly what an NTSC set-top player output.
+wire        filmp_eff  = film_want & ~interlaced_eff; // progressive-film raster wanted
 wire        film24_eff = filmp_eff & ~pal_eff;       // NTSC 23.976 Hz path
 wire        film25_eff = filmp_eff &  pal_eff;        // PAL  25.000 Hz path
-// DVD-FORK (Interlaced Out — auto detect): O[10:9] is a 3-way Off/Auto/On enum. Default
-// is Off (index 0 = power-on default) — Auto's mid-title switch still leaves audio slightly
-// out of sync on HW (2026-07-27), so Auto is kept as an opt-in for revisiting rather than
-// the default. Auto engages the native fields path when the decoder's true-interlaced
-// detector (det_video -> il_det_sync) fires; On forces it; Off keeps the progressive weave.
-// Standard-neutral: covers both NTSC 480i and PAL 576i (the detector keys on
-// progressive_frame, not the standard).
-wire [1:0]  il_mode = status[10:9];                  // 0=Off 1=Auto 2=On
-wire        il_want = (il_mode == 2'd2) | ((il_mode == 2'd1) & il_det_sync);
-// il_eff: effective interlaced-output mode (the HDMI native-fields raster, O[10:9]).
-// Film 24p/25p wins (progressive-film raster can't also be interlaced). DVD-FORK
-// (dual-raster) v1: an active ANALOG output also forces it off — the re-interlacer
-// needs the standard progressive main raster (its period check rejects the pixrep
-// fields raster), and the weave frames still carry both fields so the CRT gets true
-// 480i content. Trade-off: HDMI temporarily loses native-fields mode while an
-// analog TV is configured.
-// DVD-FORK (Analog Out = Native Fields, 2026-08-22): that mode is the field-passthrough
-// follow-up — it FORCES native fields on so the re-interlacer re-times authored fields
-// instead of deriving them from a weave. Held for the whole session (the mode is an OSD
-// bit, so a mid-title change fires il_switch's seek-equivalent flush — documented at the
-// CONF_STR). filmp_eff is already 0 here because analog_eff is 1.
-wire il_eff = analog_fields | (il_want & ~filmp_eff & ~analog_eff);
+// il_eff: the decoder/main-raster fields mode — now simply the resolved Video Output
+// verdict (kept as its own name because ~15 consumers ride it: VGA_F1, HDMI_BOB_DEINT,
+// the modeline walk, il_switch, the pixrep overlay inverses, re_interlace). Interlaced
+// mode owns the session outright: film_want does NOT override it (Film 24p is a
+// Progressive-mode feature, see filmp_eff above). The old derivation
+// (analog_fields | (il_want & ~filmp_eff & ~analog_eff)) died with the Interlaced Out
+// option and the derive modes — Video Output consolidation, 2026-09-02.
+wire il_eff = interlaced_eff;
 assign VGA_F1       = il_eff ? ~core_v_pos[0] : 1'b0;
 assign VGA_SL       = 0;
 // DVD-FORK (dual-raster analog output): VGA_SCALER is never forced any more —
@@ -609,27 +594,25 @@ parameter CONF_STR = {
     // (audio/subtitle preference, read by disc nav commands to auto-select
     // streams). Takes effect at the next menu jump / disc mount. status[43:40].
     "O[43:40],Player Language,English,French,German,Spanish,Italian,Japanese,Chinese,Korean,Portuguese,Russian,Dutch,Swedish,Danish,Norwegian,Finnish,Polish;",
-    "O[10:9],Interlaced Out,Off,Auto,On;",
+    // Video Output (DVD-FORK consolidation 2026-09-02, replaces "Interlaced Out"
+    // O[10:9] + "Analog Out" O[27:26] — bits [27:26] are left DEAD/reserved one
+    // release so stale saved status can't re-arm the old enum; the relayout is why
+    // the config version below is "v,2"). ONE output-mode choice:
+    //   Auto (default) = ini-driven: an analog TV configured in MiSTer.ini
+    //                    (vga_scaler=0 AND composite_sync/ypbpr/vga_sog, or
+    //                    direct_video=1) => Interlaced, else Progressive — the same
+    //                    ini workflow as every other core, nothing to set here.
+    //   Interlaced     = the disc's AUTHORED fields (decoder in native-fields mode;
+    //                    dvd/re_interlace.sv re-times them 1:1 onto the 15 kHz
+    //                    half-line analog raster; HDMI shows 480i via ascal, OB
+    //                    Bob/Weave below). Set it BEFORE loading a disc — a
+    //                    mid-title change fires the seek-equivalent il_switch flush.
+    //   Progressive    = the progressive raster: full HDMI quality, Film 24p
+    //                    available, analog pins carry 480p/576p through the stock
+    //                    path (component/VGA displays; also the dev A/B switch).
+    // status[10:9]. See docs/analog_dual_raster.md, docs/field_parity.md.
+    "O[10:9],Video Output,Auto,Interlaced,Progressive;",
     "OB,480i Deint,Bob,Weave;",
-    // Analog Out (DVD-FORK dual raster, supersedes O[14] "CRT 480i Out" — bit 14 is
-    // left DEAD/reserved one release so stale per-core saved status can't re-arm it):
-    // the native 15 kHz 480i/576i SECOND raster on the analog pins.
-    //   Auto (default) = engage exactly when MiSTer.ini configures an analog TV
-    //                    (vga_scaler=0 AND composite_sync/ypbpr/vga_sog) or
-    //                    direct_video=1 — same ini workflow as every other core,
-    //                    nothing to set here.
-    //   Interlaced     = force the 480i raster (15 kHz RGBHV rigs the ini bits
-    //                    can't identify).
-    //   Progressive    = force it off (component/VGA displays that take 480p/576p;
-    //                    also the dev A/B switch — the analog pins then carry the
-    //                    main progressive raster, stock path);
-    //   Native Fields  = 480i from the disc's AUTHORED fields (decoder in native-
-    //                    fields mode, re-interlacer re-times 1:1). Best CRT motion
-    //                    on video-sourced discs and immune to the field-pairing
-    //                    defect, at the cost of HDMI dropping to 480i via ascal for
-    //                    the session. Set it BEFORE loading a disc.
-    // status[27:26]. See docs/analog_dual_raster.md.
-    "O[27:26],Analog Out,Auto,Interlaced,Progressive,Native Fields;",
     // Analog Aspect: how anamorphic content is fitted to the 4:3 analog TV (ONLY
     // active while the analog 480i raster is engaged). Auto = Fit for 4:3 streams,
     // Letterbox for 16:9 (from the sequence header aspect code). Fit = raster
@@ -647,15 +630,15 @@ parameter CONF_STR = {
     // @ 50 Hz, same 27 MHz clock — 864x625 total = 50.0 Hz). Switches the runtime
     // modeline-write walk AND av_sync's STC tick rate. Auto (default) picks from the
     // stream's vertical_size (480=NTSC, 576=PAL); NTSC/PAL force it (handy for HW
-    // bring-up without a matching disc). status[17:16]: 0=Auto, 1=NTSC, 2=PAL. PAL now
-    // supports native 576i fields (Interlaced Out Auto/On) for true-interlaced video;
-    // PAL film stays 25p. PAL 576i on the analog pins is handled by the dual-raster
-    // re-interlacer (docs/analog_dual_raster.md).
+    // bring-up without a matching disc). status[17:16]: 0=Auto, 1=NTSC, 2=PAL. PAL
+    // supports native 576i fields (Video Output = Interlaced) for true-interlaced
+    // video; PAL film stays 25p. PAL 576i on the analog pins rides the fieldpass
+    // re-timer (docs/analog_dual_raster.md).
     // The governor's SHOW_N=2 gives 25 fps from a 50 Hz display. See
     // docs/frame_rate_governor.md / docs/av_sync.md / docs/interlaced_auto.md.
     "O[17:16],Video Standard,Auto,NTSC,PAL;",
     // (DVD-FORK dual raster: the bogus "O[10],Direct Video,Off,On;" entry that used
-    // to sit here is DELETED — it collided with O[10:9] Interlaced Out (setting it
+    // to sit here is DELETED — it collided with the O[10:9] enum (setting it
     // silently forced native fields), and the real direct_video signal comes from
     // the HPS cfg word, not status.)
     // -------------------------------------------------------------------------
@@ -728,7 +711,8 @@ parameter CONF_STR = {
     // by cutting the core's framebuffer re-reads, so motion-comp stops missing
     // deadlines. Off/On/Auto: On forces it (hard-telecine discs); Auto engages only on
     // a confident sustained film cadence (an in-fabric detector). HDMI-only (forced off
-    // under CRT); wins over O9 Interlaced Out. status[25:24]. See docs/film_24p_plan.md.
+    // under Video Output = Interlaced — fields and a 23.976 Hz raster are mutually
+    // exclusive). status[25:24]. See docs/film_24p_plan.md.
     // Auto is FIRST so it's the power-on default (status bits reset to 0).
     "P1O[25:24],Film 24p Out,Auto,Off,On;",
     // A/V Offset: signed playback-start trim for the PTS-scheduled audio drain
@@ -753,7 +737,7 @@ parameter CONF_STR = {
     // Menus polarity flip did exactly that pre-versioning). Bumping orphans
     // the old file and falls everyone back to defaults -- there is no per-bit
     // migration, so audit the index-0 label of every option when bumping.
-    "v,1;",
+    "v,2;",   // v2: 2026-09-02 Video Output consolidation relayout (O[10:9] re-enumerated, O[27:26] retired)
     // Gamepad transport (dvd/dvd_iso_reader seek + presentation-clock pause) +
     // disc-menu nav (Phase 2). The J1 list names buttons B1..B11 for the MiSTer
     // "Define buttons" menu (bits 4..14 of joystick_0; D-pad = bits 3:0). The
@@ -1967,10 +1951,11 @@ wire [2:0] sp_track_eff  = (menus_on && menu_active) || sp_menu_early ? 3'd0 :
                                                             sp_user_log;
 
 // =========================================================================
-// DVD-FORK (Interlaced Out auto): a LIVE interlaced<->progressive mode change must
+// DVD-FORK (live output-mode switch — built for Interlaced Out Auto, now serving the
+// Video Output OSD toggle): a LIVE interlaced<->progressive mode change must
 // re-init the pipeline the same way loading an ISO does. Flipping the modeline mid-title
 // re-kicks the register walk (emu ~2240) but the decoder/ascal keep running in the old
-// raster (observed on HW: toggling Interlaced Out mid-playback stayed progressive; setting
+// raster (observed on HW: toggling the fields mode mid-playback stayed progressive; setting
 // it BEFORE load worked because the pipeline cold-starts into the mode).
 //   il_switch therefore drives the FULL seek-equivalent flush, NOT just the VBUF flush:
 //   - seek_flush -> vbuf_flush_dec : the decoder discards its buffered bitstream and
@@ -1987,8 +1972,9 @@ wire [2:0] sp_track_eff  = (menus_on && menu_active) || sp_menu_early ? 3'd0 :
 //   ~1 s LATE under Auto (On/Off never flush mid-stream, so they stayed synced). The full
 //   flush is exactly what a chapter seek does (HW-confirmed synced); the only difference is
 //   the reader doesn't jump, so ps_demux re-hunts to the next pack boundary within the vbuf
-//   re-lock glitch. Deep detector hysteresis => Auto fires this ~once/title. Also fixes the
-//   live manual On/Off toggle. il_switch is a one-clk_sys-cycle pulse. See docs/interlaced_auto.md.
+//   re-lock glitch. Since the 2026-09-02 consolidation il_eff changes ONLY on an OSD edit
+//   of Video Output (the det_video Auto detector is gone; Auto is ini-static), so this
+//   fires at user rate. il_switch is a one-clk_sys-cycle pulse. See docs/interlaced_auto.md.
 // Declared here (above CLIP-LOAD FLUSH) so it precedes its use in load_flush/aud_flush.
 reg       il_eff_q = 1'b0;
 wire      il_switch = il_eff ^ il_eff_q;
@@ -3157,12 +3143,13 @@ wire [15:0] shim_debug_read_pend_cycles;
 wire [15:0] shim_debug_cache_missrate;   // {miss%, read-intensity} per window (row 6)
 
 // =========================================================================
-// DVD-FORK FIX (interlaced cadence): native 480i output as O9 "Interlaced Out"
+// DVD-FORK FIX (interlaced cadence): the native 480i/576i fields modeline
+// (built as O9 "Interlaced Out", now driven by Video Output = Interlaced via il_eff)
 // =========================================================================
 // Interlaced DVD content (480i60) played JUDDERY at ~half temporal rate because
 // the decoder defaults (reg_wr_en=0 => deinterlace=1, interlaced=0) WEAVE both
 // fields into one progressive frame and show only 30 distinct frames/s — the
-// 60-field motion is thrown away. Fix: when O9 is on, switch the modeline to
+// 60-field motion is thrown away. Fix: when il_eff is on, switch the modeline to
 // native 480i and force deinterlace OFF, so the resample emits TWO fields per
 // decoded frame (TOP then BOTTOM), filling the 60 Hz output with 60 distinct
 // motion phases. VGA_F1 tags the field; MiSTer's ascal scaler deinterlaces it
@@ -3435,25 +3422,20 @@ mpeg2video mpeg2video_inst (
     .menu_ff           (1'b0),                         // DVD-FORK (menu VBUF-lag §5): fast-drain RETIRED (HW-inert); menu_ff=0 = bit-identical governor
     .film24            (filmp_dec),                    // DVD-FORK (Film 24p/25p Out): 1 frame/refresh in the governor; ascal does the pulldown
     .film_det_ntsc     (core_film_det_ntsc),           // DVD-FORK (Film 24p auto-detect): 3:2 telecine verdict (clk_dec)
-    .film_det_pal      (core_film_det_pal),            // DVD-FORK (Film 24p auto-detect): sustained-progressive verdict (clk_dec)
-    .det_video         (core_det_video)                // DVD-FORK (Interlaced Out auto): sustained true-interlaced-video verdict (clk_dec)
+    .film_det_pal      (core_film_det_pal)             // DVD-FORK (Film 24p auto-detect): sustained-progressive verdict (clk_dec)
 );
 // DVD-FORK (Film 24p auto-detect): 2-FF sync the governor's clk_dec cadence verdicts
 // into clk_sys, where film_want / filmp_eff resolve the Off/On/Auto mode (the reverse
 // of the film24_eff -> filmp_dec feed above). The verdicts are hysteretic (change at
 // most ~1/s), so a plain 2-FF sync is sufficient. See docs/film_24p_plan.md §9a.
 wire core_film_det_ntsc, core_film_det_pal;
-wire core_det_video;                        // DVD-FORK (Interlaced Out auto): true-interlaced verdict (clk_dec)
 reg  film_det_ntsc_s1, film_det_ntsc_s2, film_det_pal_s1, film_det_pal_s2;
-reg  det_video_s1, det_video_s2;            // DVD-FORK (Interlaced Out auto): 2-FF clk_dec->clk_sys
 always @(posedge clk_sys) begin
     film_det_ntsc_s1 <= core_film_det_ntsc; film_det_ntsc_s2 <= film_det_ntsc_s1;
     film_det_pal_s1  <= core_film_det_pal;  film_det_pal_s2  <= film_det_pal_s1;
-    det_video_s1     <= core_det_video;     det_video_s2     <= det_video_s1;
 end
 assign film_det_ntsc_sync = film_det_ntsc_s2;
 assign film_det_pal_sync  = film_det_pal_s2;
-assign il_det_sync        = det_video_s2;
 // DVD-FORK (frame-drop governor O[12]): 2-FF sync the static toggle into clk_dec.
 // "On,Off" (default ON, 2026-07-02): with the cadence-correct governor both NTSC
 // film and PAL stutter withOUT frame drop (real lates hold the display), and the
@@ -3574,11 +3556,11 @@ always @(posedge clk_sys or negedge reset_n) begin
         sif_v_s1 <= sif_v_dec; sif_v_s2 <= sif_v_s1;
     end
 end
-// Gated on analog_eff (the Letterbox/Crop pattern): HDMI-only rigs keep the narrow DE
+// Gated on interlaced_eff (the Letterbox/Crop pattern): HDMI-only rigs keep the narrow DE
 // window + ascal's polyphase scale (HW-proven for MPEG-1); the fill exists because the
 // analog chain (re_interlace + direct video) needs a true 720-wide raster line.
-wire sif_hfill_eff = analog_eff & sif_h_s2;   // horizontal 352->720 stretch
-wire sif_v2x_eff   = analog_eff & sif_v_s2;   // vertical 2x line repeat (240->480 / 288->576)
+wire sif_hfill_eff = interlaced_eff & sif_h_s2;   // horizontal 352->720 stretch
+wire sif_v2x_eff   = interlaced_eff & sif_v_s2;   // vertical 2x line repeat (240->480 / 288->576)
 // DVD-FORK FIX (SIF analog fill): decoded height, 2-FF synced (hsz_s2 pattern) — feeds
 // crt_ov_map's v2x inverse clamp (v_src_max = vertical_size-1).
 reg  [13:0] vsz_s1, vsz_s2;
@@ -3643,7 +3625,7 @@ assign ar_wide_eff = (status[20:19] == 2'b01) ? 1'b0 :   // force 4:3
 //   - disp_hcrop_en (HORIZONTAL, dvd/disp_hstretch.sv): Crop = horizontal pan-scan — the
 //     addrgen reads only the centre columns and the stretcher fills the raster width
 //     (full vertical resolution, no bars). 0 for Fit/Letterbox.
-// ONLY active while the analog 480i raster is engaged (analog_eff). NOTE (dual
+// ONLY active while the analog 480i raster is engaged (interlaced_eff). NOTE (dual
 // raster): the rescale is upstream in the SHARED raster, so HDMI shows it too —
 // VIDEO_ARX/ARY switch to 4:3 while active (see the assign at the top) so HDMI
 // geometry stays correct instead of re-stretching the letterboxed image.
@@ -3658,9 +3640,9 @@ wire [1:0] analog_aspect_sel = status[4:3];   // 0 Auto, 1 Fit, 2 Letterbox, 3 C
 // menu-aware aspect — IFO V_ATR while a menu is up, PR #86) instead of the raw
 // stream aspect, matching what HDMI's ascal path does: an anamorphic menu now
 // letterboxes on the CRT under Auto exactly like it corrects on HDMI.
-assign analog_letterbox = analog_eff & ((analog_aspect_sel == 2'd2) |
+assign analog_letterbox = interlaced_eff & ((analog_aspect_sel == 2'd2) |
                                 ((analog_aspect_sel == 2'd0) & ar_wide_auto_eff)); // Letterbox or Auto-16:9
-assign analog_crop      = analog_eff &  (analog_aspect_sel == 2'd3);         // Crop (manual)
+assign analog_crop      = interlaced_eff &  (analog_aspect_sel == 2'd3);         // Crop (manual)
 wire       disp_vscale_en   = analog_letterbox;                             // downstream 2-tap letterbox
 // DVD-FORK FIX (SIF analog fill): mode 2 = the re-armed addrgen 2x line repeat (v_step
 // 128) for sub-D1 heights on the analog output; bit 0 stays tied (mode 1 letterbox-NN
@@ -4106,7 +4088,7 @@ assign ov_b  = 8'd0;
 // this blend (dvd/re_interlace.sv taps vga_*_q), so under the DEFAULT analog path
 // the overlay layer composes against the progressive main raster.
 // DVD-FORK FIX (2026-08-22, interlaced overlay alignment): when the main raster IS
-// interlaced (O[10:9] Interlaced Out, and the new Analog Out = Native Fields), the
+// interlaced (Video Output = Interlaced; historically Interlaced Out / Native Fields), the
 // old `1'b0` ties on spu_decode/crt_ov_map .interlaced were WRONG in both axes:
 //   - vertically, v_pos is the ABSOLUTE frame line stepping by 2 per field line, which
 //     broke the +1 row-base accumulator (both modules already implement the correct
@@ -4116,7 +4098,7 @@ assign ov_b  = 8'd0;
 //     (subtitles, menu button art, HLI highlights, HUD, seek bar) rendered into the
 //     LEFT HALF. Fixed by the uniform x2 inverse `ov_h_gen` / `sp_qx` above.
 // This was a long-standing open follow-up for HDMI-480i (docs/interlaced_auto.md) and
-// is a hard requirement for the analog Native Fields mode, where menus are the point.
+// is a hard requirement for the analog fields mode, where menus are the point.
 // =========================================================================
 // Subtitles ON (gamepad Subtitle button cycle, `sub_on`), or a MENU is up
 // (button graphics live in the subpicture stream; the subtitle toggle must not
@@ -4804,9 +4786,10 @@ assign VGA_DE = vga_de_q;
 // all included — with the raster coordinates delayed 1 clk to match the _q
 // registration. sys_top muxes the direct analog chain onto VGA2_* when
 // VGA2_EN=1; ascal/HDMI keeps consuming the main VGA_* stream untouched.
-// enable drops whenever the main raster is not the standard progressive one
-// (film / HDMI-fields raster — both already forced off under analog_eff; the
-// module's own period check is the backstop) and re-locks in <2 frames.
+// enable = interlaced_eff: the main raster is then the pixrep fields raster the
+// fieldpass re-timer expects (filmp is forced off under it). During an il_switch
+// mode walk the module's own period check is the backstop — it stays unlocked
+// until the fields raster is back, re-locking in <2 frames.
 // =========================================================================
 reg [11:0] ri_hpos_q, ri_vpos_q;
 always @(posedge clk_sys) begin
@@ -4818,12 +4801,8 @@ re_interlace re_interlace_inst (
     .clk     (clk_sys),
     .rst_n   (reset_n),
     .ce2     (ce_13m5),
-    // Native Fields RE-TIMES the interlaced main raster; every other analog mode
-    // DERIVES fields from the progressive one — so the expected source raster is the
-    // opposite in each case (the module's own period check is the backstop either way).
-    .enable  (analog_eff & ~filmp_eff & (analog_fields ? il_eff : ~il_eff)),
+    .enable  (interlaced_eff),
     .pal     (pal_eff),
-    .fieldpass (analog_fields),
     .in_r    (vga_r_q),
     .in_g    (vga_g_q),
     .in_b    (vga_b_q),
@@ -4843,7 +4822,7 @@ re_interlace re_interlace_inst (
     // load_flush is the same event that resets ps_demux and re-anchors av_sync on
     // a load / seek / menu jump, so the caption backlog is dropped with everything
     // else rather than painting the pre-seek sentence onto the new scene.
-    .cc_enable      (analog_eff & ~status[14]),
+    .cc_enable      (interlaced_eff & ~status[14]),
     .cc_test        (status[44]),
     .cc_flush       (load_flush),
     .dec_clk        (clk_dec),
@@ -4852,7 +4831,7 @@ re_interlace re_interlace_inst (
     .cc_pair_field  (core_cc_field),
     .cc_active      ()
 );
-assign VGA2_EN = analog_eff;
+assign VGA2_EN = interlaced_eff;
 
 
 // DVD-FORK: the UART debug transmitter (uart_debug + uart_tx) is REMOVED to free

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -176,10 +176,13 @@ wire pal_eff;
 // The 2026-07 dual-raster DERIVE (weave) modes — CRT 480i built from the progressive
 // raster, HDMI simultaneously progressive — are DELETED (field-reported "extremely
 // wobbly": the pairing parity flips on every governor late, ~4/s; the simultaneity was
-// deliberately traded away — pick-your-output). SET THE MODE BEFORE LOADING A DISC:
-// changing it mid-title toggles il_eff and fires the full seek-equivalent il_switch
-// flush (the parity corrector heals the field phase, but the flush itself restarts
-// playback). See docs/analog_dual_raster.md (history + fieldpass design),
+// deliberately traded away — pick-your-output). A mid-title change WORKS (HW-observed
+// 2026-09-02): it toggles il_eff and fires the full seek-equivalent il_switch flush —
+// a brief chapter-seek-style interruption — and the parity corrector lands the field
+// phase clean (pre-corrector this restart was one of the coin-flip perturbations,
+// which is where the old "set it before loading" advice came from). Setting the mode
+// before loading merely avoids the interruption.
+// See docs/analog_dual_raster.md (history + fieldpass design),
 // docs/interlaced_auto.md (superseded), docs/field_parity.md.
 wire direct_video;                        // hps_io cfg[10] (declared early for the gating here)
 wire forced_scandoubler;                  // hps_io cfg[4]
@@ -605,8 +608,9 @@ parameter CONF_STR = {
     //   Interlaced     = the disc's AUTHORED fields (decoder in native-fields mode;
     //                    dvd/re_interlace.sv re-times them 1:1 onto the 15 kHz
     //                    half-line analog raster; HDMI shows 480i via ascal, OB
-    //                    Bob/Weave below). Set it BEFORE loading a disc — a
-    //                    mid-title change fires the seek-equivalent il_switch flush.
+    //                    Bob/Weave below). Switchable mid-title — fires the
+    //                    seek-equivalent il_switch flush (brief chapter-seek-style
+    //                    cut), field phase lands clean via the parity corrector.
     //   Progressive    = the progressive raster: full HDMI quality, Film 24p
     //                    available, analog pins carry 480p/576p through the stock
     //                    path (component/VGA displays; also the dev A/B switch).

--- a/dvd/re_interlace.sv
+++ b/dvd/re_interlace.sv
@@ -1,74 +1,55 @@
-// re_interlace.sv — DVD-FORK (dual-raster analog output, 2026-07-29)
+// re_interlace.sv — DVD-FORK (analog fields re-timer; dual-raster 2026-07-29,
+// fieldpass-only since the 2026-09-02 Video Output consolidation)
 //
-// Progressive -> native 15 kHz 2:1-interlaced scan converter ("re-interlacer").
+// Native 15 kHz broadcast-timed 480i/576i for the analog pins, re-timed 1:1 from
+// the core's interlaced fields raster.
 //
-// WHY: the core's main raster stays progressive (480p/576p @ 27 MHz CE=1) for
-// ascal/HDMI quality, but a real CRT on the analog I/O board needs broadcast
-// 480i/576i (alternating 262/263 or 312/313 field totals with the half-line
-// vsync). Instead of mode-switching the whole core (the retired O[14] CRT mode),
-// this module derives a SECOND, simultaneous raster from the main one:
+// WHY: a real CRT on the analog I/O board needs broadcast 480i/576i (alternating
+// 262/263 or 312/313 field totals with the HALF-LINE vsync), but the main raster
+// must NOT carry a half-line — vsync landing at a different horizontal position
+// every field makes ascal's HDMI consumer HUNT for lock (the ff01ac8 issue: ~1-2 s
+// brightness pulse + scanline comb, HW-observed). So this module re-times the main
+// raster onto a second, local raster that adds the half-line:
 //
-//   main raster (720x480p/576p, 27 MHz, CE=1, tapped at the registered vga_*_q
-//   output stage) --> 4-line sync-read BRAM --> second sync_gen instance
-//   (rtl/mpeg2/syncgen.v, the HW-proven N64-model half-line machinery, clk_en =
-//   13.5 MHz CE) --> registered out_* --> sys_top VGA2_* --> direct analog chain.
+//   main fields raster (pixel-repeated 480i/576i, 27 MHz CE=1, no half-line,
+//   tapped at the registered vga_*_q output stage) --> 4-line sync-read BRAM -->
+//   second sync_gen instance (rtl/mpeg2/syncgen.v, the HW-proven N64-model
+//   half-line machinery, clk_en = 13.5 MHz CE) --> registered out_* -->
+//   sys_top VGA2_* --> direct analog chain.
 //
-// TIMING (the whole trick): one interlaced line = 858 dots @ 13.5 MHz = 1716
-// clk27 = exactly TWO progressive lines, and two fields (262+263 lines NTSC,
-// 312+313 PAL) = exactly TWO main frames (900900 / 1080000 clk27). So a single
-// arming alignment at a main frame top stays phase-locked FOREVER by
-// construction — one field is emitted per main frame, field A (even source
-// lines) from frame N, field B (odd source lines) from frame N+1.
-//
-// SKEW derivation (frame-top-relative clk27 units; source line L pixel x is
-// written at L*858 + x because the frame-top detector and the writes ride the
-// same in_hpos/in_vpos stream):
-//   field A (released at +SKEW): reads line L=2k at SKEW + L*858 + 2x
-//     -> read-after-write margin = SKEW + x  (always fine)
-//     -> slot L%4 overwritten by line L+4 at L*858+3432; last read at
-//        SKEW + L*858 + 2*719  ==> SKEW < 3432 - 1438 = 1994
-//   field B starts one main line EARLY relative to frame N+1's top (field A is
-//   262 lines = 449592 clk27 = one main frame MINUS 858): reads line L=2k+1 at
-//   SKEW - 1716 + L*858 + 2x
-//     -> read-after-write: SKEW - 1716 + x > 0 ==> SKEW > 1716
-//   ==> SKEW in (1716, 1994); the read-side pipeline (sync_gen 3 stages @ ce2 +
-//   BRAM reg = ~7 clk27, constant) shifts both bounds down by the same amount.
-//   SKEW = 1848 centers the window; re_interlace_tb's pixel-exact content check
-//   is the proof (it fails outside the window).
+// The source is `Video Output = Interlaced`'s main raster (il_eff): the decoder
+// emits AUTHORED TOP/BOTTOM field images in top_field_first order with the true
+// rff 3:2 field cadence, so every displayed refresh is one genuine field of
+// exactly one picture, and content-field-to-raster-field alignment is actively
+// corrected upstream (docs/field_parity.md). Source and local rasters have
+// IDENTICAL line and field structure (1716 clk27/line, field totals alternating
+// 262/263 // 312/313), so every source pixel is read a CONSTANT SKEW_FP after it
+// is written. Two differences only: the source carries 2 dots per pixel (pixel
+// repetition — decimated on the write port) and samples vsync at dot 0 in both
+// fields (no half-line; HDMI uses VGA_F1 instead), while our local sync_gen adds
+// the half-line the CRT needs.
 //
 // LOCK FSM: HUNT (sync_gen held in reset, outputs blank/no syncs) -> ARM (skew
 // countdown from a verified main frame top) -> RUN (free-run; locked=1). The
 // main raster is health-checked by PERIOD, not coordinates: consecutive frame
-// tops must be exactly 450450 (NTSC) / 540000 (PAL) clk27 apart. Any other main
-// raster (Film-24p 23.976 Hz, HDMI-480i pixrep, mid-walk garbage) fails the
-// check and the module simply stays unlocked — self-protecting. pal/enable
-// changes and a frame-top timeout also drop to HUNT.
+// tops must be exactly 900900 (NTSC) / 1080000 (PAL) clk27 apart. Any other main
+// raster (the progressive raster during a mode walk, Film-24p 23.976 Hz, mid-walk
+// garbage) fails the check and the module simply stays unlocked —
+// self-protecting. pal/enable changes and a frame-top timeout also drop to HUNT.
+// Phase lock is by construction: locked once at a frame top, the identical
+// periods mean it never drifts.
 //
-// v1 caveat (progressive-derive path only): for true-interlaced (weave-decoded)
-// content the field pairing vs the governor's frame hold is not phase-guaranteed.
-// It is WORSE than "a drop/late can swap it until the next slip": a governor LATE
-// re-scans one FRAME image = +1 refresh = an ODD hold, which flips the pairing
-// parity, and lates run at ~4/s even on healthy content (docs/lipsync_pickup.md).
-// So the pairing is re-randomised several times a second and cannot be fixed by
-// arming on a picture flip. See docs/analog_dual_raster.md caveat 2.
-//
-// FIELD PASSTHROUGH (`fieldpass`, Analog Out = Native Fields) is the structural fix:
-// the decoder is put in native-fields mode (il_eff), so resample_addrgen emits
-// authored TOP/BOTTOM field images in top_field_first order with the true rff 3:2
-// field cadence. Every displayed refresh is then one genuine field of exactly one
-// picture, so there is no "pairing" to get wrong, and a late re-scans a FIELD PAIR
-// (+2 refreshes = even) so governor churn is parity-neutral by construction.
-//
-// In that mode this module degenerates to a RE-TIMER. The source raster is the
-// pixel-repeated interlaced raster (1716 clk27/line, field totals alternating
-// 262/263 exactly as ours do), so source and local rasters have IDENTICAL line and
-// field structure and every source pixel is read exactly SKEW_FP after it is
-// written — a constant, uniform skew. Two differences only: the source carries
-// 2 dots per pixel (decimated on the write port) and samples vsync at dot 0 in both
-// fields (no half-line — HDMI uses VGA_F1 instead), while our local sync_gen adds
-// the half-line the CRT needs. That is why the main raster does NOT need a
-// half-line: putting one there would expose HDMI to the ff01ac8 receiver-hunting
-// issue for no gain.
+// HISTORY: this module originally ALSO derived 480i from the standard progressive
+// main raster (the 2026-07-29 dual-raster "weave" mode: field A = even source
+// lines of frame N, field B = odd lines of frame N+1, SKEW window (1716,1994)),
+// so a CRT could get 480i while HDMI stayed progressive. That mode was DELETED
+// 2026-09-02 (branch feature/video-output-consolidation): its field pairing vs
+// the governor's frame holds was structurally unstable — a governor late re-scans
+// one FRAME = an ODD +1 refresh that flips the pairing parity, at ~4 lates/s even
+// on healthy content — and was field-reported as "extremely wobbly" on a real
+// CRT. Fieldpass is immune (a late re-scans a field PAIR = even), so it became
+// the only mode and the derive constants/muxes were removed. The full derive
+// design lives in docs/analog_dual_raster.md (history) and git.
 
 `include "timescale.v"
 // An undeclared identifier becomes a compile ERROR, not a silent undriven net.
@@ -83,10 +64,8 @@ module re_interlace (
     input             ce2,          // free-running 13.5 MHz clock enable (ce_13m5)
 
     // quasi-static config
-    input             enable,       // analog raster wanted AND the main raster is the expected one
+    input             enable,       // analog raster wanted AND the main raster is the fields raster
     input             pal,          // 1 = 576i params (864x312/313), 0 = 480i (858x262/263)
-    input             fieldpass,    // 1 = main raster is the pixrep INTERLACED fields raster (re-time
-                                    //     1:1); 0 = standard progressive raster (derive fields)
 
     // line-21 closed captions (dvd/cc_line21.sv) — the caption inserter lives here
     // because the line number and the field parity are properties of THIS raster's
@@ -140,17 +119,16 @@ wire [13:0] p_vsize= pal ? 14'd576 : 14'd480;
 
 // Expected main-frame period in clk27 and arming skew.
 //
-// Progressive source: 858x525 / 864x625 dots at CE=1.
-// Fieldpass source:   the SAME total dots per frame, redistributed as two fields of
-//   pixel-repeated lines — NTSC 1716 clk27/line x (262+263) lines = 900900;
-//   PAL 1728 x (312+313) = 1080000. (frame_top still pulses once per FRAME: v_pos =
+// Source = the pixel-repeated fields raster: two fields of pixrep lines —
+//   NTSC 1716 clk27/line x (262+263) lines = 900900;
+//   PAL 1728 x (312+313) = 1080000. (frame_top pulses once per FRAME: v_pos =
 //   {v_cntr, ~odd_field} is only 0 when v_cntr==0 AND odd_field==1.)
-localparam [20:0] PERIOD_NTSC    = 21'd450450;
-localparam [20:0] PERIOD_PAL     = 21'd540000;
+// The progressive raster's period (450450 / 540000) fails this check, which is
+// exactly the mode-walk transient guard: during an il_switch walk the module
+// stays unlocked until the fields raster is back.
 localparam [20:0] PERIOD_FP_NTSC = 21'd900900;
 localparam [20:0] PERIOD_FP_PAL  = 21'd1080000;
-localparam [11:0] SKEW           = 12'd1848;    // progressive-derive: window (1716,1994)
-// Fieldpass skew: source pixel (x, absolute line L) is written at (L>>1)*1716 + 2x
+// Skew: source pixel (x, absolute line L) is written at (L>>1)*1716 + 2x
 // relative to the frame top (field A emits L=0,2,4..., then field B L=1,3,5...), and
 // our reader emits exactly the same line at the same offset + SKEW_FP. So every read
 // trails its write by a CONSTANT SKEW_FP. Bounds:
@@ -160,9 +138,8 @@ localparam [11:0] SKEW           = 12'd1848;    // progressive-derive: window (1
 // SKEW_FP = 858 (one main line) centres the window with ~858 clk27 of margin either
 // way. Proven pixel-exactly by bench/dvd/re_interlace_tb.sv scenario [6].
 localparam [11:0] SKEW_FP        = 12'd858;
-wire       [20:0] period_exp     = fieldpass ? (pal ? PERIOD_FP_PAL : PERIOD_FP_NTSC)
-                                             : (pal ? PERIOD_PAL    : PERIOD_NTSC);
-wire       [11:0] skew_sel       = fieldpass ? SKEW_FP : SKEW;
+wire       [20:0] period_exp     = pal ? PERIOD_FP_PAL : PERIOD_FP_NTSC;
+wire       [11:0] skew_sel       = SKEW_FP;
 
 // ---------------------------------------------------------------------------
 // Main-raster frame-top detect + period health check
@@ -281,11 +258,11 @@ sync_gen sg2 (
 reg [23:0] linebuf [0:4095];
 reg [23:0] rd_q;
 
-// Fieldpass: the source line carries each pixel TWICE (pixel repetition), so keep the
-// even dot of each pair and index by in_hpos>>1 — the buffer always holds 720 native
-// pixels per line in both modes, and the read port is untouched.
-wire [9:0] wr_col = fieldpass ? in_hpos[10:1] : in_hpos[9:0];
-wire       wr_en  = in_de & (fieldpass ? ~in_hpos[0] : 1'b1);
+// The source line carries each pixel TWICE (pixel repetition), so keep the even dot
+// of each pair and index by in_hpos>>1 — the buffer holds 720 native pixels per line,
+// and the read port is untouched.
+wire [9:0] wr_col = in_hpos[10:1];
+wire       wr_en  = in_de & ~in_hpos[0];
 
 always @(posedge clk) begin
     if (wr_en) linebuf[{in_vpos[1:0], wr_col}] <= {in_r, in_g, in_b};

--- a/dvd/resample_addrgen.v
+++ b/dvd/resample_addrgen.v
@@ -43,6 +43,7 @@ module resample_addrgen (
   pickup_tick, pickup_show, refresh_tick_dbg,       // DVD-FORK (vid_err instrument)
   film_det_ntsc, film_det_pal,                      // DVD-FORK (Film 24p auto-detect): cadence verdicts
   det_video,                                        // DVD-FORK (Interlaced Out auto): sustained true-interlaced-video verdict
+  raster_par_err,                                   // DVD-FORK (field-parity corrector): mixer frame-top parity mismatch (synced level)
   vscale_mode,                                      // DVD-FORK (CRT anamorphic vertical scaler)
   hcrop_en,                                         // DVD-FORK (CRT anamorphic horizontal crop / pan-scan)
   menu_ff,                                          // DVD-FORK (menu VBUF-lag §5): fast-drain a deeply-buffered menu
@@ -179,6 +180,13 @@ module resample_addrgen (
    * HARD-telecine film (progressive_frame==0, no rff) reads as video and gets Bob'd at
    * field rate — acceptable, no inverse-telecine attempted. See docs/interlaced_auto.md. */
   output             det_video;
+
+  /* DVD-FORK (field-parity corrector, 2026-09-02): 2-FF-synced level from the mixer —
+   * 1 while the most recent displayed frame-top began on the WRONG raster field parity
+   * (a TOP-field image scanned out during a bottom raster field or vice versa). Consumed
+   * by the corrector at the pickup decision below; qualified there by `interlaced`, so
+   * a progressive display never acts on it. Field-rate level, CDC-safe. */
+  input              raster_par_err;
 
   /* DVD-FORK (CRT anamorphic VERTICAL scaler, 2026-07-05): display-mode select for
    * the 4:3-CRT 16:9 handling. 0 = FIT (bypass — bit-identical to the pre-scaler
@@ -545,6 +553,89 @@ module resample_addrgen (
    * this wire so the hold is atomic (no half-taken pickups). */
   wire ofv_pickup = output_frame_valid && ~hold_freeze && ~pause;
 
+  /* ================= DVD-FORK (field-parity corrector, 2026-09-02) =================
+   * On an interlaced display the mixer maps each emitted field image onto the next
+   * raster field, and its frame-top matcher deliberately accepts EITHER parity slot
+   * (mixer.v display_first_pixel — the 3:2/drop "black fields" fix). The emitted field
+   * sequence normally alternates TOP/BOTTOM (authored cadence keeps strict alternation,
+   * and the STATE_REPEAT persistence re-scan below alternates too), so content parity
+   * and raster parity stay locked — but ONE odd perturbation flips the phase
+   * PERMANENTLY: every TOP image then scans out during a bottom raster field and vice
+   * versa, i.e. the whole picture sits one scan-line set off = the field-report "super
+   * aliased" CRT image (invisible under HDMI Bob, which is why it shipped unseen;
+   * visible on the analog fieldpass raster and ascal Weave). Observed phase breaks: a
+   * seek/flush released on an arbitrary first tff, the il_switch raster restart, an
+   * Analog Aspect walk's syncgen restart, a mixer underflow, cold-start lock. Toggling
+   * the output mode merely re-rolled the coin (the users' "toggle 3-4 times to fix").
+   *
+   * Correction = insert exactly ONE extra field (an odd insertion flips the slot
+   * phase back into alignment) by deferring a due pickup one refresh and re-scanning
+   * one field of the HELD frame — persistence-style, so the screen shows real content;
+   * cost one refresh (16.7 ms) per event, and a frame_late pulse hands that refresh to
+   * the frame-drop ledger (a B-drop removes an EVEN field count on video content, so
+   * the reclaim can never re-break parity). Two triggers, both evaluated at the pickup
+   * instant, both qualified by `interlaced` (the progressive display path is
+   * bit-identical by construction — par_ins can never assert there):
+   *  - FEED-FORWARD (alt_break): the pending picture's first field would repeat the
+   *    parity of the last displayed field (schedule head == last_image). Catches a
+   *    seek-released tff break BEFORE a single wrong field displays.
+   *  - FEEDBACK (par_fb): the mixer reports the on-screen frame-top landed on the
+   *    wrong raster parity (raster_par_err, 2-FF synced level). Catches what the
+   *    schedule cannot see: cold start, raster restarts, underflow slips. par_armed is
+   *    a hysteresis one-shot so the field-rate feedback latency (~1-2 refreshes + CDC)
+   *    cannot double-insert: one insertion per error assertion, re-armed when the
+   *    error level clears, plus a 4-refresh timeout re-arm for liveness in case an
+   *    insertion was absorbed while the level stayed high.
+   * Design + RED-testbench evidence: docs/field_parity.md. */
+  wire       nxt_first_top = progressive_sequence ? 1'b1 : top_field_first; // first field the pending pickup would emit (mirrors the image-build branches)
+  wire       alt_break = interlaced &&
+                         (((last_image == TOP)    &&  nxt_first_top) ||
+                          ((last_image == BOTTOM) && ~nxt_first_top));
+  reg        par_armed;
+  reg  [2:0] par_tmo;                  // completed refreshes since insertion while the error level stays high
+  wire       par_fb   = interlaced && raster_par_err && par_armed &&
+                        ((last_image == TOP) || (last_image == BOTTOM));
+  /* XOR, not OR — the triggers CANCEL when simultaneous. Slot arithmetic (fields land
+   * on strictly alternating raster slots; a frame-top is accepted at whichever slot
+   * comes next): a content alternation break on an ALIGNED stream would land the new
+   * head one slot early (alt_break: insert the OPPOSITE field to fill that slot
+   * aligned); an intact stream on a MISALIGNED raster needs a one-slot delay (par_fb:
+   * re-show the SAME field — it lands aligned on the next slot, and the resumed
+   * stream continues consistently); but a content break arriving while ALREADY
+   * misaligned lands the new head aligned by itself — two wrongs make a right,
+   * insert nothing. Inserting "opposite" on a par_fb would keep the misalignment AND
+   * manufacture a new alternation break for alt_break to un-fix — a livelock. */
+  wire       par_ins  = alt_break ^ par_fb;                      // insert one field instead of picking up
+  wire       par_slip = (state == STATE_INIT) && ofv_pickup && par_ins;  // the insertion event
+  /* Qualified pickup: every pickup-conditioned latch below consumes THIS instead of
+   * ofv_pickup, so on an insertion cycle the pending frame stays unconsumed (picked up
+   * one refresh later, schedule intact). The FSM's STATE_INIT arc keeps raw ofv_pickup —
+   * it must still advance to scan the inserted field. */
+  wire       pickup_go = ofv_pickup && ~par_ins;
+
+  always @(posedge clk)
+    if (~rst) begin
+      par_armed <= 1'b1;
+      par_tmo   <= 3'd0;
+    end else if (clk_en) begin
+      if (par_slip) begin
+        par_armed <= 1'b0;             // one insertion per error assertion
+        par_tmo   <= 3'd0;
+      end else if (~raster_par_err) begin
+        par_armed <= 1'b1;             // error observed clear: re-arm
+        par_tmo   <= 3'd0;
+      end else if (~par_armed && (state == STATE_NEXT_MB) && last_mb && last_y) begin
+        if (par_tmo == 3'd4) par_armed <= 1'b1;   // liveness: level stuck high 4 shown refreshes after an insertion
+        else                 par_tmo   <= par_tmo + 3'd1;
+      end
+    end
+
+  reg par_late_r;                      // hand the inserted refresh to the frame-drop ledger (cad_late_r pattern)
+  always @(posedge clk)
+    if (~rst) par_late_r <= 1'b0;
+    else if (clk_en) par_late_r <= par_slip;
+    else par_late_r <= par_late_r;
+
   /* next state logic */
   always @*
     case (state)
@@ -598,7 +689,7 @@ module resample_addrgen (
 
   always @(posedge clk)
     if (~rst) output_frame_rd <= 1'd0;
-    else if (clk_en) output_frame_rd <= (state == STATE_INIT) && ofv_pickup; // INIT is reached at hold release (the held frame re-scans in STATE_REPEAT), or during a cold start with nothing to hold
+    else if (clk_en) output_frame_rd <= (state == STATE_INIT) && pickup_go; // INIT is reached at hold release (the held frame re-scans in STATE_REPEAT), or during a cold start with nothing to hold; parity insertion defers the read one refresh
     else output_frame_rd <= output_frame_rd;
 
   /*
@@ -630,7 +721,7 @@ module resample_addrgen (
    * frames (progressive display), else SHOW_N. Paces the 3:2 cadence via persistence. */
   always @(posedge clk)
     if (~rst) cur_show <= SHOW_N;
-    else if (clk_en && (state == STATE_INIT) && ofv_pickup) cur_show <= show_next;
+    else if (clk_en && (state == STATE_INIT) && pickup_go) cur_show <= show_next;
     else cur_show <= cur_show;
 
   /* DVD-FORK FIX (cadence-slip corrector, see the show_next comment): step the
@@ -648,7 +739,7 @@ module resample_addrgen (
       cad_late_r <= 1'b0;
     end else if (clk_en) begin
       cad_late_r <= 1'b0;
-      if ((state == STATE_INIT) && ofv_pickup) begin
+      if ((state == STATE_INIT) && pickup_go) begin
         if (!cad_gate)                  cad_acc <= 4'sd0;
         else if (cad_next <= -5'sd5) begin
                                         cad_acc <= cad_next[3:0] + 4'sd5;
@@ -669,8 +760,8 @@ module resample_addrgen (
       pickup_show_r  <= 4'd0;
       refresh_tick_r <= 1'b0;
     end else if (clk_en) begin
-      pickup_tick_r  <= (state == STATE_INIT) && ofv_pickup;
-      if ((state == STATE_INIT) && ofv_pickup) pickup_show_r <= show_next;
+      pickup_tick_r  <= (state == STATE_INIT) && pickup_go;
+      if ((state == STATE_INIT) && pickup_go) pickup_show_r <= show_next;
       refresh_tick_r <= (state == STATE_NEXT_MB) && last_mb && last_y && video_live;
     end else begin
       pickup_tick_r  <= 1'b0;
@@ -721,7 +812,7 @@ module resample_addrgen (
   //  consumes det_ntsc — iverilog rejects declaration-after-use.)
   reg  [7:0] conf_video;                   // DVD-FORK (Interlaced Out auto): true-interlaced confidence
   reg        det_v;
-  wire       film_pickup = (state == STATE_INIT) && ofv_pickup;
+  wire       film_pickup = (state == STATE_INIT) && pickup_go;
   wire       rff_toggled = (repeat_first_field != rff_q);
   wire       good_ntsc   = progressive_frame && rff_toggled;   // clean 3:2 telecine frame
   always @(posedge clk)
@@ -826,7 +917,7 @@ module resample_addrgen (
 
   always @(posedge clk)
     if (~rst) frame_late <= 1'b0;
-    else if (clk_en) frame_late <= late_raw | late_ext | cad_late_r;  // DVD-FORK: cadence-slip deficit correction (film24; can't collide with late_raw — pickup vs REPEAT cycles)
+    else if (clk_en) frame_late <= late_raw | late_ext | cad_late_r | par_late_r;  // DVD-FORK: cadence-slip deficit correction (film24) + field-parity insertion — both pulse on pickup cycles, can't collide with late_raw (REPEAT cycles)
     else frame_late <= frame_late;
 
   /* DVD-FORK (av_sync STC reference): sticky "display has shown a decoded frame".
@@ -838,7 +929,7 @@ module resample_addrgen (
   always @(posedge clk)
     if (~rst) video_live <= 1'b0;
     else if (pickup_hold && ~pickup_hold_d) video_live <= 1'b0;  // clip load: re-arm
-    else if (clk_en && (state == STATE_INIT) && ofv_pickup) video_live <= 1'b1;
+    else if (clk_en && (state == STATE_INIT) && pickup_go) video_live <= 1'b1;
     else video_live <= video_live;
 
   /*
@@ -867,7 +958,7 @@ module resample_addrgen (
   always @(posedge clk)
     if (~rst) refresh_cnt <= 4'd0;
     else if (clk_en) begin
-      if ((state == STATE_INIT) && ofv_pickup)                refresh_cnt <= 4'd0;             // new frame picked up -> restart count
+      if ((state == STATE_INIT) && pickup_go)                 refresh_cnt <= 4'd0;             // new frame picked up -> restart count (a parity insertion keeps counting: the frame stays due)
       else if ((state == STATE_NEXT_MB) && last_mb && last_y)
         refresh_cnt <= (refresh_cnt == 4'd15) ? 4'd15 : refresh_cnt + 4'd1; // one refresh (image scan) done; saturate (see above)
     end
@@ -942,7 +1033,23 @@ module resample_addrgen (
         image_5 <= NO_OUTPUT;
         progressive_upscaling <= 1'b0;
       end
-    else if (clk_en && (state == STATE_INIT) && ofv_pickup) // build image sequence on pickup (INIT is reached paced)
+    else if (clk_en && par_slip) // DVD-FORK (field-parity corrector): insert ONE field of the HELD frame; the pending pickup waits one refresh
+      begin
+        image   <= NO_OUTPUT;
+        // par_fb (raster misaligned, content intact): re-show the SAME field — it lands
+        // aligned on the next slot. alt_break (content break, raster aligned): show the
+        // OPPOSITE field — it fills the slot the break would have skipped. par_ins
+        // guarantees last_image is TOP or BOTTOM. See the XOR note above.
+        image_0 <= par_fb ? last_image
+                          : ((last_image == TOP) ? BOTTOM : TOP);
+        image_1 <= NO_OUTPUT;
+        image_2 <= NO_OUTPUT;
+        image_3 <= NO_OUTPUT;
+        image_4 <= NO_OUTPUT;
+        image_5 <= NO_OUTPUT;
+        progressive_upscaling <= progressive_upscaling;
+      end
+    else if (clk_en && (state == STATE_INIT) && pickup_go) // build image sequence on pickup (INIT is reached paced)
       begin
         /*
          * display progressive sequence on progressive display. Display frames.
@@ -1089,13 +1196,13 @@ module resample_addrgen (
   /* save output_frame */
   always @(posedge clk)
     if (~rst) output_frame_sav <= 3'b0;
-    else if (clk_en && (state == STATE_INIT) && ofv_pickup) output_frame_sav <= output_frame;
+    else if (clk_en && (state == STATE_INIT) && pickup_go) output_frame_sav <= output_frame;
     else output_frame_sav <= output_frame_sav;
 
   /* determine frame, top, bottom sequence */
   always @(posedge clk)
     if (~rst) encoder_bug_workaround <= 1'b0;
-    else if (clk_en && (state == STATE_INIT) && ofv_pickup) encoder_bug_workaround <= progressive_frame && repeat_first_field;
+    else if (clk_en && (state == STATE_INIT) && pickup_go) encoder_bug_workaround <= progressive_frame && repeat_first_field;
     else encoder_bug_workaround <= encoder_bug_workaround;
 
   always @(posedge clk)

--- a/dvd/resample_addrgen.v
+++ b/dvd/resample_addrgen.v
@@ -42,7 +42,6 @@ module resample_addrgen (
   cur_show_out,                                     // DVD-FORK (film-aware drop reclaim)
   pickup_tick, pickup_show, refresh_tick_dbg,       // DVD-FORK (vid_err instrument)
   film_det_ntsc, film_det_pal,                      // DVD-FORK (Film 24p auto-detect): cadence verdicts
-  det_video,                                        // DVD-FORK (Interlaced Out auto): sustained true-interlaced-video verdict
   raster_par_err,                                   // DVD-FORK (field-parity corrector): mixer frame-top parity mismatch (synced level)
   vscale_mode,                                      // DVD-FORK (CRT anamorphic vertical scaler)
   hcrop_en,                                         // DVD-FORK (CRT anamorphic horizontal crop / pan-scan)
@@ -166,20 +165,9 @@ module resample_addrgen (
   output             film_det_ntsc;
   output             film_det_pal;
 
-  /* DVD-FORK (Interlaced Out — auto detect): sustained TRUE-INTERLACED-VIDEO verdict,
-   * evaluated on the same per-display-pickup committed flags as the film detectors.
-   * det_video = a sustained run of interlaced-coded frames (progressive_frame==0). This
-   * is the signal to switch the framework scaler to a NATIVE fields path (480i/576i +
-   * VGA_F1, ascal deinterlaces) so 60-field (NTSC 29.97i) / 50-field (PAL 25i) motion is
-   * preserved instead of being weaved to 30/25 unique progressive frames. Standard-
-   * neutral: keys only on progressive_frame, so it covers both NTSC and PAL. Mutually
-   * exclusive with film_det_ntsc/pal by construction (film needs progressive_frame==1).
-   * Same strong hysteresis as the film verdicts, biased toward NON-interlaced (a false
-   * positive Bob-deinterlaces progressive content = a soft resolution loss; a false
-   * negative just stays the current progressive weave = harmless). Known edge case:
-   * HARD-telecine film (progressive_frame==0, no rff) reads as video and gets Bob'd at
-   * field rate — acceptable, no inverse-telecine attempted. See docs/interlaced_auto.md. */
-  output             det_video;
+  /* (The `det_video` true-interlaced-video verdict — the "Interlaced Out: Auto"
+   * detector — lived here 2026-07-27..2026-09-02 and was removed with that option in
+   * the Video Output consolidation; see docs/interlaced_auto.md's superseded header.) */
 
   /* DVD-FORK (field-parity corrector, 2026-09-02): 2-FF-synced level from the mixer —
    * 1 while the most recent displayed frame-top began on the WRONG raster field parity
@@ -810,8 +798,6 @@ module resample_addrgen (
   reg  [7:0] conf_ntsc, conf_pal;
   // (det_ntsc/det_pal are DECLARED EARLIER, above the cadence-slip corrector that
   //  consumes det_ntsc — iverilog rejects declaration-after-use.)
-  reg  [7:0] conf_video;                   // DVD-FORK (Interlaced Out auto): true-interlaced confidence
-  reg        det_v;
   wire       film_pickup = (state == STATE_INIT) && pickup_go;
   wire       rff_toggled = (repeat_first_field != rff_q);
   wire       good_ntsc   = progressive_frame && rff_toggled;   // clean 3:2 telecine frame
@@ -820,7 +806,6 @@ module resample_addrgen (
       rff_q     <= 1'b0;
       conf_ntsc <= 8'd0; conf_pal <= 8'd0;
       det_ntsc  <= 1'b0; det_pal  <= 1'b0;
-      conf_video <= 8'd0; det_v   <= 1'b0;
     /* ★ DVD-FORK (film evidence gate, 2026-08-30) — the `informative` term.
      *
      * progressive_frame is the ENCODER's claim, not a measurement, and on a
@@ -871,25 +856,9 @@ module resample_addrgen (
         if      (cp >= ENGAGE_TH)    det_pal <= 1'b1;
         else if (cp <= DISENGAGE_TH) det_pal <= 1'b0;
       end
-      // ---- TRUE-INTERLACED-VIDEO confidence (progressive_frame==0; standard-neutral) ----
-      // Mirror of PAL 25p: rises on interlaced-coded frames, falls hard on any progressive
-      // frame. Soft-telecine (NTSC) and 25p (PAL) film are progressive_frame==1 => this
-      // only ever decays on them, so it can never engage on film. NTSC 29.97i and PAL 25i
-      // video are progressive_frame==0 => it locks. Same up/down as the film hard step.
-      begin : video_conf
-        reg [7:0] cv;
-        if (!progressive_frame)
-          cv = (conf_video > (CONF_MAX - UP_STEP)) ? CONF_MAX : conf_video + UP_STEP;
-        else
-          cv = (conf_video < DN_HARD) ? 8'd0 : conf_video - DN_HARD;
-        conf_video <= cv;
-        if      (cv >= ENGAGE_TH)    det_v <= 1'b1;
-        else if (cv <= DISENGAGE_TH) det_v <= 1'b0;
-      end
     end
   assign film_det_ntsc = det_ntsc;
   assign film_det_pal  = det_pal;
-  assign det_video     = det_v;
 
   /*
    * Emit frame_late in units of REFRESHES of hold, for frame_drop_ctl's debt ledger

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,8 +123,8 @@ nav:
       - On-screen messages: playback/on-screen-messages.md
   - Video:
       - Film (24p): video/film-24p.md
+      - Video Output: video/interlaced.md
       - Analog and CRT output: video/analog-crt.md
-      - Interlaced output: video/interlaced.md
       - Closed captions: video/closed-captions.md
   - Audio:
       - Formats and decoding: audio/formats.md

--- a/rtl/mpeg2/mixer.v
+++ b/rtl/mpeg2/mixer.v
@@ -41,7 +41,8 @@ module mixer(
   h_pos, v_pos, h_sync_in, v_sync_in, pixel_en_in,
   y_out, u_out, v_out, osd_out, h_sync_out, v_sync_out, pixel_en_out,
   dbg_lines_displayed, dbg_first_vpos, dbg_last_vpos,             // DVD-FORK DEBUG (256-line strobe probe)
-  disp_v_offset                                                   // DVD-FORK (CRT anamorphic letterbox bar offset)
+  disp_v_offset,                                                  // DVD-FORK (CRT anamorphic letterbox bar offset)
+  frame_top_par_err                                               // DVD-FORK (field-parity corrector): frame-top landed on the wrong raster field parity
   );
 
   input              clk;                      // clock
@@ -99,6 +100,19 @@ module mixer(
    * comparisons below reduce to the original (v_pos<=1) / (v_pos!=0 && v_pos!=1) — the
    * FIT path is bit-identical. Quasi-static (menu-rate) level. */
   input        [11:0]disp_v_offset;
+
+  /* DVD-FORK (field-parity corrector, 2026-09-02): latched at each frame-top start —
+   * 1 if the picture's first line began on the WRONG raster field parity: a TOP field
+   * (ROW_0_COL_0) starting at v_pos == disp_v_offset+1 (a bottom raster field), or a
+   * BOTTOM field (ROW_1_COL_0) at v_pos == disp_v_offset (a top raster field). The
+   * relaxed display_first_pixel matcher below accepts either parity ON PURPOSE (the
+   * 3:2/drop "black fields" fix) — this output merely REPORTS the mismatch so
+   * resample_addrgen can re-align the phase by inserting one field. A LEVEL, not a
+   * pulse: it holds its verdict until the next frame-top, so it is CDC-safe at field
+   * rate (2-FF synced dot->clk in mpeg2video.v). Meaningless while the raster is
+   * progressive (a FRAME image emits ROW_0_COL_0 at v_pos==disp_v_offset, so it reads
+   * 0 there anyway); the consumer additionally gates on its own `interlaced`. */
+  output reg         frame_top_par_err;
 
   /* store pixel_queue fifo output */
   reg           [7:0]y_0;
@@ -191,6 +205,17 @@ module mixer(
   always @(posedge clk)
     if(~rst) state <= STATE_INIT;
     else if (clk_en) state <= next;
+
+  /* DVD-FORK (field-parity corrector): frame-top parity verdict — see the output
+   * declaration above. Sampled exactly when a frame-top is accepted for display
+   * (STATE_WAIT -> STATE_FIRST_PIXEL with a ROW_0/ROW_1 head), i.e. once per
+   * displayed picture start. */
+  always @(posedge clk)
+    if (~rst) frame_top_par_err <= 1'b0;
+    else if (clk_en && (state == STATE_WAIT) && (next == STATE_FIRST_PIXEL) && is_frame_top)
+      frame_top_par_err <= (position_in_0 == ROW_0_COL_0) ? (v_pos != disp_v_offset)
+                                                          : (v_pos != disp_v_offset + 12'd1);
+    else frame_top_par_err <= frame_top_par_err;
 
   /* registers */
   /* store pixel_fifo output */

--- a/rtl/mpeg2/mpeg2video.v
+++ b/rtl/mpeg2/mpeg2video.v
@@ -82,8 +82,7 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
              disp_hfill_en,                                        // DVD-FORK FIX (SIF analog fill): stretch sub-D1 lines to the 720 raster
              menu_ff,                                              // DVD-FORK (menu VBUF-lag §5): fast-drain a deeply-buffered menu
              film24,                                               // DVD-FORK (Film 24p Out): 1 frame/refresh, ascal does the 3:2
-             film_det_ntsc, film_det_pal,                          // DVD-FORK (Film 24p auto-detect): cadence verdicts (up to emu)
-             det_video                                             // DVD-FORK (Interlaced Out auto): true-interlaced-video verdict (up to emu)
+             film_det_ntsc, film_det_pal                           // DVD-FORK (Film 24p auto-detect): cadence verdicts (up to emu)
 	     );
 
   input            clk;                     // clock. Typically a multiple of 27 Mhz as MPEG2 timestamps have a 27 Mhz resolution.
@@ -261,10 +260,6 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
    * resolves the Off/On/Auto mode. */
   output           film_det_ntsc;
   output           film_det_pal;
-  /* DVD-FORK (Interlaced Out — auto detect): sustained true-interlaced-video verdict
-   * (progressive_frame==0 run) from resample's detector. emu.sv CDC-syncs it to clk_sys
-   * and drives the native 480i/576i fields path when Interlaced Out = Auto. */
-  output           det_video;
 
   /* register file access */
   input       [3:0]reg_addr;
@@ -1440,7 +1435,6 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
     .refresh_tick_dbg(gov_refresh_tick),
     .film_det_ntsc(film_det_ntsc),                           // DVD-FORK (Film 24p auto-detect)
     .film_det_pal(film_det_pal),
-    .det_video(det_video),                                   // DVD-FORK (Interlaced Out auto)
     .raster_par_err(raster_par_err),                         // DVD-FORK (field-parity corrector): mixer verdict, synced
     .vscale_mode(disp_vscale_mode),                          // DVD-FORK (CRT anamorphic vscale)
     .hcrop_en(disp_hcrop_en),                                // DVD-FORK (CRT anamorphic horizontal crop)

--- a/rtl/mpeg2/mpeg2video.v
+++ b/rtl/mpeg2/mpeg2video.v
@@ -521,10 +521,11 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
   wire        [7:0]y_mixer;                 // luminance
   wire        [7:0]u_mixer;                 // chrominance
   wire        [7:0]v_mixer;                 // chrominance
-  wire        [7:0]osd_mixer;               // osd pixel color 
+  wire        [7:0]osd_mixer;               // osd pixel color
   wire             h_sync_mixer;
   wire             v_sync_mixer;
   wire             pixel_en_mixer;
+  wire             dot_frame_top_par_err;   // DVD-FORK (field-parity corrector): mixer frame-top parity verdict (dot_clk level)
 
   /* osd - yuv2rgb interface */
   wire             pixel_en_osd;            // pixel enable 
@@ -853,6 +854,14 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
   /* vertical sync synchronizer, for generating interrupt at vertical sync start */
   wire       regfile_v_sync;
   sync_reg #(.width(1))  sync_v_sync                  (clk, sync_rst, v_sync_gen, regfile_v_sync);
+
+  /* DVD-FORK (field-parity corrector): mixer frame-top parity verdict, dot -> clk.
+   * Gated with dot_interlaced at the source so a progressive raster can never assert
+   * it into the addrgen (belt and braces — the addrgen gates on `interlaced` too).
+   * A field-rate level (holds until the next displayed frame-top), so a plain 2-FF
+   * synchronizer is safe. */
+  wire       raster_par_err;
+  sync_reg #(.width(1))  sync_raster_par_err          (clk, sync_rst, dot_frame_top_par_err && dot_interlaced, raster_par_err);
 
   /* flush video buffer */
   wire       flush_vbuf;                              /* flush video buffer (regfile REG_WR_TRICK bit0) */
@@ -1432,6 +1441,7 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
     .film_det_ntsc(film_det_ntsc),                           // DVD-FORK (Film 24p auto-detect)
     .film_det_pal(film_det_pal),
     .det_video(det_video),                                   // DVD-FORK (Interlaced Out auto)
+    .raster_par_err(raster_par_err),                         // DVD-FORK (field-parity corrector): mixer verdict, synced
     .vscale_mode(disp_vscale_mode),                          // DVD-FORK (CRT anamorphic vscale)
     .hcrop_en(disp_hcrop_en),                                // DVD-FORK (CRT anamorphic horizontal crop)
     .menu_ff(menu_ff),                                       // DVD-FORK (menu VBUF-lag §5): fast-drain a deeply-buffered menu
@@ -1589,7 +1599,8 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
     .dbg_lines_displayed(dbg_lines_displayed),               // DVD-FORK DEBUG
     .dbg_first_vpos(dbg_first_vpos),                 // DVD-FORK DEBUG
     .dbg_last_vpos(dbg_last_vpos),               // DVD-FORK DEBUG
-    .disp_v_offset(disp_v_offset)                            // DVD-FORK (CRT anamorphic letterbox bar offset)
+    .disp_v_offset(disp_v_offset),                           // DVD-FORK (CRT anamorphic letterbox bar offset)
+    .frame_top_par_err(dot_frame_top_par_err)                // DVD-FORK (field-parity corrector): to the addrgen via sync_raster_par_err
     );
 
   /* On-Screen Display */

--- a/rtl/mpeg2/resample.v
+++ b/rtl/mpeg2/resample.v
@@ -46,6 +46,7 @@ module resample(
   pickup_tick, pickup_show, refresh_tick_dbg,       // DVD-FORK (vid_err instrument)
   film_det_ntsc, film_det_pal,                      // DVD-FORK (Film 24p auto-detect)
   det_video,                                        // DVD-FORK (Interlaced Out auto): true-interlaced verdict
+  raster_par_err,                                   // DVD-FORK (field-parity corrector): mixer frame-top parity mismatch (synced level)
   vscale_mode,                                      // DVD-FORK (CRT anamorphic vertical scaler)
   hcrop_en,                                         // DVD-FORK (CRT anamorphic horizontal crop)
   menu_ff,                                          // DVD-FORK (menu VBUF-lag §5): fast-drain a deeply-buffered menu
@@ -105,6 +106,7 @@ module resample(
   output             film_det_ntsc;               // DVD-FORK (Film 24p auto-detect): sustained 3:2 telecine verdict (NTSC 24p)
   output             film_det_pal;                // DVD-FORK (Film 24p auto-detect): sustained progressive verdict (PAL 25p)
   output             det_video;                   // DVD-FORK (Interlaced Out auto): sustained true-interlaced-video verdict (480i/576i)
+  input              raster_par_err;              // DVD-FORK (field-parity corrector): mixer frame-top parity mismatch (2-FF synced level)
   input        [1:0] vscale_mode;                 // DVD-FORK (CRT anamorphic vscale): 0=fit 1=letterbox
   input              hcrop_en;                    // DVD-FORK (CRT anamorphic horizontal crop / pan-scan)
   input              menu_ff;                      // DVD-FORK (menu VBUF-lag §5): fast-drain a deeply-buffered menu
@@ -170,6 +172,7 @@ module resample(
     .film_det_ntsc(film_det_ntsc),                 // DVD-FORK (Film 24p auto-detect)
     .film_det_pal(film_det_pal),
     .det_video(det_video),                         // DVD-FORK (Interlaced Out auto)
+    .raster_par_err(raster_par_err),               // DVD-FORK (field-parity corrector)
     .vscale_mode(vscale_mode),                     // DVD-FORK (CRT anamorphic vscale)
     .hcrop_en(hcrop_en),                           // DVD-FORK (CRT anamorphic horizontal crop)
     .menu_ff(menu_ff),                             // DVD-FORK (menu VBUF-lag §5): fast-drain a deeply-buffered menu

--- a/rtl/mpeg2/resample.v
+++ b/rtl/mpeg2/resample.v
@@ -45,7 +45,6 @@ module resample(
   cur_show_out,                                     // DVD-FORK (film-aware drop reclaim)
   pickup_tick, pickup_show, refresh_tick_dbg,       // DVD-FORK (vid_err instrument)
   film_det_ntsc, film_det_pal,                      // DVD-FORK (Film 24p auto-detect)
-  det_video,                                        // DVD-FORK (Interlaced Out auto): true-interlaced verdict
   raster_par_err,                                   // DVD-FORK (field-parity corrector): mixer frame-top parity mismatch (synced level)
   vscale_mode,                                      // DVD-FORK (CRT anamorphic vertical scaler)
   hcrop_en,                                         // DVD-FORK (CRT anamorphic horizontal crop)
@@ -105,7 +104,6 @@ module resample(
   output             refresh_tick_dbg;            // one pulse per displayed refresh (video_live-gated)
   output             film_det_ntsc;               // DVD-FORK (Film 24p auto-detect): sustained 3:2 telecine verdict (NTSC 24p)
   output             film_det_pal;                // DVD-FORK (Film 24p auto-detect): sustained progressive verdict (PAL 25p)
-  output             det_video;                   // DVD-FORK (Interlaced Out auto): sustained true-interlaced-video verdict (480i/576i)
   input              raster_par_err;              // DVD-FORK (field-parity corrector): mixer frame-top parity mismatch (2-FF synced level)
   input        [1:0] vscale_mode;                 // DVD-FORK (CRT anamorphic vscale): 0=fit 1=letterbox
   input              hcrop_en;                    // DVD-FORK (CRT anamorphic horizontal crop / pan-scan)
@@ -171,7 +169,6 @@ module resample(
     .refresh_tick_dbg(refresh_tick_dbg),
     .film_det_ntsc(film_det_ntsc),                 // DVD-FORK (Film 24p auto-detect)
     .film_det_pal(film_det_pal),
-    .det_video(det_video),                         // DVD-FORK (Interlaced Out auto)
     .raster_par_err(raster_par_err),               // DVD-FORK (field-parity corrector)
     .vscale_mode(vscale_mode),                     // DVD-FORK (CRT anamorphic vscale)
     .hcrop_en(hcrop_en),                           // DVD-FORK (CRT anamorphic horizontal crop)

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -65,10 +65,9 @@ the data-track `.bin` and the core strips the raw CD sectors in fabric, demuxes 
 (VCD) or MPEG-2 (SVCD) stream, and plays it with correct 44.1 kHz audio pitch, seek and
 pause.
 
-**Analog / CRT** — two simultaneous rasters: the progressive one for HDMI, plus a native
-15 kHz 480i/576i raster on the analog pins. It engages from `MiSTer.ini` alone, like any
-other core. A [field-passthrough mode](video/analog-crt.md) hands the CRT the disc's
-authored fields 1:1.
+**Analog / CRT** — a native 15 kHz 480i/576i raster on the analog pins, built from the
+disc's [authored fields](video/analog-crt.md), re-timed 1:1 — the presentation a set-top
+player feeds a TV. It engages from `MiSTer.ini` alone, like any other core.
 
 **Closed captions** — NTSC discs carry EIA-608 captions hidden in the MPEG-2 video stream,
 separately from subtitles. The core extracts them and re-modulates them onto

--- a/site/content/playback/settings.md
+++ b/site/content/playback/settings.md
@@ -4,7 +4,7 @@ Everything here is in the core's OSD. The **default is shown in bold**, and the
 defaults are chosen to be correct for most setups — on a normal HDMI installation you
 should not need to change anything.
 
-Settings are saved to `/media/fat/config/DVD_v1.CFG` and persist across core reloads.
+Settings are saved to `/media/fat/config/DVD_v2.CFG` and persist across core reloads.
 
 ## Main page
 
@@ -17,11 +17,16 @@ Settings are saved to `/media/fat/config/DVD_v1.CFG` and persist across core rel
 | **Audio Out** | **Decode PCM** / Passthru (SPDIF+HDMI) | Decode PCM decodes in fabric and sends stereo. Passthru sends the undecoded bitstream to an AV receiver — see [Bitstream passthrough](../audio/passthrough.md). |
 | **SPDIF Byte Order** | **Normal** / Swap | Applies to *both* bitstream outputs despite the name. If a receiver names the format but plays static, toggle this. |
 | **Player Language** | **English** / 15 others | The player's language preference for menus, audio and subtitles, like a set-top player's setup screen. Discs use it to pick a default track. |
-| **Interlaced Out** | **Off** / Auto / On | Native 480i/576i to HDMI — see [Interlaced output](../video/interlaced.md). |
-| **480i Deint** | **Bob** / Weave | How the framework scaler deinterlaces when receiving 480i. |
-| **Analog Out** | **Auto** / Interlaced / Progressive / Native Fields | The analog CRT raster — see [Analog and CRT output](../video/analog-crt.md). |
+| **Video Output** | **Auto** / Interlaced / Progressive | The core's one output-mode choice: authored interlaced fields (CRTs, true-video content) or progressive (HDMI, film) — see [Video Output](../video/interlaced.md). Auto follows `MiSTer.ini`. |
+| **480i Deint** | **Bob** / Weave | How the framework scaler deinterlaces when receiving 480i (HDMI, while Video Output is Interlaced). |
 | **Analog Aspect** | **Auto** / Fit / Letterbox / Crop | How anamorphic content fits a 4:3 analog TV — see [Analog Aspect](../video/analog-crt.md#analog-aspect). |
 | **Video Standard** | **Auto** / NTSC / PAL | Auto detects from the stream's vertical size (480 = NTSC, 576 = PAL). |
+
+!!! info "Unreleased"
+    **Video Output** replaces the previous `Interlaced Out` and `Analog Out` settings
+    (which overlapped confusingly), and this relayout bumps the saved-settings file to
+    `DVD_v2.CFG` — [settings reset once](#settings-that-reset-after-an-update) on
+    updating. Releases up to and including v0.3.0 still have the old pair.
 
 ### Reset
 
@@ -74,7 +79,7 @@ If lip sync is wrong in a way this does not fix, that is a bug rather than a set
 
 ## Settings that reset after an update
 
-Saved settings live in `/media/fat/config/DVD_v1.CFG`, where `v1` is a **layout version**.
+Saved settings live in `/media/fat/config/DVD_v2.CFG`, where `v2` is a **layout version**.
 
 When a release changes the OSD option layout incompatibly, that number is bumped, and your
 settings fall back to the defaults rather than being silently misread — an old file's bits

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -125,7 +125,7 @@ into a 4:3 raster and needs unsqueezing. See
 ### Motion looks juddery or wobbly on a CRT
 
 Make sure **`Video Output`** is `Interlaced` (or `Auto` with the
-[analog ini bits](../video/analog-crt.md#turning-it-on) set) *before loading the disc* —
+[analog ini bits](../video/analog-crt.md#turning-it-on) set) —
 the CRT then gets the disc's authored fields. See [Video Output](../video/interlaced.md).
 On builds up to v0.3.0 the equivalent setting is `Analog Out = Native Fields`; those
 builds' other analog modes have a known field-pairing wobble on video-sourced content.

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -122,11 +122,19 @@ Set **`Analog Aspect`** to `Letterbox` (or `Crop`). Anamorphic content is stored
 into a 4:3 raster and needs unsqueezing. See
 [Analog Aspect](../video/analog-crt.md#analog-aspect).
 
-### Motion looks juddery on a CRT
+### Motion looks juddery or wobbly on a CRT
 
-If the content is video-sourced — television, concert footage — set
-**`Analog Out` = `Native Fields`** *before loading the disc*. See
-[Native Fields](../video/analog-crt.md#native-fields).
+Make sure **`Video Output`** is `Interlaced` (or `Auto` with the
+[analog ini bits](../video/analog-crt.md#turning-it-on) set) *before loading the disc* —
+the CRT then gets the disc's authored fields. See [Video Output](../video/interlaced.md).
+On builds up to v0.3.0 the equivalent setting is `Analog Out = Native Fields`; those
+builds' other analog modes have a known field-pairing wobble on video-sourced content.
+
+### The picture goes aliased / screen-door after a chapter skip on a CRT
+
+Fixed in current builds — field alignment now recovers automatically within a couple of
+fields. On builds up to v0.3.0, toggle `Analog Out` away and back (sometimes several
+times) to re-roll the field phase.
 
 ### A film disc keeps changing resolution, or judders
 

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -148,6 +148,17 @@ Also confirm **`Frame Drop` is On** — the cadence corrector runs on that path.
 
 Fixed in current builds. Update the core.
 
+### Black & white picture over composite or S-video
+
+`MiSTer.ini` is missing `vga_mode=svideo` (or `vga_mode=cvbs` for composite). Without it
+the framework's Y/C encoder is off, the pins carry raw RGB, and the luma line shows a
+stable colorless picture. The chroma standard (PAL/NTSC) is picked automatically once the
+encoder is on. See [Analog and CRT output](../video/analog-crt.md#turning-it-on).
+
+If `vga_mode` is set and other cores show color on the same cable but the DVD core does
+not — or an NTSC disc shows color while a PAL disc is B&W — that is worth
+[reporting](reporting-a-bug.md), along with the OSD's reported resolution line.
+
 ### Nothing on the analog output at all
 
 Check `MiSTer.ini` has `vga_scaler=0` and a sync mode matching your cable

--- a/site/content/video/analog-crt.md
+++ b/site/content/video/analog-crt.md
@@ -1,8 +1,14 @@
 # Analog and CRT output
 
-The core drives a real CRT natively. It emits **two rasters at the same time**: the normal
-progressive one for HDMI, and a native 15 kHz 480i/576i raster on the analog pins. The two
-are independent, so **HDMI quality is never reduced by having the CRT connected**.
+!!! info "Unreleased"
+    The `Analog Out` setting described here for releases up to v0.3.0 has been replaced
+    by the single [`Video Output`](interlaced.md) option. This page describes the
+    current development build.
+
+The core drives a real CRT natively: with
+[`Video Output = Interlaced`](interlaced.md) (or Auto with the ini below), the analog
+pins carry a native 15 kHz 480i/576i raster built from the disc's **authored fields**,
+re-timed 1:1 — the same presentation a set-top player feeds a TV.
 
 ## Turning it on
 
@@ -14,49 +20,23 @@ vga_scaler=0        ; (the default) native video on the analog pins
 composite_sync=1    ; or ypbpr=1, or vga_sog=1 — match your cable
 ```
 
-That is the whole setup. `Analog Out` in the OSD is an override for cases where the ini
-bits alone do not describe your rig.
+That is the whole setup — `Video Output = Auto` reads those bits and lands on Interlaced.
+Set the mode explicitly only when the ini bits cannot describe your rig (a 15 kHz RGBHV
+monitor: **Interlaced**) or when your analog display wants a progressive signal
+(480p/576p component or VGA: **Progressive**). The mode table and the full description
+live on the [Video Output](interlaced.md) page.
 
-## Analog Out modes
+!!! warning "HDMI shows 480i while a CRT is active"
+    Interlaced mode puts the whole core in field mode, so HDMI drops to 480i via the
+    framework scaler for the session. The earlier dual-raster arrangement that kept HDMI
+    progressive alongside the CRT was removed with its structurally unstable
+    field-pairing (the "wobbly interlace" reports) — pick the output that matters and
+    set `Video Output` for it.
 
-`Auto` follows `MiSTer.ini` and is right for most setups.
-
-| Your setup | Mode |
-|---|---|
-| CRT only, video-sourced content (TV, concerts, live recordings) | **Native Fields** — smoothest motion |
-| CRT only, film | **Native Fields** or **Auto** — little difference |
-| CRT **and** HDMI at the same time | **Auto** or **Interlaced** |
-| A 15 kHz RGBHV rig the ini bits cannot identify | **Interlaced** |
-| A display that wants 480p/576p on the analog pins | **Progressive** |
-
-An explicit choice always overrides `MiSTer.ini` and persists across reloads.
-
-### Native Fields
-
-The other modes build the CRT's fields by taking a woven progressive frame apart again.
-**Native Fields** instead puts the decoder itself into field mode, so the CRT receives the
-disc's **authored** fields, re-timed 1:1.
-
-On true-interlaced content — television, concert footage, anything shot on video rather
-than film — this is visibly smoother. It is the correct answer for a CRT-only setup.
-
-!!! warning "It puts the whole core in field mode"
-    HDMI drops to 480i for the session and is deinterlaced by the framework scaler, which
-    is not cadence-aware — so **film content regresses on HDMI** while this mode is active.
-    That is why it is opt-in rather than automatic.
-
-!!! danger "Set it before loading a disc"
-    Changing `Analog Out` mid-title fires a full seek-equivalent flush. Pick the mode
-    first, then load.
-
-Why this exists rather than a cheaper fix: on the derived-field path, whether you see a
-coherent picture depends on which field of the pair lands on which raster field, and the
-frame-rate governor re-randomises that several times a second under normal load. There is
-no phase adjustment that holds. Feeding the decoder's own fields removes the pairing
-question entirely — every displayed refresh is one genuine field of exactly one picture.
-
-Film content barely notices the difference, because each field still lies wholly within one
-picture either way. **True 29.97i video is where it shows.**
+Motion looks right on video-sourced discs by construction — every displayed refresh is
+one genuine authored field — and film's 3:2 field cadence on a CRT is exactly what an
+NTSC player output. Seeks and aspect changes land clean:
+[field alignment is automatic](interlaced.md#field-alignment-is-automatic).
 
 ## Analog Aspect
 
@@ -102,7 +82,6 @@ upscale.
 - **PAL on an analog CRT is implemented but unconfirmed.** The 576i timings are derived by
   analogy with the hardware-proven NTSC ones, and no PAL CRT was available to test them.
   PAL over HDMI is confirmed working.
-- While the analog raster is active, [Film 24p](film-24p.md) output is suppressed — the
-  re-interlacer needs the standard progressive raster to work from.
-- In the derive modes (`Auto`, `Interlaced`), [Interlaced Out](interlaced.md) is forced
-  off for the same reason.
+- While `Video Output = Interlaced`, [Film 24p](film-24p.md) output is unavailable — a
+  23.976 Hz raster cannot carry fields. Film on the CRT plays with its normal 3:2 field
+  cadence instead, which is what an NTSC player always did.

--- a/site/content/video/analog-crt.md
+++ b/site/content/video/analog-crt.md
@@ -26,6 +26,13 @@ monitor: **Interlaced**) or when your analog display wants a progressive signal
 (480p/576p component or VGA: **Progressive**). The mode table and the full description
 live on the [Video Output](interlaced.md) page.
 
+In Progressive mode the analog pins carry the plain progressive raster through the stock
+path — a **31 kHz** signal a 15 kHz CRT cannot sync — and the analog-only extras
+(line-21 captions, sub-720 fill, Analog Aspect) are off. One thing to know on a
+progressive-analog rig: [Film 24p](film-24p.md) is *not* suppressed there, so with it on
+Auto a film disc switches the pins to a 23.976/25 Hz raster that almost no analog
+display accepts — set `Film 24p Out = Off`, or run `vga_scaler=1`.
+
 !!! warning "HDMI shows 480i while a CRT is active"
     Interlaced mode puts the whole core in field mode, so HDMI drops to 480i via the
     framework scaler for the session. The earlier dual-raster arrangement that kept HDMI

--- a/site/content/video/analog-crt.md
+++ b/site/content/video/analog-crt.md
@@ -20,6 +20,16 @@ vga_scaler=0        ; (the default) native video on the analog pins
 composite_sync=1    ; or ypbpr=1, or vga_sog=1 — match your cable
 ```
 
+**Composite or S-video** additionally needs the framework's Y/C encoder switched on —
+without it the pins carry raw RGB and the picture arrives **black & white**:
+
+```ini
+vga_mode=svideo     ; or vga_mode=cvbs for composite
+```
+
+The chroma standard (PAL/NTSC subcarrier) follows the disc automatically — the framework
+picks it from the video rate.
+
 That is the whole setup — `Video Output = Auto` reads those bits and lands on Interlaced.
 Set the mode explicitly only when the ini bits cannot describe your rig (a 15 kHz RGBHV
 monitor: **Interlaced**) or when your analog display wants a progressive signal

--- a/site/content/video/closed-captions.md
+++ b/site/content/video/closed-captions.md
@@ -23,7 +23,8 @@ core.
 
 1. **An NTSC disc that actually has captions.** Only about **1 disc in 6** does. Every PAL
    disc scanned has none — line 21 is an NTSC construct, and PAL discs use subtitles instead.
-2. **The analog output engaged** — see [Analog and CRT output](analog-crt.md).
+2. **The analog output engaged** — `Video Output = Interlaced`, or Auto with the analog
+   ini bits set; see [Analog and CRT output](analog-crt.md).
 3. **A connection that carries line 21.** Composite and S-video always do. Component does
    on many sets. **Consumer sets generally do not slice captions from RGB**, so an RGB
    SCART path often will not work even though the waveform is present on all three channels.

--- a/site/content/video/film-24p.md
+++ b/site/content/video/film-24p.md
@@ -92,6 +92,7 @@ left to detect. Nothing can infer it from the stream, which is why the manual **
 
 - **When Auto engages a couple of seconds into a title, audio can end up slightly offset**
   until the next seek re-syncs it. A chapter jump or a D-pad seek clears it.
-- **If the analog CRT raster is active, the film raster is suppressed** — the re-interlacer
-  needs the standard progressive raster to work from. See
-  [Analog and CRT output](analog-crt.md).
+- **Film 24p needs `Video Output = Progressive`** (or Auto on an HDMI rig) — a 23.976 Hz
+  raster cannot carry interlaced fields, so it is unavailable while
+  [Interlaced mode](interlaced.md) is active. Film on a CRT plays with its normal 3:2
+  field cadence instead.

--- a/site/content/video/interlaced.md
+++ b/site/content/video/interlaced.md
@@ -1,54 +1,83 @@
-# Interlaced output (HDMI)
+# Video Output
 
-`Interlaced Out` controls whether the core sends **native 480i/576i fields** to HDMI
-instead of a progressive picture. Default **Off**.
+!!! info "Unreleased"
+    `Video Output` replaces the previous `Interlaced Out` and `Analog Out` settings.
+    Releases up to and including v0.3.0 still have the old pair — this page describes
+    the current development build.
 
-This is separate from [Analog and CRT output](analog-crt.md), which has its own raster and
-its own setting.
+`Video Output` is the core's one output-mode choice:
 
 | Mode | Behaviour |
 |---|---|
-| **Off** *(default)* | Weave both fields into a progressive frame. |
-| **Auto** | Engage native fields when the content is detected as true-interlaced video. |
-| **On** | Always send native fields. |
+| **Auto** *(default)* | Follows `MiSTer.ini`: an analog TV configured there means **Interlaced**, otherwise **Progressive**. |
+| **Interlaced** | The decoder emits the disc's **authored fields**. The analog pins carry a native 15 kHz 480i/576i raster for a CRT; HDMI shows 480i through the framework scaler. |
+| **Progressive** | The progressive picture, as before. HDMI at full quality, [Film 24p](film-24p.md) available, and the analog pins carry the progressive raster for displays that take 480p/576p. |
 
-`480i Deint` (Bob / Weave) then picks how the framework scaler deinterlaces what it
-receives.
+An explicit choice always overrides `MiSTer.ini` and persists across reloads.
 
-## What it is for
+## Which one you want
+
+| Your setup | Mode |
+|---|---|
+| HDMI | **Auto** (lands on Progressive) |
+| A 15 kHz CRT — composite, s-video, YPbPr, RGB SCART | **Auto** with the ini set up as below (lands on Interlaced) |
+| A 15 kHz RGBHV rig the ini bits cannot identify | **Interlaced**, explicitly |
+| A display that wants 480p/576p on the analog pins | **Progressive**, explicitly |
+| HDMI, but a disc of true-interlaced video (TV, concerts) and you want native fields | **Interlaced**, explicitly |
+
+For a CRT there is nothing to set in the OSD — it engages from `MiSTer.ini` exactly like
+any other core:
+
+```ini
+vga_scaler=0        ; (the default) native video on the analog pins
+composite_sync=1    ; or ypbpr=1, or vga_sog=1 — match your cable
+```
+
+## What Interlaced mode does
 
 DVD content shot on video — television, concerts, documentaries — is genuinely interlaced
-at 59.94 (or 50) fields per second. Weaving those fields into 29.97 progressive frames
-throws away half the motion information, which reads as juddery movement.
+at 59.94 (or 50) fields per second. Weaving those fields into progressive frames throws
+away half the motion information, which reads as juddery movement. In Interlaced mode
+every displayed refresh is one genuine authored field of exactly one picture, which is
+what a CRT is built to show.
 
-Sending native fields preserves it. On film content it makes no real difference, because
-film has only 24 distinct images per second regardless.
+While it is active:
 
-## Off by default, and Auto is opt-in
+- The **CRT** gets the fields re-timed 1:1 on a native 15 kHz raster — the smoothest
+  presentation for video-sourced discs, and the same thing a set-top player outputs.
+- **HDMI** drops to 480i for the session, deinterlaced by the framework scaler.
+  `480i Deint` picks Bob (smooth motion, half vertical resolution) or Weave (full
+  resolution, combing on motion). The scaler is not cadence-aware, so **film content
+  looks better in Progressive mode on HDMI** — which is why Interlaced is not forced
+  whenever a CRT is merely present, only chosen.
+- [Film 24p](film-24p.md) output is unavailable (a 23.976 Hz raster cannot carry fields).
 
-**`On` plays correctly with A/V sync** — the mode is fixed at load time, so nothing changes
-mid-title.
+Film on a **CRT** in Interlaced mode is fine — 3:2 fields at 60 Hz is exactly what an NTSC
+player fed a TV — so a CRT-only setup can simply stay in Interlaced (or Auto) for
+everything.
 
-**`Auto` still has a known problem.** The detector's verdict lands about 1.7 seconds into
-playback, so the switch is inherently mid-title, and even with the full seek-style re-sync
-that follows it, **audio ends up slightly out of sync**. It is kept as an opt-in to revisit
-rather than being the default.
+!!! danger "Set it before loading a disc"
+    Changing `Video Output` mid-title fires a full seek-equivalent flush. Pick the mode
+    first, then load.
 
-So: if you know a disc is video-sourced and you want native fields on HDMI, set **On**
-before loading it. Leave the default alone otherwise.
+## Field alignment is automatic
 
-!!! tip "On a CRT, use Native Fields instead"
-    If your target is an analog CRT rather than HDMI,
-    [`Analog Out = Native Fields`](analog-crt.md#native-fields) is the better route — it is
-    hardware-confirmed, has no mid-title switch, and gives the CRT the disc's authored
-    fields directly.
+Earlier builds could come back from a chapter skip, fast-forward or aspect change with a
+**badly aliased, screen-door picture** that only cleared after toggling the output mode a
+few times. That was a field-parity coin flip in the display pipeline, and it is fixed: the
+core now checks every displayed field against the raster phase and re-aligns within a
+field or two, so seeks and mode changes land clean without any ritual.
 
-## Interactions
+## What changed from the old settings
 
-- While the analog raster is engaged in `Auto` or `Interlaced` mode, `Interlaced Out` is
-  **forced off** — the re-interlacer needs the progressive main raster to derive from.
-- `Analog Out = Native Fields` does the opposite: it forces field mode on for the whole
-  session, which is what makes HDMI drop to 480i in that mode.
-- Overlays — subtitles, menu highlights, the transport HUD and seek bar — render correctly
-  in interlaced mode. They previously appeared squashed into the left half of the screen;
-  that is fixed.
+- The old `Analog Out = Native Fields` **is** the new Interlaced mode, renamed — it was
+  the mode worth keeping.
+- The old derive modes (`Analog Out = Auto/Interlaced`), which rebuilt CRT fields from a
+  woven progressive frame, are gone: field pairing on that path was structurally unstable
+  (the "wobbly interlace" field reports) and Interlaced mode is immune by construction.
+  This also means the old "CRT 480i and full-quality progressive HDMI at the same time"
+  combination no longer exists — with a CRT active, HDMI shows 480i. Pick the output that
+  matters and set the mode for it.
+- The old `Interlaced Out` (HDMI fields) is subsumed: `Video Output = Interlaced` gives
+  HDMI the same 480i-via-scaler picture. Its `Auto` content detector is retired — it
+  switched mid-title, which never worked cleanly with audio.

--- a/site/content/video/interlaced.md
+++ b/site/content/video/interlaced.md
@@ -56,9 +56,13 @@ Film on a **CRT** in Interlaced mode is fine — 3:2 fields at 60 Hz is exactly 
 player fed a TV — so a CRT-only setup can simply stay in Interlaced (or Auto) for
 everything.
 
-!!! danger "Set it before loading a disc"
-    Changing `Video Output` mid-title fires a full seek-equivalent flush. Pick the mode
-    first, then load.
+!!! note "Switching mid-title works, with a brief interruption"
+    Changing `Video Output` during playback fires a full seek-equivalent flush — a short
+    cut to black while the raster and A/V sync re-anchor, like a chapter jump — and then
+    plays on cleanly (field alignment recovers automatically). Setting the mode before
+    loading just avoids the interruption; it is not required. On builds up to v0.3.0
+    the equivalent switch could come back badly aliased — that is the
+    [fixed parity bug](#field-alignment-is-automatic).
 
 ## Field alignment is automatic
 

--- a/tools/video_cadence_census.py
+++ b/tools/video_cadence_census.py
@@ -16,9 +16,10 @@
 # progressive_frame @12) rather than from the spec, so the census and the RTL
 # cannot drift apart.
 #
-# WHY IT EXISTS: `Analog Out = Native Fields` (docs/analog_dual_raster.md) only
-# shows its benefit on TRUE-INTERLACED (video-sourced) content -- on film the
-# derive path is nearly as good. Picking a test disc by intuition ("a concert
+# WHY IT EXISTS: `Video Output = Interlaced` (the authored-fields mode; was
+# "Analog Out = Native Fields" before the 2026-09 consolidation) only shows its
+# benefit on TRUE-INTERLACED (video-sourced) content -- film's 3:2 fields look
+# much the same either way. Picking a test disc by intuition ("a concert
 # is probably video") is a guess; this measures it.
 #
 # ★ SAMPLES DEEP, NOT HEADS. The Thayer's Quest diagnosis was derailed for
@@ -152,13 +153,13 @@ def verdict(acc):
     tog = acc['rff_toggle'] / n
     if pf < 0.10:
         return "VIDEO (true interlaced)", \
-               "det_video engages -> the ideal Native Fields test disc"
+               "the ideal Interlaced-mode (authored fields) test disc"
     if pf > 0.90 and tog > 0.20:
         return "FILM (3:2 soft telecine)", \
-               "det_ntsc engages; Native Fields gains little here"
+               "det_ntsc engages; Interlaced mode gains little here"
     if pf > 0.90 and rf < 0.05:
         return "FILM/PROGRESSIVE (25p or 30p)", \
-               "sustained progressive_frame; Native Fields gains little"
+               "sustained progressive_frame; Interlaced mode gains little"
     if pf > 0.90:
         return "FILM (progressive, irregular rff)", "mostly progressive_frame"
     return "MIXED", "neither detector would sit engaged -- inspect per-window"
@@ -200,7 +201,7 @@ def main():
             print(f"{'':44s}   per-window prog_frame%%: {sp}")
 
     if len(rows) > 1:
-        print("\n=== Native Fields test candidates (lowest progressive_frame%% first) ===")
+        print("\n=== Interlaced-mode (authored fields) test candidates (lowest progressive_frame%% first) ===")
         for name, vts, acc, v, _ in sorted(
                 rows, key=lambda r: r[2]['prog'] / max(1, r[2]['n'])):
             n = acc['n'] or 1


### PR DESCRIPTION
Two CRT field reports drove this branch: the derive/weave analog path looking
"extremely wobbly" (the long-documented field-pairing defect, finally seen in the
wild), and `Native Fields` coming back from any chapter skip / fast-forward /
Analog Aspect change "super aliased" until the mode was toggled 3–4 times.

Reported by #32 

## What's in it

**1. Field-parity re-engage corrector** (`docs/field_parity.md`)
The mixer's relaxed frame-top matcher accepts a field at either raster parity slot
(the old 3:2/drop black-fields fix), and nothing carried raster parity back to the
display pickup — so one odd perturbation (a seek's arbitrary first `tff`, a raster
restart, cold-start luck) flipped content-field↔raster-field phase *permanently*.
Invisible under HDMI Bob, glaring on a CRT. Fix: a feed-forward alternation guard
plus a mixer→addrgen parity feedback loop that inserts exactly one held-frame
field. The triggers compose by XOR and the inserted field's type depends on which
fired (the naive OR design livelocks). Proven RED on pre-fix RTL / GREEN after, on
the real display chain (`bench/dvd/field_parity_tb.sv`); progressive path
bit-identical by construction and A/B'd.

**2. Video Output consolidation** (reverses the 2026-08-23 "all four modes stay"
review — rationale recorded at that block in `docs/roadmap.md`)
`O[10:9] Interlaced Out` + `O[27:26] Analog Out` become one
**`Video Output: Auto / Interlaced / Progressive`**. Interlaced = the old Native
Fields renamed (authored fields session-wide; fieldpass analog raster; HDMI 480i
via ascal); Auto follows the MiSTer.ini analog bits, boot-static; Progressive
keeps Film 24p. Deleted: the weave/derive analog path, the `det_video` Auto
detector, the old enums. `re_interlace` is fieldpass-only. Config layout bumps to
`v,2` (saved settings reset once). Deliberate trade: the "CRT 480i + progressive
HDMI simultaneously" combination no longer exists — pick your output.

**3. Boot-time modeline-walk reset race fix** (found by HW round 1: Interlaced
boot showed `719x...i @ 31.48 kHz`, dead CRT)
The walk keyed on raw `reset_n` while the decoder synchronizes its resets
internally, so the boot walk's register writes were silently swallowed — a latent
race the ini-driven `Auto` was the first to arm. Kicks now wait for the decoder's
own `sync_rst_out`. Proven RED/GREEN over the real `reset.v` + `regfile.v`
(`bench/dvd/modeline_boot_tb.sv`).

Manual updated throughout in the same commits (`docs_check` + `mkdocs --strict`
green); README headline corrected; engineering docs carry superseded headers and
the decision-reversal note.

Timing: SEED 5 held first-roll twice — clk_dec 93.28/89.91 (gate 86.0), 88% ALM.
Build for testing: `DVD_videoout2_20260902_1312.rbf`.

## Test plan

- [x] `field_parity_tb` RED on pre-fix RTL (both raster-phase arms), GREEN after
- [x] `modeline_boot_tb` RED pre-fix / GREEN after (boot, OSD toggle, reload)
- [x] Progressive-path bit-identity: `run_prefetch_chain.sh` A/B vs pre-fix baseline
- [x] `run_film_evidence.sh`, all direct addrgen TBs, reworked `re_interlace_tb`
      (6 fieldpass scenarios), `cc_e2e_tb` on the fields raster — green
- [x] `docs_check.py` + `mkdocs build --strict`
- [x] HW: Interlaced boots correctly from ini (post race-fix build); mid-title
      mode switch lands clean (user report)
- [ ] HW: reporter scenarios — chapter skip / FF / Analog Aspect changes on a CRT
      in Interlaced mode land clean, no toggle ritual (the parity gate)
- [ ] HW: NTSC no-regression pass (HDMI progressive, Film 24p, menus, captions)
- [ ] HW: PAL 576i on a PAL CRT (first-ever hardware data point; tester lined up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
