### PR TITLE
docs: flip the field-parity corrector's status markers to DISABLED

### DIFF
--- a/docs/field_parity.md
+++ b/docs/field_parity.md
@@ -1,13 +1,33 @@
 # Field-parity re-engage corrector (2026-09-02)
 
-**Status: ✅ MERGED (PR #37, 2026-09-02); sim-proven (RED pre-fix / GREEN post-fix,
-`bench/dvd/field_parity_tb.sv`); ⏳ HW-confirm pending — the gate is the two field
-reports below (chapter skip / FF / Analog Aspect change on a CRT in Native Fields no
-longer needs mode-toggling to fix). HW so far: a mid-title switch to Interlaced lands
-clean (user report). NOTE 2026-09-03: the analog delivery under this corrector changed —
-`re_interlace` is gone and the interlaced main raster drives the CRT directly
-(`docs/single_raster_analog.md`); the corrector itself is untouched and `run_field_parity.sh`
-stays green (it never touched the raster, only which field image is picked up).**
+**Status: ⛔ DISABLED ON HARDWARE (2026-09-03, PR #40) — `par_ins` is tied 0 in
+`dvd/resample_addrgen.v`. Tracking issue: #41.**
+
+★ **It made BOTH displayed fields carry the SAME source lines.** Measured from HW
+screenshots of a still by splitting each woven frame into its two fields and correlating
+them: **+0.00** frame lines of offset with the corrector on, where a correct interlaced
+still measures **+0.50**. That is a combed still under Weave and a picture that jumps a
+field line under Bob — on **every** output, HDMI included, which is what finally
+distinguished it from the sync-shape theories five HW rounds were spent on
+(`docs/single_raster_analog.md` §3.9). v0.3.0 `Analog Out = Native Fields` — the same
+authored-fields content path WITHOUT this corrector — measures +0.50 and is clean.
+
+⚠ **`bench/dvd/field_parity_tb.sv` stayed GREEN throughout.** Two reasons, both worth
+reading before trusting it again: its behavioural framestore returns a CONSTANT word (no
+displayed pixel carries evidence of which source line it came from), and its pass
+condition is the SAME EXPRESSION as the RTL's `frame_top_par_err` (it restates the
+design's convention instead of checking an external one — the POST-only PGC trap again).
+Replacement, committed UNFINISHED: `bench/dvd/field_phase_tb.sv`. Finish it FIRST.
+
+Disabling re-opens the coin flip this document was written to fix (below): after a chapter
+skip / FF / aspect change the field phase can land wrong on some sets, cleared by toggling
+`Video Output`. The maintainer's late-model CRT has never shown it; the two Discord
+reporters' older sets do.
+
+*(Historical status:)* ✅ MERGED (PR #37, 2026-09-02); sim-proven (RED pre-fix / GREEN
+post-fix, `bench/dvd/field_parity_tb.sv` — see the caveat above); the analog delivery
+under it later changed (`re_interlace` is gone, the interlaced main raster drives the CRT
+directly, `docs/single_raster_analog.md`).**
 
 ## The field reports
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1783,7 +1783,10 @@ contact with the field: (1) the derive path's field-pairing wobble (this doc's
 "re-randomised several times a second") was REPORTED FROM THE WILD as "extremely wobbly,
 not how an interlaced signal normally looks on a CRT"; (2) Native Fields shipped with a
 separate field-parity re-engage coin flip ("super aliased after a chapter skip, toggle
-the mode 3-4 times to fix") — root-caused and FIXED (`docs/field_parity.md`); (3) with
+the mode 3-4 times to fix") — root-caused and fixed at the time, but ⛔ **that corrector is
+DISABLED as of 2026-09-03 (PR #40, issue #41): on HW it made both interlaced fields carry
+the same source lines.** The coin flip is therefore OPEN again — `docs/field_parity.md`,
+`docs/single_raster_analog.md` §3.9; (3) with
 that fixed, fieldpass strictly dominates derive on the CRT side, and the maintainer chose
 to drop the one thing derive still bought (CRT 480i + progressive HDMI simultaneously —
 pick-your-output instead). The surface collapsed to **one option, `O[10:9] Video Output


### PR DESCRIPTION
#40 disabled the field-parity corrector (`par_ins` tied 0 in `dvd/resample_addrgen.v`)
but left two engineering notes asserting it was shipped and working:

- `docs/field_parity.md` — "✅ MERGED … sim-proven … the corrector itself is untouched"
- `docs/roadmap.md` — the chapter-skip coin flip "root-caused and FIXED"

A session picking up #41 would have read either and concluded the problem was closed.
That is the stale-status-marker class CLAUDE.md treats as fix-on-sight.

Both now state the corrector is **DISABLED**, carry the hardware measurement that
condemned it (**+0.00** frame lines of offset between the two displayed fields, where a
correct interlaced still measures **+0.50**), record that the coin flip is **open again**,
and point at issue #41.

`docs/field_parity.md` also gains the warning that matters most for whoever fixes it:
`bench/dvd/field_parity_tb.sv` stayed green throughout, because its framestore returns a
constant word (no displayed pixel carries evidence of which source line it came from) and
its pass condition is the same expression as the RTL's own `frame_top_par_err`. The
replacement bench is committed unfinished and must be finished first.

## Test plan

- [x] `python3 tools/docs_check.py` — OSD/controls/extensions parity
- [x] `mkdocs build --strict`
- [x] README self-anchors resolve
- [x] Documentation only; no RTL, no user-manual pages, no build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
