### PR TITLE
Repair and re-enable the field-parity corrector, and fix an inverted VGA_F1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,9 +268,14 @@ worse maintenance burden than targeted in-place edits. So:
   behavioural framestore returns a CONSTANT word (no displayed pixel carries evidence of
   which source line it came from) and its pass condition is the SAME EXPRESSION as the
   RTL's `frame_top_par_err` — a golden model that agrees with its RTL by construction
-  (the POST-only PGC trap again). Replacement: `field_phase_tb` (address-derived
-  framestore, per-field hashes of what the mixer EMITTED, consecutive fields must differ
-  and repeat with period 2).
+  (the POST-only PGC trap again). Replacement: `field_phase_tb` (LINE-STAMPED
+  framestore, per-field measurement of what the mixer EMITTED, consecutive fields must
+  differ and repeat with period 2). ★ **And the perturbation that finally exposed the
+  corrector was the MUNDANE one:** every scenario written from the field reports (seeks,
+  cold start, cadence breaks) passed with it on — the defect only appeared once the bench
+  STARVED the pixel queue, which is what this compute-bound core does several times a
+  second on real content. When a bench exonerates the code the hardware indicts, ask what
+  the hardware does all the time that the bench never does.
   ★ **The raster is the N64 model, on ONE raster** — halfline 429/432 in the interlaced
   modeline, doubled 2x (not 2x+1) by `syncgen_intf` to 858/864 = exactly half the line,
   with the 262/263 alternation ⇒ vsync exactly 262.5 lines apart EVERY field, so Main
@@ -325,6 +330,29 @@ worse maintenance burden than targeted in-place edits. So:
   ⏳ Not gated: PAL on an analog CRT, RGBHV, `direct_video=1` through an HDMI DAC, and
   the parity coin flip (the maintainer's late-model CRT has never shown it — the two
   Discord reporters' older sets do, so the corrector fix leans on `field_phase_tb`).
+- 🔧 **FIELD-PARITY CORRECTOR REPAIRED AND RE-ENABLED (2026-09-03, issue #41, branch
+  `fix/field-parity-corrector`) — sim-proven RED/GREEN, ⏳ HW-confirm pending (gate: a
+  still measures +0.50 field offset, and a chapter skip needs no toggle ritual).**
+  ★ **Root cause of the withdrawal: the FEEDBACK arm was chasing STARVATION.** Its cure
+  is a REPEATED field (re-showing `last_image` is the only insertion that lands the
+  resumed stream aligned — see the XOR note below), and it was firing at field rate,
+  because when the pixel queue runs dry the mixer displays nothing at that frame-top
+  opportunity and every following content field lands one raster slot later. That IS a
+  genuine parity error — but this core is compute-bound and does it repeatedly, so the
+  error churns, and one repeated field per starve is a far worse picture than the
+  half-line offset it removes. The old `par_armed` + **4-refresh** liveness re-arm
+  permitted an insertion every five refreshes = exactly the measured +0.00.
+  FIX = the feedback arm only acts on a **STABLE** error: `PAR_CONFIRM` (30 refreshes,
+  ~0.5 s) of a continuously-asserted verdict, plus `PAR_HOLD` (120 refreshes, ~2 s) as a
+  hard budget so a repeated field can never appear more often than that whatever the
+  starvation rate is. `par_age` starts saturated so the cold-start landing is not
+  delayed. The FEED-FORWARD arm (`alt_break`) is unchanged and ungated — it inserts the
+  OPPOSITE field, can never repeat one, and it is the arm that handles the reported
+  chapter-skip symptom. Gate: **`bench/dvd/field_phase_tb.sv`** (finished here; it was
+  committed unfinished by PR #40) + `run_field_phase.sh`, 7 windows × 2 raster phases.
+  Measured, not asserted: 4 starvation events cost **4** repeated fields with the shipped
+  corrector, **0** with the gate and **0** with the corrector off. Detail:
+  `docs/field_parity.md`.
 - 🔧 **VIDEO OUTPUT CONSOLIDATION + FIELD-PARITY RE-ENGAGE FIX (2026-09-02, branch
   `feature/video-output-consolidation`) — sim-proven (RED/GREEN), ⏳ HW-confirm pending
   (gate = the two CRT field reports below reproduce clean).** Two CRT field reports

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,16 +248,15 @@ worse maintenance burden than targeted in-place edits. So:
   maintainer's rig: HDMI and the composite CRT both clean, no jumpy image, steady
   `720x480i @ 59.9` (build `DVD_n64model_20260903_0148.rbf`, SEED 5, clk_dec 93.01/88.94).
   Design + post-mortem: `docs/single_raster_analog.md`.**
-  ★★ **THE DEFECT USERS REPORTED WAS THE FIELD-PARITY CORRECTOR (PR #37), NOT SYNC —
-  and it is DISABLED, not fixed** (`par_ins` tied 0 in `dvd/resample_addrgen.v`).
+  ★★ **THE DEFECT USERS REPORTED WAS THE FIELD-PARITY CORRECTOR (PR #37), NOT SYNC.**
   MEASURED from screenshots by splitting each woven frame into its two fields and
   correlating: with the corrector on, consecutive fields carry the SAME source lines
   (offset **+0.00** frame lines; a correct interlaced still measures **+0.50**) — weave
   combs on a STILL and bob jumps a field line, on HDMI and the CRT alike. v0.3.0
   `Analog Out = Native Fields` (same authored-fields content path, no corrector) measures
-  +0.50 and is clean. ⚠ Disabling re-opens the "super aliased after a chapter skip" coin
-  flip the corrector was written for — fixing it properly is the NEXT JOB, gated by the
-  new `bench/dvd/field_phase_tb.sv`.
+  +0.50 and is clean. This branch tied `par_ins` 0; the corrector is now ✅ **REPAIRED,
+  re-enabled and HW-CONFIRMED** — see the field-parity bullet below and
+  `docs/field_parity.md`.
   ★ **FIVE HW ROUNDS WERE SPENT ON THE WRONG LAYER; the rules that earns are in
   `docs/single_raster_analog.md` §3.9 and worth reading before the next hunt:** (1) when
   a build changes X and the symptom persists, X is EXONERATED — round 4 had no half-line
@@ -330,10 +329,11 @@ worse maintenance burden than targeted in-place edits. So:
   ⏳ Not gated: PAL on an analog CRT, RGBHV, `direct_video=1` through an HDMI DAC, and
   the parity coin flip (the maintainer's late-model CRT has never shown it — the two
   Discord reporters' older sets do, so the corrector fix leans on `field_phase_tb`).
-- 🔧 **FIELD-PARITY CORRECTOR REPAIRED AND RE-ENABLED (2026-09-03, issue #41, branch
-  `fix/field-parity-corrector`) — sim-proven RED/GREEN; ✅ HW ROUND 1 CONFIRMS THE CRT
-  ("always gets the fields right on the TV" where PR #40 was a coin flip); ⏳ round 2
-  gates the `VGA_F1` fix round 1 exposed.**
+- ✅ **FIELD-PARITY CORRECTOR REPAIRED AND RE-ENABLED (2026-09-03, issue #41, branch
+  `fix/field-parity-corrector`) — sim-proven RED/GREEN and ✅ HW-CONFIRMED: round 1 gave
+  the CRT ("always gets the fields right on the TV" where PR #40 was a coin flip) and
+  exposed an inverted `VGA_F1`; round 2 confirmed that fix
+  (`DVD_parityf1_20260903_1253.rbf`).**
   ★★ **ROUND 1 ALSO EXPOSED AN INVERTED `VGA_F1`, and only determinism could:** with the
   phase now fixed, HDMI Weave went from a coin flip to CONSISTENTLY COMBED while the CRT
   became consistently right. Two outputs disagreeing by exactly one field pins it to the
@@ -343,7 +343,7 @@ worse maintenance burden than targeted in-place edits. So:
   active pixel, so it uses the value from the PREVIOUS field's last line ⇒ the effective
   convention is **F1 = 0 on the TOP field**. `emu.sv` emitted `~core_v_pos[0]` (1 on top)
   ⇒ ascal stored the top field in the odd rows = a pairwise line swap = Weave combing on
-  a STILL. Now `core_v_pos[0]`. ⚠ Unfalsifiable while the parity was random — HDMI was
+  a STILL. Now `core_v_pos[0]`, ✅ HW-confirmed. ⚠ Unfalsifiable while the parity was random — HDMI was
   right half the time — and the line's own comment had said "polarity may need flipping on
   HW" since it was written. ⚠ **Not sim-gateable here**: ascal is VHDL, the benches are
   Icarus.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,8 +331,22 @@ worse maintenance burden than targeted in-place edits. So:
   the parity coin flip (the maintainer's late-model CRT has never shown it — the two
   Discord reporters' older sets do, so the corrector fix leans on `field_phase_tb`).
 - 🔧 **FIELD-PARITY CORRECTOR REPAIRED AND RE-ENABLED (2026-09-03, issue #41, branch
-  `fix/field-parity-corrector`) — sim-proven RED/GREEN, ⏳ HW-confirm pending (gate: a
-  still measures +0.50 field offset, and a chapter skip needs no toggle ritual).**
+  `fix/field-parity-corrector`) — sim-proven RED/GREEN; ✅ HW ROUND 1 CONFIRMS THE CRT
+  ("always gets the fields right on the TV" where PR #40 was a coin flip); ⏳ round 2
+  gates the `VGA_F1` fix round 1 exposed.**
+  ★★ **ROUND 1 ALSO EXPOSED AN INVERTED `VGA_F1`, and only determinism could:** with the
+  phase now fixed, HDMI Weave went from a coin flip to CONSISTENTLY COMBED while the CRT
+  became consistently right. Two outputs disagreeing by exactly one field pins it to the
+  FLAG, not the corrector — the analog pins never read `VGA_F1` (the raster half-line
+  carries the CRT's interleave). `sys/ascal.vhd` latches the flag at every DE rise and the
+  write-placement decision reads it in the SAME clocked process on the field's first
+  active pixel, so it uses the value from the PREVIOUS field's last line ⇒ the effective
+  convention is **F1 = 0 on the TOP field**. `emu.sv` emitted `~core_v_pos[0]` (1 on top)
+  ⇒ ascal stored the top field in the odd rows = a pairwise line swap = Weave combing on
+  a STILL. Now `core_v_pos[0]`. ⚠ Unfalsifiable while the parity was random — HDMI was
+  right half the time — and the line's own comment had said "polarity may need flipping on
+  HW" since it was written. ⚠ **Not sim-gateable here**: ascal is VHDL, the benches are
+  Icarus.
   ★ **Root cause of the withdrawal: the FEEDBACK arm was chasing STARVATION.** Its cure
   is a REPEATED field (re-showing `last_image` is the only insertion that lands the
   resumed stream aligned — see the XOR note below), and it was firing at field rate,

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -730,4 +730,9 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # field-parity corrector disabled, csync back to stock, Film 24p override): SEED 5 held
 # FIRST roll throughout -- the shipped build DVD_analogfinal_20260903_0235.rbf reads
 # clk_dec 96.44 @100C / 92.11 @-40C at 88% ALM. Eleventh consecutive first-roll fit.
+# 2026-09-03b (fix/field-parity-corrector, issue #41 -- the corrector re-enabled behind
+# a stability gate: two counters, a 6-bit and an 8-bit, replacing par_armed/par_tmo):
+# SEED 5 held FIRST roll again -- clk_dec 94.06 @100C / 91.29 @-40C at 88% ALM (36,906),
+# RAM 494/553, DSP 92/112. Twelfth consecutive first-roll fit. Build
+# DVD_parityfix_20260903_0450.rbf.
 set_global_assignment -name SEED 5

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -735,4 +735,7 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # SEED 5 held FIRST roll again -- clk_dec 94.06 @100C / 91.29 @-40C at 88% ALM (36,906),
 # RAM 494/553, DSP 92/112. Twelfth consecutive first-roll fit. Build
 # DVD_parityfix_20260903_0450.rbf.
+# 2026-09-03c (same branch + the VGA_F1 polarity flip after HW round 1 -- one inverter):
+# SEED 5, clk_dec 94.06 @100C / 91.29 @-40C, identical to the entry above as expected.
+# Build DVD_parityf1_20260903_1253.rbf (the HW round 2 candidate).
 set_global_assignment -name SEED 5

--- a/bench/dvd/cc_e2e_tb.sv
+++ b/bench/dvd/cc_e2e_tb.sv
@@ -21,7 +21,8 @@
  * model, sampling at the pixel enable (858 samples per line):
  *
  *   [1] finds caption bursts in the VBI (never during DE),
- *   [2] classifies each field by the raster's own field marker (v_pos[0] = ~VGA_F1);
+ *   [2] classifies each field by the raster's own field marker (v_pos[0], which is
+ *       what VGA_F1 carries since 2026-09-03);
  *       that it is the broadcast field 1 is proven by cc_field_map_tb (sync signature)
  *       and csync_field_tb (the analog pin),
  *   [3] demodulates each burst (slice at ~25 IRE, sample at bit centres) and
@@ -222,7 +223,8 @@ module cc_e2e_tb;
       // (a half-line here combs ascal's weave — HW round 3), so the vsync position no
       // longer distinguishes them; the 2:1 half-line is applied downstream, to the
       // analog composite sync, by sys_top's csync. The raster's own field marker is
-      // v_pos[0] (= ~VGA_F1), and that it marks the BROADCAST field-1 line-aligned
+      // v_pos[0] (what VGA_F1 carries since 2026-09-03), and that it marks the
+      // BROADCAST field-1 line-aligned
       // vsync is proven by bench/dvd/cc_field_map_tb.sv (sync_gen with the analog
       // half-line) and bench/dvd/csync_field_tb.sv (the csync pin, both fields
       // 262.5 lines apart).

--- a/bench/dvd/field_parity_tb.sv
+++ b/bench/dvd/field_parity_tb.sv
@@ -247,15 +247,20 @@ module field_parity_tb;
     begin t0 = ft_seen; wait (ft_seen >= t0 + n); @(posedge dot_clk); end
   endtask
 
-  localparam SETTLE = 6;       // frame-tops allowed for the correction to land
-  localparam NCHK   = 16;      // frame-tops that must ALL be aligned after it
+  localparam SETTLE    = 6;    // frame-tops allowed for a FEED-FORWARD correction to land
+  /* The FEEDBACK arm waits for the mixer's verdict to hold across PAR_CONFIRM refreshes
+   * before it inserts (dvd/resample_addrgen.v — the issue #41 fix: its cure costs a
+   * repeated field, so it must not chase a churning error). The windows that exercise it
+   * therefore need a settle window that long. */
+  localparam SETTLE_FB = 40;
+  localparam NCHK      = 16;   // frame-tops that must ALL be aligned after it
   integer errors = 0;
   integer settle_worst = 0;
 
-  task check_window(input [8*40-1:0] name);
+  task check_window_s(input [8*40-1:0] name, input integer settle);
     begin
       settling = 1; settle_mis = 0;
-      wait_fts(SETTLE);
+      wait_fts(settle);
       settling = 0;
       if (settle_mis > settle_worst) settle_worst = settle_mis;
       checking = 1; mis_seen = 0;
@@ -272,6 +277,10 @@ module field_parity_tb;
     end
   endtask
 
+  task check_window(input [8*40-1:0] name);
+    begin check_window_s(name, SETTLE); end
+  endtask
+
   integer phase = 0;
 
   initial begin
@@ -286,7 +295,7 @@ module field_parity_tb;
     repeat (2) @(negedge v_sync);
     repeat (phase) @(negedge v_sync);          // one field period shifts landing parity
     output_frame_valid = 1;
-    check_window("1-cold-start");
+    check_window_s("1-cold-start", SETTLE_FB);   // the feedback arm's window
 
     // [2] SEEK released on a SAME-parity tff (alternation break; the chapter skip)
     output_frame_valid = 0;

--- a/bench/dvd/field_phase_tb.sv
+++ b/bench/dvd/field_phase_tb.sv
@@ -1,15 +1,6 @@
 /*
  * field_phase_tb.sv — do the two displayed fields actually carry DIFFERENT lines?
  *
- * ⚠ WORK IN PROGRESS — DOES NOT YET PRODUCE A VERDICT. It elaborates and runs, but no
- * window result is printed: `fld_n` is not advancing, so `wait_flds` never returns and
- * the run ends on the global watchdog. Most likely the per-field hash stays 0 because
- * the accumulate condition (`pixel_en_out` with address-derived data) is not what this
- * harness actually presents — debug that first. It is committed unfinished ON PURPOSE:
- * it is the designated gate for repairing the field-parity corrector (which is DISABLED
- * in the RTL right now), and the reasoning below is the part worth keeping. Finish it
- * with that work; do not treat a silent run as a pass.
- *
  * WHY THIS EXISTS (2026-09-03, HW rounds 1-5). The field-parity corrector shipped with
  * a bench (bench/dvd/field_parity_tb.sv) that could not see the defect it introduced,
  * for two reasons worth remembering:
@@ -26,21 +17,52 @@
  * On hardware the corrector produced two fields sampling the picture at the SAME
  * vertical phase: a still measured +0.00 frame lines of offset between the fields where
  * a correct interlaced still measures +0.50, which is a weave comb and a bob that jumps
- * a field line. This bench measures exactly that, in RTL, with no reference to the
- * corrector's own idea of correctness:
+ * a field line.
  *
- *   - the framestore returns ADDRESS-DERIVED data, so every displayed pixel identifies
- *     the memory word it came from;
- *   - each displayed field is reduced to a hash of the data the mixer actually emitted;
- *   - INVARIANT A: consecutive displayed fields must DIFFER (they must not sample the
- *     same source lines) — this is what the HW defect violates;
- *   - INVARIANT B: over a steady window the hashes must repeat with period 2 (field N
- *     and field N+2 show the same lines), i.e. the display alternates cleanly.
+ * ★ HOW THIS BENCH MEASURES THAT, WITH NO REFERENCE TO ANY RTL CONVENTION.
+ * The behavioural framestore returns a word whose every byte is a code derived from the
+ * source line number — the memory is LINE-STAMPED, so every displayed pixel names the
+ * source line it came from (verified: the emitted luma is constant along a displayed line
+ * and steps by 2 down a field, because a field image walks source lines y, y+2, y+4 ...).
+ * For each displayed field the bench records, off the mixer's OWN output pins:
+ *
+ *   - `code`  — the stamp of the field's FIRST picture line  => its source line;
+ *   - `vpar`  — the raster field it landed in (v_pos parity at that line: even = the
+ *               raster's top field, odd = the bottom field);
+ *   - `hash`  — an FNV-1a hash of every luma sample the mixer emitted in the field.
+ *
+ * and checks three things:
+ *
+ *   INVARIANT A (the HW defect): consecutive fields must carry DIFFERENT source lines.
+ *     `line(n) - line(n-1)` must be +/-1 — the RTL equivalent of the screenshot's
+ *     +0.50 frame-line field offset. The shipped corrector made it 0.
+ *   INVARIANT B: over a steady window the emitted content must repeat with period 2
+ *     (hash(n) == hash(n-2)) — the display alternates cleanly rather than wandering.
+ *   INVARIANT C (what the corrector is FOR, checked externally): an EVEN source line
+ *     must be displayed in an EVEN (top) raster field. `base_code` — the smallest
+ *     first-line stamp seen in the whole run — is source line 0 by construction, so
+ *     the line parity is derived from the DATA, not from the mixer's ROW_0/ROW_1
+ *     labelling that field_parity_tb (and the corrector's own feedback) both use.
  *
  * A field that is a deliberate REPEAT of its predecessor (the corrector inserting one
  * field to re-align a cadence break, or the governor holding a frame) legitimately
- * violates A once. So the check is windowed: at most ONE repeat may occur inside a
- * settle window, and NONE inside the check window that follows.
+ * violates A once, and a field or two may land misaligned before the feedback arm
+ * reacts. So each scenario is windowed: a SETTLE window absorbs the correction (its
+ * violations are counted and reported, bounded), and the CHECK window that follows must
+ * be clean on all three invariants.
+ *
+ * ★ SCENARIO [6] IS THE ONE THAT FOUND THE HW DEFECT, and it is the mundane one: it
+ * STARVES the pixel queue. Every scenario written from the field reports (seeks, cold
+ * start, cadence breaks) passed with the withdrawn corrector enabled. A starved raster
+ * field displays nothing and shifts every following content field one slot, so the parity
+ * error it raises is REAL — but this core is compute-bound and does that several times a
+ * second, and the feedback arm's cure is a REPEATED field. [6] budgets those repeats:
+ * shipped corrector 4 per 4 starves, corrector disabled 0, corrector with the stability
+ * gate 0.
+ *
+ * ⚠ FAILS BY DESIGN ON A BUILD WITH THE CORRECTOR DISABLED — invariant C is exactly the
+ * "super aliased after a chapter skip" coin flip (docs/field_parity.md). A silent run is
+ * not a pass: every window prints a verdict line and the run prints a summary.
  *
  * Scenarios mirror field_parity_tb's so the two can be compared directly.
  *
@@ -51,25 +73,26 @@
  *     rtl/mpeg2/pixel_queue.v rtl/mpeg2/syncgen.v rtl/mpeg2/read_write.v \
  *     rtl/mpeg2/wrappers.v rtl/mpeg2/fwft.v rtl/mpeg2/xilinx_fifo_dc.v \
  *     rtl/mpeg2/xfifo_sc.v bench/dvd/field_phase_tb.sv
- *   vvp bench/dvd/field_phase_sim
+ *   vvp bench/dvd/field_phase_sim +phase=0 [+dbg]
  * Or: bash bench/dvd/run_field_phase.sh
  */
+`timescale 1ns/1ps
 module field_phase_tb;
 
 `include "resample_codes.v"
 
-  // ---- narrow/fast interlaced geometry (resample_chain_tb's narrow modeline,
-  //      il variant: content 64x256 -> 128-line fields) ----
+  // ---- narrow/fast interlaced geometry (field_parity_tb's, halved vertically:
+  //      content 64x128 -> 64-line fields) ----
+  // 128 source lines rather than that bench's 256 for two reasons: it halves a
+  // 5-window run's wall time, and it keeps the line stamp below (7 bits) unique for
+  // every source line, so a displayed pixel names its line with no ambiguity.
   localparam [7:0]  MB_WIDTH        = 8'd4;
-  localparam [7:0]  MB_HEIGHT       = 8'd16;
+  localparam [7:0]  MB_HEIGHT       = 8'd8;
   localparam [13:0] HORIZONTAL_SIZE = 14'd64;
-  localparam [13:0] VERTICAL_SIZE   = 14'd256;
+  localparam [13:0] VERTICAL_SIZE   = 14'd128;
   localparam [11:0] H_RES = 12'd64,  H_SS = 12'd70,  H_SE = 12'd78,  H_LEN = 12'd84;
-  // Shortened vertical raster (content-woven 256 lines + small blanking) — the
-  // resample_chain_tb narrow modeline's 505-line vertical made a full 5-window run
-  // take ~10 min of wall time for no extra coverage; v_sync verified toggling and
-  // all windows behave identically at this height.
-  localparam [11:0] V_RES = 12'd260, V_SS = 12'd268, V_SE = 12'd271, V_LEN = 12'd280;
+  // Vertical raster = content-woven 128 lines + small blanking.
+  localparam [11:0] V_RES = 12'd132, V_SS = 12'd140, V_SE = 12'd143, V_LEN = 12'd152;
 
   // ---- clocks (2:1 like HW clk_dec 54 / dot_clk 27) ----
   reg clk = 0;      always #5  clk = ~clk;
@@ -145,15 +168,28 @@ module field_phase_tb;
     .vscale_mode(2'd0), .hcrop_en(1'b0), .menu_ff(1'b0), .film24(1'b0)
   );
 
-  // framestore_reader + full-rate behavioural memory (constant non-black word)
+  // framestore_reader + full-rate behavioural memory, LINE-STAMPED.
   wire        rd_addr_empty, rd_addr_valid;
   wire [21:0] rd_addr;
   wire        wr_dta_full, wr_dta_almost_full, wr_dta_ack, wr_dta_overflow;
   reg         wr_dta_en;
-  wire        rd_addr_en = ~rd_addr_empty && ~wr_dta_almost_full;
+  /* Scenario [6] stalls the framestore to starve the pixel queue — the "mixer underflow
+   * slip" docs/field_parity.md lists as a phase-flip trigger, and the one the real core
+   * hits several times a second when it is compute-bound. */
+  reg         mem_stall = 1'b0;
+  wire        rd_addr_en = ~rd_addr_empty && ~wr_dta_almost_full && ~mem_stall;
   reg [21:0] rd_addr_q;
   always @(posedge clk) rd_addr_q <= rd_addr;
-  wire [7:0] addr_code = rd_addr_q[7:0] ^ rd_addr_q[15:8] ^ {2'b0, rd_addr_q[21:16]};
+  /* A 64-pixel luma line is 8 memory words, so rd_addr[2:0] is the column and the bits
+   * above it are the source line number: the stamp is constant ALONG a displayed line
+   * (verified at three columns) and identifies WHICH line it is.
+   * ⚠ The display path adds a MEASURED +128 to the luma between here and the mixer's
+   * pins, so a 7-bit stamp comes out as 128..255 — deliberately chosen: that band can
+   * never collide with the mixer's black level (16) and never wraps, so "this pixel is
+   * picture, not blanking" is a >= 128 test. Nothing below assumes a particular
+   * absolute value: `base_code` is measured, and the self-check after the run asserts
+   * that exactly two first-line stamps appeared and that they differ by 1. */
+  wire [7:0] addr_code = {1'b0, rd_addr_q[9:3]};
   wire [63:0] mem_word = {8{addr_code}};
 
   framestore_reader #(
@@ -172,9 +208,6 @@ module field_phase_tb;
     .rd_addr(rd_addr), .rd_addr_valid(rd_addr_valid),
     .wr_dta_full(wr_dta_full), .wr_dta_almost_full(wr_dta_almost_full),
     .wr_dta_en(wr_dta_en), .wr_dta_ack(wr_dta_ack), .wr_dta_overflow(wr_dta_overflow),
-    // ADDRESS-DERIVED content: every returned word identifies the memory word it came
-    // from, so a displayed pixel says which source line produced it. (field_parity_tb
-    // returns a constant here, which is why it cannot see a content-phase error.)
     .wr_dta(mem_word)
   );
   always @(posedge clk)
@@ -220,49 +253,58 @@ module field_phase_tb;
   );
 
   // ====================================================================
-  // CONTENT-PHASE CHECK. Hash what the mixer actually emitted for each displayed
-  // field, then compare consecutive fields. No reference to the corrector's own
-  // notion of parity — this is the RTL equivalent of measuring a screenshot.
+  // CONTENT-PHASE MEASUREMENT — off the mixer's output pins only.
   // ====================================================================
-  wire ft_evt     = (mixer.state == mixer.STATE_WAIT) &&
-                    (mixer.next  == mixer.STATE_FIRST_PIXEL) &&
-                    mixer.is_frame_top;
+  localparam [7:0] CODE_LO = 8'd128;      // luma at/above this is picture, below is blanking
+  localparam [31:0] FNV_OFF = 32'h811C_9DC5, FNV_PRM = 32'h0100_0193;
+  localparam integer MAXFLD = 600;
 
-  integer ft_seen = 0;
-  always @(posedge dot_clk) if (rst && ft_evt) ft_seen = ft_seen + 1;
+  // one sample per displayed line, at a fixed column safely inside the 64-pixel picture
+  wire       pix_probe = pixel_en_out && (h_pos == 12'd4);
+  wire       is_code   = (y_out >= CODE_LO);
 
-  // Per-field hash of the emitted luma, closed at each vsync (one field per vsync).
-  reg  [31:0] fld_hash = 0;
-  reg  [31:0] h_prev = 32'hFFFF_FFFF, h_prev2 = 32'hFFFF_FFFF;
-  reg         vs_q = 0;
-  integer     fld_n = 0;
-  integer     same_run = 0;      // consecutive-field repeats seen in the active window
-  integer     alt_bad  = 0;      // period-2 violations seen in the active window
-  reg         checking = 0, settling = 0;
-  integer     settle_same = 0;
+  reg  [7:0]  rec_code [0:MAXFLD-1];   // source-line stamp of the field's first line
+  reg         rec_vpar [0:MAXFLD-1];   // raster field it landed in (v_pos parity)
+  reg  [31:0] rec_hash [0:MAXFLD-1];   // FNV-1a over every emitted luma sample
+
+  integer     fld_n = 0;               // displayed fields WITH picture content so far
+  reg  [7:0]  base_code = 8'hFF;       // smallest first-line stamp = source line 0
+  reg  [7:0]  peak_code = 8'h00;       // largest  first-line stamp (must be base_code + 1)
+  reg         stamp_track = 1'b1;      // 0 while starvation can resume a field mid-picture
+  reg  [31:0] acc_hash  = FNV_OFF;
+  reg         got_first = 1'b0;
+  reg  [7:0]  f_code    = 8'd0;
+  reg         f_vpar    = 1'b0;
+  integer     f_lines   = 0;
+  reg         vs_q      = 1'b0;
+  integer     dbg = 0;
 
   always @(posedge dot_clk) if (rst) begin
     vs_q <= v_sync;
-    if (pixel_en_out) fld_hash <= {fld_hash[30:0], fld_hash[31]} ^ {24'd0, y_out};
-    if (v_sync && !vs_q) begin                       // field boundary
-      if (fld_hash != 32'd0) begin                   // a field with content
-        fld_n = fld_n + 1;
-        if (fld_n > 1) begin
-          if (fld_hash == h_prev) begin              // INVARIANT A
-            if (checking) begin
-              same_run = same_run + 1;
-              $display("  [%0t] field %0d REPEATS field %0d (hash %08x) - both fields carry the same source lines",
-                       $time, fld_n, fld_n-1, fld_hash);
-            end
-            if (settling) settle_same = settle_same + 1;
-          end
-          if (fld_n > 2 && checking && (fld_hash != h_prev2) && (fld_hash != h_prev))
-            alt_bad = alt_bad + 1;                   // INVARIANT B (period 2)
-        end
-        h_prev2 <= h_prev;
-        h_prev  <= fld_hash;
+    if (pixel_en_out) acc_hash <= (acc_hash ^ {24'd0, y_out}) * FNV_PRM;
+    if (pix_probe && is_code) begin
+      f_lines = f_lines + 1;
+      if (!got_first) begin
+        got_first <= 1'b1;
+        f_code    <= y_out;
+        f_vpar    <= v_pos[0];
       end
-      fld_hash <= 0;
+    end
+    if (v_sync && !vs_q) begin                       // field boundary: close the field
+      if (got_first && fld_n < MAXFLD) begin
+        rec_code[fld_n] = f_code;
+        rec_vpar[fld_n] = f_vpar;
+        rec_hash[fld_n] = acc_hash;
+        if (stamp_track && f_code < base_code) base_code <= f_code;
+        if (stamp_track && f_code > peak_code) peak_code <= f_code;
+        if (dbg)   // stamp, not line: base_code is only known once both stamps are in
+          $display("    field %0d: stamp %0d in the %s raster field, %0d lines, hash %08x",
+                   fld_n, f_code, f_vpar ? "BOTTOM" : "TOP", f_lines, acc_hash);
+        fld_n = fld_n + 1;
+      end
+      acc_hash  <= FNV_OFF;
+      got_first <= 1'b0;
+      f_lines   = 0;
     end
   end
 
@@ -271,32 +313,123 @@ module field_phase_tb;
     begin t0 = fld_n; wait (fld_n >= t0 + n); @(posedge dot_clk); end
   endtask
 
-  task wait_fts(input integer n);
-    integer t0;
-    begin t0 = ft_seen; wait (ft_seen >= t0 + n); @(posedge dot_clk); end
+  localparam SETTLE    = 8;    // fields allowed for a feed-forward correction to land
+  localparam SETTLE_FB = 40;   // ... and for a feedback one (PAR_CONFIRM refreshes + slack)
+  localparam NCHK      = 16;   // fields that must all carry alternating content after it
+  localparam SETTLE_MAX_SAME = 2;   // bounded: at most one inserted field per trigger arm
+  localparam SETTLE_MAX_MIS  = 3;   // bounded: the feed-forward arm acts at the pickup
+  /* [6] budget. A starved field is a REAL phase flip, but the cure costs a repeated
+   * field, so a corrector that chases every one of them at field rate is worse than the
+   * error: that is the shipped-corrector HW failure (a still measured +0.00). Four
+   * starvation events may cost at most this many repeated fields in total. */
+  localparam STUTTER_MAX_SAME = 2;
+
+  integer errors = 0;
+  integer settle_worst_same = 0, settle_worst_mis = 0;
+
+  // count invariant violations over recorded fields [a,b)
+  //
+  // A field STARVED mid-picture is resumed by the mixer at whatever line was next in the
+  // queue, so its head is neither source line 0 nor 1. Such a field is the starvation
+  // artefact itself, not a scheduling decision, so it is skipped (and counted): judging
+  // it would manufacture verdicts out of the perturbation rather than out of the
+  // corrector's behaviour.
+  integer v_same, v_alt, v_mis, v_part;
+  function clean_head(input integer i);
+    clean_head = (rec_code[i] == base_code) || (rec_code[i] == base_code + 8'd1);
+  endfunction
+  task tally(input integer a, input integer b, input reg verbose);
+    integer i;
+    begin
+      v_same = 0; v_alt = 0; v_mis = 0; v_part = 0;
+      for (i = (a < 2) ? 2 : a; i < b; i = i + 1) begin
+        if (!clean_head(i)) begin
+          v_part = v_part + 1;
+        end else if (!clean_head(i-1)) begin
+          // neighbour was resumed mid-picture: nothing to compare against, but the
+          // alignment of THIS field still is a verdict.
+          if (((rec_code[i] - base_code) & 1) != rec_vpar[i]) v_mis = v_mis + 1;
+        end else begin
+        if (rec_code[i] == rec_code[i-1]) begin
+          v_same = v_same + 1;
+          if (verbose)
+            $display("  field %0d REPEATS field %0d: both carry source line %0d (field offset +0.00 - the fields do not interleave)",
+                     i, i-1, rec_code[i] - base_code);
+        end
+        if (clean_head(i-2) && (rec_hash[i] != rec_hash[i-2])) begin
+          v_alt = v_alt + 1;
+          if (verbose)
+            $display("  field %0d breaks period 2: hash %08x != field %0d's %08x",
+                     i, rec_hash[i], i-2, rec_hash[i-2]);
+        end
+        if (((rec_code[i] - base_code) & 1) != rec_vpar[i]) begin
+          v_mis = v_mis + 1;
+          if (verbose)
+            $display("  field %0d MISALIGNED: %s source line %0d displayed in the %s raster field",
+                     i, ((rec_code[i]-base_code) & 1) ? "odd (bottom)" : "even (top)",
+                     rec_code[i] - base_code, rec_vpar[i] ? "BOTTOM" : "TOP");
+        end
+        end
+      end
+    end
   endtask
 
-  localparam SETTLE = 8;       // fields allowed for any correction/insertion to land
-  localparam NCHK   = 16;      // fields that must all carry alternating content after it
-  integer errors = 0;
-  integer settle_worst = 0;
-
-  task check_window(input [8*40-1:0] name);
+  /* `settle` is the number of fields a scenario is allowed for its correction to land.
+   * The feed-forward arm acts at the pickup, so SETTLE is plenty; the FEEDBACK arm only
+   * fires once the mixer's verdict has HELD for PAR_CONFIRM refreshes (see
+   * dvd/resample_addrgen.v — the fix for issue #41), so the windows that exercise it get
+   * SETTLE_FB instead. */
+  task check_window_s(input [8*40-1:0] name, input integer settle, input integer max_mis);
+    integer s0, c0, s_same, s_mis;
     begin
-      settling = 1; settle_same = 0;
-      wait_flds(SETTLE);
-      settling = 0;
-      if (settle_same > settle_worst) settle_worst = settle_same;
-      checking = 1; same_run = 0; alt_bad = 0;
-      wait_flds(NCHK);
-      checking = 0;
-      if (same_run == 0 && alt_bad == 0)
-        $display("[%0s] PASS: %0d fields, every one carries different lines from its neighbour (period-2 clean; settle saw %0d repeat(s))",
-                 name, NCHK, settle_same);
+      s0 = fld_n;  wait_flds(settle);          // settle region [s0, s0+settle)
+      tally(s0, s0 + settle, 1'b0);
+      s_same = v_same;  s_mis = v_mis;
+      if (s_same > settle_worst_same) settle_worst_same = s_same;
+      if (s_mis  > settle_worst_mis)  settle_worst_mis  = s_mis;
+
+      c0 = fld_n;  wait_flds(NCHK);            // check region [c0, c0+NCHK)
+      tally(c0, c0 + NCHK, 1'b1);
+
+      if (v_same == 0 && v_alt == 0 && v_mis == 0 &&
+          s_same <= SETTLE_MAX_SAME && s_mis <= max_mis)
+        $display("[%0s] PASS: %0d fields, every one carries the OTHER field's lines (offset +/-1) on the matching raster parity; settle saw %0d repeat(s), %0d misaligned",
+                 name, NCHK, s_same, s_mis);
       else begin
         errors = errors + 1;
-        $display("[%0s] FAIL: %0d consecutive-field REPEAT(s) and %0d period-2 break(s) in %0d fields (settle saw %0d)",
-                 name, same_run, alt_bad, NCHK, settle_same);
+        $display("[%0s] FAIL: %0d repeat(s), %0d period-2 break(s), %0d misaligned in %0d fields (settle saw %0d repeat(s) [max %0d], %0d misaligned [max %0d])",
+                 name, v_same, v_alt, v_mis, NCHK, s_same, SETTLE_MAX_SAME, s_mis, max_mis);
+      end
+    end
+  endtask
+
+  task check_window(input [8*40-1:0] name);
+    begin check_window_s(name, SETTLE, SETTLE_MAX_MIS); end
+  endtask
+
+  /* Stutter the display: n short framestore stalls, spread out. Counts the repeated
+   * fields the corrector spent on them. */
+  task stutter(input integer n);
+    integer i, s0;
+    begin
+      s0 = fld_n;
+      stamp_track = 1'b0;              // a resumed field's head line is arbitrary
+      for (i = 0; i < n; i = i + 1) begin
+        wait_flds(5);
+        mem_stall = 1'b1;
+        repeat (2) @(negedge v_sync);
+        mem_stall = 1'b0;
+      end
+      wait_flds(3);
+      stamp_track = 1'b1;
+      tally(s0, fld_n, 1'b0);
+      if (v_same <= STUTTER_MAX_SAME)
+        $display("[6-stutter] PASS: %0d starvation event(s) cost %0d repeated field(s) over %0d fields (%0d resumed mid-picture)",
+                 n, v_same, fld_n - s0, v_part);
+      else begin
+        errors = errors + 1;
+        $display("[6-stutter] FAIL: %0d starvation event(s) cost %0d repeated field(s) over %0d fields (budget %0d, %0d resumed mid-picture) - the corrector is chasing starvation at field rate",
+                 n, v_same, fld_n - s0, STUTTER_MAX_SAME, v_part);
       end
     end
   endtask
@@ -305,6 +438,7 @@ module field_phase_tb;
 
   initial begin
     void'($value$plusargs("phase=%d", phase));
+    if ($test$plusargs("dbg")) dbg = 1;
     $display("\n==== field_phase_tb  +phase=%0d ====", phase);
 
     rst = 0; output_frame_valid = 0;
@@ -315,7 +449,9 @@ module field_phase_tb;
     repeat (2) @(negedge v_sync);
     repeat (phase) @(negedge v_sync);          // one field period shifts landing parity
     output_frame_valid = 1;
-    check_window("1-cold-start");
+    // the feedback arm's window: misaligned fields are expected while its verdict is
+    // still being confirmed, so only the repeat budget is enforced across the settle.
+    check_window_s("1-cold-start", SETTLE_FB, SETTLE_FB);
 
     // [2] SEEK released on a SAME-parity tff (alternation break; the chapter skip)
     output_frame_valid = 0;
@@ -344,19 +480,36 @@ module field_phase_tb;
     progressive_frame = 1; repeat_first_field = 1; film_mode = 1;
     check_window("5-film-3:2");
 
+    // self-check the measurement itself: a field can only ever head on source line 0
+    // or 1, so exactly two stamps may appear and they must be adjacent. Anything else
+    // means the line stamp is not identifying lines and no verdict above is meaningful.
+    // [6] STUTTER: brief framestore stalls. Each starved raster field displays nothing
+    // and shifts every following content field one slot, so the raster phase flips for
+    // real — but the corrector must not chase that at field rate, because its cure is a
+    // repeated field and several of those a second is a far worse picture than the
+    // half-line offset it removes. This is the shipped corrector's HW failure mode.
+    progressive_frame = 0; repeat_first_field = 0; film_mode = 0; top_field_first = 1;
+    stutter(4);
+    check_window_s("7-post-stutter", SETTLE_FB, SETTLE_FB); // the feedback arm heals the rest
+
+    $display("(source line 0 stamps %0d, line 1 stamps %0d; %0d fields measured)",
+             base_code, peak_code, fld_n);
+    if (fld_n < 4*(SETTLE+NCHK) || peak_code != base_code + 8'd1)
+      $fatal(1, "==== BENCH BROKEN (+phase=%0d): %0d fields, stamps %0d/%0d (expected two adjacent) ====",
+             phase, fld_n, base_code, peak_code);
     if (errors == 0) begin
-      $display("\n==== PASS (+phase=%0d): every window alternates content field to field; worst settle window saw %0d repeat(s) ====",
-               phase, settle_worst);
+      $display("==== PASS (+phase=%0d): every window interleaves field to field and lands on the matching raster parity; worst settle window %0d repeat(s), %0d misaligned ====",
+               phase, settle_worst_same, settle_worst_mis);
       $finish;
     end else
-      $fatal(1, "==== FAIL (+phase=%0d): %0d window(s) where consecutive fields carry the SAME lines ====",
+      $fatal(1, "==== FAIL (+phase=%0d): %0d window(s) violated the field-phase invariants ====",
              phase, errors);
   end
 
-  // global watchdog: the raster must keep producing frame-tops
+  // global watchdog: the raster must keep producing fields
   initial begin
     #400_000_000;  // 400 ms sim time
-    $fatal(1, "TIMEOUT: field flow stalled (fields=%0d, frame-tops=%0d)", fld_n, ft_seen);
+    $fatal(1, "TIMEOUT: field flow stalled (fields=%0d)", fld_n);
   end
 
 endmodule

--- a/bench/dvd/run_field_phase.sh
+++ b/bench/dvd/run_field_phase.sh
@@ -1,13 +1,26 @@
 #!/usr/bin/env bash
 #
-# run_field_phase.sh — do the two displayed fields carry DIFFERENT source lines?
-# (bench/dvd/field_phase_tb.sv; docs/single_raster_analog.md §3.10.)
+# run_field_phase.sh — do the two displayed fields carry DIFFERENT source lines,
+# on the matching raster parity? (bench/dvd/field_phase_tb.sv; docs/field_parity.md.)
 #
 # This is the bench that can see the HW defect field_parity_tb could not: it feeds the
-# behavioural framestore address-derived data and compares what the mixer EMITTED for
-# consecutive fields, instead of restating the RTL's own parity convention.
+# behavioural framestore LINE-STAMPED data and measures what the mixer EMITTED for
+# consecutive fields, instead of restating the RTL's own parity convention. It is the
+# gate for the field-parity corrector (issue #41).
 #
-# Both raster-phase arms must pass.
+# It checks three invariants per window (see the testbench header):
+#   A  consecutive fields must carry DIFFERENT source lines  (the +0.50 field offset a
+#      real interlaced still measures; the withdrawn corrector made it +0.00)
+#   B  the emitted content repeats with period 2
+#   C  an even (top) source line lands in an even (top) raster field — derived from the
+#      DATA, so it does not agree with the RTL by construction
+#
+# Both raster-phase arms must pass. Add +dbg to either vvp line for a per-field table.
+#
+# Runtime: ~10 minutes per arm. Most of it is scenario [1] and [7], whose settle windows
+# have to be long enough for the FEEDBACK arm to confirm (PAR_CONFIRM refreshes in
+# dvd/resample_addrgen.v) — shortening them would make the bench green against a
+# corrector that never heals.
 set -e
 cd "$(dirname "$0")/../.."
 

--- a/docs/analog_dual_raster.md
+++ b/docs/analog_dual_raster.md
@@ -21,7 +21,8 @@ bumped to `v,2`).** Why reversed (this doc's caveat 2 was the decisive evidence)
 field reports — the derive path's pairing wobble seen in the wild ("extremely wobbly,
 not how interlace normally looks"), and the Native Fields post-seek "super aliased /
 toggle 3-4 times" defect, root-caused as a separate field-parity re-engage coin flip and
-FIXED (`docs/field_parity.md`). With fieldpass immune to caveat 2 by construction and the
+FIXED (`docs/field_parity.md` — that corrector was later withdrawn and repaired; it is
+✅ HW-confirmed as of 2026-09-03). With fieldpass immune to caveat 2 by construction and the
 parity corrector closing the re-engage hole, the derive machinery's only remaining value
 was CRT-480i-plus-progressive-HDMI simultaneity, which the maintainer chose to drop
 (pick-your-output). `re_interlace.sv` keeps only the fieldpass timing (PERIOD_FP_*/

--- a/docs/field_parity.md
+++ b/docs/field_parity.md
@@ -1,12 +1,12 @@
 # Field-parity re-engage corrector (2026-09-02, repaired 2026-09-03)
 
-**Status: ✅ RE-ENABLED with a stability gate (2026-09-03, issue #41) — sim-proven
-RED/GREEN by the new `bench/dvd/field_phase_tb.sv`, and ✅ HW round 1 confirms the analog
-CRT: "this one seems to always get the fields right on the TV", where PR #40 was a coin
-flip. ⏳ Round 2 gates the `VGA_F1` polarity fix that same round exposed (below).**
+**Status: ✅ RE-ENABLED and ✅ HW-CONFIRMED (2026-09-03, issue #41). Round 1 confirmed the
+analog CRT — "this one seems to always get the fields right on the TV", where PR #40 was a
+coin flip — and exposed an inverted `VGA_F1`; round 2 confirmed that fix
+(`DVD_parityf1_20260903_1253.rbf`). Sim gate: `bench/dvd/field_phase_tb.sv`, RED/GREEN.**
 
 ★ **HW ROUND 1 (2026-09-03) — the corrector is right, and it exposed an INVERTED
-`VGA_F1`.** With the field phase now deterministic, HDMI Weave went from a coin flip to
+`VGA_F1` (fixed; ✅ confirmed in round 2).** With the field phase now deterministic, HDMI Weave went from a coin flip to
 **consistently combed** while the CRT became consistently correct. Two outputs disagreeing
 by exactly one field is what pins this to the flag rather than to the corrector: the analog
 pins never look at `VGA_F1` (the raster half-line carries the CRT's interleave), so only
@@ -26,7 +26,7 @@ HDMI was right half the time and nobody could tell a flag polarity error from th
 bug. The comment on that line had said "polarity may need flipping on HW if the two fields
 come out swapped" since it was written; determinism is what finally made the question
 answerable. There is no ascal model in this repo (it is VHDL, the benches are Icarus), so
-this one is HW-gated by construction — it cannot be closed in sim.
+this one is HW-gated by construction — it cannot be closed in sim. Round 2 closed it.
 
 ★ **The withdrawal (PR #40) and what actually caused it.** As shipped in PR #37 the
 corrector made both displayed fields carry the SAME source lines — a still measured

--- a/docs/field_parity.md
+++ b/docs/field_parity.md
@@ -1,33 +1,68 @@
-# Field-parity re-engage corrector (2026-09-02)
+# Field-parity re-engage corrector (2026-09-02, repaired 2026-09-03)
 
-**Status: ⛔ DISABLED ON HARDWARE (2026-09-03, PR #40) — `par_ins` is tied 0 in
-`dvd/resample_addrgen.v`. Tracking issue: #41.**
+**Status: ✅ RE-ENABLED with a stability gate (2026-09-03, issue #41) — sim-proven
+RED/GREEN by the new `bench/dvd/field_phase_tb.sv`; ⏳ HW-confirm pending (gate: a still
+must measure +0.50 field offset, and a chapter skip must not need the toggle ritual).**
 
-★ **It made BOTH displayed fields carry the SAME source lines.** Measured from HW
-screenshots of a still by splitting each woven frame into its two fields and correlating
-them: **+0.00** frame lines of offset with the corrector on, where a correct interlaced
-still measures **+0.50**. That is a combed still under Weave and a picture that jumps a
-field line under Bob — on **every** output, HDMI included, which is what finally
-distinguished it from the sync-shape theories five HW rounds were spent on
-(`docs/single_raster_analog.md` §3.9). v0.3.0 `Analog Out = Native Fields` — the same
-authored-fields content path WITHOUT this corrector — measures +0.50 and is clean.
+★ **The withdrawal (PR #40) and what actually caused it.** As shipped in PR #37 the
+corrector made both displayed fields carry the SAME source lines — a still measured
+**+0.00** frame lines of field-to-field offset where a correct interlaced still measures
+**+0.50**, i.e. a combed still under Weave and a picture that jumps a field line under
+Bob, on **every** output. `par_ins` was tied 0 in `dvd/resample_addrgen.v` until this
+repair.
 
-⚠ **`bench/dvd/field_parity_tb.sv` stayed GREEN throughout.** Two reasons, both worth
-reading before trusting it again: its behavioural framestore returns a CONSTANT word (no
-displayed pixel carries evidence of which source line it came from), and its pass
-condition is the SAME EXPRESSION as the RTL's `frame_top_par_err` (it restates the
-design's convention instead of checking an external one — the POST-only PGC trap again).
-Replacement, committed UNFINISHED: `bench/dvd/field_phase_tb.sv`. Finish it FIRST.
+**Root cause: the FEEDBACK arm was chasing STARVATION.** Its cure is a REPEATED field —
+re-showing `last_image` is the only insertion that lands the resumed stream aligned (see
+the XOR table below) — and it was firing at field rate. What made it fire that often is
+the pixel queue running dry: when the mixer reaches a frame-top opportunity with no pixel
+to show it displays nothing there, and every following content field lands one raster slot
+later. **That is a genuine parity error**, but this core is compute-bound on heavy content
+and does it repeatedly, so the "error" churns back and forth — and one repeated field per
+starve is a far worse picture than the half-line offset it removes. The churn rate is
+already on the record from an unrelated investigation: `docs/roadmap.md` measured governor
+**lates at ~4/s on healthy content** and noted that the old derive path's field pairing was
+"re-randomised several times a second" by exactly this class of event. The old hysteresis
+(`par_armed` + a **4-refresh** liveness re-arm) capped insertions at one per five
+refreshes — 12 repeated fields a second, which is what a still measuring +0.00 looks
+like; the bench's four starvation events land inside that cap, one insertion each.
 
-Disabling re-opens the coin flip this document was written to fix (below): after a chapter
-skip / FF / aspect change the field phase can land wrong on some sets, cleared by toggling
-`Video Output`. The maintainer's late-model CRT has never shown it; the two Discord
-reporters' older sets do.
+**Reproduced in RTL**, `bench/dvd/field_phase_tb.sv` scenario [6] — four framestore stalls
+starving the pixel queue:
 
-*(Historical status:)* ✅ MERGED (PR #37, 2026-09-02); sim-proven (RED pre-fix / GREEN
-post-fix, `bench/dvd/field_parity_tb.sv` — see the caveat above); the analog delivery
-under it later changed (`re_interlace` is gone, the interlaced main raster drives the CRT
-directly, `docs/single_raster_analog.md`).**
+| build | repeated fields over 4 starvation events |
+|---|---|
+| corrector disabled (PR #40 … #41) | **0** |
+| corrector as shipped in PR #37 | **4** — one per starve |
+| corrector with the stability gate | **0** |
+
+**The fix — the feedback arm only acts on a STABLE error.**
+
+- `PAR_CONFIRM` (30 refreshes, ~0.5 s): the mixer's verdict must hold across that many
+  completed image scans before an insertion. A genuine phase flip (cold start, an
+  `il_switch`/aspect raster restart, an isolated underflow slip) is a **step** — it
+  persists until corrected, so it heals ~0.5 s in and stays healed. Churn resets the count
+  and is ignored. This also subsumes the old `par_armed`/`par_tmo` hysteresis: after an
+  insertion the count restarts, so the feedback latency can never double-insert.
+- `PAR_HOLD` (120 refreshes, ~2 s): a hard budget on top, so that whatever the starvation
+  rate turns out to be on a given disc, a repeated field can never appear more often than
+  once per two seconds. It starts saturated, so the first correction of a session is not
+  delayed. Feed-forward insertions do not spend it.
+- The **feed-forward arm is unchanged and ungated** — it inserts the OPPOSITE field, so it
+  can never repeat one, and it must act before a wrong field displays. It is also the arm
+  that handles the reported symptom (a chapter skip), which is why the repair keeps the
+  reported bug fixed while removing the cure's cost.
+
+⚠ **`bench/dvd/field_parity_tb.sv` stayed GREEN throughout the defect.** Two reasons, both
+worth reading before trusting it again: its behavioural framestore returns a CONSTANT word
+(no displayed pixel carries evidence of which source line it came from), and its pass
+condition is the SAME EXPRESSION as the RTL's `frame_top_par_err` (it restates the design's
+convention instead of checking an external one — the POST-only PGC trap again). It is kept
+as the alignment view; **`bench/dvd/field_phase_tb.sv` is the gate** (see "Proof" below).
+
+*(Historical status:)* ✅ MERGED (PR #37, 2026-09-02); ⛔ disabled in PR #40 after five HW
+rounds mis-attributed the symptom to sync shape (`docs/single_raster_analog.md` §3.9); the
+analog delivery under it later changed (`re_interlace` is gone, the interlaced main raster
+drives the CRT directly).
 
 ## The field reports
 
@@ -135,54 +170,57 @@ next pickup — an oscillation that never converges.
   the CRT's half-line sequence is fixed alternating and cannot follow content — the
   alignment must happen at the source.
 
-## Proof — `bench/dvd/field_parity_tb.sv` (`bash bench/dvd/run_field_parity.sh`)
+## Proof — `bench/dvd/field_phase_tb.sv` (`bash bench/dvd/run_field_phase.sh`)
 
-The real display chain (resample + addrgen → framestore model → pixel_queue → mixer ←
-interlaced sync_gen) with the parity feedback loop closed exactly as in `mpeg2video.v`.
-The checker reads **the wire the defect lives on**, hierarchically into the unmodified
-mixer: at every accepted frame-top, content field type (`position_in_0`) must match
-raster parity (`v_pos`) — it asserts what the screen gets, not a corrector register.
-Five windows per run: cold start (at a `+phase`-selected raster parity), two
-alternation-break seeks (the chapter-skip model), a clean-seek control, and soft-telecine
-film with authored tff toggling (the corrector must stay silent). Both `+phase` arms run.
+The gate. Same display chain (resample + addrgen → framestore model → pixel_queue → mixer
+← interlaced sync_gen) with the parity feedback loop closed exactly as in `mpeg2video.v`,
+but it measures the picture instead of restating the RTL's convention:
 
-**RED (pre-fix RTL, `--red`; captured 2026-09-02 against pre-fix
-`resample.v`/`resample_addrgen.v`/`mixer.v` extracted from main)** — the coin flip,
-verbatim:
+- the behavioural framestore is **LINE-STAMPED** — every returned word carries a code that
+  is constant along a source line and steps with the line number, so a displayed pixel
+  names the source line it came from (`field_parity_tb` returns a constant here, which is
+  why it cannot see a content-phase error at all);
+- each displayed field is reduced to its first picture line's stamp, the raster field it
+  landed in, and an FNV hash of every luma sample the mixer emitted;
+- **A** consecutive fields must carry DIFFERENT source lines (offset ±1 — the RTL
+  equivalent of the screenshot's +0.50); **B** the content repeats with period 2;
+  **C** an even (top) source line must land in an even (top) raster field — and the line
+  parity comes from the DATA, with source line 0 identified as the smaller of the two
+  first-line stamps ever observed, so the check cannot agree with the RTL by construction.
 
-```
-+phase=0  [1-cold-start]  PASS  16/16 aligned        (lucky landing)
-          [2-seek-break]  FAIL  16/16 MISALIGNED     (the break flips the phase...)
-          [3-seek-clean]  FAIL  16/16 MISALIGNED     (...and it PERSISTS through a clean seek)
-          [4-seek-break-2]PASS  16/16 aligned        (only another break flips it back)
-          [5-film-3:2]    PASS  16/16 aligned
-+phase=1  [1-cold-start]  FAIL  16/16 MISALIGNED     (unlucky landing — the feedback-only case)
-          [2-seek-break]  PASS  16/16 aligned        (two wrongs make a right)
-          [3-seek-clean]  PASS  16/16 aligned
-          [4-seek-break-2]FAIL  16/16 MISALIGNED
-          [5-film-3:2]    FAIL  16/16 MISALIGNED     (stays broken indefinitely)
-```
+Seven windows per run, both raster-phase arms (`+phase=0/1`): cold start at the selected
+raster parity, two alternation-break seeks (the chapter skip), a clean-seek control,
+soft-telecine film, **[6] four framestore stalls (starvation)**, and the recovery after
+them. `+dbg` prints the per-field table.
 
-Misalignment is a persistent STATE that perturbations toggle — which is precisely why
-the users' "change the setting and change it back, sometimes 3–4 times" ritual worked:
-each toggle re-rolled the coin.
-
-**GREEN (fixed RTL)**:
+**RED, corrector disabled (`main` at PR #40):** the coin flip, measured externally —
 
 ```
-+phase=0: all 5 windows 16/16 aligned; worst settle window 0 misaligned tops
-          (feed-forward: not a single wrong field ever displayed)
-+phase=1: all 5 windows 16/16 aligned; worst settle window 2 misaligned tops
-          (the misaligned cold start — feedback corrects within its designed
-           ~2-field latency bound, then stays aligned)
++phase=0  [1-cold-start]   PASS
+          [2-seek-break]   FAIL  16/16 MISALIGNED   (the break flips the phase...)
+          [3-seek-clean]   FAIL  16/16 MISALIGNED   (...and it PERSISTS through a clean seek)
+          [4-seek-break-2] PASS
+          [5-film-3:2]     PASS
+          [6-stutter]      PASS  4 starves, 0 repeated fields
++phase=1  [1-cold-start]   FAIL  16/16 MISALIGNED   (the feedback-only case)
+          [4-seek-break-2] FAIL
+          [5-film-3:2]     FAIL                     (stays broken indefinitely)
 ```
 
-Also green after the change: `run_prefetch_chain.sh` (progressive chain unchanged),
-`gov_field_late_tb` (its stimulus needed a real-disc fix: tff must toggle after an rff
-picture — holding it constant is an authored-cadence break the corrector now rightly
-handles), `resample_cadence(_rate)_tb`, `pickup_hold_tb`, `menu_ff_tb`,
-`cadence_slip_tb`, `resample_persist_tb`, `resample_addr_realstride_tb`,
-`run_film_evidence.sh`.
+**RED, corrector as shipped in PR #37** — every window aligned, but:
+
+```
++phase=0  [6-stutter]  FAIL  4 starvation events cost 4 repeated field(s)  <- the HW defect
+```
+
+**GREEN, with the stability gate:** all seven windows in both arms, and [6] costs zero
+repeated fields.
+
+Also green after the change: `run_field_parity.sh` (its cold-start window's settle was
+lengthened to the feedback arm's new latency — an expectation change, not a stimulus one),
+`run_prefetch_chain.sh`, `gov_field_late_tb`, `resample_cadence(_rate)_tb`,
+`pickup_hold_tb`, `menu_ff_tb`, `cadence_slip_tb`, `resample_persist_tb`,
+`resample_addr_realstride_tb`, `film_detect_tb`.
 
 ## Consequences for the HW symptom
 
@@ -201,6 +239,8 @@ handles), `resample_cadence(_rate)_tb`, `pickup_hold_tb`, `menu_ff_tb`,
 - `rtl/mpeg2/resample.v` — pass-through
 - `dvd/resample_addrgen.v` — the corrector (`alt_break` / `par_fb` / `par_armed` /
   `pickup_go` / the insertion branch)
-- `bench/dvd/field_parity_tb.sv`, `bench/dvd/run_field_parity.sh` — the suite
+- `bench/dvd/field_phase_tb.sv`, `bench/dvd/run_field_phase.sh` — **the gate**
+- `bench/dvd/field_parity_tb.sv`, `bench/dvd/run_field_parity.sh` — the alignment view
+  (kept, but it agrees with the RTL by construction: see the caveat above)
 - Every TB that instantiates `resample`/`resample_addrgen` directly ties
   `.raster_par_err(1'b0)` (an unconnected input would read X into the interlaced arms)

--- a/docs/field_parity.md
+++ b/docs/field_parity.md
@@ -1,8 +1,32 @@
 # Field-parity re-engage corrector (2026-09-02, repaired 2026-09-03)
 
 **Status: ✅ RE-ENABLED with a stability gate (2026-09-03, issue #41) — sim-proven
-RED/GREEN by the new `bench/dvd/field_phase_tb.sv`; ⏳ HW-confirm pending (gate: a still
-must measure +0.50 field offset, and a chapter skip must not need the toggle ritual).**
+RED/GREEN by the new `bench/dvd/field_phase_tb.sv`, and ✅ HW round 1 confirms the analog
+CRT: "this one seems to always get the fields right on the TV", where PR #40 was a coin
+flip. ⏳ Round 2 gates the `VGA_F1` polarity fix that same round exposed (below).**
+
+★ **HW ROUND 1 (2026-09-03) — the corrector is right, and it exposed an INVERTED
+`VGA_F1`.** With the field phase now deterministic, HDMI Weave went from a coin flip to
+**consistently combed** while the CRT became consistently correct. Two outputs disagreeing
+by exactly one field is what pins this to the flag rather than to the corrector: the analog
+pins never look at `VGA_F1` (the raster half-line carries the CRT's interleave), so only
+HDMI can be affected by it.
+
+`sys/ascal.vhd` samples the flag into `i_flm` at every DE rising edge, and the
+write-placement decision that consumes it runs in the SAME clocked process on the field's
+first active pixel — so it reads the value latched at the PREVIOUS DE rise, i.e. the last
+active line of the PREVIOUS field. `i_flm='0'` then offsets the CURRENT field's base
+address by one line. Net convention: **F1 = 0 on the top field, 1 on the bottom** — the
+standard "F1 = second field" reading. `dvd/emu.sv` emitted the inverse
+(`~core_v_pos[0]`), so ascal stored the top field in the odd rows: a pairwise line swap,
+which is Weave combing on a STILL. Fixed to `core_v_pos[0]`.
+
+⚠ **This was invisible for as long as the parity was random** — with a coin-flip phase,
+HDMI was right half the time and nobody could tell a flag polarity error from the parity
+bug. The comment on that line had said "polarity may need flipping on HW if the two fields
+come out swapped" since it was written; determinism is what finally made the question
+answerable. There is no ascal model in this repo (it is VHDL, the benches are Icarus), so
+this one is HW-gated by construction — it cannot be closed in sim.
 
 ★ **The withdrawal (PR #40) and what actually caused it.** As shipped in PR #37 the
 corrector made both displayed fields carry the SAME source lines — a still measured

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -655,6 +655,15 @@ Progressive; vsync anchored on the hsync edge after `csync_field_tb` measured fi
 first broad pulse at 18 µs. Driven by the RGBS/YPbPr/RT4K field reports on the PR #37
 prerelease. Design + HW checklist: `docs/single_raster_analog.md`.**
 
+**★ 2026-09-03 follow-up (issue #41, branch `fix/field-parity-corrector`): the
+field-parity corrector that branch had to disable is REPAIRED and re-enabled** —
+sim-proven RED/GREEN, ⏳ HW-confirm pending. Its feedback arm was chasing pixel-queue
+starvation, and its cure is a repeated field, so on this compute-bound core it repeated
+one several times a second (the "+0.00 field offset" measurement). It now only acts on a
+parity error that has HELD for ~0.5 s, with a hard ~2 s budget on top. Gate:
+`bench/dvd/field_phase_tb.sv` (finished; scenario [6] starves the pixel queue and counts
+the repeated fields). See `docs/field_parity.md`.
+
 **Status (history): ✅ HW-CONFIRMED 2026-07-05 (branch `feature/crt-480i-native`, MERGED PR fj#65) —
 then REWORKED 2026-07-29 into the DUAL-RASTER architecture, ✅ HW-CONFIRMED + MERGED
 2026-07-30 (PR fj#146):** the O[14] whole-core CRT mode is retired; the 15 kHz raster is
@@ -1783,10 +1792,12 @@ contact with the field: (1) the derive path's field-pairing wobble (this doc's
 "re-randomised several times a second") was REPORTED FROM THE WILD as "extremely wobbly,
 not how an interlaced signal normally looks on a CRT"; (2) Native Fields shipped with a
 separate field-parity re-engage coin flip ("super aliased after a chapter skip, toggle
-the mode 3-4 times to fix") — root-caused and fixed at the time, but ⛔ **that corrector is
-DISABLED as of 2026-09-03 (PR #40, issue #41): on HW it made both interlaced fields carry
-the same source lines.** The coin flip is therefore OPEN again — `docs/field_parity.md`,
-`docs/single_raster_analog.md` §3.9; (3) with
+the mode 3-4 times to fix") — root-caused and fixed at the time, then ⛔ **DISABLED
+2026-09-03 (PR #40): on HW it made both interlaced fields carry the same source lines**,
+and now ✅ **REPAIRED and re-enabled (issue #41, branch `fix/field-parity-corrector`;
+sim-proven, ⏳ HW-confirm pending)** — its feedback arm was chasing pixel-queue
+starvation, and its cure is a repeated field, so it now only acts on a parity error that
+has HELD. See `docs/field_parity.md`, `docs/single_raster_analog.md` §3.9; (3) with
 that fixed, fieldpass strictly dominates derive on the CRT side, and the maintainer chose
 to drop the one thing derive still bought (CRT 480i + progressive HDMI simultaneously —
 pick-your-output instead). The surface collapsed to **one option, `O[10:9] Video Output

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -657,7 +657,8 @@ prerelease. Design + HW checklist: `docs/single_raster_analog.md`.**
 
 **★ 2026-09-03 follow-up (issue #41, branch `fix/field-parity-corrector`): the
 field-parity corrector that branch had to disable is REPAIRED and re-enabled** —
-sim-proven RED/GREEN, ⏳ HW-confirm pending. Its feedback arm was chasing pixel-queue
+sim-proven RED/GREEN and ✅ HW-CONFIRMED over two rounds (round 1 gave the CRT its fields
+and exposed an inverted `VGA_F1`; round 2 confirmed that fix). Its feedback arm was chasing pixel-queue
 starvation, and its cure is a repeated field, so on this compute-bound core it repeated
 one several times a second (the "+0.00 field offset" measurement). It now only acts on a
 parity error that has HELD for ~0.5 s, with a hard ~2 s budget on top. Gate:
@@ -1795,7 +1796,7 @@ separate field-parity re-engage coin flip ("super aliased after a chapter skip, 
 the mode 3-4 times to fix") — root-caused and fixed at the time, then ⛔ **DISABLED
 2026-09-03 (PR #40): on HW it made both interlaced fields carry the same source lines**,
 and now ✅ **REPAIRED and re-enabled (issue #41, branch `fix/field-parity-corrector`;
-sim-proven, ⏳ HW-confirm pending)** — its feedback arm was chasing pixel-queue
+sim-proven and HW-CONFIRMED)** — its feedback arm was chasing pixel-queue
 starvation, and its cure is a repeated field, so it now only acts on a parity error that
 has HELD. See `docs/field_parity.md`, `docs/single_raster_analog.md` §3.9; (3) with
 that fixed, fieldpass strictly dominates derive on the CRT side, and the maintainer chose

--- a/docs/single_raster_analog.md
+++ b/docs/single_raster_analog.md
@@ -15,7 +15,9 @@ repeated one several times a second. It now only acts on a parity error that has
 (`PAR_CONFIRM`), with a hard budget on top (`PAR_HOLD`). `bench/dvd/field_phase_tb.sv` is
 finished and is the gate — it reproduces the defect (scenario [6] starves the pixel queue
 and counts the repeated fields) and measures field phase from LINE-STAMPED framestore
-content, so it cannot agree with the RTL by construction.
+content, so it cannot agree with the RTL by construction. ✅ HW round 1 confirms the CRT;
+it also exposed an inverted `VGA_F1` (HDMI Weave went from a coin flip to consistently
+combed once the phase stopped being random) — `docs/field_parity.md` "HW ROUND 1".
 
 **HW round 6 (2026-09-03) — the follow-up sweep, all on the maintainer's rig:**
 line-21 captions ✅, overlays/subtitles/menus/HUD on the analog output ✅, sub-720 fill

--- a/docs/single_raster_analog.md
+++ b/docs/single_raster_analog.md
@@ -8,12 +8,14 @@ steady `720x480i @ 59.9`. Shipping build after the round-6 fix:
 
 ★ **THE DEFECT WAS THE FIELD-PARITY CORRECTOR, NOT THE SYNC.** Five HW rounds chased sync
 shape on a wrong hypothesis; §3.9 is the post-mortem and it is the part of this document
-worth reading. The corrector (PR #37, `docs/field_parity.md`) is **DISABLED** pending a
-real fix — `par_ins` is tied 0 in `dvd/resample_addrgen.v`. That re-opens the "super
-aliased after a chapter skip" coin flip it was written for, so fixing it properly is the
-next job; `bench/dvd/field_phase_tb.sv` is the gate that can tell a correct field phase
-from an inverted one — ⚠ committed **unfinished** (it runs but prints no verdict; see its
-header), because it belongs with the corrector fix rather than with this branch.
+worth reading. The corrector (PR #37, `docs/field_parity.md`) was **DISABLED** here and is
+now **repaired and re-enabled** (2026-09-03, issue #41): its feedback arm was chasing
+pixel-queue STARVATION, and its cure is a repeated field, so on compute-bound content it
+repeated one several times a second. It now only acts on a parity error that has HELD
+(`PAR_CONFIRM`), with a hard budget on top (`PAR_HOLD`). `bench/dvd/field_phase_tb.sv` is
+finished and is the gate — it reproduces the defect (scenario [6] starves the pixel queue
+and counts the repeated fields) and measures field phase from LINE-STAMPED framestore
+content, so it cannot agree with the RTL by construction.
 
 **HW round 6 (2026-09-03) — the follow-up sweep, all on the maintainer's rig:**
 line-21 captions ✅, overlays/subtitles/menus/HUD on the analog output ✅, sub-720 fill
@@ -30,8 +32,8 @@ line-21 captions ✅, overlays/subtitles/menus/HUD on the analog output ✅, sub
 
 ⏳ Not yet gated: PAL on an analog CRT (no PAL CRT available), RGBHV, `direct_video=1`
 through an HDMI DAC, and the parity behaviour after a chapter skip (the maintainer's
-late-model CRT has never shown the coin flip that two Discord users report, so that fix
-will lean on `bench/dvd/field_phase_tb.sv` rather than on his rig).
+late-model CRT has never shown the coin flip that two Discord users report, so the
+repaired corrector leans on `bench/dvd/field_phase_tb.sv` rather than on his rig).
 
 ## 1. The field reports that started it
 
@@ -211,9 +213,16 @@ between every combed capture and every clean one was the corrector.
    it restates the design's convention instead of checking an external one. CLAUDE.md
    already warns about golden models that agree suspiciously well with their RTL (the
    POST-only PGC case) — same trap, different corner. `bench/dvd/field_phase_tb.sv` is the
-   replacement: address-derived framestore content, per-field hashes of what the mixer
+   replacement: LINE-STAMPED framestore content, per-field measurement of what the mixer
    actually emitted, and the invariant that consecutive fields must DIFFER and repeat with
    period 2.
+5. ★ **The perturbation the bench was missing was the mundane one.** Scenarios written
+   from the field reports (seeks, cold start, cadence breaks) all passed with the
+   corrector on — the defect only appeared once the bench STARVED the pixel queue, which
+   is what this compute-bound core does several times a second on real content and what
+   no scenario derived from a user's description would have contained. When a bench
+   exonerates the code the hardware indicts, ask what the hardware is doing all the time
+   that the bench never does.
 
 ## 4. Tests
 

--- a/docs/single_raster_analog.md
+++ b/docs/single_raster_analog.md
@@ -15,9 +15,10 @@ repeated one several times a second. It now only acts on a parity error that has
 (`PAR_CONFIRM`), with a hard budget on top (`PAR_HOLD`). `bench/dvd/field_phase_tb.sv` is
 finished and is the gate — it reproduces the defect (scenario [6] starves the pixel queue
 and counts the repeated fields) and measures field phase from LINE-STAMPED framestore
-content, so it cannot agree with the RTL by construction. ✅ HW round 1 confirms the CRT;
-it also exposed an inverted `VGA_F1` (HDMI Weave went from a coin flip to consistently
-combed once the phase stopped being random) — `docs/field_parity.md` "HW ROUND 1".
+content, so it cannot agree with the RTL by construction. ✅ HW-CONFIRMED over two rounds:
+round 1 gave the CRT its fields and exposed an inverted `VGA_F1` (HDMI Weave went from a
+coin flip to consistently combed once the phase stopped being random), round 2 confirmed
+that fix — `docs/field_parity.md` "HW ROUND 1".
 
 **HW round 6 (2026-09-03) — the follow-up sweep, all on the maintainer's rig:**
 line-21 captions ✅, overlays/subtitles/menus/HUD on the analog output ✅, sub-720 fill
@@ -32,10 +33,9 @@ line-21 captions ✅, overlays/subtitles/menus/HUD on the analog output ✅, sub
 - **PAL + a mid-title `Video Output` change can freeze the decoder** — ⚠ **PRE-EXISTING,
   not from this branch**: v0.3.0 does the same on an `Analog Out` mode change. See §6.
 
-⏳ Not yet gated: PAL on an analog CRT (no PAL CRT available), RGBHV, `direct_video=1`
-through an HDMI DAC, and the parity behaviour after a chapter skip (the maintainer's
-late-model CRT has never shown the coin flip that two Discord users report, so the
-repaired corrector leans on `bench/dvd/field_phase_tb.sv` rather than on his rig).
+⏳ Not yet gated: PAL on an analog CRT (no PAL CRT available), RGBHV, and
+`direct_video=1` through an HDMI DAC. (The field-parity coin flip that was open here is
+✅ fixed and HW-confirmed — `docs/field_parity.md`.)
 
 ## 1. The field reports that started it
 

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -134,12 +134,30 @@ assign VIDEO_ARX    = (analog_letterbox | analog_crop) ? 13'd4 : (ar_wide_eff | 
 assign VIDEO_ARY    = (analog_letterbox | analog_crop) ? 13'd3 : (ar_wide_eff | idle_wide) ? 13'd9  : 13'd3;
 
 // DVD-FORK FIX (interlaced cadence): interlaced field indicator. In interlaced
-// mode the syncgen encodes the field in v_pos[0] (rtl/mpeg2/syncgen.v:289:
+// mode the syncgen encodes the field in v_pos[0] (rtl/mpeg2/syncgen.v:
 // v_pos = {v_cntr, ~odd_field}), so v_pos[0] == ~odd_field and is constant for a
-// whole field. core_v_pos is in the dot_clk(=clk_sys) domain, same as VGA_F1, so
-// no CDC is needed. Progressive mode (O9=off) forces F1=0 (v_pos[0] toggles every
-// line there). Polarity may need flipping on HW if the two fields come out
-// swapped — see docs/history.md.
+// whole field: v_pos EVEN is the TOP field. core_v_pos is in the dot_clk(=clk_sys)
+// domain, same as VGA_F1, so no CDC is needed. Progressive mode forces F1=0
+// (v_pos[0] toggles every line there).
+//
+// ★ POLARITY (2026-09-03, HW round 1 of issue #41 — the comment here used to say
+// "may need flipping on HW"; it did, and this is the flip). F1 = v_pos[0], i.e.
+// 0 on the TOP field, because that is what ascal wants:
+//   sys/ascal.vhd samples the flag into `i_flm` at every DE rising edge, and the
+//   write-placement decision that uses it runs in the SAME clocked process on the
+//   field's first active pixel — so it reads the value latched at the PREVIOUS DE
+//   rise, which is the last active line of the PREVIOUS field. `i_flm='0'` then
+//   offsets the CURRENT field's base address by one line. Net convention: the field
+//   FOLLOWING an F1=0 field is written to rows 1,3,5..., so F1=1 marks the BOTTOM
+//   field and F1=0 the TOP one - the standard "F1 = second field" reading.
+// Emitting the inverse made ascal store the top field in the odd rows: a pairwise
+// line swap, i.e. Weave combed on a STILL. It was invisible until the field-parity
+// corrector was repaired, because until then the content<->raster phase was a coin
+// flip and HDMI was right half the time. MEASURED on HW: with the corrector fixed
+// the CRT is consistently right and HDMI Weave consistently combed - the two
+// outputs disagreeing by exactly one field is what pins this to the flag, not to
+// the corrector (the analog pins never look at VGA_F1; the raster half-line carries
+// the CRT's interleave).
 // pal_eff: resolved PAL/50Hz flag (Auto-detected or forced via O[17:16]); assigned
 // near the decoder instance once core_vertical_size / pal_det_s2 exist.
 wire pal_eff;
@@ -275,7 +293,7 @@ wire        film25_eff = filmp_eff &  pal_eff;        // PAL  25.000 Hz path
 // (analog_fields | (il_want & ~filmp_eff & ~analog_eff)) died with the Interlaced Out
 // option and the derive modes — Video Output consolidation, 2026-09-02.
 wire il_eff = interlaced_eff;
-assign VGA_F1       = il_eff ? ~core_v_pos[0] : 1'b0;
+assign VGA_F1       = il_eff ? core_v_pos[0] : 1'b0;   // 0 = TOP field (see above)
 assign VGA_SL       = 0;
 // DVD-FORK (dual-raster analog output): VGA_SCALER is never forced any more —
 // sys_top ORs this into the ini bit (vga_scaler = cfg[2] | vga_force_scaler), so

--- a/dvd/resample_addrgen.v
+++ b/dvd/resample_addrgen.v
@@ -569,19 +569,49 @@ module resample_addrgen (
    *    seek-released tff break BEFORE a single wrong field displays.
    *  - FEEDBACK (par_fb): the mixer reports the on-screen frame-top landed on the
    *    wrong raster parity (raster_par_err, 2-FF synced level). Catches what the
-   *    schedule cannot see: cold start, raster restarts, underflow slips. par_armed is
-   *    a hysteresis one-shot so the field-rate feedback latency (~1-2 refreshes + CDC)
-   *    cannot double-insert: one insertion per error assertion, re-armed when the
-   *    error level clears, plus a 4-refresh timeout re-arm for liveness in case an
-   *    insertion was absorbed while the level stayed high.
+   *    schedule cannot see: cold start, raster restarts, underflow slips. Gated by
+   *    PAR_CONFIRM (see below) so it only acts on an error that has HELD — its cure
+   *    costs a repeated field, and chasing a churning error at field rate is worse
+   *    than the error.
    * Design + RED-testbench evidence: docs/field_parity.md. */
   wire       nxt_first_top = progressive_sequence ? 1'b1 : top_field_first; // first field the pending pickup would emit (mirrors the image-build branches)
   wire       alt_break = interlaced &&
                          (((last_image == TOP)    &&  nxt_first_top) ||
                           ((last_image == BOTTOM) && ~nxt_first_top));
-  reg        par_armed;
-  reg  [2:0] par_tmo;                  // completed refreshes since insertion while the error level stays high
-  wire       par_fb   = interlaced && raster_par_err && par_armed &&
+  /* ★ THE FEEDBACK ARM ONLY ACTS ON A *STABLE* ERROR (2026-09-03, issue #41 — this is
+   * the fix that let the corrector be re-enabled). Its cure costs a REPEATED FIELD:
+   * re-showing last_image is the only insertion that lands the resumed stream aligned
+   * (inserting the opposite field keeps the misalignment and manufactures an alternation
+   * break for alt_break to un-fix — the livelock noted above). One repeated field per
+   * genuine phase flip is a fair price; several a second is NOT — that is a still
+   * measuring +0.00 field offset where a correct interlaced still measures +0.50, which
+   * is exactly what shipped in PR #37 and had to be withdrawn.
+   * The trigger it must not chase is a STARVED raster field: when the pixel queue runs
+   * dry at a frame-top opportunity the mixer displays nothing there and every following
+   * content field lands one slot late, so the parity error is REAL — but this core is
+   * compute-bound on heavy content and does that repeatedly, and each starve flips the
+   * phase back and forth. Correcting churn at field rate is worse than the churn.
+   * So: require the error level to hold across PAR_CONFIRM completed refreshes before
+   * inserting. A genuine phase flip (cold start, an il_switch/aspect raster restart, an
+   * underflow slip that is not part of a burst) is a STEP — it persists until corrected,
+   * so it heals ~0.5 s in and stays healed. Churn resets the count and is ignored.
+   * This also subsumes the old par_armed/par_tmo hysteresis: after an insertion the count
+   * restarts, so the feedback latency (~1-2 refreshes + CDC) can never double-insert, and
+   * insertions are inherently >= PAR_CONFIRM refreshes apart.
+   * The FEED-FORWARD arm below is deliberately NOT gated this way: it inserts the
+   * OPPOSITE field, so it can never repeat one, and it must act before a wrong field
+   * displays. */
+  localparam [5:0] PAR_CONFIRM = 6'd30;   // refreshes (~0.5 s at 59.94) the error must hold
+  localparam [7:0] PAR_HOLD    = 8'd120;  // refreshes (~2 s) between feedback insertions
+  reg  [5:0] par_cnt;                     // consecutive completed refreshes with the error asserted
+  reg  [7:0] par_age;                     // refreshes since the last FEEDBACK insertion (saturating)
+  wire       par_stable = (par_cnt == PAR_CONFIRM);
+  /* Second guard, belt to PAR_CONFIRM's braces: whatever the starvation rate turns out
+   * to be on a given disc, a repeated field can never appear more often than once per
+   * PAR_HOLD refreshes. PAR_CONFIRM alone bounds it at one per 30 refreshes (2/s), which
+   * is still inside the range that reads as judder. Feed-forward insertions do NOT spend
+   * this budget — they never repeat a field. */
+  wire       par_fb   = interlaced && raster_par_err && par_stable && (par_age == PAR_HOLD) &&
                         ((last_image == TOP) || (last_image == BOTTOM));
   /* XOR, not OR — the triggers CANCEL when simultaneous. Slot arithmetic (fields land
    * on strictly alternating raster slots; a frame-top is accepted at whichever slot
@@ -593,18 +623,11 @@ module resample_addrgen (
    * misaligned lands the new head aligned by itself — two wrongs make a right,
    * insert nothing. Inserting "opposite" on a par_fb would keep the misalignment AND
    * manufacture a new alternation break for alt_break to un-fix — a livelock. */
-  /* ⛔ DISABLED 2026-09-03 (HW round 5) pending root-cause. MEASURED on hardware: with
-   * the corrector active the two displayed fields carry content at the SAME vertical
-   * phase (screenshot analysis of a still: field offset +0.00 frame lines, where a
-   * correct interlaced still measures +0.50) — weave combs and bob jumps a field line.
-   * v0.3.0 `Analog Out = Native Fields`, the same content path WITHOUT this corrector,
-   * measures +0.50 and is clean. Both arms are suppressed here so the field schedule is
-   * exactly v0.3.0's; the logic is left in place (and prunes) so the fix can re-enable it
-   * once bench/dvd/field_phase_tb.sv can tell a right phase from a wrong one — the
-   * existing field_parity_tb encodes the same convention as the RTL, so it agreed with
-   * the defect. Re-opens the "super aliased after a chapter skip" coin flip
-   * (docs/field_parity.md) until then. */
-  wire       par_ins  = 1'b0 && (alt_break ^ par_fb);             // insert one field instead of picking up
+  /* Re-enabled 2026-09-03 with the PAR_CONFIRM gate above (issue #41). It was tied 0
+   * between PR #40 and that fix because the ungated feedback arm repeated a field
+   * several times a second on real content; bench/dvd/field_phase_tb.sv scenario [6]
+   * is the regression guard (it starves the pixel queue and budgets the repeats). */
+  wire       par_ins  = alt_break ^ par_fb;                       // insert one field instead of picking up
   wire       par_slip = (state == STATE_INIT) && ofv_pickup && par_ins;  // the insertion event
   /* Qualified pickup: every pickup-conditioned latch below consumes THIS instead of
    * ofv_pickup, so on an insertion cycle the pending frame stays unconsumed (picked up
@@ -612,21 +635,25 @@ module resample_addrgen (
    * it must still advance to scan the inserted field. */
   wire       pickup_go = ofv_pickup && ~par_ins;
 
+  /* PAR_CONFIRM stability counter: one tick per completed image scan (the same refresh
+   * event the governor counts), cleared whenever the mixer's verdict clears — so the
+   * count only reaches PAR_CONFIRM for an error that held that whole time — and cleared
+   * by an insertion, so the next one is at least PAR_CONFIRM refreshes away. */
+  wire       refresh_done = (state == STATE_NEXT_MB) && last_mb && last_y;
   always @(posedge clk)
-    if (~rst) begin
-      par_armed <= 1'b1;
-      par_tmo   <= 3'd0;
-    end else if (clk_en) begin
-      if (par_slip) begin
-        par_armed <= 1'b0;             // one insertion per error assertion
-        par_tmo   <= 3'd0;
-      end else if (~raster_par_err) begin
-        par_armed <= 1'b1;             // error observed clear: re-arm
-        par_tmo   <= 3'd0;
-      end else if (~par_armed && (state == STATE_NEXT_MB) && last_mb && last_y) begin
-        if (par_tmo == 3'd4) par_armed <= 1'b1;   // liveness: level stuck high 4 shown refreshes after an insertion
-        else                 par_tmo   <= par_tmo + 3'd1;
-      end
+    if (~rst) par_cnt <= 6'd0;
+    else if (clk_en) begin
+      if (par_slip || ~raster_par_err)             par_cnt <= 6'd0;
+      else if (refresh_done && ~par_stable)        par_cnt <= par_cnt + 6'd1;
+    end
+
+  /* par_age starts SATURATED so the first correction of a session (the cold-start
+   * landing, the one case the schedule cannot see at all) is not delayed by the budget. */
+  always @(posedge clk)
+    if (~rst) par_age <= PAR_HOLD;
+    else if (clk_en) begin
+      if (par_slip && par_fb)                      par_age <= 8'd0;
+      else if (refresh_done && (par_age != PAR_HOLD)) par_age <= par_age + 8'd1;
     end
 
   reg par_late_r;                      // hand the inserted refresh to the frame-drop ledger (cad_late_r pattern)

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -151,9 +151,11 @@ attempts. On builds up to v0.3.0 the same trick works on `Analog Out`. Many tele
 never show this; it depends on the set.
 
 !!! info "Unreleased"
-    v0.4.0's automatic corrector for this is switched off in the current development
-    build — it was making both fields carry the same picture lines, which combed still
-    images on every output including HDMI. A corrected version is being worked on. See
+    The current development build corrects the field phase automatically, so the toggle
+    should no longer be needed. (v0.4.0's first attempt at that corrector was switched
+    off again — it was making both fields carry the same picture lines, which combed
+    still images on every output including HDMI.) If a skip still leaves the picture
+    aliased on a current build, please [report it](reporting-a-bug.md). See
     [Field alignment](../video/interlaced.md#field-alignment).
 
 ### A film disc keeps changing resolution, or judders

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -151,11 +151,13 @@ attempts. On builds up to v0.3.0 the same trick works on `Analog Out`. Many tele
 never show this; it depends on the set.
 
 !!! info "Unreleased"
-    The current development build corrects the field phase automatically, so the toggle
-    should no longer be needed. (v0.4.0's first attempt at that corrector was switched
-    off again — it was making both fields carry the same picture lines, which combed
-    still images on every output including HDMI.) If a skip still leaves the picture
-    aliased on a current build, please [report it](reporting-a-bug.md). See
+    The current development build corrects the field phase automatically — confirmed on
+    hardware, and the toggle is no longer needed. (v0.4.0's first attempt at that
+    corrector was switched off again: it was making both fields carry the same picture
+    lines, which combed still images on every output including HDMI.) The same fix run
+    also corrected HDMI `480i Deint` = `Weave`, which used to comb on a still about half
+    the time. Televisions differ, so if either symptom survives on a current build,
+    please [report it](reporting-a-bug.md). See
     [Field alignment](../video/interlaced.md#field-alignment).
 
 ### A film disc keeps changing resolution, or judders

--- a/site/content/video/interlaced.md
+++ b/site/content/video/interlaced.md
@@ -78,16 +78,16 @@ back**, sometimes taking a few attempts. Not every set shows it — a television
 tolerant sync separator may never see it at all.
 
 !!! info "Unreleased"
-    The current development build corrects this automatically, so the toggle should no
-    longer be needed. (v0.4.0's first attempt at the corrector had to be switched off
-    again — it made both interlaced fields carry the same picture lines, which showed as
-    a combed still image and a picture that jumped a line at field rate on every set,
-    HDMI included. The repaired version only steps in for a misalignment that persists,
-    so it cannot do that.) The same coin flip decided whether **HDMI with `480i Deint` =
-    `Weave`** came up combed on a still; that is fixed too, by a separate correction to
-    the field flag the core hands the framework scaler. **If a skip still leaves the
-    picture aliased, or a still combs under Weave, please report it** — see
-    [Reporting a bug](../reference/reporting-a-bug.md).
+    The current development build corrects this automatically — the toggle is no longer
+    needed. (v0.4.0's first attempt at the corrector had to be switched off again: it made
+    both interlaced fields carry the same picture lines, which showed as a combed still
+    image and a picture that jumped a line at field rate on every set, HDMI included. The
+    repaired version only steps in for a misalignment that persists, so it cannot do
+    that.) The same coin flip decided whether **HDMI with `480i Deint` = `Weave`** came up
+    combed on a still; that is fixed too, by a separate correction to the field flag the
+    core hands the framework scaler. Both are confirmed on hardware. Televisions differ,
+    so if a skip still leaves the picture aliased, or a still combs under Weave,
+    [please report it](../reference/reporting-a-bug.md).
 
 ## What changed from the old settings
 

--- a/site/content/video/interlaced.md
+++ b/site/content/video/interlaced.md
@@ -70,19 +70,21 @@ everything.
 
 ## Field alignment
 
-On some televisions the picture can come back from a chapter skip, fast-forward or aspect
-change looking **aliased, like a screen door**. It is a field-parity coin flip in the
-display pipeline: the two interlaced fields can land the wrong way round after an
-interruption. **Toggling `Video Output` away and back re-rolls it**, sometimes taking a
-few attempts. Not every set shows it — a television with a tolerant sync separator may
-never see it at all.
+On some televisions the picture could come back from a chapter skip, fast-forward or
+aspect change looking **aliased, like a screen door**. It is a field-parity coin flip in
+the display pipeline: the two interlaced fields land the wrong way round after an
+interruption. On older releases the workaround is to **toggle `Video Output` away and
+back**, sometimes taking a few attempts. Not every set shows it — a television with a
+tolerant sync separator may never see it at all.
 
 !!! info "Unreleased"
-    v0.4.0 shipped an automatic corrector for this, and it is **switched off** in the
-    current development build: on hardware it made both interlaced fields carry the same
-    picture lines, which showed as a combed still image and a picture that jumped a line
-    at field rate on **every** set, HDMI included. Turning it off restores the v0.3.0
-    behaviour described above. A corrected version is being worked on.
+    The current development build corrects this automatically, so the toggle should no
+    longer be needed. (v0.4.0's first attempt at the corrector had to be switched off
+    again — it made both interlaced fields carry the same picture lines, which showed as
+    a combed still image and a picture that jumped a line at field rate on every set,
+    HDMI included. The repaired version only steps in for a misalignment that persists,
+    so it cannot do that.) **If a skip still leaves the picture aliased, please report
+    it** — see [Reporting a bug](../reference/reporting-a-bug.md).
 
 ## What changed from the old settings
 

--- a/site/content/video/interlaced.md
+++ b/site/content/video/interlaced.md
@@ -83,8 +83,11 @@ tolerant sync separator may never see it at all.
     again — it made both interlaced fields carry the same picture lines, which showed as
     a combed still image and a picture that jumped a line at field rate on every set,
     HDMI included. The repaired version only steps in for a misalignment that persists,
-    so it cannot do that.) **If a skip still leaves the picture aliased, please report
-    it** — see [Reporting a bug](../reference/reporting-a-bug.md).
+    so it cannot do that.) The same coin flip decided whether **HDMI with `480i Deint` =
+    `Weave`** came up combed on a still; that is fixed too, by a separate correction to
+    the field flag the core hands the framework scaler. **If a skip still leaves the
+    picture aliased, or a still combs under Weave, please report it** — see
+    [Reporting a bug](../reference/reporting-a-bug.md).
 
 ## What changed from the old settings
 


### PR DESCRIPTION
Closes #41.

The field-parity corrector shipped in #37 and was tied off in #40 because it made both
displayed fields carry the same source lines — a still measured **+0.00** frame lines of
field offset where a correct interlaced still measures **+0.50**. This repairs it and
turns it back on, and fixes a second, older defect that only became measurable once the
first one was gone.

## 1. The bench, finished first

`bench/dvd/field_phase_tb.sv` was committed unfinished by #40: it elaborated and ran but
recorded nothing, so it printed no verdict. Two real causes — a rotate-XOR hash that
self-cancels to zero over a field (and the "did this field have content?" test keyed on
it), and a code band that did not match the **+128 the display path adds to the luma**
between the framestore and the mixer pins.

It now measures the picture rather than restating the RTL's convention. The behavioural
framestore is **line-stamped**, so every displayed pixel names the source line it came
from, and per displayed field the bench records the first picture line's stamp, the raster
field it landed in, and an FNV hash of every luma sample the mixer emitted:

- **A** consecutive fields must carry DIFFERENT source lines (the RTL equivalent of +0.50);
- **B** the emitted content repeats with period 2;
- **C** an even (top) source line lands in an even (top) raster field — with source line 0
  identified as the smaller of the two first-line stamps ever seen, so the parity verdict
  comes from the DATA, not from the `ROW_0`/`ROW_1` labelling that `field_parity_tb` and
  the corrector's own feedback both use.

## 2. Root cause: the feedback arm was chasing starvation

Its cure is a **repeated field** — re-showing `last_image` is the only insertion that
lands the resumed stream aligned. And when the pixel queue runs dry at a frame-top
opportunity the mixer shows nothing there and every following content field lands one
raster slot late. That is a genuine parity error, but this core is compute-bound and does
it several times a second, so the corrector repeated a field at roughly that rate. The old
`par_armed` + 4-refresh liveness re-arm capped it at one per five refreshes — 12 repeated
fields a second, which is what a still measuring +0.00 looks like.

★ **The scenario that found it was the mundane one.** Every scenario written from the field
reports — seeks, cold start, cadence breaks — passed with the withdrawn corrector enabled.
New scenario [6] starves the pixel queue, which no scenario derived from a user's
description would have contained. Four starvation events:

| build | repeated fields |
|---|---|
| corrector disabled (`main`) | 0 |
| corrector as shipped in #37 | **4** |
| corrector with the stability gate | 0 |

**Fix:** `PAR_CONFIRM` (30 refreshes, ~0.5 s) — the mixer's verdict must *hold* before the
feedback arm inserts; a genuine flip is a step and heals, churn resets the count. Plus
`PAR_HOLD` (120 refreshes, ~2 s) as a hard budget, starting saturated so cold start is not
delayed. The feed-forward arm — which handles the chapter-skip symptom users reported, and
can never repeat a field — is untouched.

## 3. `VGA_F1` was inverted, and only determinism could show it

HW round 1 gave the CRT its fields consistently and left **HDMI Weave consistently
combed**, where both had been coin flips. Two outputs disagreeing by exactly one field
pins it to the flag: the analog pins never read `VGA_F1`.

`sys/ascal.vhd` latches the flag at every DE rise and the write-placement decision reads it
in the same clocked process on the field's first active pixel — so it uses the value from
the previous field's last line. Effective convention: **F1 = 0 on the top field**. We
emitted `~core_v_pos[0]` (1 on top), so ascal stored the top field in the odd rows: a
pairwise line swap, i.e. Weave combing on a still. Now `core_v_pos[0]`.

This was unfalsifiable while the parity was random — HDMI was right half the time, so a
flag error and the parity bug looked identical. The line's own comment had said "polarity
may need flipping on HW" since it was written.

## Test plan

- [x] `bench/dvd/run_field_phase.sh` — 7 windows × 2 raster phases, GREEN. RED on `main`:
      2 windows fail at `+phase=0`, 3 at `+phase=1`, persistent misalignment
- [x] Scenario [6] reproduces the withdrawn corrector's defect (4 repeats) and the fix (0)
- [x] `bench/dvd/run_field_parity.sh` — both phases green (cold-start settle lengthened for
      the feedback arm's new latency: an expectation change, not a stimulus one)
- [x] `gov_field_late`, `resample_cadence`/`_rate`, `pickup_hold`, `menu_ff`,
      `cadence_slip`, `resample_persist`, `resample_addr_realstride`, `film_detect` green
- [x] `run_prefetch_chain.sh` identical to `main` (verified by rebuilding its one STARVED
      case against `main`'s RTL — the progressive path cannot be reached, both arms are
      gated by `interlaced`)
- [x] `csync_field_tb`, `cc_e2e_tb` green after the `VGA_F1` flip (neither reads it)
- [x] `tools/docs_check.py` and `mkdocs build --strict` clean
- [x] Fit: SEED 5 first roll, clk_dec 94.06 @100C / 91.29 @-40C (gate 86.0), 88 % ALM
- [x] **HW round 1** (`DVD_parityfix_20260903_0450.rbf`) — CRT consistently correct, where
      #40 was a coin flip
- [x] **HW round 2** (`DVD_parityf1_20260903_1253.rbf`) — HDMI Weave confirmed

⚠ The `VGA_F1` polarity is **not sim-gateable in this repo** — ascal is VHDL, the benches
are Icarus. It rests on the hardware A/B plus the ascal read, both recorded in
`docs/field_parity.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
