### PR TITLE
Fix the mid-title Video Output freeze: re-align the reader instead of flushing in place

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,15 +320,87 @@ worse maintenance burden than targeted in-place edits. So:
   `~analog_want` film gate was over-blunt — it removed the only way to watch 24p over
   HDMI with the CRT off, and it never bit anything else (Auto already resolves such a rig
   to Interlaced), so it now applies to the AUTO verdict only and `Film 24p Out = On`
-  overrides it; (b) ⚠ **PAL + a mid-title `Video Output` change can FREEZE the decoder**
+  overrides it; (b) ⚠ **a mid-title `Video Output` change can FREEZE the decoder**
   (malformed frame, never self-recovers, a chapter seek clears it, either direction,
   intermittent) — **PRE-EXISTING: v0.3.0 does the same on an `Analog Out` change**, so it
-  is NOT from this branch. Analysis + fix direction (re-align the reader to the next NAV
-  pack instead of flushing in place — the same mid-stream-flush trap as the reverted
-  film switch, `docs/film_24p_plan.md` §13): `docs/single_raster_analog.md` §6.
+  is NOT from this branch. ⚠ **First seen on PAL and recorded here as PAL-only; that was
+  WRONG — it reproduces on NTSC (2026-09-03), which is what disproved the `pal_eff`-only
+  hypothesis and pointed at the standard-neutral cause.** Now **🔧 FIXED (issue #42,
+  branch `fix/mode-switch-realign`), sim-proven RED/GREEN, ⏳ HW-confirm pending** — see
+  the mode-switch re-align bullet below and `docs/single_raster_analog.md` §6.
   ⏳ Not gated: PAL on an analog CRT, RGBHV, `direct_video=1` through an HDMI DAC, and
   the parity coin flip (the maintainer's late-model CRT has never shown it — the two
   Discord reporters' older sets do, so the corrector fix leans on `field_phase_tb`).
+- 🔧 **MODE-SWITCH READER RE-ALIGN + PAL/NTSC VERDICT HARDENING (2026-09-03, issue #42,
+  branch `fix/mode-switch-realign`) — sim-proven RED/GREEN, ⏳ HW-confirm pending
+  (gate = a PAL disc AND an NTSC disc, `Video Output` toggled mid-title both directions
+  ×20 each, plus the T2 menu→Play logo chain).** Fixes: a mid-title `Video Output` change
+  could freeze the decoder on a malformed frame with no self-recovery; a chapter seek
+  cleared it. Pre-existing (v0.3.0 does it on `Analog Out`).
+  ★★ **THE FIX WAS WRITTEN IN THE EXISTING COMMENT AND HAD BEEN READ AS HARMLESS FOR
+  MONTHS.** `emu.sv`'s `il_switch` block said: "the full flush is exactly what a chapter
+  seek does (HW-confirmed synced); the only difference is the reader doesn't jump, so
+  ps_demux re-hunts to the next pack boundary within the vbuf re-lock glitch." That
+  difference IS the bug — the decoder resumed **mid-VOBU with no GOP boundary to re-lock
+  on** — and the reason a chapter seek cured it is that a seek is the same trio **plus a
+  reader jump**. The clue was in the workaround the whole time. New `dvd/mode_realign.sv`
+  turns the edge into a **seek to the playhead's own VOBU** and lets `seek_ack` drive the
+  trio, so a mode switch is byte-identical to a chapter jump. `flush_ctl.mode_switch`
+  survives as the **fallback** (menus, raw `.m2v`, no trustworthy playhead, or an
+  unacknowledged seek) — `flush_ctl.sv` itself is unchanged.
+  ★ **"PAL-only" was a WRONG CONSTRAINT that shaped the first diagnosis.** The report,
+  this file, `docs/single_raster_analog.md` and the manual all said NTSC was unaffected,
+  which pointed straight at the PAL-only `pal_eff` feedback path. The maintainer then saw
+  it on NTSC. The cause is the standard-neutral mid-VOBU resume; `pal_eff` is one of TWO
+  garbage-header amplifiers and the other (`filmp_eff` via `film_det`) flips on either
+  standard. ⚠ Worth the habit: when a symptom is reported as specific to one
+  configuration, that specificity is a *hypothesis*, not a measurement.
+  ★ **Three design points, each learned the hard way elsewhere:** (1) the target is the
+  playhead's OWN VOBU because `dsi_nv_pck_lbn` already IS a NAV pack — the reader's snap
+  probe hits candidate #1 and moves nowhere; the next VOBU would walk forward a sector at
+  a time up to `NAV_CAP=1024` reads (`iso_reader_seek_tb` TEST9 **measures** the walk at
+  1 read/sector over three points: 3 / 4 / 8 reads, so the cost model is proven not
+  claimed). (2) **Edges are COALESCED** — `il_eff` is a level, so N toggles converge on
+  one raster and need ONE re-align; that makes the repeated-mid-parse-flush loop class
+  (the thing that killed the film edge) structurally unreachable, and is why a future
+  `filmp_eff` edge belongs here and never straight in `flush_ctl`. (3) `tgt_rbn` is
+  latched ONCE and gated on `dsi_fresh` — `nav_dsi` is on `pipe_rst_n`, so the re-align's
+  OWN `load_flush` zeroes the playhead and the reader's clamp would turn that into a jump
+  to the start of the title (the `dpad_seek` stale-table trap).
+  ★ **Leg 2 — `dvd/pal_detect.sv`:** `pal_detect_dec` latched on ANY non-zero
+  `vertical_size`, so one garbage header flipped `pal_eff` → a raster restart **with no
+  flush at all** (the walk keys on `il_eff | pal_eff | filmp_eff`; only `il_eff` carries
+  the trio) → `film_det` → `filmp_eff` → the walk again. Now a plausibility bound
+  (64…1152 lines — a BOUND, not a whitelist: flat `.mpg` files exist and 1080 is not a
+  multiple of 16) plus a **sustained**-disagreement requirement to CHANGE an established
+  verdict; the first header after a mount still latches immediately. The 2026-09-03
+  `!= 0` hold is subsumed. ⚠ **Confirmation is a TIMER, not a count of headers:**
+  `vertical_size` is a REGISTER, not an event — a real disc re-parses a sequence header
+  every GOP but writes the SAME value, so a transition-counting rule can never reach N
+  for a genuine change and would freeze the verdict forever. That design was written and
+  discarded before it shipped.
+  ★ **Both benches are built against the `bench-that-cannot-fail` failure mode.**
+  `pal_detect_tb` counts **verdict EDGES, not end states** — the pre-fix rule self-heals
+  on the next real header, so an end-state check PASSED the stray-header and churn
+  scenarios (measured RED: 12 walk kicks during a garbage burst, 2 for one stray header).
+  `mode_realign_chain_tb` runs the REAL reader over a synthetic disc and reads **the first
+  bytes delivered after the flush**: pre-fix `b0 b0 b0 b0` (mid-sector cell payload),
+  fixed `00 00 01 BA / BB / BF` (a NAV pack) — a property of the byte stream, not a
+  restatement of an RTL expression. Suite: `bench/dvd/run_mode_realign.sh` (`--red` runs
+  the pre-fix arms first). ⚠ `mode_realign_tb`'s first version failed all 11 scenarios
+  against correct RTL: blocking stimulus assignments landed **on** the clock edge and
+  raced the DUT, so every count read 0. Stimulus is driven from the negedge now.
+  ⚠ **The field-parity suites pass unchanged BY CONSTRUCTION, which is not evidence:**
+  they compile `resample_addrgen`/`mixer`/`syncgen` and never see `emu.sv`. The corrector
+  names an `il_switch` raster restart as one of its expected triggers, and what this
+  branch changes is the flush's TIMING relative to that restart — so the interaction is
+  HW-only and belongs in the same round.
+  ⚠ **No `modeline_boot_tb` phase was added, deliberately:** the walk is NOT gated on
+  `realign_pend` — `il_eff` still changes the instant the OSD bit does, so only the FLUSH
+  is deferred. The existing bench passing unchanged IS that evidence. **If HW still
+  freezes, the remaining suspect is the raster restart** and the next step is to gate
+  `il_out` on `~realign_pend` — one behavioural delta per round
+  (`docs/single_raster_analog.md` §3.9). Detail: `docs/single_raster_analog.md` §6.
 - ✅ **FIELD-PARITY CORRECTOR REPAIRED AND RE-ENABLED (2026-09-03, issue #41, branch
   `fix/field-parity-corrector`) — sim-proven RED/GREEN and ✅ HW-CONFIRMED: round 1 gave
   the CRT ("always gets the fields right on the TV" where PR #40 was a coin flip) and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,8 @@ worse maintenance burden than targeted in-place edits. So:
   still is not. Gate: `mode_realign_tb` [12]–[17], **mutation-checked** (5 targeted RTL
   mutations, each caught by its own scenario — these are cheap level assertions, exactly
   the shape that passes without proving anything).
-  ★★ **THE RESIDUAL IS NOW A TRANSPORT ITEM, NOT A MODE-SWITCH ONE, and the user's own
+  ★★ **THE RESIDUAL IS NOW A TRANSPORT ITEM (tracked as issue #45), NOT A MODE-SWITCH
+  ONE, and the user's own
   report is what establishes that:** *"still some visible glitches but I think these are
   more decoder issues than mode switch since it looks similar to when a chapter skip is
   performed."* The design goal was to make a mode switch **byte-identical to a chapter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,13 +334,30 @@ worse maintenance burden than targeted in-place edits. So:
 - ✅ **MODE-SWITCH READER RE-ALIGN + PAL/NTSC VERDICT HARDENING (2026-09-03, issue #42,
   branch `fix/mode-switch-realign`) — sim-proven RED/GREEN and ✅ HW-CONFIRMED 2026-09-03
   (user report: the freeze is gone; build `DVD_modeswitch_20260903_1538.rbf`, SEED 5 first
-  roll, clk_dec 91.90/88.88).** ⏳ Still open on that build: the ~1 s SWITCH TRANSIENT is
-  ugly (to Interlaced = a full-screen rolling image flashing between black frames = the
-  display losing vertical lock; to Progressive = the picture squished into the top half =
-  field-height content in a frame-height DE window). Cosmetic and inherent to changing the
-  raster under in-flight content; the proposed fix (blank RGB — never sync — from
-  `il_switch` to the `video_live` rising edge, in `mode_realign`) plus why "repeat the last
-  good frame" is the weaker option are recorded in `docs/single_raster_analog.md` §7. Fixes: a mid-title `Video Output` change
+  roll, clk_dec 91.90/88.88).** ★ **SWITCH BLANK added on top (2026-09-03, user
+  request; ⏳ HW-confirm pending):** the fix left the ~1 s transient visible and ugly (to
+  Interlaced = a full-screen rolling image flashing between black frames = the display
+  losing vertical lock; to Progressive = the picture squished into the top half =
+  field-height content in a frame-height DE window). Both are inherent to changing the
+  raster under in-flight content, so the fix is cosmetic: `mode_realign` now holds the
+  picture BLACK from the edge until the first frame of the new mode is on screen.
+  ★ **The window needed no new signal — `video_live` already is it** (our own `load_flush`
+  re-arms it via `pickup_hold`). ⚠ **The rule is "clear on the first HIGH *after* a LOW"**:
+  at the edge `video_live` is still high from the OLD content, so a naive "clear when
+  video_live" blanks nothing. ⚠ `BLANK_MAX` (~1.5 s) is load-bearing twice — in a MENU
+  `video_live` never drops (emu forces the STD hold off while `menu_active`), so the
+  ceiling is the only exit; and it stops a cosmetic fix masking a persistent fault.
+  ⚠ Placement in the output mux is the design: **after** `cc_on` (line-21 captions live in
+  the VBI), **after** `dbg_px_q` (the `O[2]` blk10 "il_switch fired" readout must stay
+  visible during exactly this event), **before** `sub_r` (picture+subs+HUD+logo go dark
+  together). **RGB only — never sync** (the `re_interlace` `S_HUNT` defect). `blank_en` =
+  `media_seen` so the boot idle screen is never blanked. A second edge RESTARTS the window
+  (the seek arm coalesces; the blank must not). ⛔ "Repeat the last good frame" lost: the
+  symptom is a ROLL, so a held frame rolls too — rolling black is invisible, a rolling
+  still is not. Gate: `mode_realign_tb` [12]–[17], **mutation-checked** (5 targeted RTL
+  mutations, each caught by its own scenario — these are cheap level assertions, exactly
+  the shape that passes without proving anything). Detail:
+  `docs/single_raster_analog.md` §6.8. Fixes: a mid-title `Video Output` change
   could freeze the decoder on a malformed frame with no self-recovery; a chapter seek
   cleared it. Pre-existing (v0.3.0 does it on `Analog Out`).
   ★★ **THE FIX WAS WRITTEN IN THE EXISTING COMMENT AND HAD BEEN READ AS HARMLESS FOR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,10 +331,16 @@ worse maintenance burden than targeted in-place edits. So:
   ⏳ Not gated: PAL on an analog CRT, RGBHV, `direct_video=1` through an HDMI DAC, and
   the parity coin flip (the maintainer's late-model CRT has never shown it — the two
   Discord reporters' older sets do, so the corrector fix leans on `field_phase_tb`).
-- 🔧 **MODE-SWITCH READER RE-ALIGN + PAL/NTSC VERDICT HARDENING (2026-09-03, issue #42,
-  branch `fix/mode-switch-realign`) — sim-proven RED/GREEN, ⏳ HW-confirm pending
-  (gate = a PAL disc AND an NTSC disc, `Video Output` toggled mid-title both directions
-  ×20 each, plus the T2 menu→Play logo chain).** Fixes: a mid-title `Video Output` change
+- ✅ **MODE-SWITCH READER RE-ALIGN + PAL/NTSC VERDICT HARDENING (2026-09-03, issue #42,
+  branch `fix/mode-switch-realign`) — sim-proven RED/GREEN and ✅ HW-CONFIRMED 2026-09-03
+  (user report: the freeze is gone; build `DVD_modeswitch_20260903_1538.rbf`, SEED 5 first
+  roll, clk_dec 91.90/88.88).** ⏳ Still open on that build: the ~1 s SWITCH TRANSIENT is
+  ugly (to Interlaced = a full-screen rolling image flashing between black frames = the
+  display losing vertical lock; to Progressive = the picture squished into the top half =
+  field-height content in a frame-height DE window). Cosmetic and inherent to changing the
+  raster under in-flight content; the proposed fix (blank RGB — never sync — from
+  `il_switch` to the `video_live` rising edge, in `mode_realign`) plus why "repeat the last
+  good frame" is the weaker option are recorded in `docs/single_raster_analog.md` §7. Fixes: a mid-title `Video Output` change
   could freeze the decoder on a malformed frame with no self-recovery; a chapter seek
   cleared it. Pre-existing (v0.3.0 does it on `Analog Out`).
   ★★ **THE FIX WAS WRITTEN IN THE EXISTING COMMENT AND HAD BEEN READ AS HARMLESS FOR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,7 +335,8 @@ worse maintenance burden than targeted in-place edits. So:
   branch `fix/mode-switch-realign`) — sim-proven RED/GREEN and ✅ HW-CONFIRMED 2026-09-03
   (user report: the freeze is gone; build `DVD_modeswitch_20260903_1538.rbf`, SEED 5 first
   roll, clk_dec 91.90/88.88).** ★ **SWITCH BLANK added on top (2026-09-03, user
-  request; ⏳ HW-confirm pending):** the fix left the ~1 s transient visible and ugly (to
+  request; ✅ HW-CONFIRMED same day, build `DVD_swblank_20260903_1638.rbf` — the roll and
+  the top-half squish are GONE):** the fix left the ~1 s transient visible and ugly (to
   Interlaced = a full-screen rolling image flashing between black frames = the display
   losing vertical lock; to Progressive = the picture squished into the top half =
   field-height content in a frame-height DE window). Both are inherent to changing the
@@ -356,8 +357,25 @@ worse maintenance burden than targeted in-place edits. So:
   symptom is a ROLL, so a held frame rolls too — rolling black is invisible, a rolling
   still is not. Gate: `mode_realign_tb` [12]–[17], **mutation-checked** (5 targeted RTL
   mutations, each caught by its own scenario — these are cheap level assertions, exactly
-  the shape that passes without proving anything). Detail:
-  `docs/single_raster_analog.md` §6.8. Fixes: a mid-title `Video Output` change
+  the shape that passes without proving anything).
+  ★★ **THE RESIDUAL IS NOW A TRANSPORT ITEM, NOT A MODE-SWITCH ONE, and the user's own
+  report is what establishes that:** *"still some visible glitches but I think these are
+  more decoder issues than mode switch since it looks similar to when a chapter skip is
+  performed."* The design goal was to make a mode switch **byte-identical to a chapter
+  jump**; once it is, it cannot carry a class of artifact a chapter seek does not. So a
+  symptom that matches a chapter skip is the goal being MET, and it relocates the remaining
+  work. ⚠ Do NOT re-chase it under issue #42.
+  Likely mechanism, for whoever picks it up: the trio discards BUFFERED data but leaves the
+  decode pipeline (`vld`/`getbits`/`motcomp`/`picbuf` are on `sync_rst`; `mount_flush` is
+  MOUNT-ONLY, *"NEVER on seeks/jumps/mode switches"*), so across any seek the in-flight
+  picture completes on the new stream's first start code (one truncated frame) and the old
+  references stay valid for an open-GOP VOBU's first B-frames. ★ **The blank changes the
+  argument for this path only:** the stated reason not to soft-reset on a seek is *display
+  continuity*, and during a blanked mode switch there is none to protect — so adding the
+  mode-switch/re-align acks to `mount_flush` is now arguable. ⚠ It would gate the modeline
+  walk via `dec_ready`/`sync_rst` (§3.2's boot race — the regfile survives on `hard_rst`,
+  but TB it in `modeline_boot_tb` first), and it would leave chapter skips untouched, i.e.
+  fix one path and leave the class open. Detail: `docs/single_raster_analog.md` §6.8. Fixes: a mid-title `Video Output` change
   could freeze the decoder on a malformed frame with no self-recovery; a chapter seek
   cleared it. Pre-existing (v0.3.0 does it on `Analog Out`).
   ★★ **THE FIX WAS WRITTEN IN THE EXISTING COMMENT AND HAD BEEN READ AS HARMLESS FOR

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -77,6 +77,10 @@ set_global_assignment -name SYSTEMVERILOG_FILE dvd/av_sync.sv
 # Flush/reset trigger matrix (extracted from emu.sv 2026-08-28 for TB coverage of
 # the mount/seek/jump/mode_switch flush trio). See bench/dvd/flush_ctl_tb.sv.
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/flush_ctl.sv
+# PAL/NTSC verdict from the parsed frame height, hardened so a garbage sequence header
+# cannot flip it (issue #42 leg 2): a pal_eff change restarts the raster with NO flush.
+# See bench/dvd/pal_detect_tb.sv.
+set_global_assignment -name SYSTEMVERILOG_FILE dvd/pal_detect.sv
 # Reference-read run-ahead prefetch (O[18]): single-bitstream A/B gate for the deepened
 # fwd/bwd motion-comp reference data fifos. See dvd/ref_dta_gate.sv / docs/motcomp_throughput.md.
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/ref_dta_gate.sv

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -757,4 +757,14 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # seek_rbn latch -- a path with cycles of slack. The +62 ALM is the honest logic delta here
 # (compare the dpad_seek entry above, where a large "ALMs needed" jump was mostly the
 # collapse of the recoverable-by-packing estimate, not new logic).
+# 2026-09-03e (same branch + the SWITCH BLANK -- mode_realign grows a 26-bit ceiling
+# counter, a vl_dropped latch and a blank register: 78 -> 141 combinational ALUTs, and one
+# extra mux level in emu's registered output stage): SEED 5 held FIRST roll again --
+# clk_dec 93.17 @100C / 91.27 @-40C (BETTER than the entry above, which is fit variance on
+# a fresh netlist, not the logic delta) at 88% ALM (37,027, +59), RAM 494/553 and DSP
+# 92/112 both unchanged. FOURTEENTH consecutive first-roll fit. Build
+# DVD_swblank_20260903_1638.rbf.
+# ⚠ The added mux level sits in the ALREADY-REGISTERED output stage (reg -> pin), which is
+# why a blank on the pixel path costs nothing in clk_dec: that stage was retimed in
+# 2026-06-28 precisely to make it a short hop.
 set_global_assignment -name SEED 5

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -81,6 +81,10 @@ set_global_assignment -name SYSTEMVERILOG_FILE dvd/flush_ctl.sv
 # cannot flip it (issue #42 leg 2): a pal_eff change restarts the raster with NO flush.
 # See bench/dvd/pal_detect_tb.sv.
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/pal_detect.sv
+# Mode-switch reader re-align (issue #42): a live raster-mode change issues a seek to the
+# current VOBU instead of flushing mid-parse, so seek_ack drives the trio and the decoder
+# gets a GOP boundary. See bench/dvd/mode_realign_tb.sv.
+set_global_assignment -name SYSTEMVERILOG_FILE dvd/mode_realign.sv
 # Reference-read run-ahead prefetch (O[18]): single-bitstream A/B gate for the deepened
 # fwd/bwd motion-comp reference data fifos. See dvd/ref_dta_gate.sv / docs/motcomp_throughput.md.
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/ref_dta_gate.sv

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -746,4 +746,15 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # 2026-09-03c (same branch + the VGA_F1 polarity flip after HW round 1 -- one inverter):
 # SEED 5, clk_dec 94.06 @100C / 91.29 @-40C, identical to the entry above as expected.
 # Build DVD_parityf1_20260903_1253.rbf (the HW round 2 candidate).
+# 2026-09-03d (fix/mode-switch-realign, issue #42 -- dvd/mode_realign.sv (78 combinational
+# ALUTs / 62 regs: a 32-bit target latch, a 32-bit 2:1 mux, one 24-bit watchdog and a 2-bit
+# FSM) + dvd/pal_detect.sv (84 / 43, clk_dec) + the emu seek-port arbitration): SEED 5 held
+# FIRST roll -- clk_dec 91.90 @100C / 88.88 @-40C (gate 86.0, PASS both corners) at 88% ALM
+# (36,968, up 62 from the parity netlist's 36,906), RAM 494/553 unchanged, DSP 92/112
+# unchanged. THIRTEENTH consecutive first-roll fit. Build DVD_modeswitch_20260903_1538.rbf.
+# ⚠ Both new modules are clk_sys control path at user rate or clk_dec quasi-static, and the
+# only added logic in an existing path is one LUT level of mux in front of the reader's
+# seek_rbn latch -- a path with cycles of slack. The +62 ALM is the honest logic delta here
+# (compare the dpad_seek entry above, where a large "ALMs needed" jump was mostly the
+# collapse of the recoverable-by-packing estimate, not new logic).
 set_global_assignment -name SEED 5

--- a/bench/dvd/mode_realign_chain_tb.sv
+++ b/bench/dvd/mode_realign_chain_tb.sv
@@ -56,7 +56,7 @@ module mode_realign_chain_tb;
     // instance below is fed by nets the chain further down drives.
     wire        rd_seek_pulse;
     wire [31:0] rd_seek_rbn;
-    wire        mr_sp, mr_ms, mr_pend;
+    wire        mr_sp, mr_ms, mr_pend, mr_blank;
     wire [31:0] mr_srbn;
     wire        load_flush, aud_flush, aud_resync, seek_flush, mount_flush;
     wire        pipe_rst_n, aud_rst_n;
@@ -430,9 +430,13 @@ module mode_realign_chain_tb;
         .dsi_nv_pck_lbn(ph_lbn), .lin_blk(32'd0),
         .seek_ack(seek_ack), .jump_ack(1'b0), .keep_vbuf(keep_vbuf),
         .start_streaming(start),
+        // The switch blank is irrelevant here: this bench measures the DELIVERED BYTE
+        // STREAM, which is upstream of emu's output mux. Held inert so it cannot perturb
+        // the seek FSM.
+        .video_live(1'b1), .blank_en(1'b0),
         .scrub_pulse(1'b0), .scrub_rbn(32'd0),
         .seek_rbn_pulse(mr_sp), .seek_rbn(mr_srbn),
-        .mode_switch(mr_ms), .realign_pend(mr_pend)
+        .mode_switch(mr_ms), .realign_pend(mr_pend), .sw_blank(mr_blank)
     );
 
     // +realign=0 removes the re-align entirely: the reader never sees an RBN seek, and

--- a/bench/dvd/mode_realign_chain_tb.sv
+++ b/bench/dvd/mode_realign_chain_tb.sv
@@ -1,32 +1,46 @@
-// iso_reader_seek_tb.sv - transport SEEK test for dvd/dvd_iso_reader.sv.
-//
-// The gamepad transport (emu.sv) can jump playback to an arbitrary PGC cell by
-// pulsing seek_pulse with seek_cell. This tb drives that port directly and
-// proves the reader re-streams from the target cell (forward + backward),
-// no-ops an out-of-range target, and reports cur_cell / seek_ack correctly.
-//
-// Disc: ONE title set (VTS_01), a 4-cell PGC in physical order. Each cell spans
-// CELLSEC=10 sectors (20 KB) of a single distinct marker byte, so the captured
-// stream identifies which cell is playing:
-//   cell0 -> RBN  0..9  = 0xB0    cell1 -> RBN 10..19 = 0xB1
-//   cell2 -> RBN 20..29 = 0xB2    cell3 -> RBN 30..39 = 0xB3
-// (reorder is already covered by iso_reader_pgc_tb; here order is physical so
-//  the ONLY thing that changes the marker mid-stream is a seek.)
-//
-// Cells are deliberately LARGER than the reader's 16 KB read-ahead cache so the
-// fetch pointer (cur_cell = cell_i) can't race whole cells ahead of the display
-// - which mirrors real DVDs (multi-MB cells) and keeps cur_cell == displayed
-// cell within the sub-cell cache lead.
-//
-// Layout (2048-byte logical sectors), same skeleton as iso_reader_pgc_tb:
-//   16 PVD  17 root  18 VIDEO_TS dir
-//   19 VMGI sec0 (VMGI_MAT tt_srpt@196 -> 20)   20 VMGI TT_SRPT
-//   21 VTSI sec0 (VTSI_MAT vts_pgcit@204 -> 22) 22 VTS_PGCIT+PGC+cells
-//   24..63 VTS_01_1.VOB RBN 0..39 (four 10-sector cells)
-
 `timescale 1ns/1ps
+//
+// mode_realign_chain_tb.sv — THE PROOF for issue #42, measured in the delivered bytes.
+//
+// dvd/mode_realign.sv + dvd/flush_ctl.sv + the REAL dvd/dvd_iso_reader.sv over a
+// synthetic DVD image (fixture skeleton shared with bench/dvd/iso_reader_seek_tb.sv).
+//
+// ★ WHAT IS MEASURED, AND WHY IT IS THIS. The bug was never visible in a signal: the
+// trio fired correctly, on time, with the right levels. What was wrong was WHERE IN THE
+// BYTE STREAM it landed -- mid-VOBU, so the decoder had no GOP boundary to re-lock on.
+// So this bench fires one raster-mode change while the reader is mid-VOBU and then reads
+// the FIRST BYTES DELIVERED AFTER THE FLUSH, checking them against the 12-byte NAV-pack
+// signature (00 00 01 BA @0, 00 00 01 BB @14, 00 00 01 BF @38 -- the same bytes the
+// reader's own VOBU-snap probe matches, and the definition of a VOBU boundary).
+//
+//   pre-fix (+realign=0): the reader never moves, so the stream continues from wherever
+//                         it was -- the bytes after the flush are mid-sector payload.
+//   fixed:                the re-align seeks to the current VOBU, so the bytes after the
+//                         flush ARE a NAV pack.
+//
+// That criterion is external to the RTL: it is a property of the byte stream, not a
+// re-statement of any expression inside the design. bench/dvd/field_parity_tb.sv is the
+// cautionary tale (CLAUDE.md) -- its pass condition was the same expression as the RTL's,
+// so it agreed with the defect by construction.
+//
+// ⚠ The playhead (dsi_nv_pck_lbn) is modelled HERE rather than by instantiating nav_dsi
+// and ps_demux: it is an INPUT to the module under test, and modelling it keeps the
+// fixture honest -- the bench knows which sector is streaming because it counts the bytes
+// it received, so a wrong latched target shows up as a wrong seek.
+//
+// NAV packs sit at every 5th title sector (RBN 0,5,10,...), i.e. 5-sector VOBUs. Sectors
+// in between are deliberately NOT NAV packs, or a mid-VOBU landing would look aligned and
+// the pre-fix arm would pass.
+//
+// Build/run: bench/dvd/run_mode_realign.sh   (or, standalone)
+//   iverilog -g2012 -o bench/dvd/mode_realign_chain_sim \
+//       dvd/dvd_iso_reader.sv dvd/flush_ctl.sv dvd/mode_realign.sv \
+//       bench/dvd/mode_realign_chain_tb.sv
+//   vvp bench/dvd/mode_realign_chain_sim             # GREEN
+//   vvp bench/dvd/mode_realign_chain_sim +realign=0  # RED — failure EXPECTED
+//
 
-module iso_reader_seek_tb;
+module mode_realign_chain_tb;
 
     localparam CELLSEC   = 10;              // sectors per cell (> 16 KB cache)
     localparam VOBSEC    = 4*CELLSEC;       // 40 title sectors
@@ -38,11 +52,18 @@ module iso_reader_seek_tb;
     reg         start = 0;
     reg  [63:0] file_size = 0;
 
+    // Forward declarations: Icarus requires declaration before use, and the reader
+    // instance below is fed by nets the chain further down drives.
+    wire        rd_seek_pulse;
+    wire [31:0] rd_seek_rbn;
+    wire        mr_sp, mr_ms, mr_pend;
+    wire [31:0] mr_srbn;
+    wire        load_flush, aud_flush, aud_resync, seek_flush, mount_flush;
+    wire        pipe_rst_n, aud_rst_n;
+
     // transport seek port
     reg         seek_pulse = 0;
     reg  [7:0]  seek_cell = 0;
-    reg         seek_rbn_pulse = 0;    // Phase-8 sub-cell scrub
-    reg  [31:0] seek_rbn = 0;
     wire        seek_ack;
     wire [7:0]  cur_cell;
     wire        cell_ready;
@@ -81,14 +102,14 @@ module iso_reader_seek_tb;
     // NAV_CAP(8): a small VOBU-align probe budget so TEST7 can exhaust it on this
     // 40-sector title (TEST8 exercises the title-end clamp before the budget runs).
     dvd_iso_reader #(.NAV_CAP(8)) dut (
-        .clk(clk), .rst_n(rst_n), .start(start), .file_size(file_size), .title_sel(4'd0), .vbuf_empty(1'b0), .menu_snap(1'b0),
+        .clk(clk), .rst_n(rst_n), .start(start), .file_size(file_size), .title_sel(7'd0), .vbuf_empty(1'b0), .menu_snap(1'b0),
         // Phase-4 DVD-VM ports: legacy mode (vm_mode=0 keeps prior behaviour)
         .jump_ttn(7'd0), .jump_pgn(8'd0),
         .vm_mode(1'b0), .vm_adv(1'b0), .vm_replay(1'b0),
         .vm_cell_cmd(), .vm_pgc_end(), .nav_ready_o(), .auto_vts(), .cell_count_o(),
         .pm_we(), .pm_waddr(), .pm_wdata(), .cmd_nr_pgm(),
         .seek_pulse(seek_pulse), .seek_natural(1'b0), .seek_cell(seek_cell), .seek_ack(seek_ack),
-        .seek_rbn_pulse(seek_rbn_pulse), .seek_rbn(seek_rbn),
+        .seek_rbn_pulse(rd_seek_pulse), .seek_rbn(rd_seek_rbn),
         .chap_pulse(1'b0), .chap_dir(1'b0), .chap_mag(5'd1),
         .keep_vbuf(keep_vbuf),
         .cur_cell(cur_cell), .cell_ready(cell_ready),
@@ -102,16 +123,6 @@ module iso_reader_seek_tb;
     );
 
     always #5 clk = ~clk;
-
-    // ---- SD read counter: every sd_rd rising edge is one 2048-byte sector fetch.
-    // Used by TEST9 to MEASURE the VOBU-snap probe cost, which the mode-switch re-align
-    // (dvd/mode_realign.sv, issue #42) depends on being one read for an on-NAV target.
-    integer sd_reads = 0;
-    reg     sd_rd_q = 0;
-    always @(posedge clk) begin
-        if (sd_rd && !sd_rd_q) sd_reads = sd_reads + 1;
-        sd_rd_q <= sd_rd;
-    end
 
     // ---- mock HPS: serve one 2048-byte block (sector) per sd_rd ----
     integer m = 0;
@@ -376,207 +387,186 @@ module iso_reader_seek_tb;
         end
     endfunction
 
-    // Drive a raw-RBN scrub, wait for the jump to execute, capture from byte 0.
-    task do_scrub(input [31:0] rbn);
+
+
+    // =====================================================================
+    // THE CHAIN UNDER TEST
+    // =====================================================================
+    integer realign = 1;                  // 1 = the fix, 0 = the pre-fix path
+    localparam VOBU = 5;                  // title sectors per VOBU in this fixture
+
+    reg  mode_edge = 0;
+    reg  legacy_ms = 0;                   // pre-fix: `wire mode_switch = il_switch;`
+    always @(posedge clk) legacy_ms <= rst_n ? mode_edge : 1'b0;
+
+    // ---- the playhead model: which VOBU's NAV pack is the demux front on? -----------
+    // Bytes delivered since the stream last (re)started, and the title RBN that restart
+    // began at. Only needs to be valid up to the mode edge -- after that the module has
+    // latched, and the pass criterion below does not depend on it.
+    integer strm_bytes = 0;
+    integer base_rbn   = 0;
+    reg     ph_track   = 1;               // stop tracking once the edge has been taken
+    always @(posedge clk) if (stream_valid && ph_track) strm_bytes = strm_bytes + 1;
+
+    wire integer cur_sec  = base_rbn + (strm_bytes / SECBYTES);
+    wire integer cur_vobu = (cur_sec / VOBU) * VOBU;
+
+    reg  [31:0] ph_lbn  = 32'd0;
+    reg         ph_cmt  = 0;
+    always @(posedge clk) begin
+        ph_cmt <= 1'b0;
+        if (ph_track && (cur_vobu != ph_lbn)) begin
+            ph_lbn <= cur_vobu;
+            ph_cmt <= 1'b1;               // a DSI finished parsing for this VOBU
+        end
+    end
+
+    mode_realign #(.WDOG(24'd20000)) mr (
+        .clk(clk), .rst_n(rst_n),
+        .mode_edge(mode_edge),
+        .in_title(cell_ready), .dvd_mode(cell_ready), .lin_mode(1'b0),
+        .still_active(1'b0), .hold_freeze(1'b0),
+        .nav_flush(load_flush), .dsi_commit(ph_cmt), .dsi_stream(1'b0),
+        .dsi_nv_pck_lbn(ph_lbn), .lin_blk(32'd0),
+        .seek_ack(seek_ack), .jump_ack(1'b0), .keep_vbuf(keep_vbuf),
+        .start_streaming(start),
+        .scrub_pulse(1'b0), .scrub_rbn(32'd0),
+        .seek_rbn_pulse(mr_sp), .seek_rbn(mr_srbn),
+        .mode_switch(mr_ms), .realign_pend(mr_pend)
+    );
+
+    // +realign=0 removes the re-align entirely: the reader never sees an RBN seek, and
+    // flush_ctl is driven straight off the mode edge, exactly as it was before the fix.
+    assign rd_seek_pulse = realign[0] ? mr_sp   : 1'b0;
+    assign rd_seek_rbn   = realign[0] ? mr_srbn : 32'd0;
+    wire   fc_mode_sw    = realign[0] ? mr_ms   : legacy_ms;
+
+    flush_ctl fc (
+        .clk(clk), .rst_n(rst_n),
+        .start_streaming(start), .seek_ack(seek_ack), .jump_ack(1'b0),
+        .mode_switch(fc_mode_sw), .aud_switch(1'b0), .keep_vbuf(keep_vbuf),
+        .load_flush(load_flush), .aud_flush(aud_flush), .aud_resync(aud_resync),
+        .seek_flush(seek_flush), .mount_flush(mount_flush),
+        .pipe_rst_n(pipe_rst_n), .aud_rst_n(aud_rst_n)
+    );
+
+    // ---- the measurement: capture from the first byte after the flush RISES ----------
+    reg seek_flush_q = 0;
+    reg armed_cap    = 0;
+    integer n_trio   = 0;
+    always @(posedge clk) begin
+        if (seek_flush && !seek_flush_q) begin
+            n_trio    = n_trio + 1;
+            cap_n     = 0;                // the next captured byte is the first post-flush
+            armed_cap = 1;
+        end
+        seek_flush_q <= seek_flush;
+    end
+
+    // NAV packs every VOBU. build_iso puts them at 14/20/26 for the scrub tests; put the
+    // fixture back to plain markers there so "NAV pack" means exactly "VOBU boundary".
+    task build_chain_iso;
+        integer q;
         begin
-            ack_seen = 1'b0;
-            @(posedge clk); seek_rbn_pulse <= 1'b1; seek_rbn <= rbn;
-            @(posedge clk); seek_rbn_pulse <= 1'b0;
-            k = 0; while (!ack_seen && k < 200000) begin @(posedge clk); k = k + 1; end
-            cap_n = 0;                          // capture the landed stream from byte 0
-            k = 0; while (cap_n < 1 && k < 200000) begin @(posedge clk); k = k + 1; end
+            build_iso;
+            fill_sec(24 + 14, 8'hB1);
+            fill_sec(24 + 26, 8'hB2);
+            for (q = 0; q < VOBSEC; q = q + VOBU) put_nav(q);
         end
     endtask
 
     initial begin
-        rst_n = 0;
+        if (!$value$plusargs("realign=%d", realign)) realign = 1;
+        $display("mode_realign_chain_tb: %0s path", realign[0] ? "FIXED" : "PRE-FIX (+realign=0)");
+
+        build_chain_iso;
+        file_size = VOBSEC*2048;
+
         repeat (4) @(posedge clk);
         rst_n = 1;
-        @(posedge clk);
+        repeat (4) @(posedge clk);
+        @(negedge clk) start = 1;
+        @(negedge clk) start = 0;
 
-        build_iso;
-        file_size = IMG_BYTES;
-        @(posedge clk);
-        start = 1; @(posedge clk); start = 0;
+        // Let the reader mount, parse the IFOs and start streaming cell 0 from RBN 0.
+        k = 0;
+        while (!cell_ready && k < 400000) begin @(posedge clk); k = k + 1; end
+        if (!cell_ready) begin
+            $display("FAIL: reader never reached cell mode");
+            errors = errors + 1;
+        end
+        base_rbn   = 0;
+        strm_bytes = 0;
+        wait_bytes(1);
+        strm_bytes = 0;                    // count from the first delivered byte
 
-        // ---- baseline: playback begins at cell 0 (marker B0) ----
-        wait_bytes(1024);
-        if (dut.cell_mode !== 1'b1) begin errors=errors+1; $display("  FAIL: cell_mode not set"); end
-        if (!cell_ready)            begin errors=errors+1; $display("  FAIL: cell_ready low"); end
-        if (cur_cell !== 8'd0)      begin errors=errors+1; $display("  FAIL: cur_cell!=0 at start (%0d)", cur_cell); end
-        expect_marker(8'hB0, "baseline cell0");
-        $display("TEST0: cell_mode=%b cell_count=%0d cur_cell=%0d",
-                 dut.cell_mode, dut.cell_count, cur_cell);
-
-        // ---- TEST 1: forward seek cell0 -> cell3 (marker B3) ----
-        do_seek(8'd3);
-        if (!ack_seen)         begin errors=errors+1; $display("  FAIL: no seek_ack on forward seek"); end
-        if (cur_cell !== 8'd3) begin errors=errors+1; $display("  FAIL: cur_cell!=3 after fwd seek (%0d)", cur_cell); end
-        // Phase-5: a TITLE transport seek is NOT a menu transition -> keep_vbuf=0
-        // (the VBUF must flush so the picture jumps with the audio).
-        if (kv_at_seek !== 1'b0) begin errors=errors+1; $display("  FAIL: keep_vbuf!=0 on a title transport seek (%b)", kv_at_seek); end
-        wait_bytes(1024);
-        expect_marker(8'hB3, "TEST1 forward seek -> cell3");
-
-        // ---- TEST 2: backward seek cell3 -> cell1 (marker B1) ----
-        do_seek(8'd1);
-        if (!ack_seen)         begin errors=errors+1; $display("  FAIL: no seek_ack on backward seek"); end
-        if (cur_cell !== 8'd1) begin errors=errors+1; $display("  FAIL: cur_cell!=1 after bwd seek (%0d)", cur_cell); end
-        wait_bytes(1024);
-        expect_marker(8'hB1, "TEST2 backward seek -> cell1");
-
-        // ---- TEST 3: out-of-range seek (cell 10 >= cell_count 4) = no-op ----
-        // Must not ack and must not jump the cell cursor. Playback keeps running
-        // from where it was, so we only assert: no ack, cur_cell < cell_count.
-        ack_seen = 1'b0;
-        @(posedge clk); seek_pulse <= 1'b1; seek_cell <= 8'd10;
-        @(posedge clk); seek_pulse <= 1'b0;
-        repeat (40) @(posedge clk);
-        if (ack_seen)                    begin errors=errors+1; $display("  FAIL: out-of-range seek acked"); end
-        if (cur_cell >= dut.cell_count)  begin errors=errors+1; $display("  FAIL: cur_cell ran out of range (%0d)", cur_cell); end
-        else $display("  ok: TEST3 out-of-range seek ignored (no ack, cur_cell=%0d)", cur_cell);
-
-        // ---- TEST 4: scrub to RBN 25 (mid cell2) SNAPS forward to the NAV @26 ----
-        // A raw mid-VOBU target would leave the decoder mid-GOP and mis-anchor the
-        // STC; the reader now walks forward to the first NAV pack (RBN 26) so the
-        // landing is VOBU-aligned. cur_cell stays 2; the stream begins with the NAV
-        // signature; RBN 26..29 (4 sectors) precede cell3's B3.
-        do_scrub(32'd25);
-        if (!ack_seen)         begin errors=errors+1; $display("  FAIL: no seek_ack on RBN scrub"); end
-        if (cur_cell !== 8'd2) begin errors=errors+1; $display("  FAIL: TEST4 cur_cell!=2 (%0d)", cur_cell); end
-        wait_bytes(20000);
-        check_sig("TEST4");
-        if (first_of(8'hB3) !== 4*2048)
-            begin errors=errors+1;
-                $display("  FAIL: TEST4 snapped to wrong RBN - first B3 at %0d (want %0d = RBN 26..29)",
-                         first_of(8'hB3), 4*2048); end
-        else
-            $display("  ok: TEST4 scrub RBN 25 -> NAV-aligned RBN 26 (cell2, 4 sectors then B3)");
-
-        // ---- TEST 5: scrub to RBN 20 (already a NAV = cell2 head) = NO shift ----
-        do_scrub(32'd20);
-        if (cur_cell !== 8'd2) begin errors=errors+1; $display("  FAIL: TEST5 cur_cell!=2 (%0d)", cur_cell); end
-        wait_bytes(30000);
-        check_sig("TEST5");
-        if (first_of(8'hB3) !== 10*2048)
-            begin errors=errors+1;
-                $display("  FAIL: TEST5 shifted off an on-NAV target - first B3 at %0d (want %0d)",
-                         first_of(8'hB3), 10*2048); end
-        else
-            $display("  ok: TEST5 scrub RBN 20 (on NAV) -> no shift (RBN 20..29 then B3)");
-
-        // ---- TEST 6: scrub to RBN 17 (cell1, next NAV @20) CROSSES into cell2 ----
-        // The align target (20) is in the NEXT cell, so the containing-cell scan
-        // re-selects cell2 -> proves the cross-cell path.
-        do_scrub(32'd17);
-        if (cur_cell !== 8'd2) begin errors=errors+1; $display("  FAIL: TEST6 cur_cell!=2 cross-cell (%0d)", cur_cell); end
-        wait_bytes(30000);
-        check_sig("TEST6");
-        if (first_of(8'hB3) !== 10*2048)
-            begin errors=errors+1;
-                $display("  FAIL: TEST6 cross-cell align wrong - first B3 at %0d (want %0d)",
-                         first_of(8'hB3), 10*2048); end
-        else
-            $display("  ok: TEST6 scrub RBN 17 -> NAV @20 (cross-cell to cell2)");
-
-        // ---- TEST 7: scrub into NAV-free cell3 (RBN 31); budget exhausts -> raw ----
-        // cell3 (RBN 30..39) has no NAV; with NAV_CAP=8 the probe checks 31..38 then
-        // falls back to the RAW target 31 (pre-fix behaviour = no regression).
-        do_scrub(32'd31);
-        if (!ack_seen)         begin errors=errors+1; $display("  FAIL: no seek_ack on TEST7 scrub"); end
-        if (cur_cell !== 8'd3) begin errors=errors+1; $display("  FAIL: TEST7 cur_cell!=3 (%0d)", cur_cell); end
-        if (cap[0] !== 8'hB3)  begin errors=errors+1; $display("  FAIL: TEST7 fallback did not land raw (cap[0]=%02x)", cap[0]); end
-        wait_bytes(18432);
-        begin : t7count
-            integer b3run;
-            b3run = 0;
-            while (b3run < cap_n && cap[b3run] === 8'hB3) b3run = b3run + 1;
-            if (b3run !== 9*2048)
-                begin errors=errors+1;
-                    $display("  FAIL: TEST7 raw fallback wrong RBN - %0d B3 bytes (want %0d = RBN 31..39)", b3run, 9*2048); end
-            else
-                $display("  ok: TEST7 budget-exhausted fallback -> raw RBN 31 (%0d B3 bytes)", b3run);
+        // ---- park the demux front MID-VOBU -----------------------------------------
+        // Half a sector into VOBU 1 (RBN 5..9): a landing here is not a VOBU boundary,
+        // which is the whole point -- with no reader jump the flush lands right here.
+        wait_bytes(6*SECBYTES + 700);
+        if ((strm_bytes % SECBYTES) == 0) begin
+            $display("FAIL: setup -- the front is on a sector boundary, nothing to prove");
+            errors = errors + 1;
+        end
+        $display("  front: %0d bytes streamed (sector %0d, VOBU %0d), playhead RBN %0d",
+                 strm_bytes, cur_sec, cur_vobu, ph_lbn);
+        if (ph_lbn != 32'd5) begin
+            $display("FAIL: setup -- playhead model says %0d, expected 5", ph_lbn);
+            errors = errors + 1;
         end
 
-        // ---- TEST 8: scrub to RBN 36; probe hits the title-end clamp -> raw ----
-        do_scrub(32'd36);
-        if (cur_cell !== 8'd3) begin errors=errors+1; $display("  FAIL: TEST8 cur_cell!=3 (%0d)", cur_cell); end
-        if (cap[0] !== 8'hB3)  begin errors=errors+1; $display("  FAIL: TEST8 fallback did not land raw (cap[0]=%02x)", cap[0]); end
-        wait_bytes(8192);
-        begin : t8count
-            integer b3run;
-            b3run = 0;
-            while (b3run < cap_n && cap[b3run] === 8'hB3) b3run = b3run + 1;
-            if (b3run !== 4*2048)
-                begin errors=errors+1;
-                    $display("  FAIL: TEST8 title-end fallback wrong - %0d B3 bytes (want %0d = RBN 36..39)", b3run, 4*2048); end
-            else
-                $display("  ok: TEST8 title-end-clamp fallback -> raw RBN 36 (%0d B3 bytes)", b3run);
+        // ---- ONE raster-mode change -------------------------------------------------
+        n_trio = 0;
+        @(negedge clk) mode_edge = 1;
+        @(negedge clk) mode_edge = 0;
+        ph_track = 0;                      // freeze the model; the module has latched
+
+        // Wait for the trio, then for the first bytes to arrive behind it.
+        k = 0;
+        while (n_trio == 0 && k < 400000) begin @(posedge clk); k = k + 1; end
+        if (n_trio == 0) begin
+            $display("FAIL: no flush ever fired for the mode change");
+            errors = errors + 1;
+        end
+        k = 0;
+        while (cap_n < 64 && k < 400000) begin @(posedge clk); k = k + 1; end
+
+        // ---- THE CRITERION ----------------------------------------------------------
+        if (cap_n < 64) begin
+            $display("FAIL: fewer than 64 bytes delivered after the flush");
+            errors = errors + 1;
+        end else begin
+            $display("  first bytes after the flush: %02x %02x %02x %02x  (@14: %02x %02x %02x %02x)",
+                     cap[0], cap[1], cap[2], cap[3], cap[14], cap[15], cap[16], cap[17]);
+            check_sig("flush must land on a NAV pack");
         end
 
-        // ---- TEST 9: MEASURE the VOBU-snap probe cost ------------------------------
-        // The probe walks forward ONE SECTOR AT A TIME from the raw target (S_NAV_SEEK ->
-        // S_SECREAD -> S_NAV_CHK, budget NAV_CAP), so where the target sits relative to
-        // the next NAV pack is the whole cost. dvd/mode_realign.sv (issue #42) targets the
-        // playhead's OWN VOBU precisely because that is already a NAV pack: the first
-        // probe hits and the snap moves nowhere. This measures the difference rather than
-        // asserting it, by counting sector fetches from the jump to the first byte out.
-        begin : t9
-            integer r0, n_on_nav, n_short, n_one;
-            // (a) target RBN 20 -- already a NAV pack (cell2's head)
-            ack_seen = 1'b0;
-            @(posedge clk); seek_rbn_pulse <= 1'b1; seek_rbn <= 32'd20;
-            @(posedge clk); seek_rbn_pulse <= 1'b0;
-            k = 0; while (!ack_seen && k < 200000) begin @(posedge clk); k = k + 1; end
-            r0 = sd_reads; cap_n = 0;
-            k = 0; while (cap_n < 1 && k < 200000) begin @(posedge clk); k = k + 1; end
-            n_on_nav = sd_reads - r0;
-
-            // (b) target RBN 25 -- ONE sector short of the next NAV pack (26)
-            ack_seen = 1'b0;
-            @(posedge clk); seek_rbn_pulse <= 1'b1; seek_rbn <= 32'd25;
-            @(posedge clk); seek_rbn_pulse <= 1'b0;
-            k = 0; while (!ack_seen && k < 200000) begin @(posedge clk); k = k + 1; end
-            r0 = sd_reads; cap_n = 0;
-            k = 0; while (cap_n < 1 && k < 200000) begin @(posedge clk); k = k + 1; end
-            n_one = sd_reads - r0;
-
-            // (c) target RBN 21 -- five sectors short of the next NAV pack (26)
-            ack_seen = 1'b0;
-            @(posedge clk); seek_rbn_pulse <= 1'b1; seek_rbn <= 32'd21;
-            @(posedge clk); seek_rbn_pulse <= 1'b0;
-            k = 0; while (!ack_seen && k < 200000) begin @(posedge clk); k = k + 1; end
-            r0 = sd_reads; cap_n = 0;
-            k = 0; while (cap_n < 1 && k < 200000) begin @(posedge clk); k = k + 1; end
-            n_short = sd_reads - r0;
-
-            // Three points, so the cost MODEL is measured rather than assumed: each
-            // reading is a fixed landing cost (the cell-table reload and the first stream
-            // fetch) plus ONE sector read per probed candidate. Two independent
-            // differences pin the slope at 1 read/sector, which is what makes an on-NAV
-            // target -- the one dvd/mode_realign.sv uses -- a single-probe snap.
-            $display("  TEST9 probe cost: on-NAV %0d reads, 1-short %0d, 5-short %0d",
-                     n_on_nav, n_one, n_short);
-            if (n_one - n_on_nav !== 1) begin
-                errors = errors + 1;
-                $display("  FAIL: TEST9 one extra sector must cost one extra read (got %0d)",
-                         n_one - n_on_nav);
-            end else if (n_short - n_on_nav !== 5) begin
-                errors = errors + 1;
-                $display("  FAIL: TEST9 a 5-sector gap must cost 5 extra reads (got %0d)",
-                         n_short - n_on_nav);
-            end else
-                $display("  ok: TEST9 the probe walk is 1 read/sector; an on-NAV target snaps on the first probe");
+        // Exactly one flush for one mode change, whichever path was taken.
+        if (n_trio != 1) begin
+            $display("  flushes=%0d, want 1", n_trio);
+            errors = errors + 1;
+            $display("FAIL: one mode change must cost exactly one flush");
         end
 
-        if (errors == 0) $display("ISO_READER_SEEK_TB: ALL TESTS PASSED");
-        else             $display("ISO_READER_SEEK_TB: FAILED with %0d errors", errors);
+        // And it must have re-aligned to the VOBU the demux front was in -- not to the
+        // start of the title (the stale-playhead trap) and not forward past content.
+        if (realign[0] && mr_srbn != 32'd5) begin
+            $display("  re-align target=%0d, want 5", mr_srbn);
+            errors = errors + 1;
+            $display("FAIL: the re-align must target the CURRENT VOBU");
+        end
+
+        if (errors == 0) $display("mode_realign_chain_tb: ALL TESTS PASSED");
+        else begin
+            $display("mode_realign_chain_tb: FAILED with %0d errors", errors);
+            $fatal(1, "mode_realign_chain_tb FAILED");
+        end
         $finish;
     end
 
     initial begin
         #400000000;
-        $display("ISO_READER_SEEK_TB: TIMEOUT");
+        $display("mode_realign_chain_tb: TIMEOUT");
         $finish;
     end
 

--- a/bench/dvd/mode_realign_tb.sv
+++ b/bench/dvd/mode_realign_tb.sv
@@ -28,7 +28,8 @@
 //
 module mode_realign_tb;
 
-  localparam [23:0] WDOG = 24'd200;      // sim-scale watchdog
+  localparam [23:0] WDOG      = 24'd200;   // sim-scale watchdog
+  localparam [25:0] BLANK_MAX = 26'd300;   // sim-scale blank ceiling
 
   reg clk = 0, rst_n = 0;
   reg mode_edge = 0;
@@ -40,14 +41,15 @@ module mode_realign_tb;
   reg seek_ack = 0, jump_ack = 0, keep_vbuf = 0, start_streaming = 0;
   reg scrub_pulse = 0;
   reg [31:0] scrub_rbn = 32'd0;
+  reg video_live = 1, blank_en = 1;
 
   wire        dut_sp;
   wire [31:0] dut_srbn;
-  wire        dut_ms, realign_pend;
+  wire        dut_ms, realign_pend, sw_blank;
 
   integer realign = 1;                   // 1 = the fixed module, 0 = the pre-fix path
 
-  mode_realign #(.WDOG(WDOG)) dut (
+  mode_realign #(.WDOG(WDOG), .BLANK_MAX(BLANK_MAX)) dut (
     .clk(clk), .rst_n(rst_n),
     .mode_edge(mode_edge),
     .in_title(in_title), .dvd_mode(dvd_mode), .lin_mode(lin_mode),
@@ -56,9 +58,10 @@ module mode_realign_tb;
     .dsi_nv_pck_lbn(dsi_nv_pck_lbn), .lin_blk(lin_blk),
     .seek_ack(seek_ack), .jump_ack(jump_ack), .keep_vbuf(keep_vbuf),
     .start_streaming(start_streaming),
+    .video_live(video_live), .blank_en(blank_en),
     .scrub_pulse(scrub_pulse), .scrub_rbn(scrub_rbn),
     .seek_rbn_pulse(dut_sp), .seek_rbn(dut_srbn),
-    .mode_switch(dut_ms), .realign_pend(realign_pend)
+    .mode_switch(dut_ms), .realign_pend(realign_pend), .sw_blank(sw_blank)
   );
 
   // ---- the PRE-FIX path: `wire mode_switch = il_switch;` and scrub_ctrl as the only
@@ -126,6 +129,17 @@ module mode_realign_tb;
     end
   endtask
 
+  task wait_n(input integer n); begin repeat (n) @(negedge clk); end endtask
+
+  task chk_blank(input want, input [8*76-1:0] msg);
+    begin
+      if (sw_blank !== want) begin
+        $display("  sw_blank=%0b, want %0b", sw_blank, want);
+        fail(msg);
+      end
+    end
+  endtask
+
   task edge_pulse; begin mode_edge = 1; @(negedge clk); mode_edge = 0; @(negedge clk); end endtask
 
   // A DSI packet finished parsing and left this VOBU NAV-pack RBN in force.
@@ -144,6 +158,7 @@ module mode_realign_tb;
       rst_n = 0; mode_edge = 0; in_title = 1; dvd_mode = 1; lin_mode = 0;
       still_active = 0; hold_freeze = 0; nav_flush = 0; dsi_commit = 0; dsi_stream = 0;
       start_streaming = 0; scrub_pulse = 0; ack_en = 1; ack_lat = 6; ack_keep = 0;
+      video_live = 1; blank_en = 1;
       repeat (4) @(negedge clk);
       rst_n = 1;
       repeat (2) @(negedge clk);
@@ -284,7 +299,83 @@ module mode_realign_tb;
     chk_counts(1, 0, "[11b] the release seek must satisfy the arm");
     chk_tgt(32'd11500, "[11c] the release target must be the scrub's");
 
-    if (errors == 0) $display("mode_realign_tb: ALL TESTS PASSED (11 scenarios)");
+    // =====================================================================
+    // THE SWITCH BLANK. Tested against the DUT directly and NOT through the eff_*
+    // muxes: it is new behaviour with no pre-fix counterpart, so there is nothing for
+    // a +realign=0 arm to disagree with. What these lock is the WINDOW's two endpoints.
+    // =====================================================================
+    do_reset;
+    commit_lbn(32'd20000);
+
+    // ============================================================= [12]
+    // The normal path: blank on the edge, clear on the first video_live HIGH *after*
+    // it has been seen LOW (our own flush re-arms it). Modelled explicitly here.
+    ack_en = 0;                            // drive the timeline by hand
+    chk_blank(1'b0, "[12a] no blank before the switch");
+    edge_pulse;
+    chk_blank(1'b1, "[12b] the edge must start the blank");
+    video_live = 0; wait_n(8);             // the flush lands: video_live re-arms
+    chk_blank(1'b1, "[12c] blank must hold while no frame is displayed");
+    video_live = 1; wait_n(4);
+    chk_blank(1'b0, "[12d] the first new-mode frame must clear the blank");
+
+    // ============================================================= [13]  ** the trap **
+    // ⚠ At the edge itself video_live is STILL HIGH (from the old content — the flush
+    // lands a few ms later). A naive "clear when video_live" would clear immediately and
+    // blank nothing at all. Requiring the LOW first is what makes the window real.
+    wait_n(4);
+    edge_pulse;
+    wait_n(BLANK_MAX/3);                   // video_live left HIGH throughout
+    chk_blank(1'b1, "[13] a still-high video_live must NOT clear the blank early");
+    video_live = 0; wait_n(4); video_live = 1; wait_n(4);
+    chk_blank(1'b0, "[13b] ...and the drop-then-rise still clears it");
+
+    // ============================================================= [14]
+    // THE MENU PATH. emu forces the STD mux-lead hold off while a menu is up, so
+    // pickup_hold never rises and video_live never re-arms: the timeout is the ONLY exit.
+    // It also bounds the fix so it can never mask a persistent fault.
+    wait_n(4);
+    edge_pulse;
+    wait_n(BLANK_MAX - 20);
+    chk_blank(1'b1, "[14a] blank must still be up just before the ceiling");
+    wait_n(60);
+    chk_blank(1'b0, "[14b] the ceiling must release the blank with video_live stuck high");
+
+    // ============================================================= [15]
+    // Never blank before the first mount: the boot-time edge (il_eff_q resets to 0, so an
+    // Interlaced rig pulses one at reset release) would otherwise black the idle screen
+    // for the whole ceiling -- the launch-feedback regression docs/idle_screen.md exists
+    // to prevent.
+    blank_en = 0;
+    wait_n(4);
+    edge_pulse;
+    wait_n(30);
+    chk_blank(1'b0, "[15] blank_en low must suppress the blank entirely");
+    blank_en = 1;
+
+    // ============================================================= [16]
+    // A second edge mid-blank RESTARTS the window. The seek arm coalesces; the blank must
+    // not, or the second toggle uncovers the transient it just caused.
+    wait_n(4);
+    edge_pulse;
+    wait_n(BLANK_MAX - 40);
+    edge_pulse;                            // re-trigger
+    wait_n(BLANK_MAX - 40);
+    chk_blank(1'b1, "[16] a second edge must restart the blank window, not ride the old one");
+    video_live = 0; wait_n(4); video_live = 1; wait_n(4);
+    chk_blank(1'b0, "[16b] ...and it still clears normally");
+
+    // ============================================================= [17]
+    // A mount cuts to black and cold-starts on its own; holding a blank across it would
+    // only delay the new disc's first frame.
+    wait_n(4);
+    edge_pulse;
+    chk_blank(1'b1, "[17a] setup: blank is up");
+    start_streaming = 1; wait_n(1); start_streaming = 0; wait_n(4);
+    chk_blank(1'b0, "[17b] a mount must clear the blank");
+    ack_en = 1;
+
+    if (errors == 0) $display("mode_realign_tb: ALL TESTS PASSED (17 scenarios)");
     else begin
       $display("mode_realign_tb: %0d FAILURE(S)", errors);
       $fatal(1, "mode_realign_tb FAILED");

--- a/bench/dvd/mode_realign_tb.sv
+++ b/bench/dvd/mode_realign_tb.sv
@@ -1,0 +1,295 @@
+`timescale 1ns/1ps
+//
+// mode_realign_tb.sv — unit test for dvd/mode_realign.sv (issue #42 leg 1).
+//
+// A live raster-mode change used to fire the flush trio WITHOUT moving the reader, so the
+// decoder resumed mid-VOBU with no GOP boundary and could freeze on a malformed frame.
+// The fix turns the mode switch into a reader seek and lets seek_ack drive the trio.
+//
+// ⚠ THE TRAP THIS BENCH IS BUILT TO AVOID (CLAUDE.md: bench-that-cannot-fail). Every
+// expectation below is a COUNT or a VALUE the testbench itself supplied — never a read of
+// the DUT's internals and never a copy of an RTL expression. The playhead is driven to a
+// distinctive value per scenario, so a DUT that latched the wrong one (at the mode edge
+// instead of at the issue, or re-sampled after its own flush cleared nav_dsi) is visible.
+// The pre-fix behaviour is modelled alongside and selected by +realign=0, and it MUST FAIL
+// scenarios [1], [3] and [7].
+//
+// ⚠ TIMING DISCIPLINE: all stimulus is driven from the NEGEDGE and all sampling/counting
+// from the posedge. Driving a blocking assignment at the posedge itself is a race between
+// this process and the DUT's, and it silently read as "nothing ever happened" -- every
+// count came back 0 and the first version of this bench failed all eleven scenarios
+// against correct RTL.
+//
+// Build/run: bench/dvd/run_mode_realign.sh   (or, standalone)
+//   iverilog -g2012 -o bench/dvd/mode_realign_sim \
+//       dvd/mode_realign.sv bench/dvd/mode_realign_tb.sv
+//   vvp bench/dvd/mode_realign_sim             # GREEN
+//   vvp bench/dvd/mode_realign_sim +realign=0  # RED — failures EXPECTED
+//
+module mode_realign_tb;
+
+  localparam [23:0] WDOG = 24'd200;      // sim-scale watchdog
+
+  reg clk = 0, rst_n = 0;
+  reg mode_edge = 0;
+  reg in_title = 1, dvd_mode = 1, lin_mode = 0;
+  reg still_active = 0, hold_freeze = 0;
+  reg nav_flush = 0, dsi_commit = 0, dsi_stream = 0;
+  reg [31:0] dsi_nv_pck_lbn = 32'd0;
+  reg [31:0] lin_blk = 32'd0;
+  reg seek_ack = 0, jump_ack = 0, keep_vbuf = 0, start_streaming = 0;
+  reg scrub_pulse = 0;
+  reg [31:0] scrub_rbn = 32'd0;
+
+  wire        dut_sp;
+  wire [31:0] dut_srbn;
+  wire        dut_ms, realign_pend;
+
+  integer realign = 1;                   // 1 = the fixed module, 0 = the pre-fix path
+
+  mode_realign #(.WDOG(WDOG)) dut (
+    .clk(clk), .rst_n(rst_n),
+    .mode_edge(mode_edge),
+    .in_title(in_title), .dvd_mode(dvd_mode), .lin_mode(lin_mode),
+    .still_active(still_active), .hold_freeze(hold_freeze),
+    .nav_flush(nav_flush), .dsi_commit(dsi_commit), .dsi_stream(dsi_stream),
+    .dsi_nv_pck_lbn(dsi_nv_pck_lbn), .lin_blk(lin_blk),
+    .seek_ack(seek_ack), .jump_ack(jump_ack), .keep_vbuf(keep_vbuf),
+    .start_streaming(start_streaming),
+    .scrub_pulse(scrub_pulse), .scrub_rbn(scrub_rbn),
+    .seek_rbn_pulse(dut_sp), .seek_rbn(dut_srbn),
+    .mode_switch(dut_ms), .realign_pend(realign_pend)
+  );
+
+  // ---- the PRE-FIX path: `wire mode_switch = il_switch;` and scrub_ctrl as the only
+  //      producer of the reader's RBN-seek port. Registered once so the two arms are
+  //      counted on the same footing.
+  reg legacy_ms;
+  always @(posedge clk) legacy_ms <= rst_n ? mode_edge : 1'b0;
+
+  wire        eff_sp   = realign[0] ? dut_sp   : scrub_pulse;
+  wire [31:0] eff_srbn = realign[0] ? dut_srbn : scrub_rbn;
+  wire        eff_ms   = realign[0] ? dut_ms   : legacy_ms;
+
+  always #5 clk = ~clk;
+
+  integer errors = 0;
+  integer n_sp = 0, n_ms = 0;
+  reg [31:0] last_srbn = 32'hFFFF_FFFF;
+
+  task fail(input [8*76-1:0] msg);
+    begin errors = errors + 1; $display("FAIL: %0s  (t=%0t)", msg, $time); end
+  endtask
+
+  // Global invariant: a seek to RBN 0 is the stale-playhead trap landing on the start of
+  // the title. Nothing in this bench ever legitimately targets 0.
+  always @(posedge clk) begin
+    if (eff_sp) begin
+      n_sp      = n_sp + 1;
+      last_srbn = eff_srbn;
+      if (eff_srbn == 32'd0) fail("a seek was issued against a STALE (zero) playhead");
+    end
+    if (eff_ms) n_ms = n_ms + 1;
+  end
+
+  // ---- reader model: acknowledge a seek after ack_lat cycles ------------------------
+  integer ack_lat = 6;
+  reg     ack_en  = 1;
+  reg     ack_keep = 0;
+  always @(posedge clk) begin
+    if (eff_sp && ack_en) begin
+      repeat (ack_lat) @(posedge clk);
+      keep_vbuf <= ack_keep;
+      seek_ack  <= 1'b1;
+      @(posedge clk);
+      seek_ack  <= 1'b0;
+    end
+  end
+
+  task clr;  begin @(negedge clk); n_sp = 0; n_ms = 0; last_srbn = 32'hFFFF_FFFF; end endtask
+
+  task chk_counts(input integer wsp, input integer wms, input [8*76-1:0] msg);
+    begin
+      if (n_sp !== wsp || n_ms !== wms) begin
+        $display("  seeks=%0d flushes=%0d, want %0d/%0d", n_sp, n_ms, wsp, wms);
+        fail(msg);
+      end
+    end
+  endtask
+
+  task chk_tgt(input [31:0] want, input [8*76-1:0] msg);
+    begin
+      if (last_srbn !== want) begin
+        $display("  target=%0d, want %0d", last_srbn, want);
+        fail(msg);
+      end
+    end
+  endtask
+
+  task edge_pulse; begin mode_edge = 1; @(negedge clk); mode_edge = 0; @(negedge clk); end endtask
+
+  // A DSI packet finished parsing and left this VOBU NAV-pack RBN in force.
+  task commit_lbn(input [31:0] v);
+    begin
+      dsi_stream = 1; dsi_nv_pck_lbn = v; repeat (2) @(negedge clk);
+      dsi_stream = 0; dsi_commit = 1;     @(negedge clk);
+      dsi_commit = 0;                     @(negedge clk);
+    end
+  endtask
+
+  task flush_pulse; begin nav_flush = 1; repeat (3) @(negedge clk); nav_flush = 0; @(negedge clk); end endtask
+
+  task do_reset;
+    begin
+      rst_n = 0; mode_edge = 0; in_title = 1; dvd_mode = 1; lin_mode = 0;
+      still_active = 0; hold_freeze = 0; nav_flush = 0; dsi_commit = 0; dsi_stream = 0;
+      start_streaming = 0; scrub_pulse = 0; ack_en = 1; ack_lat = 6; ack_keep = 0;
+      repeat (4) @(negedge clk);
+      rst_n = 1;
+      repeat (2) @(negedge clk);
+    end
+  endtask
+
+  initial begin
+    if (!$value$plusargs("realign=%d", realign)) realign = 1;
+    $display("mode_realign_tb: %0s path", realign[0] ? "FIXED" : "PRE-FIX (+realign=0)");
+
+    do_reset;
+    commit_lbn(32'd5000);
+
+    // ============================================================= [1]
+    // A mode switch on a title with a trustworthy playhead issues ONE seek at that
+    // playhead and NO in-place flush. This is the whole fix.
+    clr;
+    edge_pulse;
+    repeat (20) @(negedge clk);
+    chk_counts(1, 0, "[1] a title mode switch must seek, not flush in place");
+    chk_tgt(32'd5000, "[1] the seek target must be the live playhead");
+
+    // ============================================================= [2]
+    // The reader's ack completes the arm (and it is the ack that drove the trio).
+    repeat (10) @(negedge clk);
+    if (realign[0] && realign_pend) fail("[2] the arm must clear on the reader's ack");
+    chk_counts(1, 0, "[2] no fallback flush after a successful re-align");
+
+    // ============================================================= [3]
+    // If the reader never acknowledges, the mode change must still get its flush.
+    ack_en = 0;
+    commit_lbn(32'd6100);
+    clr;
+    edge_pulse;
+    repeat (WDOG/4) @(negedge clk);
+    chk_counts(1, 0, "[3a] must not fall back before the watchdog elapses");
+    repeat (WDOG + 40) @(negedge clk);
+    chk_counts(1, 1, "[3b] an unacknowledged seek must fall back to the in-place trio");
+    ack_en = 1;
+
+    // ============================================================= [4]  control
+    // A disc menu: no re-align possible (the reader's VOBU snap is bypassed there), so
+    // this is today's behaviour exactly. Must pass in BOTH arms.
+    in_title = 0;
+    clr;
+    edge_pulse;
+    repeat (20) @(negedge clk);
+    chk_counts(0, 1, "[4] a menu-domain switch must flush in place, immediately");
+    in_title = 1;
+
+    // ============================================================= [5]  control
+    // A raw .m2v elementary stream: not seekable at all.
+    dvd_mode = 0; lin_mode = 0;
+    clr;
+    edge_pulse;
+    repeat (20) @(negedge clk);
+    chk_counts(0, 1, "[5] an unseekable stream must flush in place, immediately");
+    dvd_mode = 1;
+
+    // ============================================================= [6]
+    // THE STALE-TABLE TRAP. nav_dsi is on pipe_rst_n, so a flush clears the playhead to
+    // 0; seeking against that lands at the start of the title. The arm must WAIT for a
+    // freshly parsed DSI and then seek THAT — the global invariant above catches a 0.
+    flush_pulse;
+    dsi_nv_pck_lbn = 32'd0;
+    clr;
+    edge_pulse;
+    repeat (30) @(negedge clk);
+    chk_counts(0, 0, "[6a] must not seek while the playhead is stale");
+    commit_lbn(32'd7350);
+    repeat (20) @(negedge clk);
+    chk_counts(1, 0, "[6b] must seek once the playhead is fresh again");
+    chk_tgt(32'd7350, "[6c] the target must be the FRESH playhead");
+
+    // ============================================================= [7]  ** RED **
+    // COALESCING. il_eff is a level, so N toggles converge on one raster and need exactly
+    // ONE re-align. The pre-fix path fires the trio five times, mid-parse, which is the
+    // repeated-flush loop class that killed the film edge (docs/film_24p_plan.md §13).
+    commit_lbn(32'd8000);
+    clr;
+    edge_pulse; edge_pulse; edge_pulse; edge_pulse; edge_pulse;
+    repeat (WDOG + 60) @(negedge clk);
+    if (n_sp > 1 || n_ms > 1) begin
+      $display("  seeks=%0d flushes=%0d, want at most 1/1", n_sp, n_ms);
+      fail("[7] five mode edges must coalesce into ONE re-align and ONE flush");
+    end
+
+    // ============================================================= [8]
+    // The user's own scrub outranks ours: the reader must latch the SCRUB's target, and
+    // the arm completes on that seek rather than issuing a second one.
+    commit_lbn(32'd9000);
+    clr;
+    mode_edge = 1; @(negedge clk); mode_edge = 0;
+    scrub_rbn = 32'd12345; scrub_pulse = 1; @(negedge clk); scrub_pulse = 0;
+    repeat (30) @(negedge clk);
+    chk_counts(1, 0, "[8a] a scrub during the arm must not add a second seek");
+    chk_tgt(32'd12345, "[8b] the scrub's target must win the mux");
+
+    // ============================================================= [9]
+    // A mount supersedes: it fires its own trio AND the decoder soft reset, and our
+    // latched target belongs to the previous disc.
+    ack_en = 0;
+    commit_lbn(32'd9500);
+    clr;
+    in_title = 0;                          // a mount unloads the title first
+    edge_pulse;                            // (fallback path) -- then re-arm properly
+    in_title = 1; commit_lbn(32'd9600);
+    clr;
+    mode_edge = 1; @(negedge clk); mode_edge = 0;
+    start_streaming = 1; @(negedge clk); start_streaming = 0;
+    repeat (WDOG + 60) @(negedge clk);
+    chk_counts(0, 0, "[9] a mount during the arm must cancel it silently");
+    ack_en = 1;
+
+    // ============================================================= [10]
+    // Linear playback (raw VCD/SVCD .bin, flat .mpg): the base is the linear block.
+    dvd_mode = 0; lin_mode = 1; lin_blk = 32'd4242;
+    clr;
+    edge_pulse;
+    repeat (20) @(negedge clk);
+    chk_counts(1, 0, "[10a] a linear-file mode switch must also re-align");
+    chk_tgt(32'd4242, "[10b] the linear target must be the linear playhead");
+    dvd_mode = 1; lin_mode = 0;
+
+    // ============================================================= [11]
+    // A held Fast Fwd / Rewind is not a timeout — its release issues the seek that
+    // satisfies the arm. Spending the watchdog during the hold would fire the in-place
+    // flush mid-gesture, which is the thing being removed.
+    commit_lbn(32'd11000);
+    clr;
+    hold_freeze = 1;
+    edge_pulse;
+    repeat (WDOG*3) @(negedge clk);
+    chk_counts(0, 0, "[11a] a held scrub must not spend the fallback watchdog");
+    hold_freeze = 0;
+    scrub_rbn = 32'd11500; scrub_pulse = 1; @(negedge clk); scrub_pulse = 0;
+    repeat (30) @(negedge clk);
+    chk_counts(1, 0, "[11b] the release seek must satisfy the arm");
+    chk_tgt(32'd11500, "[11c] the release target must be the scrub's");
+
+    if (errors == 0) $display("mode_realign_tb: ALL TESTS PASSED (11 scenarios)");
+    else begin
+      $display("mode_realign_tb: %0d FAILURE(S)", errors);
+      $fatal(1, "mode_realign_tb FAILED");
+    end
+    $finish;
+  end
+
+endmodule

--- a/bench/dvd/pal_detect_tb.sv
+++ b/bench/dvd/pal_detect_tb.sv
@@ -1,0 +1,232 @@
+`timescale 1ns/1ps
+//
+// pal_detect_tb.sv — the PAL/NTSC verdict must not follow a garbage sequence header
+// (dvd/pal_detect.sv; issue #42 leg 2, docs/single_raster_analog.md §6).
+//
+// WHY THIS BENCH EXISTS. pal_eff kicks the runtime modeline walk, and unlike an il_eff
+// change that walk carries NO pipeline flush — so one wrong verdict restarts the raster
+// mid-drain, and through film_det (= pal_eff ? det_pal : det_ntsc) it can restart it
+// again. The pre-fix rule flipped on a SINGLE non-zero header of any value.
+//
+// ⚠ THE TRAP THIS BENCH IS BUILT TO AVOID (CLAUDE.md: bench-that-cannot-fail).
+// bench/dvd/field_parity_tb.sv could not see its defect because its pass condition was
+// the same expression as the RTL's. So:
+//   - every expectation here is a HAND-WRITTEN constant or a hand-written case table,
+//     never a call to the DUT's vs_pal / pal_detect_raw expression;
+//   - the stimulus models the REAL register semantics (vertical_size is a register that
+//     holds between sequence headers and only changes when a header writes a different
+//     value — NOT an event stream), because a rule that counts header events instead of
+//     elapsed time passes a naive bench and freezes the verdict forever on real content;
+//   - the pre-fix rule is instantiated verbatim alongside the DUT and selected by
+//     +hyst=0, and it MUST FAIL scenarios [4] and [5b].
+//
+// Build/run: bench/dvd/run_mode_realign.sh   (or, standalone)
+//   iverilog -g2012 -o bench/dvd/pal_detect_sim dvd/pal_detect.sv bench/dvd/pal_detect_tb.sv
+//   vvp bench/dvd/pal_detect_sim            # GREEN (the fixed rule)
+//   vvp bench/dvd/pal_detect_sim +hyst=0    # RED   (the pre-fix rule) — failures EXPECTED
+//
+module pal_detect_tb;
+
+  localparam [26:0] HOLD = 27'd200;      // sim-scale confirmation window
+  localparam integer GOP = 60;           // cycles a real header holds before the next one
+
+  reg         clk = 0;
+  reg         rst_n = 0;
+  reg         mount_arm = 0;
+  reg  [13:0] vsize = 14'd0;
+
+  wire        dut_pal;
+  integer     hyst = 1;                  // 1 = the fixed rule, 0 = the pre-fix rule
+
+  pal_detect #(.HOLD_CYC(HOLD)) dut (
+    .clk       (clk),
+    .rst_n     (rst_n),
+    .mount_arm (mount_arm),
+    .vsize     (vsize),
+    .pal       (dut_pal)
+  );
+
+  // ---- the PRE-FIX rule, verbatim from dvd/emu.sv before this change ----------------
+  reg legacy_pal;
+  always @(posedge clk or negedge rst_n) begin
+    if (!rst_n)               legacy_pal <= 1'b0;
+    else if (vsize != 14'd0)  legacy_pal <= (vsize > 14'd480) || (vsize == 14'd288);
+  end
+
+  wire verdict = hyst[0] ? dut_pal : legacy_pal;
+
+  always #5 clk = ~clk;
+
+  integer errors = 0;
+
+  // ★ THE LOAD-BEARING MEASUREMENT: how many times the verdict CHANGED. A verdict that
+  // flips and flips back looks correct at the end of the window and is exactly the
+  // defect -- every change kicks the modeline walk, which restarts the raster with no
+  // pipeline flush. Counting edges, not end states, is what makes this bench able to
+  // fail; the first version of it checked end states and the pre-fix rule PASSED
+  // scenarios [3] and [4] by self-healing on the next real header.
+  reg     verdict_q;
+  integer edges = 0;
+  always @(posedge clk) begin
+    if (verdict !== verdict_q) edges = edges + 1;
+    verdict_q <= verdict;
+  end
+
+  task fail(input [8*72-1:0] msg);
+    begin
+      errors = errors + 1;
+      $display("FAIL: %0s  (verdict=%0b, t=%0t)", msg, verdict, $time);
+    end
+  endtask
+
+  task chk(input want, input [8*72-1:0] msg);
+    begin if (verdict !== want) fail(msg); end
+  endtask
+
+  task edges_clr;   begin @(posedge clk); edges = 0; end   endtask
+
+  task chk_edges(input integer want, input [8*72-1:0] msg);
+    begin
+      if (edges !== want) begin
+        $display("  verdict changed %0d time(s), want %0d", edges, want);
+        fail(msg);
+      end
+    end
+  endtask
+
+  // Drive one parsed height for `n` cycles. This is the real register behaviour: the
+  // value simply STAYS until another header writes a different one.
+  task hdr(input [13:0] v, input integer n);
+    begin
+      vsize = v;
+      repeat (n) @(posedge clk);
+    end
+  endtask
+
+  task cold_reset;
+    begin
+      rst_n = 0; mount_arm = 0; vsize = 14'd0;
+      repeat (4) @(posedge clk);
+      rst_n = 1;
+      repeat (2) @(posedge clk);
+    end
+  endtask
+
+  task mount;                            // a new file: re-arm the immediate latch
+    begin
+      vsize = 14'd0;                     // the mount soft reset zeroes vertical_size
+      mount_arm = 1; repeat (8) @(posedge clk);
+      mount_arm = 0; repeat (2) @(posedge clk);
+    end
+  endtask
+
+  // Hand-written meaning table — NOT derived from the RTL.
+  function want_pal(input [13:0] v);
+    case (v)
+      14'd240:  want_pal = 1'b0;         // VCD / MPEG-1 SIF NTSC
+      14'd288:  want_pal = 1'b1;         // VCD / MPEG-1 SIF PAL
+      14'd480:  want_pal = 1'b0;         // DVD / SVCD NTSC
+      14'd576:  want_pal = 1'b1;         // DVD / SVCD PAL
+      14'd720:  want_pal = 1'b1;         // flat-file 720p: pre-existing ">480" reading
+      14'd1080: want_pal = 1'b1;         // flat-file 1080
+      14'd1088: want_pal = 1'b1;
+      default:  want_pal = 1'bx;
+    endcase
+  endfunction
+
+  integer i;
+  reg [13:0] tbl [0:6];
+
+  initial begin
+    if (!$value$plusargs("hyst=%d", hyst)) hyst = 1;
+    $display("pal_detect_tb: %0s rule", hyst[0] ? "FIXED" : "PRE-FIX (+hyst=0)");
+
+    tbl[0]=14'd240; tbl[1]=14'd288; tbl[2]=14'd480; tbl[3]=14'd576;
+    tbl[4]=14'd720; tbl[5]=14'd1080; tbl[6]=14'd1088;
+
+    // ================================================================= [1]
+    // First plausible header after a cold reset latches IMMEDIATELY. A PAL disc must
+    // not pay a detection delay at load (that would fire a spurious NTSC->PAL walk).
+    cold_reset;
+    hdr(14'd576, 3);
+    chk(1'b1, "[1] first header 576 must latch PAL at once");
+
+    // ================================================================= [2]
+    // vsize == 0 (watchdog expiry / mount soft reset cleared the VLD register) must
+    // HOLD the verdict. This locks the 2026-09-03 fix that this module subsumes.
+    hdr(14'd0, 10000);
+    chk(1'b1, "[2] vsize=0 must hold the established verdict");
+    hdr(14'd576, GOP);
+    chk(1'b1, "[2b] verdict must survive the gap");
+
+    // ================================================================= [3]
+    // ONE stray disagreeing header, overwritten by the next real one a GOP later.
+    edges_clr;
+    hdr(14'd480, 20);
+    hdr(14'd576, GOP);
+    chk(1'b1, "[3] a single stray 480 must not flip an established verdict");
+    chk_edges(0, "[3] a single stray 480 must not even momentarily flip it");
+
+    // ================================================================= [4]  ** RED **
+    // The real garbage signature: a burst of DIFFERENT implausible-and-plausible
+    // heights, each overwritten within a GOP. Nothing here is sustained, so nothing
+    // here is a verdict. The pre-fix rule flips on the first 480 and never comes back.
+    edges_clr;
+    hdr(14'd480, 15); hdr(14'd576, 25);
+    hdr(14'd240, 15); hdr(14'd576, 25);
+    hdr(14'd480, 15); hdr(14'd576, 25);
+    hdr(14'd208, 15); hdr(14'd576, 25);
+    hdr(14'd480, 15); hdr(14'd576, 25);
+    hdr(14'd186, 15); hdr(14'd576, GOP);
+    chk(1'b1, "[4] churning garbage headers must never flip the verdict");
+    chk_edges(0, "[4] churning garbage must not kick the modeline walk even once");
+
+    // ================================================================= [5]
+    // A SUSTAINED disagreement is a real standard change and must be followed --
+    // but only after the confirmation window, not before.
+    edges_clr;
+    hdr(14'd480, HOLD/2);
+    chk(1'b1, "[5a] must not flip before the confirmation window elapses");
+    hdr(14'd480, HOLD + 40);
+    chk(1'b0, "[5b] a sustained 480 must flip the verdict to NTSC");
+    chk_edges(1, "[5c] a real standard change costs exactly ONE walk kick");
+
+    // ================================================================= [6]
+    // Implausible heights are parse errors, not verdicts -- even when sustained.
+    edges_clr;
+    hdr(14'd7, HOLD*3);
+    chk(1'b0, "[6a] a sustained height of 7 must not arm a verdict");
+    hdr(14'd3000, HOLD*3);
+    chk(1'b0, "[6b] a sustained height of 3000 must not arm a verdict");
+    hdr(14'd480, GOP);
+    chk(1'b0, "[6c] verdict must be unchanged after implausible input");
+    chk_edges(0, "[6d] implausible heights must not kick the walk");
+
+    // ================================================================= [7]
+    // A MOUNT is the one event that may legitimately change the standard, so the
+    // first header of the new file latches at once -- no confirmation window.
+    mount;
+    hdr(14'd576, 3);
+    chk(1'b1, "[7] first header after a mount must latch at once");
+
+    // ================================================================= [8]
+    // Meaning table, from the hand-written function above. Both rules must agree
+    // here: leg 2 changes WHEN a verdict may take effect, never WHAT a height means.
+    for (i = 0; i < 7; i = i + 1) begin
+      mount;
+      hdr(tbl[i], 3);
+      if (verdict !== want_pal(tbl[i])) begin
+        $display("  vsize=%0d -> %0b, want %0b", tbl[i], verdict, want_pal(tbl[i]));
+        fail("[8] meaning table mismatch");
+      end
+    end
+
+    if (errors == 0) $display("pal_detect_tb: ALL TESTS PASSED (8 scenarios)");
+    else begin
+      $display("pal_detect_tb: %0d FAILURE(S)", errors);
+      $fatal(1, "pal_detect_tb FAILED");
+    end
+    $finish;
+  end
+
+endmodule

--- a/bench/dvd/run_mode_realign.sh
+++ b/bench/dvd/run_mode_realign.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# run_mode_realign.sh — the issue #42 gate: a mid-title `Video Output` change must
+# re-align the reader instead of flushing mid-parse, and a garbage sequence header must
+# not flip the PAL/NTSC verdict.
+#
+# Design: docs/single_raster_analog.md §6.  Modules: dvd/mode_realign.sv, dvd/pal_detect.sv.
+#
+# Default: the GREEN suite (the shipped RTL). Everything must pass.
+#
+# --red: run the PRE-FIX variants FIRST (failures EXPECTED, printed for reference), then
+# the GREEN suite. The pre-fix behaviour is modelled inside each bench and selected by a
+# plusarg, so one compile covers both arms:
+#   mode_realign_tb       +realign=0  -> mode_switch straight into flush_ctl, no seek
+#   mode_realign_chain_tb +realign=0  -> the reader never moves; the flush lands mid-VOBU
+#   pal_detect_tb         +hyst=0     -> the old two-line verdict rule, verbatim
+#
+set -e
+cd "$(dirname "$0")/../.."
+
+echo "### build"
+iverilog -g2012 -o bench/dvd/mode_realign_sim \
+  dvd/mode_realign.sv bench/dvd/mode_realign_tb.sv
+iverilog -g2012 -o bench/dvd/mode_realign_chain_sim \
+  dvd/dvd_iso_reader.sv dvd/bcd_time_add.sv dvd/flush_ctl.sv dvd/mode_realign.sv \
+  bench/dvd/mode_realign_chain_tb.sv
+iverilog -g2012 -o bench/dvd/pal_detect_sim \
+  dvd/pal_detect.sv bench/dvd/pal_detect_tb.sv
+# The re-align rides the reader's existing raw-RBN seek + VOBU-snap contract, so that
+# bench is part of this gate: TEST9 is the one-probe cost claim the design leans on.
+iverilog -g2012 -o bench/dvd/iso_reader_seek_sim \
+  dvd/dvd_iso_reader.sv dvd/bcd_time_add.sv bench/dvd/iso_reader_seek_tb.sv
+# flush_ctl is unchanged by this work; its matrix (rows [7]-[9] = the fallback leg) is a
+# regression, not a new test.
+iverilog -g2012 -o bench/dvd/flush_ctl_sim \
+  dvd/flush_ctl.sv bench/dvd/flush_ctl_tb.sv
+
+if [ "$1" = "--red" ]; then
+  echo
+  echo "### RED — pre-fix variants, FAILURES EXPECTED"
+  echo "--- mode_realign_tb +realign=0"
+  vvp bench/dvd/mode_realign_sim +realign=0 || true
+  echo "--- mode_realign_chain_tb +realign=0"
+  vvp bench/dvd/mode_realign_chain_sim +realign=0 || true
+  echo "--- pal_detect_tb +hyst=0"
+  vvp bench/dvd/pal_detect_sim +hyst=0 || true
+fi
+
+echo
+echo "### GREEN"
+fail=0
+for t in mode_realign mode_realign_chain pal_detect iso_reader_seek flush_ctl; do
+  echo "--- $t"
+  vvp "bench/dvd/${t}_sim" || fail=1
+done
+if [ "$fail" != "0" ]; then echo; echo "run_mode_realign.sh: FAILURES"; exit 1; fi
+echo
+echo "run_mode_realign.sh: all green"

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -1130,6 +1130,12 @@ no async table indexing (the repeated 106%/226% ALM trap).
 
 ## Seeking / Phase 8 — chapter skip + time scrub (`feature/dvd-seek-chapters`)
 
+> **Three things reposition the reader through this machinery:** the user's chapter skip and
+> hold-to-seek scrub (§1, §2a), the opt-in D-Pad fixed-time seek (§2b), and — since
+> 2026-09-03 — a live `Video Output` change, which re-aligns to the current VOBU instead of
+> flushing mid-parse (§2c, issue #42). Anything new that wants to move the reader should
+> read §2c's arbitration and stale-playhead rules before adding a fourth.
+
 Phase 8 turns the Phase-7 DSI seek tables + the PGC program_map into two interactive
 transport actions, both built **on the existing cell-seek primitive** (block-boundary
 latch + `seek_ack` → the VBUF-flush/A/V-reanchor contract; see "Transport" above). A
@@ -1429,6 +1435,65 @@ T18–T20 the popup. `bench/dvd/run_dpad_seek.sh` runs the lot.
   (TEST5); a target whose next NAV is in the following cell re-selects that cell (TEST6,
   cross-cell); a NAV-free stretch falls back to the raw target when the probe budget
   (`NAV_CAP`) exhausts (TEST7) or the title end is reached (TEST8).
+
+### 2c. Mode-switch re-align — the third producer of a reader reposition (`dvd/mode_realign.sv`) — 🔧 issue #42, ⏳ HW-confirm pending
+
+Until 2026-09-03 the reader's raw-RBN seek port had exactly one producer (`scrub_ctrl`,
+with `dpad_seek` feeding its jump port). It now has two: a **live raster-mode change**
+(`Video Output`) issues one as well.
+
+**Why.** A mode switch used to fire the flush trio through `flush_ctl` **without moving
+the reader**, so the decoder resumed mid-VOBU with no GOP boundary and could freeze on a
+malformed frame (issue #42 — and it is not PAL-specific, despite the original report). A
+chapter seek cleared it because a seek is the same trio *plus* a reader jump. So the mode
+switch now becomes a seek and lets `seek_ack` drive the trio: the same contract §2a's
+scrub landings use, and the one that is HW-proven to re-sync cleanly.
+
+**The target is the playhead's own VOBU** — `dsi_nv_pck_lbn`, which already *is* a NAV-pack
+RBN. `S_NAV_SEEK` therefore hits on candidate #1 and snaps nowhere: **one sector read**.
+That is not an assumption; `bench/dvd/iso_reader_seek_tb.sv` TEST9 measures the probe walk
+at one read per candidate over three points (on-NAV 3 reads, one-short 4, five-short 8), so
+targeting the *next* VOBU instead would cost up to `NAV_CAP = 1024` reads. Re-reading the
+VOBU being parsed also re-supplies roughly what the VBUF flush discards, so nothing is
+skipped.
+
+**Arbitration lives in `mode_realign`, and the scrub always wins the mux.** Even in a state
+its FSM does not allow, the reader latches the user's target rather than the re-align's,
+and the resulting `seek_ack` completes the arm — self-healing, with no cycle in which the
+reader can see a pulse carrying the wrong target. `emu.sv` keeps `seek_rbn_pulse`/`seek_rbn`
+as the reader-facing names; `scrub_ctrl` now drives `scrub_seek_pulse`/`scrub_seek_rbn`.
+⚠ `hud_user_evt` must watch the **scrub's** pulse: a re-align is not a user transport
+action and must not pop the HUD.
+
+**Inherited rules, both load-bearing:**
+
+- The **stale-table rule** from §2b applies verbatim. `nav_dsi` is on `pipe_rst_n`, so any
+  `load_flush` — including the one this seek itself causes — zeroes `dsi_nv_pck_lbn`, and
+  the containing-cell clamp turns a zero target into a jump to the start of the title. The
+  base is gated on a `dsi_fresh` latch and latched exactly **once**, on the issuing cycle.
+- A **`keep_vbuf` ack is not a completion.** A menu→menu hop fires `load_flush` only, so it
+  does not give the mode switch the trio it needs; such an ack leaves the arm open and the
+  watchdog fires the in-place fallback — correct, because by then we are in a menu, where
+  the VOBU snap is bypassed anyway.
+
+**Where a re-align is impossible, behaviour is exactly as it was:** the menu domain, a raw
+`.m2v` (`lin_seek_ok_o` is already low for a bare elementary stream), a reader parked on a
+still, or a seek unacknowledged within ~0.5 s — all take `flush_ctl.mode_switch`, the
+in-place trio. Note `seek_jump` has **no state qualifier** (unlike `jump_go`), which is
+why `still_active` has to be excluded explicitly: a re-align would otherwise fire from
+`S_STILL` and restart a title-domain timed still.
+
+**Path exactness by media type:**
+
+| media | landing |
+|---|---|
+| DVD title (cell mode) | exact — the target is a NAV pack, snap is a no-op |
+| flat `.mpg` / `.VOB` | exact (`strm_blk <= ls_tgt`) **and** arms the `00 00 01 BA` pack hunt |
+| raw MODE2/2352 `.bin` (VCD/SVCD) | ≈ **0.07 % early** (`ls_sec = r − r/8 − r/256 − r/1024`), i.e. up to ~2–3 s of rewind late in a long image — the same landing every VCD scrub already produces |
+| raw `.m2v` | not seekable; takes the fallback |
+
+Design + the RED/GREEN evidence: `docs/single_raster_analog.md` §6. Suite:
+`bench/dvd/run_mode_realign.sh`.
 
 ### HW status — ✅ CONFIRMED (PR fj#96)
 

--- a/docs/film_24p_plan.md
+++ b/docs/film_24p_plan.md
@@ -657,8 +657,7 @@ content/history dependent). ⚠ Lesson: `il_switch`'s "fire the trio on a live m
 edge" pattern is only safe for a signal that changes ~once/title — a bare `filmp_eff`
 edge can OSCILLATE, and the flush itself perturbs the very parse the detector feeds on.
 
-**Disposition:** reverted to `mode_switch = il_switch` (emu.sv carries a ⛔ comment at
-the edge-detect). The engage skew is back to pre-branch behavior (constant offset until
+**Disposition:** reverted (emu.sv carries a ⛔ comment at the edge-detect). The engage skew is back to pre-branch behavior (constant offset until
 the next seek; chapter skip clears it — README notes this). **The proper fix is the
 early-film-detect feature** (`feature/film-early-detect` plan): a parse-front sniffer
 classifies cadence during the load hold and seeds the detector, so the raster is
@@ -666,6 +665,35 @@ correct BEFORE the first frame and every title/logo entry is covered by its jump
 trio — no mid-play engage at all on the common path. If a mid-title film_switch flush
 is reintroduced there it MUST have hold-suppression + a post-discontinuity holdoff,
 TB'd in `flush_ctl_tb`, **with the T2 menu→Play logo chain as an explicit HW gate**.
+
+### ★ AMENDMENT (2026-09-03, issue #42): two of the three missing pieces now exist
+
+The post-mortem above named three things this attempt lacked. Issue #42 built two of them
+for its own reasons, and a future film edge should ride them rather than re-derive them:
+
+1. **Reader re-alignment.** `dvd/mode_realign.sv` turns a raster-mode edge into a seek to
+   the playhead's own VOBU and lets `seek_ack` drive the trio, so the flush lands on a GOP
+   boundary instead of an arbitrary mid-stream byte. That was the *primary* failure here —
+   "no reader jump = no VOBU re-alignment, unlike a chapter seek".
+2. **Edge coalescing.** Further edges arriving while an arm is open are absorbed, so a
+   flapping signal produces ONE re-align and ONE flush rather than one per flap. That
+   directly removes "repeated mid-parse flushes yielded garbage sequence headers".
+
+And the feedback half of the loop is gone independently: `dvd/pal_detect.sv` means a
+garbage 576-line parse can no longer flip `pal_eff` from a single header, so
+`pal_eff → film_det → film_want → filmp_eff → another flush` cannot self-feed. ⚠ Note the
+loop was never PAL-specific — `film_det` reads `det_pal` *or* `det_ntsc` off `pal_eff`, so
+the same churn is reachable on NTSC; issue #42's freeze reproduced on both standards.
+
+⚠ **This does NOT make the film edge safe, and the ⛔ above stands.** What remains
+unaddressed is the third piece: the flush **perturbs the very parse the detector feeds
+on**, so a detector whose input is degraded by its own output is still a feedback system,
+and coalescing bounds the rate without breaking the loop. A reintroduction still needs
+hold-suppression and a post-discontinuity holdoff, and it must go **through
+`mode_realign`** (never straight into `flush_ctl`). The T2 menu→Play logo chain remains
+the HW gate. The evidence gate of §14 also removes most of the flapping that made this
+lethal, which is a fourth reason to expect a different outcome — but expectation is not a
+gate.
 
 
 ## 14. ★★ THE EVIDENCE GATE — measuring what the stream actually carries (2026-08-30, PR pending)

--- a/docs/interlaced_auto.md
+++ b/docs/interlaced_auto.md
@@ -9,7 +9,14 @@ ini-driven and boot-static, and the mid-title `Auto` content detector died with 
 audio-skew problem. The fields RASTER this doc designed (the il_eff modeline branch,
 syncgen behavior, VGA_F1/ascal handling, the mid-stream `il_switch` flush) **still ships
 unchanged** and is what Video Output=Interlaced engages — only the option surface and the
-detector are gone. Rationale + field reports: `docs/field_parity.md`,
+detector are gone.
+⚠ **One exception, added 2026-09-03 (issue #42): the `il_switch` flush described in §"Fix"
+below is NO LONGER fired in place.** It froze the decoder — the trio landed mid-VOBU with
+no GOP boundary to re-lock on. `dvd/mode_realign.sv` now turns the edge into a reader seek
+at the current VOBU and lets `seek_ack` drive the same trio, so the flush lands on a
+boundary; the in-place path survives only as the fallback where no re-align is possible.
+The trio itself, and every word below about *why* all three legs are needed, is unchanged.
+See `docs/single_raster_analog.md` §6 and `docs/dvd_nav.md` §2c. Rationale + field reports: `docs/field_parity.md`,
 `docs/analog_dual_raster.md` status, roadmap "Video Output consolidation". The body below
 is kept as the engineering history of the raster design.
 
@@ -157,6 +164,9 @@ same three coordinated resets a chapter seek uses:
 Because the detector hysteresis is deep, Auto fires this ~once per title, so the brief
 (~1 s) re-lock glitch is acceptable. This also fixes the live manual On/Off toggle.
 `il_switch` bypasses `keep_vbuf` (a mode switch always needs the flush).
+⚠ **Amended 2026-09-03 (issue #42):** still true, but the flush is now issued *by a reader
+seek* rather than in place — see the header note. Firing it where the parse happened to be
+was the freeze.
 
 **Why the VBUF flush alone was not enough (2026-07-26 HW round 1):** the first version
 pulsed only `seek_flush`. That jumped video ~1 s **forward** (discarded the decode-ahead

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -665,6 +665,20 @@ parity error that has HELD for ~0.5 s, with a hard ~2 s budget on top. Gate:
 `bench/dvd/field_phase_tb.sv` (finished; scenario [6] starves the pixel queue and counts
 the repeated fields). See `docs/field_parity.md`.
 
+**★ 2026-09-03 follow-up (issue #42, branch `fix/mode-switch-realign`): a mid-title
+`Video Output` change no longer freezes the decoder** — 🔧 sim-proven RED/GREEN,
+⏳ HW-confirm pending. The `il_switch` flush trio fired **without moving the reader**, so
+the decoder resumed mid-VOBU with no GOP boundary; a chapter seek cured it because a seek
+is the same trio *plus* a reader jump. `dvd/mode_realign.sv` now turns the edge into a seek
+to the playhead's own VOBU (already a NAV pack ⇒ a single-probe snap) and lets `seek_ack`
+drive the trio; the in-place path survives as the fallback for menus, raw `.m2v`, a still,
+or an unacknowledged seek, and it coalesces repeated edges. Leg 2: `dvd/pal_detect.sv`
+stops a garbage sequence header flipping `pal_eff` (a verdict change restarts the raster
+with **no** flush and feeds back through `film_det`). ⚠ Filed and documented as PAL-only;
+it reproduces on **NTSC** too, which is what disproved the `pal_eff`-only hypothesis.
+Gate: `bench/dvd/run_mode_realign.sh`. See `docs/single_raster_analog.md` §6,
+`docs/dvd_nav.md` §2c.
+
 **Status (history): ✅ HW-CONFIRMED 2026-07-05 (branch `feature/crt-480i-native`, MERGED PR fj#65) —
 then REWORKED 2026-07-29 into the DUAL-RASTER architecture, ✅ HW-CONFIRMED + MERGED
 2026-07-30 (PR fj#146):** the O[14] whole-core CRT mode is retired; the 15 kHz raster is
@@ -1820,7 +1834,8 @@ also forces `il_eff`, which makes the MAIN raster interlaced ⇒ HDMI drops to 4
 ascal for the session, and ascal is not cadence-aware ⇒ **film regresses on HDMI**.
 `Interlaced` keeps HDMI progressive. It also remains the only override for a 15 kHz
 RGBHV rig that the ini bits cannot identify, and unlike Native Fields it can be changed
-mid-title (Native Fields fires the `il_switch` flush).
+mid-title (Native Fields fires the `il_switch` flush). *(That flush is what issue #42
+fixed — it is now a reader re-align, so a mid-title switch is safe in either mode.)*
 
 | Setup | Mode |
 |---|---|

--- a/docs/single_raster_analog.md
+++ b/docs/single_raster_analog.md
@@ -508,7 +508,17 @@ observation that relocates the remaining work. (It is an observation of appearan
 measurement — but it is the right shape, and it is the same reasoning that closed §3.9:
 when a build changes X and the symptom persists unchanged, X is exonerated.)
 
-**What the residual most likely is, for whoever picks it up.** `flush_ctl`'s trio discards
+**The residual is now tracked as [issue #45](https://github.com/owenb321/MiSTer_DVD/issues/45)**
+— *"Macroblocking for ~6 frames after any seek: reference frames survive the VBUF flush"*.
+Measured there from a 60 Hz HDMI recording: ~6 frames (~100 ms), on all four transport
+paths and every disc tried, with the target chapter decoding and in motion while the old
+scene bleeds through as residual. That last detail is what identifies it — motion
+compensation against stale references, not a corrupt picture. Root cause confirmed in the
+RTL: `motcomp_picbuf`'s `prev_i_p_frame_valid` is cleared only by `~rst` or a sequence end,
+never by a flush, so the reference slots survive a seek still holding the old scene and
+still flagged valid.
+
+**The original note, kept because it is the reasoning that got there:** `flush_ctl`'s trio discards
 *buffered* data but deliberately leaves the decode pipeline's state — `vld`/`getbits`/
 `motcomp`/`picbuf` are all on `sync_rst`, and `mount_flush` (the decoder soft reset) is
 MOUNT-ONLY, "NEVER on seeks/jumps/mode switches ... where the display must hold the last

--- a/docs/single_raster_analog.md
+++ b/docs/single_raster_analog.md
@@ -417,44 +417,89 @@ kicks the walk. And `mode_realign_tb`'s first version failed all 11 scenarios ag
 correct RTL: blocking stimulus assignments landed **on** the clock edge and raced the DUT,
 so every count read 0. Stimulus is driven from the negedge now, sampling from the posedge.
 
+### 6.8 The switch blank (2026-09-03) — ⏳ HW-confirm pending
+
+Fixing the freeze left the transient visible, and the maintainer's HW round named it
+exactly: switching **to Interlaced** gives *"a full screen rolling image flashing between
+black frames"*; switching **to Progressive** *"squishes the image into the top half of the
+screen"*. The first is the display losing vertical lock across the raster change; the
+second is field-height content in a frame-height DE window. Both are inherent to changing
+the raster under in-flight content — you cannot make the frames already in the pipe correct
+for the new mode — so the fix is cosmetic by construction: hold the picture **black** until
+the first frame of the new mode is on screen.
+
+**The window needed no new measurement.** `video_live` already is that signal: the
+re-align's own `load_flush` re-arms it (through `pickup_hold` in `resample_addrgen`), so it
+goes LOW at the flush and HIGH again when the governor picks up the first frame for
+display. `dvd/mode_realign.sv` owns the window because it already knows both endpoints.
+
+⚠ **The rule is "clear on the first HIGH *after* a LOW", and the ordering is the whole
+trick.** At the edge itself `video_live` is still HIGH — it belongs to the OLD content, and
+the flush only lands a few ms later. A naive "clear when `video_live`" would clear
+immediately and blank nothing at all. `mode_realign_tb` [13] is that exact trap, and
+mutating the RTL to drop the requirement fails six checks.
+
+**`BLANK_MAX` (~1.5 s) is load-bearing twice.** In the **menu domain** `video_live` never
+drops — emu forces the STD mux-lead hold off while `menu_active` (menus aren't lip-synced),
+so `pickup_hold` never rises and nothing re-arms it; the ceiling is the only exit there.
+And it bounds the cosmetic fix so it can only ever hide a **transient**: if the roll or the
+squish ever outlived the window the artifact must come back into view rather than be masked
+forever.
+
+**Three placement decisions, all in the `emu.sv` output-mux priority chain:**
+
+- **After `cc_on`** — the line-21 caption waveform still goes out. It lives in the VBI,
+  outside DE, and blanking it would kill captions for a second on every switch.
+- **After `ov_on` / `dbg_px_q`** — the `DEBUG_OVERLAY` rows and the release-visible `O[2]`
+  diagnostic blocks stay readable. `blk10` of the `O[2]` third row *is* the "il_switch
+  fired" readout; hiding it exactly when a switch happens would blind the one instrument
+  pointed at this event.
+- **Before `sub_r`** — picture, subtitles, HUD and idle logo go dark together, which is the
+  intent: everything content-derived at once.
+
+⚠ **RGB only. Sync is untouched.** Dropping sync across a raster change is the
+`re_interlace` `S_HUNT` defect (§3.2): it emitted no sync at all while hunting, costing
+33–67 ms of dead CRT sync per event, and it lengthens the display's lock-up instead of
+hiding it.
+
+★ **The MiSTer OSD is composited DOWNSTREAM** (`sys_top`: `emu` → `scanlines` → `osd` →
+pins), so the menu the user is standing in when they flip the setting stays fully visible
+over the black. That is what makes a full-screen blank acceptable rather than alarming.
+
+⚠ **`blank_en` (= `media_seen`) keeps it off until the first mount.** `il_eff_q` resets to
+0, so an Interlaced/Auto-analog rig pulses one `il_switch` at reset release — without the
+gate that would black the idle screen for the whole ceiling, and "nothing on screen after
+the core loads" is precisely what the launch-feedback work exists to prevent
+(`docs/idle_screen.md`).
+
+★ **A second edge mid-blank RESTARTS the window** — the opposite of the seek arm, which
+coalesces. Riding the old window would uncover the transient the second toggle just caused.
+
+⛔ **"Repeat the last good frame" was the other candidate and lost**, despite the machinery
+already existing (the governor's persistence re-scan, `repeat_frame=31`, as used by pause
+and `hold_freeze`). Three reasons: the Interlaced symptom is a **roll**, i.e. the display
+has lost lock, so a held frame rolls too — a rolling still is no better than a rolling
+picture, whereas rolling *black* is invisible; the re-scan goes back through the same
+mode-dependent scan path that produces the Progressive squish, and the held image was built
+for the OLD mode, so it is not obviously immune to the artifact it is meant to hide; and it
+needs the coordinated hold set (watchdog suppression et al.), where freezing video without
+audio for ~1 s diverges the timelines the flush just re-anchored. Blanking acts at the
+**pin**, after every mode-dependent path, so it is immune by construction.
+
+**Gate:** `mode_realign_tb` [12]–[17], and — because these are cheap assertions about a
+level, exactly the shape that passes without proving anything — **mutation-checked**: five
+targeted RTL mutations (clear without requiring the drop, no ceiling, no `blank_en` gate,
+coalesce instead of restart, no mount clear) are each caught by the scenario written for
+them.
+
 ## 7. Follow-ups
-- **Blank the video during a `Video Output` switch (proposed 2026-09-03, user request after
-  the issue #42 HW round; NOT implemented).** The freeze is fixed, but the ~1 s transient is
-  ugly: switching *to* Interlaced shows a full-screen rolling image flashing between black
-  frames (the display has lost vertical lock across the raster change), and switching *to*
-  Progressive squishes the picture into the top half (field-height content in a frame-height
-  DE window). Both are inherent to changing the raster under in-flight content, so the fix
-  is cosmetic by nature: force `vga_r_q/g_q/b_q` to 0 at the output mux (`emu.sv`, the
-  registered stage) for the duration.
-  - **The window already has a signal.** Blank on `il_switch`, clear on **`video_live`
-    rising** — the re-align's `load_flush` re-arms it via `pickup_hold`, and it rises when
-    the first frame is actually picked up for display, i.e. the first frame of the NEW mode.
-    Needs a minimum (the few ms before the flush lands, during which `video_live` is still
-    high) and a timeout. `dvd/mode_realign.sv` is the natural home: it knows both endpoints
-    and already owns a watchdog, and `realign_pend` is half of it.
-  - ⚠ **Blank RGB ONLY, never sync.** That is the `re_interlace` `S_HUNT` defect (§3.2): it
-    emitted no sync at all while hunting, costing 33–67 ms of dead CRT sync per event.
-    Killing sync across a raster change lengthens the lock-up.
-  - ★ **The MiSTer OSD is composited DOWNSTREAM** (`emu` → `scanlines` → `osd` → pins,
-    `sys/sys_top.v`), so blanking at the emu stage leaves the menu the user is standing in
-    fully visible. The HUD/subtitles/idle logo ride `sub_r` and would blank — acceptable for
-    a ~1 s transient.
-  - ⛔ **"Repeat the last good frame" was considered and is the WEAKER option**, despite the
-    machinery already existing (the governor's persistence re-scan, `repeat_frame=31`, as
-    used by pause and `hold_freeze`). Three reasons: the interlaced symptom is a *roll*, so a
-    held frame rolls too and a rolling still is no better than a rolling picture, whereas
-    rolling black is invisible; the re-scan goes back through the same mode-dependent scan
-    path that produces the progressive squish, and the held image was built for the OLD mode,
-    so it is not obviously immune to the artifact it is meant to hide; and it needs the
-    coordinated hold set (watchdog suppression etc.), where freezing video without audio for
-    ~1 s diverges the timelines the flush just re-anchored. Blanking acts at the PIN, after
-    every mode-dependent path, so it is immune by construction.
-  - Cost: ~20–30 ALMs, but a netlist change ⇒ re-rolls the pinned seed and needs a fresh
-    `tools/fmax_check.sh` verdict. **Bound the window with a timeout** — unbounded, it would
-    hide a persistent fault rather than a transient.
-  - The same ugliness on an **Analog Aspect** change would need its own trigger: per
-    `docs/field_parity.md` that walk issues no flush at all, so there is no `video_live`
-    re-arm to key on.
+- **✅ Blank the video during a `Video Output` switch — IMPLEMENTED 2026-09-03 (user
+  request after the issue #42 HW round; ⏳ HW-confirm pending).** See §6.8. The proposal
+  that was recorded here is now the shipped design; the reasoning that survived is in §6.8
+  including why "repeat the last good frame" lost.
+- The same ugliness on an **Analog Aspect** change is NOT covered: per `docs/field_parity.md`
+  that walk issues no flush at all, so there is no `video_live` re-arm to key on and the
+  blank would have to invent its own trigger. Nobody has reported it; left alone.
 - **`pal_detect_raw` reads `> 480` as PAL, so a 720p or 1080i flat `.mpg` already reads
   PAL** and gets a 50 Hz STC tick rate plus the PAL modeline. That predates issue #42 and
   is unchanged by it — `dvd/pal_detect.sv` altered *when* a verdict may take effect, never

--- a/docs/single_raster_analog.md
+++ b/docs/single_raster_analog.md
@@ -30,8 +30,11 @@ line-21 captions ✅, overlays/subtitles/menus/HUD on the analog output ✅, sub
   off. It now applies to an **Auto** verdict only; `Film 24p Out = On` is an explicit
   choice and is honoured. (The gate never bit anything else — under Auto such a rig
   resolves to Interlaced, where `filmp_eff` is 0 anyway.)
-- **PAL + a mid-title `Video Output` change can freeze the decoder** — ⚠ **PRE-EXISTING,
-  not from this branch**: v0.3.0 does the same on an `Analog Out` mode change. See §6.
+- **A mid-title `Video Output` change can freeze the decoder** — ⚠ **PRE-EXISTING, not
+  from this branch**: v0.3.0 does the same on an `Analog Out` mode change. First seen on
+  PAL and filed as PAL-only; it reproduces on NTSC too (2026-09-03), which is what
+  disproved the PAL hypothesis. **FIXED** in `fix/mode-switch-realign` (issue #42), ⏳
+  HW-confirm pending. See §6.
 
 ⏳ Not yet gated: PAL on an analog CRT (no PAL CRT available), RGBHV, and
 `direct_video=1` through an HDMI DAC. (The field-parity coin flip that was open here is
@@ -250,33 +253,184 @@ between every combed capture and every clean one was the corrector.
 - [ ] Idle logo reports `720x480i`; no resolution popup on disc load.
 - [ ] Toggling `Video Output` mid-title: the chapter-seek-style interruption, then clean.
 
-## 6. Known issue: PAL freezes on a mid-title Video Output change (pre-existing)
+## 6. A mid-title `Video Output` change froze the decoder — FIXED (issue #42)
 
-**Symptom** (HW round 6): with a PAL disc playing, changing `Video Output` mid-title can
-freeze the decoder — the picture stops on a malformed image and never recovers by itself.
-A chapter seek clears it. Either switch direction, not every time. NTSC is unaffected.
+**Status: sim-proven RED/GREEN on branch `fix/mode-switch-realign`, ⏳ HW-confirm
+pending.** Gate: a PAL disc **and** an NTSC disc, `Video Output` toggled mid-title in both
+directions ×20 each (it is intermittent, so a small N proves nothing), plus the T2
+menu→Play Dolby/THX logo chain — `docs/film_24p_plan.md` §13 names that chain as the gate
+for anything touching this glue.
 
-**Not from this branch.** v0.3.0 shows the same on an `Analog Out` mode change, so it
-predates the consolidation as well as the single-raster work.
+Also on the HW list, and **not coverable in sim**: the field-parity corrector (§ issue #41)
+names an "`il_switch`/aspect raster restart" as a genuine phase-flip step its feedback arm
+heals ~0.5 s in, so a mode switch is one of its expected triggers. Nothing in this change
+touches the corrector's RTL — `run_field_parity.sh` and `run_field_phase.sh` compile
+`resample_addrgen`/`mixer`/`syncgen` and never see `emu.sv`, so they pass unchanged **by
+construction, which is not evidence about the interaction**. What changed is the *timing*
+of the flush relative to the raster restart, and only a rig can say whether the corrector
+still lands the phase after a mode switch. Check it in the same round.
 
-**Analysis (not yet proven).** A mode switch fires the full flush trio through
-`flush_ctl` (load + aud + seek/vbuf) but **does not move the reader**, so the decoder
-resumes mid-VOBU with no GOP boundary to re-lock on — exactly the failure mode the
-reverted film-switch attempt hit (`docs/film_24p_plan.md` §13: "each flap flushed at an
-arbitrary mid-stream position (no reader jump = no VOBU re-alignment), garbage seq
-headers ... flipped `pal_eff` (25 Hz) which feeds back"). That a chapter seek clears it
-fits: a seek is the same flush trio **plus** a reader jump to a cell boundary. Why PAL
-specifically is the open part — the `pal_eff` feedback path is PAL-only by construction,
-so a garbage sequence header there can re-fire the modeline walk while the pipeline is
-still draining.
+### 6.1 The symptom, and the constraint that was wrong
 
-**Fix direction.** Make `mode_switch` re-align the reader instead of flushing in place:
-issue a seek to the CURRENT position snapped forward to the next NAV pack, reusing the
-reader's existing `S_NAV_SEEK*` probe (the same contract `seek_is_rbn` scrub landings
-already use, `docs/dvd_nav.md` §2a). That gives the decoder a clean GOP entry for the
-price of the interruption a mode switch already has.
+With a disc playing, changing `Video Output` mid-title could freeze the decoder: the
+picture stopped on a malformed image and never recovered by itself. A chapter seek cleared
+it. Either switch direction, not every time. **Not from this branch** — v0.3.0 does the
+same on an `Analog Out` change.
+
+It was reported on a PAL disc, and this section, `CLAUDE.md`, the GitHub issue and the user
+manual all recorded "NTSC is unaffected". That pointed the first analysis straight at the
+**PAL-only** `pal_eff` feedback path. The maintainer then saw the freeze on an **NTSC**
+disc (2026-09-03).
+
+⚠ **The lesson is worth more than the bug.** A symptom reported as specific to one
+configuration is a *hypothesis*, not a measurement — and here the wrongly-narrow
+constraint was the thing making the diagnosis hard, because it excluded the actual cause
+(which is standard-neutral) and made a secondary amplifier look like the mechanism. The
+same shape as §3.9's five rounds on the wrong layer.
+
+### 6.2 The cause was already written down, and had been read as harmless
+
+`dvd/emu.sv`'s `il_switch` block explained the whole thing and dismissed it:
+
+> The full flush is exactly what a chapter seek does (HW-confirmed synced); the only
+> difference is the reader doesn't jump, so ps_demux re-hunts to the next pack boundary
+> within the vbuf re-lock glitch.
+
+That difference **is** the defect. A mode switch fired the trio (`load_flush` +
+`aud_flush` + `seek_flush`) but did not move the reader, so the decoder resumed **mid-VOBU
+with no GOP boundary to re-lock on**. And the reason a chapter seek cured it is that a seek
+is the same trio **plus a reader jump to a boundary** — the workaround was naming the
+missing ingredient the entire time. It is also exactly the trap the reverted film-engage
+flush hit (`docs/film_24p_plan.md` §13).
+
+### 6.3 What ships — `dvd/mode_realign.sv`
+
+`il_switch` no longer drives `flush_ctl` directly. The new module turns it into a **seek to
+the playhead's own VOBU** and lets the resulting `seek_ack` drive the trio, which makes a
+mode switch byte-identical to a chapter jump. `flush_ctl.mode_switch` survives as the
+**in-place fallback** — a disc menu, a raw `.m2v`, no trustworthy playhead, or a seek the
+reader never acknowledges within ~0.5 s — so a mode change can never silently lose its
+flush. **`flush_ctl.sv` itself is unchanged**; rows [7]–[9] of `flush_ctl_tb` now describe
+the fallback leg.
+
+Three points that are not obvious from the code:
+
+- **Why the CURRENT VOBU, not the next one.** `dsi_nv_pck_lbn` already *is* the RBN of a
+  NAV pack, in the same VTSTT_VOBS space `seek_rbn` uses, so the reader arms its snap probe
+  at the target and **hits on candidate #1**: one 2048-byte sector read, no movement.
+  Targeting `+1` would walk forward one sector at a time up to `NAV_CAP = 1024` reads.
+  `bench/dvd/iso_reader_seek_tb.sv` TEST9 **measures** this over three points — on-NAV 3
+  reads, one-short 4, five-short 8 — so the walk is proven at one read per sector and the
+  cost model is measured rather than asserted. Re-reading the VOBU being parsed also
+  re-supplies roughly what the VBUF flush discards, so no content is skipped.
+- **Edges are coalesced, and that is a correctness property.** `il_eff` is a LEVEL: the
+  modeline walk always converges on its final value, so N toggles need exactly ONE
+  re-align. Absorbing further edges while an arm is open makes the
+  repeated-mid-parse-flush loop class — the thing that killed the film edge — structurally
+  unreachable from this path. That is why a future `filmp_eff` edge belongs **here** and
+  must never go straight into `flush_ctl`.
+- **The stale-playhead trap, inherited.** `nav_dsi` is on `pipe_rst_n`, so *any*
+  `load_flush` — including the one this module's own seek causes — clears
+  `dsi_nv_pck_lbn` to 0, and the reader's clamp turns that into a jump to the start of the
+  title. Hence `dsi_fresh`, and hence `tgt_rbn` is latched exactly **once**, on the
+  issuing cycle. `dvd/dpad_seek.sv` hit this first; its header is the long version.
+
+Two smaller things: `hud_user_evt` now watches the **scrub's** pulse rather than the
+arbitrated one (a re-align rides the same reader port and must not pop the transport HUD),
+and a `keep_vbuf` ack is **not** a completion — a menu→menu hop fires `load_flush` only, so
+such an ack leaves the arm open and the watchdog fires the fallback, which is right,
+because by then we are in a menu where a re-align is not possible anyway.
+
+### 6.4 Leg 2 — a garbage sequence header must not flip a raster verdict
+
+`pal_detect_dec` latched a new verdict on **any non-zero** `core_vertical_size`. The
+2026-09-03 hold fix (§3.3) only masked the `== 0` case, so a garbage height — the 186-wide
+popups a mid-VOBU flush produces — still flipped `pal_eff` from a single header. That
+matters because the modeline walk keys on `il_eff | pal_eff | filmp_eff` but **only
+`il_eff` carries a flush**: a flipped verdict restarts the raster mid-drain, and through
+`film_det = pal_eff ? det_pal : det_ntsc` → `filmp_eff` it can restart it again. That is
+the self-feeding loop, and `filmp_eff` flips on **either** standard — which is the NTSC
+path, and the reason `pal_eff` is an amplifier here rather than the cause.
+
+`dvd/pal_detect.sv` adds a **plausibility bound** (64…1152 lines — a bound, not a whitelist
+of {240,288,480,576}: the core plays flat `.mpg` files too, and 1080 is not a multiple of
+16) and a **sustained-disagreement** requirement to CHANGE an established verdict. The
+first plausible header after a mount still latches immediately, so PAL detection is not
+delayed at load. The `!= 0` hold is subsumed, not dropped.
+
+⚠ **The confirmation is a TIMER, not a count of sequence headers.** That design was
+written first and is wrong: `vertical_size` is a **register**, not an event stream — a real
+disc re-parses a sequence header every GOP but writes the *same* value, so the register
+does not change and there is no observable header event to count. A transition-counting
+rule can never reach N for a genuine change and would freeze the verdict forever. Counting
+time against the value actually in force has neither problem and is the right shape anyway:
+garbage is transient, a standard is persistent.
+
+### 6.5 The deferral window, and the pre-planned round-2 lever
+
+`il_eff` is combinational off the OSD bits, so at the moment the user commits, the raster
+(and `VGA_F1`, `CE_PIXEL`, the pixrep overlay inverses) still changes with zero delay,
+**exactly as before**. Only the *flush* moves — to `seek_ack`, which is one outstanding
+block completion plus one probe read (tens of µs to a few ms; an RBN seek forces
+`snat_l = 0`, so there is no `vbuf_empty` drain wait), worst case the 0.5 s watchdog. For
+that window the new raster shows the old timeline's already-decoded frames. Nothing needs
+holding: the overlay is briefly squashed and `VGA_F1` briefly toggles on a progressive
+raster, both sub-frame, neither able to wedge the decoder.
+
+⚠ **No `modeline_boot_tb` phase was added, deliberately.** The walk is *not* gated on
+`realign_pend`, so this change does not touch it; the existing bench passing unchanged is
+the evidence for that, and a new phase would test behaviour nothing altered.
+
+**If a hardware round still shows the freeze**, the flush is exonerated and the remaining
+suspect is the **raster restart**. The next step is then to gate `il_out` on
+`~realign_pend` so the walk and the flush land together on the VOBU boundary — one hold
+register and one mux. It is deliberately **not** in v1: one behavioural delta per round is
+what makes a round diagnostic (§3.9).
+
+### 6.6 Residual, stated plainly
+
+On a **raw** MODE2/2352 `.bin` (VCD/SVCD) the seek target round-trips through
+`ls_sec = r − r/8 − r/256 − r/1024` (`dvd_iso_reader.sv`), which biases ≈ **−0.07 %**, so a
+re-align lands slightly early — up to ~2–3 s of rewind at the end of a 74-minute image. It
+is the same landing every VCD scrub already produces. Accepted and documented rather than
+corrected: a 32-bit inverse-bias adder is not worth the area on an 88 % fit. Flat
+`.mpg`/`.VOB` is exact (`strm_blk <= ls_tgt`) *and* arms the `00 00 01 BA` pack hunt — a
+perfect re-align. A raw `.m2v` elementary stream is not seekable at all and takes the
+fallback.
+
+### 6.7 Gates
+
+`bash bench/dvd/run_mode_realign.sh` (`--red` runs the pre-fix arms first, failures
+expected):
+
+| bench | what it proves | RED evidence |
+|---|---|---|
+| `mode_realign_chain_tb` | the real reader over a synthetic disc: one mode edge fired mid-VOBU, then **the first bytes delivered after the flush** | pre-fix `b0 b0 b0 b0` (mid-sector cell payload); fixed `00 00 01 BA / BB / BF` |
+| `mode_realign_tb` | 11 scenarios: the seek, the target, the fallbacks, the stale table, coalescing, the scrub arbitration, the mount cancel, the held scrub | 15 checks fail on `+realign=0`; **both "no re-align possible" controls pass in BOTH arms** |
+| `pal_detect_tb` | 8 scenarios, counting **verdict EDGES** | `+hyst=0`: 12 walk kicks in a garbage burst, 2 for one stray header |
+| `iso_reader_seek_tb` TEST9 | the probe walk is 1 read/sector, so an on-NAV target is a single-probe snap | measured 3 / 4 / 8 reads |
+
+⚠ Two bench-construction notes worth carrying forward. `pal_detect_tb` originally checked
+**end states** and the pre-fix rule PASSED the stray-header and churn scenarios, because it
+self-heals on the next real header — the harm is the *transient*, since every verdict change
+kicks the walk. And `mode_realign_tb`'s first version failed all 11 scenarios against
+correct RTL: blocking stimulus assignments landed **on** the clock edge and raced the DUT,
+so every count read 0. Stimulus is driven from the negedge now, sampling from the posedge.
 
 ## 7. Follow-ups
+- **`pal_detect_raw` reads `> 480` as PAL, so a 720p or 1080i flat `.mpg` already reads
+  PAL** and gets a 50 Hz STC tick rate plus the PAL modeline. That predates issue #42 and
+  is unchanged by it — `dvd/pal_detect.sv` altered *when* a verdict may take effect, never
+  *what* a height means, so those files behave bit-identically. Tightening to
+  `(v == 576) || (v == 288)` would change the raster for content that currently works and
+  nobody has reported, so it is deliberately not bundled.
+- **`sif_h_dec` / `sif_v_dec` are the same class as the old `pal_detect_dec`**: raw
+  `core_horizontal_size` / `core_vertical_size` behind only a `!= 0` guard, driving the
+  2× fill. A garbage 288 mid-title flips the fill. Issue #42 left them alone to keep one
+  variable per hardware round; the plausibility bound from `dvd/pal_detect.sv` is the
+  ready-made fix if a report ever points here.
+- **The `vsz_s2` / `hsz_s2` overlay-crop geometry** reads the same raw sizes. Lower risk
+  (a wrong value is a misplaced overlay, not a raster restart), same remedy.
 - Done in round 2 (user decision): the idle logo moves on every FIELD tick in Interlaced
   (`dvd/idle_logo.sv`; the old every-other-field divider made it half speed on the CRT).
 - Native 13.5 MHz dot pacing (720-wide internally) — only if a reason appears; needs the

--- a/docs/single_raster_analog.md
+++ b/docs/single_raster_analog.md
@@ -417,7 +417,7 @@ kicks the walk. And `mode_realign_tb`'s first version failed all 11 scenarios ag
 correct RTL: blocking stimulus assignments landed **on** the clock edge and raced the DUT,
 so every count read 0. Stimulus is driven from the negedge now, sampling from the posedge.
 
-### 6.8 The switch blank (2026-09-03) — ⏳ HW-confirm pending
+### 6.8 The switch blank (2026-09-03) — ✅ HW-CONFIRMED
 
 Fixing the freeze left the transient visible, and the maintainer's HW round named it
 exactly: switching **to Interlaced** gives *"a full screen rolling image flashing between
@@ -491,6 +491,45 @@ level, exactly the shape that passes without proving anything — **mutation-che
 targeted RTL mutations (clear without requiring the drop, no ceiling, no `blank_en` gate,
 coalesce instead of restart, no mount clear) are each caught by the scenario written for
 them.
+
+**HW round (2026-09-03, `DVD_swblank_20260903_1638.rbf`): ✅ better — the roll and the
+top-half squish are gone.** The maintainer's verdict on what remains is the useful part:
+
+> *"there are still some visible glitches but I think these are more decoder issues than
+> mode switch since it looks similar to when a chapter skip is performed"*
+
+★ **That observation is the fix's own success criterion being met, and it should be read as
+a result rather than as a leftover.** §6.3's whole design was to make a mode switch
+*byte-identical to a chapter jump* — same trio, same VOBU-boundary landing, same reader
+contract. Once it is, a mode switch cannot have a class of artifact that a chapter seek
+does not: anything still visible is generic **seek re-lock**, i.e. a pre-existing item that
+belongs to the transport, not to `Video Output`. The symptom matching a chapter skip is the
+observation that relocates the remaining work. (It is an observation of appearance, not a
+measurement — but it is the right shape, and it is the same reasoning that closed §3.9:
+when a build changes X and the symptom persists unchanged, X is exonerated.)
+
+**What the residual most likely is, for whoever picks it up.** `flush_ctl`'s trio discards
+*buffered* data but deliberately leaves the decode pipeline's state — `vld`/`getbits`/
+`motcomp`/`picbuf` are all on `sync_rst`, and `mount_flush` (the decoder soft reset) is
+MOUNT-ONLY, "NEVER on seeks/jumps/mode switches ... where the display must hold the last
+frame and the reference frames are same-file valid". So across any seek the in-flight
+picture still "completes" on the new stream's first start code (one truncated frame), and
+the previous references stay flagged valid — an open-GOP VOBU then motion-compensates its
+first B-frames against frames from the *old* position. Same mechanism as the mid-play mount
+garbage (`docs/av_sync.md`), just bounded, because within one title the references are at
+least same-file.
+
+★ **And the switch blank changes the cost/benefit for the mode-switch case specifically.**
+The stated reason not to soft-reset on a seek is *display continuity* — the screen must
+hold the last frame while the decoder re-locks. During a blanked mode switch there is no
+display continuity to protect: the screen is black by design. So adding `mode_switch` (the
+fallback leg) **and** the re-align's `seek_ack` to `mount_flush` is now arguable for this
+path alone, and would remove the truncated frame and the stale references. ⚠ Two things to
+design against before trying it: the soft reset asserts `sync_rst`, which drops `dec_ready`
+and gates the modeline walk (§3.2's boot race) — the regfile is on `hard_rst` so the walk's
+writes survive, but the interaction wants a `modeline_boot_tb` phase before a build; and
+chapter skips would still be untouched, so it fixes the symptom on one path while leaving
+the class open. Not attempted; recorded so the next session starts from here.
 
 ## 7. Follow-ups
 - **✅ Blank the video during a `Video Output` switch — IMPLEMENTED 2026-09-03 (user

--- a/docs/single_raster_analog.md
+++ b/docs/single_raster_analog.md
@@ -418,6 +418,43 @@ correct RTL: blocking stimulus assignments landed **on** the clock edge and race
 so every count read 0. Stimulus is driven from the negedge now, sampling from the posedge.
 
 ## 7. Follow-ups
+- **Blank the video during a `Video Output` switch (proposed 2026-09-03, user request after
+  the issue #42 HW round; NOT implemented).** The freeze is fixed, but the ~1 s transient is
+  ugly: switching *to* Interlaced shows a full-screen rolling image flashing between black
+  frames (the display has lost vertical lock across the raster change), and switching *to*
+  Progressive squishes the picture into the top half (field-height content in a frame-height
+  DE window). Both are inherent to changing the raster under in-flight content, so the fix
+  is cosmetic by nature: force `vga_r_q/g_q/b_q` to 0 at the output mux (`emu.sv`, the
+  registered stage) for the duration.
+  - **The window already has a signal.** Blank on `il_switch`, clear on **`video_live`
+    rising** — the re-align's `load_flush` re-arms it via `pickup_hold`, and it rises when
+    the first frame is actually picked up for display, i.e. the first frame of the NEW mode.
+    Needs a minimum (the few ms before the flush lands, during which `video_live` is still
+    high) and a timeout. `dvd/mode_realign.sv` is the natural home: it knows both endpoints
+    and already owns a watchdog, and `realign_pend` is half of it.
+  - ⚠ **Blank RGB ONLY, never sync.** That is the `re_interlace` `S_HUNT` defect (§3.2): it
+    emitted no sync at all while hunting, costing 33–67 ms of dead CRT sync per event.
+    Killing sync across a raster change lengthens the lock-up.
+  - ★ **The MiSTer OSD is composited DOWNSTREAM** (`emu` → `scanlines` → `osd` → pins,
+    `sys/sys_top.v`), so blanking at the emu stage leaves the menu the user is standing in
+    fully visible. The HUD/subtitles/idle logo ride `sub_r` and would blank — acceptable for
+    a ~1 s transient.
+  - ⛔ **"Repeat the last good frame" was considered and is the WEAKER option**, despite the
+    machinery already existing (the governor's persistence re-scan, `repeat_frame=31`, as
+    used by pause and `hold_freeze`). Three reasons: the interlaced symptom is a *roll*, so a
+    held frame rolls too and a rolling still is no better than a rolling picture, whereas
+    rolling black is invisible; the re-scan goes back through the same mode-dependent scan
+    path that produces the progressive squish, and the held image was built for the OLD mode,
+    so it is not obviously immune to the artifact it is meant to hide; and it needs the
+    coordinated hold set (watchdog suppression etc.), where freezing video without audio for
+    ~1 s diverges the timelines the flush just re-anchored. Blanking acts at the PIN, after
+    every mode-dependent path, so it is immune by construction.
+  - Cost: ~20–30 ALMs, but a netlist change ⇒ re-rolls the pinned seed and needs a fresh
+    `tools/fmax_check.sh` verdict. **Bound the window with a timeout** — unbounded, it would
+    hide a persistent fault rather than a transient.
+  - The same ugliness on an **Analog Aspect** change would need its own trigger: per
+    `docs/field_parity.md` that walk issues no flush at all, so there is no `video_live`
+    re-arm to key on.
 - **`pal_detect_raw` reads `> 480` as PAL, so a 720p or 1080i flat `.mpg` already reads
   PAL** and gets a 50 Hz STC tick rate plus the PAL modeline. That predates issue #42 and
   is unchanged by it — `dvd/pal_detect.sv` altered *when* a verdict may take effect, never

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -1088,8 +1088,14 @@ wire [5:0] chap_net_abs = chap_net[5] ? (6'd0 - chap_net) : chap_net;
 wire       chap_at_start;            // 1 = <~5 s into the current chapter (from DSI
                                      // c_eltm) -> prev steps back; else prev restarts
                                      // the current chapter. Assigned near nav_dsi below.
-wire       seek_rbn_pulse;           // pulse: time scrub -> reader (from scrub_ctrl)
-wire [31:0] seek_rbn;                // target RBN (2048-sector, VTSTT_VOBS-rel)
+// The reader has ONE raw-RBN seek port and two producers now: the user's hold-to-seek
+// scrub and dvd/mode_realign.sv's re-align on a raster-mode change. mode_realign owns the
+// arbitration (the scrub always wins) -- see its header. scrub_seek_* are the scrub's own
+// outputs; seek_rbn_pulse/seek_rbn are what reaches dvd_iso_reader.
+wire       scrub_seek_pulse;         // pulse: time scrub (from scrub_ctrl)
+wire [31:0] scrub_seek_rbn;          // its target RBN (2048-sector, VTSTT_VOBS-rel)
+wire       seek_rbn_pulse;           // pulse: arbitrated raw-RBN seek -> reader
+wire [31:0] seek_rbn;                // its target RBN (2048-sector, VTSTT_VOBS-rel)
 reg        angle_pulse;              // pulse: cycle camera angle (Phase 9) -> reader
 wire [3:0] cur_angle;                // from reader: current camera angle (1-based)
 wire [3:0] angle_count;              // from reader: angles in the current block (0=none)
@@ -1244,12 +1250,14 @@ wire sel_edge   = joy_sel   & ~joy_prev[7];
 // also pulses on VM-driven jumps/resumes (a menu Play, a CallSS/RSM featurette
 // enter/return, a menu next_pgcn advance) - those are "clip starts", not user
 // actions, and should not pop the HUD. (Audio/subtitle/angle cycles drive the
-// popup line separately.) seek_rbn_pulse is the scrub-release seek (user).
+// popup line separately.) scrub_seek_pulse is the scrub-release seek (user); note it is
+// the SCRUB's pulse and not the arbitrated seek_rbn_pulse -- a mode-switch re-align rides
+// that same port and must not pop the HUD (issue #42).
 // dpad_pend_evt pops the HUD on the FIRST D-pad press rather than ~0.4 s later
 // when the coalesced jump actually fires, so the seconds readout tracks the taps.
 wire hud_user_evt = pause_edge
                   | ((chnext_edge | chprev_edge) && cell_ready && !menu_active)
-                  | seek_rbn_pulse
+                  | scrub_seek_pulse
                   | dpad_pend_evt;
 wire menu_edge  = joy_menu  & ~joy_prev[8];
 wire angle_edge = joy_angle & ~joy_prev[9];
@@ -1588,8 +1596,8 @@ scrub_ctrl scrub_ctrl_inst (
     .cur_rbn         (cell_ready ? dsi_nv_pck_lbn : lin_blk_w),
     .title_first_rbn (title_first_rbn_w),
     .title_last_rbn  (title_last_rbn_w),
-    .seek_rbn_pulse  (seek_rbn_pulse),
-    .seek_rbn        (seek_rbn),
+    .seek_rbn_pulse  (scrub_seek_pulse),   // arbitrated by mode_realign (issue #42)
+    .seek_rbn        (scrub_seek_rbn),
     .hold_freeze     (hold_freeze),
     .bar_active      (bar_active_w),
     .bar_base_rbn    (bar_base_rbn_w),
@@ -2041,13 +2049,59 @@ wire      il_switch = il_eff ^ il_eff_q;
 // the raster is right BEFORE display; a mid-title film_switch then needs hold-
 // suppression + a post-discontinuity holdoff, TB'd in flush_ctl_tb) — see
 // docs/film_24p_plan.md §13.
-// mode_switch = live raster-regime change -> full flush trio (load+aud+seek).
-// Today that is il_switch alone.
-wire      mode_switch = il_switch;
+// ★ AMENDED 2026-09-03 (issue #42). The paragraph above is still the right account of
+// WHAT the trio does; what it got wrong is WHEN. "The full flush is exactly what a chapter
+// seek does; the only difference is the reader doesn't jump" turned out not to be a
+// harmless difference: with a disc playing, a mid-title Video Output change could freeze
+// the decoder on a malformed frame with no self-recovery, on EITHER standard, and a
+// chapter seek cleared it. The reader not jumping IS the bug -- the decoder resumed
+// mid-VOBU with no GOP boundary to re-lock on, the same failure the film edge below hit.
+// So il_switch no longer drives flush_ctl directly: dvd/mode_realign.sv turns it into a
+// reader seek at the current VOBU and lets the resulting seek_ack drive the trio, which
+// makes a mode switch byte-identical to a chapter jump. mode_switch below is now only the
+// FALLBACK (menus, a raw .m2v, no trustworthy playhead, or an unacknowledged seek), where
+// it behaves exactly as it always did.
 always @(posedge clk_sys) begin
     if (~reset_n) il_eff_q <= 1'b0;
     else          il_eff_q <= il_eff;
 end
+
+// =========================================================================
+// MODE-SWITCH READER RE-ALIGN — dvd/mode_realign.sv (issue #42). Design, the
+// coalescing rule, the stale-playhead trap and the deferral window: its header.
+wire       mode_switch;                 // the in-place FALLBACK trio (see above)
+wire       realign_pend;                // an arm is open
+wire load_flush, aud_flush, aud_resync, seek_flush, mount_flush;
+wire pipe_rst_n, aud_rst_n;
+mode_realign mode_realign_i (
+    .clk             (clk_sys),
+    .rst_n           (reset_n),         // NOT pipe_rst_n: the arm must survive its
+                                        // own load_flush
+    .mode_edge       (il_switch),
+    // in_title deliberately does NOT exclude in_title_menu (unlike scrub_ctrl): that
+    // gate exists because the D-pad is contested there, and an OSD edit contests
+    // nothing. Title content is streaming, so a re-align is both valid and wanted.
+    .in_title        ((cell_ready || lin_seek_ok_w) && !menu_active),
+    .dvd_mode        (cell_ready),
+    .lin_mode        (lin_seek_ok_w && !cell_ready),
+    .still_active    (still_active),    // parked on a still: nothing to re-align
+    .hold_freeze     (hold_freeze),
+    .nav_flush       (load_flush),      // clears nav_dsi => the playhead goes stale
+    .dsi_commit      (dsi_commit),
+    .dsi_stream      (ps_dsi_valid),
+    .dsi_nv_pck_lbn  (dsi_nv_pck_lbn),
+    .lin_blk         (lin_blk_w),
+    .seek_ack        (seek_ack),
+    .jump_ack        (jump_ack),
+    .keep_vbuf       (keep_vbuf),       // a menu hop's ack is not a full trio
+    .start_streaming (start_streaming),
+    .scrub_pulse     (scrub_seek_pulse),
+    .scrub_rbn       (scrub_seek_rbn),
+    .seek_rbn_pulse  (seek_rbn_pulse),  // -> dvd_iso_reader (arbitrated)
+    .seek_rbn        (seek_rbn),
+    .mode_switch     (mode_switch),
+    .realign_pend    (realign_pend)
+);
 
 // =========================================================================
 // FLUSH / RESET TRIGGER MATRIX — dvd/flush_ctl.sv (extracted 2026-08-28 so the
@@ -2056,8 +2110,9 @@ end
 // deliberately does NOT reset), AUDIO-ONLY RE-SYNC (aud_resync), keep_vbuf
 // audio-continuity (aud_flush gating), the SEEK VBUF FLUSH + the 2026-08-28
 // mount/mode_switch flush-trio rule. Events in, ~64-cycle flush levels out.
-wire load_flush, aud_flush, aud_resync, seek_flush, mount_flush;
-wire pipe_rst_n, aud_rst_n;
+// ⚠ Its mode_switch input is now the FALLBACK leg only (issue #42): the normal path for
+// a raster-mode change arrives as seek_ack, from the re-align above. flush_ctl itself is
+// unchanged -- rows [7]-[9] of bench/dvd/flush_ctl_tb.sv still describe this input.
 flush_ctl flush_ctl_i (
     .clk             (clk_sys),
     .rst_n           (reset_n),

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -3600,23 +3600,39 @@ end
 // (clk_dec domain). 480 => NTSC, 576 => PAL. We derive a 1-bit "tall" flag and 2-FF
 // sync it into clk_sys, where pal_eff (below) resolves the Auto/NTSC/PAL override.
 wire [13:0] core_vertical_size;
-// DVD-FORK FIX (mpeg1): MPEG-1 PAL/SIF is 352x288 (288 = half of 576), which the
-// ">480" test misses — key on it explicitly. MPEG-1 NTSC/SIF is 240 (not >480, and
-// not 288), so it correctly stays NTSC.
-wire        pal_detect_raw = (core_vertical_size > 14'd480)    // PAL frame is 576 lines
-                          || (core_vertical_size == 14'd288);  // MPEG-1 PAL SIF (352x288)
-// DVD-FORK FIX (single-raster analog, 2026-09-03): HOLD the verdict while no sequence
-// header is in force. vertical_size is a VLD register on sync_rst, so every watchdog
-// expiry / mount soft reset zeroed it - and a PAL disc then read "NTSC" for the gap
-// until the next header: pal_eff flipped, the modeline walk re-fired (PAL->NTSC->PAL,
-// two raster restarts), and av_sync's STC tick rate went with it. Same trap the
-// film-switch post-mortem hit (a garbage 576-line parse flipping pal_eff mid-title,
-// docs/film_24p_plan.md §13). Last verdict held across resets; reset_n clears it.
-reg         pal_detect_dec;
-always @(posedge clk_dec or negedge reset_n) begin
-    if (!reset_n)                          pal_detect_dec <= 1'b0;
-    else if (core_vertical_size != 14'd0)  pal_detect_dec <= pal_detect_raw;
+// DVD-FORK FIX (issue #42 leg 2, 2026-09-03): the verdict rule moved to
+// dvd/pal_detect.sv so it is testbenchable (bench/dvd/pal_detect_tb.sv) and so the
+// two guards it now carries have somewhere to be explained. It replaces:
+//     wire pal_detect_raw = (vsize > 480) || (vsize == 288);
+//     always @(posedge clk_dec or negedge reset_n)
+//       if (!reset_n) pal_detect_dec <= 0; else if (vsize != 0) pal_detect_dec <= raw;
+// The `!= 0` hold (added 2026-09-03 for the watchdog/soft-reset gap) is SUBSUMED, not
+// dropped. What it did not cover: any NON-ZERO garbage height still flipped the verdict
+// from a single header, and a pal_eff change RESTARTS THE RASTER WITH NO FLUSH (the
+// modeline walk keys on il_eff | pal_eff | filmp_eff, but only il_eff carries the flush
+// trio) and feeds back through film_det -> filmp_eff -> the walk again. That amplifier
+// is how issue #42's mid-VOBU flush reached a freeze, and it is NOT PAL-only: film_det
+// flips on either standard. Now a height must be plausible AND, to CHANGE an already
+// established verdict, must still be in force half a second later. See the module
+// header for why that is a timer and not a count of sequence headers.
+// A mount is the ONE event that may legitimately change the standard, so it re-arms the
+// immediate latch. mount_flush is MOUNT-ONLY by design (dvd/flush_ctl.sv) - deliberately
+// not load_flush, which also fires on a mode switch, i.e. exactly when the parse is
+// least trustworthy. 2-FF into clk_dec, same pattern as vbuf_flush_dec above; the
+// 64-cycle clk_sys level is ~192 clk_dec cycles, far wider than the synchronizer.
+reg         mnt_arm_s1, mnt_arm_dec;
+always @(posedge clk_dec) begin
+    mnt_arm_s1  <= mount_flush;
+    mnt_arm_dec <= mnt_arm_s1;
 end
+wire        pal_detect_dec;
+pal_detect pal_detect_i (
+    .clk       (clk_dec),               // the domain vertical_size is parsed in
+    .rst_n     (reset_n),
+    .mount_arm (mnt_arm_dec),
+    .vsize     (core_vertical_size),
+    .pal       (pal_detect_dec)
+);
 reg         pal_det_s1, pal_det_s2;
 always @(posedge clk_sys or negedge reset_n) begin
     if (!reset_n) begin pal_det_s1 <= 1'b0; pal_det_s2 <= 1'b0; end

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -2070,7 +2070,11 @@ end
 // MODE-SWITCH READER RE-ALIGN — dvd/mode_realign.sv (issue #42). Design, the
 // coalescing rule, the stale-playhead trap and the deferral window: its header.
 wire       mode_switch;                 // the in-place FALLBACK trio (see above)
-wire       realign_pend;                // an arm is open
+// realign_pend is deliberately UNCONNECTED today. It exists for the round-2 lever
+// docs/single_raster_analog.md §6.5 describes: if hardware still freezes, gate il_out on
+// ~realign_pend so the modeline walk and the flush land together on the VOBU boundary.
+// Keeping it out of the netlist now is the point -- one behavioural delta per HW round.
+wire       realign_pend;                // an arm is open (see above)
 wire load_flush, aud_flush, aud_resync, seek_flush, mount_flush;
 wire pipe_rst_n, aud_rst_n;
 mode_realign mode_realign_i (

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -2070,6 +2070,7 @@ end
 // MODE-SWITCH READER RE-ALIGN — dvd/mode_realign.sv (issue #42). Design, the
 // coalescing rule, the stale-playhead trap and the deferral window: its header.
 wire       mode_switch;                 // the in-place FALLBACK trio (see above)
+wire       sw_blank;                    // hold the picture black across a mode switch
 // realign_pend is deliberately UNCONNECTED today. It exists for the round-2 lever
 // docs/single_raster_analog.md §6.5 describes: if hardware still freezes, gate il_out on
 // ~realign_pend so the modeline walk and the flush land together on the VOBU boundary.
@@ -2099,12 +2100,15 @@ mode_realign mode_realign_i (
     .jump_ack        (jump_ack),
     .keep_vbuf       (keep_vbuf),       // a menu hop's ack is not a full trio
     .start_streaming (start_streaming),
+    .video_live      (video_live_s2),   // clears the blank on the first new-mode frame
+    .blank_en        (media_seen),      // never blank the boot idle screen
     .scrub_pulse     (scrub_seek_pulse),
     .scrub_rbn       (scrub_seek_rbn),
     .seek_rbn_pulse  (seek_rbn_pulse),  // -> dvd_iso_reader (arbitrated)
     .seek_rbn        (seek_rbn),
     .mode_switch     (mode_switch),
-    .realign_pend    (realign_pend)
+    .realign_pend    (realign_pend),
+    .sw_blank        (sw_blank)
 );
 
 // =========================================================================
@@ -5086,12 +5090,30 @@ cc_vbi cc_vbi_inst (
 // the analog pins (the dual-raster VGA2_* path is gone). Outside DE the stage emits
 // black except the line-21 caption level (equal on R/G/B = luma only, no chroma), and
 // ce_pix_q is the framework-facing pixel enable (see CE_PIXEL near the top).
+// DVD-FORK (switch blank, 2026-09-03 — issue #42 follow-up): sw_blank holds the PICTURE
+// black from a Video Output change until the first frame of the new mode is on screen
+// (dvd/mode_realign.sv owns the window). Its position in this priority chain is the whole
+// design:
+//   - AFTER cc_on, so the line-21 caption waveform still goes out. It lives in the VBI,
+//     i.e. outside DE, and blanking it would kill captions for a second every switch.
+//   - AFTER ov_on / dbg_px_q, so the DEBUG_OVERLAY rows and the release-visible O[2]
+//     diagnostic blocks stay readable. blk10 of the O[2] third row IS the "il_switch
+//     fired" readout — hiding it exactly when a switch happens would blind the one
+//     instrument pointed at this event.
+//   - BEFORE sub_r, so it takes out the picture, subtitles, HUD and idle logo together.
+//     That is the intent: everything content-derived goes dark as one.
+// ⚠ RGB ONLY — vga_hs_q/vga_vs_q/vga_de_q below are UNTOUCHED. Dropping sync across a
+// raster change is the re_interlace S_HUNT defect (docs/single_raster_analog.md §3.2):
+// it lengthens the display's lock-up instead of hiding it.
+// ★ The MiSTer OSD is composited DOWNSTREAM of these pins (sys_top: emu -> scanlines ->
+// osd), so the menu the user is standing in when they flip the setting stays fully
+// visible over the black.
 reg [7:0] vga_r_q, vga_g_q, vga_b_q;
 reg       vga_hs_q, vga_vs_q, vga_de_q, ce_pix_q;
 always @(posedge clk_sys) begin
-    vga_r_q  <= cc_on ? cc_level : ~core_pixel_en ? 8'd0 : ov_on ? ov_r : (dbg_px_q ? dbg_r_q : sub_r);
-    vga_g_q  <= cc_on ? cc_level : ~core_pixel_en ? 8'd0 : ov_on ? ov_g : (dbg_px_q ? dbg_g_q : sub_g);
-    vga_b_q  <= cc_on ? cc_level : ~core_pixel_en ? 8'd0 : ov_on ? ov_b : (dbg_px_q ? dbg_b_q : sub_b);
+    vga_r_q  <= cc_on ? cc_level : ~core_pixel_en ? 8'd0 : ov_on ? ov_r : dbg_px_q ? dbg_r_q : sw_blank ? 8'd0 : sub_r;
+    vga_g_q  <= cc_on ? cc_level : ~core_pixel_en ? 8'd0 : ov_on ? ov_g : dbg_px_q ? dbg_g_q : sw_blank ? 8'd0 : sub_g;
+    vga_b_q  <= cc_on ? cc_level : ~core_pixel_en ? 8'd0 : ov_on ? ov_b : dbg_px_q ? dbg_b_q : sw_blank ? 8'd0 : sub_b;
     vga_hs_q <= core_h_sync;
     vga_vs_q <= core_v_sync;
     vga_de_q <= core_pixel_en;

--- a/dvd/mode_realign.sv
+++ b/dvd/mode_realign.sv
@@ -1,0 +1,205 @@
+/*
+ * mode_realign.sv — a live raster-mode change must RE-ALIGN THE READER, not flush in place
+ *
+ * DVD-FORK (2026-09-03, issue #42). Fixes: changing `Video Output` mid-title could freeze
+ * the decoder on a malformed frame, with no self-recovery, on either standard. A chapter
+ * seek cleared it.
+ *
+ * ★ THE MECHANISM. A mode switch fired the full flush trio through dvd/flush_ctl.sv
+ * (load_flush + aud_flush + seek_flush) but DID NOT MOVE THE READER, so the decoder
+ * resumed mid-VOBU with no GOP boundary to re-lock on. That a chapter seek cured it is
+ * the whole diagnosis: a seek is the same trio PLUS a reader jump to a boundary. Same
+ * trap the reverted film-engage flush died of (docs/film_24p_plan.md §13): "each flap
+ * flushed at an arbitrary mid-stream position (no reader jump = no VOBU re-alignment),
+ * garbage seq headers ... flipped pal_eff ... = a self-feeding corruption loop".
+ *
+ * So: don't synthesize the trio here. Issue a SEEK and let the reader's seek_ack drive
+ * the trio, which makes a mode switch byte-identical to a chapter jump — the contract
+ * that is HW-proven to re-sync cleanly.
+ *
+ * ★ THE TARGET IS THE CURRENT VOBU, AND THAT IS WHY IT IS CHEAP. dsi_nv_pck_lbn IS the
+ * RBN of the NAV pack of the VOBU being demuxed, in the same VTSTT_VOBS space seek_rbn
+ * uses. The reader arms its VOBU-snap probe at the target and tests that sector first
+ * (dvd_iso_reader.sv S_NAV_SEEK), so the snap HITS on candidate #1 and moves nowhere:
+ * ONE 2048-byte sector read. Targeting the NEXT VOBU instead would walk forward a sector
+ * at a time up to NAV_CAP=1024 reads. Restarting the VOBU being parsed also re-supplies
+ * roughly what the VBUF flush discards, so no content is skipped.
+ *
+ * ★ EDGES ARE COALESCED, AND THAT IS A CORRECTNESS PROPERTY, NOT AN OPTIMISATION. il_eff
+ * is a LEVEL: the modeline walk always converges on its final value, so N toggles need
+ * exactly ONE re-align. Absorbing further edges while an arm is open is what makes the
+ * "repeated mid-parse flush" loop class — the thing that killed the film edge —
+ * structurally unreachable from this path. A future filmp_eff edge belongs here for
+ * exactly that reason, and must never go straight into flush_ctl.
+ *
+ * ★ THE FALLBACK IS THE OLD BEHAVIOUR, ON PURPOSE. Where no re-align is possible (a disc
+ * menu, a raw .m2v elementary stream, a still, no trustworthy playhead yet) or where the
+ * reader does not acknowledge within WDOG, mode_switch pulses and the in-place trio fires
+ * exactly as before. A mode change can therefore never silently lose its flush, and there
+ * is no toggle to add for it (a CONF_STR string edit alone re-rolls the pinned fitter
+ * seed — see DVD.qsf's ledger).
+ *
+ * ⚠ THE STALE-PLAYHEAD TRAP (dvd/dpad_seek.sv hit this first; its header is the long
+ * version). nav_dsi's reset is pipe_rst_n, so ANY load_flush clears dsi_nv_pck_lbn to 0 —
+ * including the one this module's own seek causes. Re-sampling the playhead later reads 0
+ * and the reader's clamp turns that into a jump to the start of the title. Hence
+ * dsi_fresh, and hence tgt_rbn is latched exactly ONCE, on the issuing cycle.
+ *
+ * ⚠ A keep_vbuf ack is NOT a completion. A menu->menu hop fires load_flush only (audio
+ * continuity, docs/dvd_menu_refinements.md §5d), so it does not give the mode switch the
+ * trio it needs. Such an ack leaves the arm open; the watchdog then fires the fallback,
+ * which is right — by then we are in a menu, where a re-align is not possible anyway.
+ *
+ * NOTE ON THE DEFERRAL WINDOW. il_eff is combinational off the OSD bits, so the raster
+ * (and VGA_F1, CE_PIXEL, the pixrep overlay inverses) still changes the instant the user
+ * commits, exactly as before — only the FLUSH moves, to the moment it can land on a GOP
+ * boundary. For those few ms the new raster shows the old timeline's already-decoded
+ * frames, which is strictly less perturbing than flushing mid-parse. If a hardware round
+ * ever shows the freeze surviving this, the remaining suspect is the RASTER RESTART, and
+ * the next step is to gate il_out on ~realign_pend so the walk and the flush land
+ * together — one behavioural delta at a time (docs/single_raster_analog.md §3.9).
+ */
+
+`default_nettype none
+
+module mode_realign #(
+    parameter [23:0] WDOG = 24'd13_500_000       // ~0.5 s @ 27 MHz clk_sys
+) (
+    input  wire        clk,              // clk_sys (27 MHz)
+    input  wire        rst_n,            // core reset_n — NOT pipe_rst_n: the arm has to
+                                         // survive the very load_flush it causes
+
+    input  wire        mode_edge,        // 1-cyc: a live raster-regime change (il_switch)
+
+    // ---- context: is a re-align possible at all? -------------------------------------
+    input  wire        in_title,         // title-domain playback (not a disc menu)
+    input  wire        dvd_mode,         // cell mode: the DSI playhead is the base
+    input  wire        lin_mode,         // linear file: the linear block is the base
+    input  wire        still_active,     // reader parked on a still — nothing to re-align
+    input  wire        hold_freeze,      // a Fast Fwd / Rewind gesture owns the playhead
+
+    // ---- the base, and whether it can be trusted -------------------------------------
+    input  wire        nav_flush,        // load_flush: nav_dsi scalars cleared => STALE
+    input  wire        dsi_commit,       // 1-cyc: a DSI packet finished parsing
+    input  wire        dsi_stream,       // DSI bytes are rewriting nav_dsi right now
+    input  wire [31:0] dsi_nv_pck_lbn,   // VOBU NAV-pack RBN (the demux front)
+    input  wire [31:0] lin_blk,          // linear playhead block
+
+    // ---- reader feedback -------------------------------------------------------------
+    input  wire        seek_ack,         // reader executed a transport seek
+    input  wire        jump_ack,         // reader executed a VM jump
+    input  wire        keep_vbuf,        // valid on the ack: 1 = menu hop, load_flush only
+    input  wire        start_streaming,  // a new file was mounted => cancel
+
+    // ---- the other producer of the reader's single RBN-seek port ---------------------
+    input  wire        scrub_pulse,      // dvd/scrub_ctrl.sv seek_rbn_pulse
+    input  wire [31:0] scrub_rbn,        // dvd/scrub_ctrl.sv seek_rbn
+
+    // ---- outputs ---------------------------------------------------------------------
+    output wire        seek_rbn_pulse,   // -> dvd_iso_reader (the arbitrated port)
+    output wire [31:0] seek_rbn,
+    output reg         mode_switch,      // -> flush_ctl: THE IN-PLACE FALLBACK ONLY
+    output wire        realign_pend      // level: an arm is open (debug readout / gating)
+);
+
+localparam [1:0] S_IDLE = 2'd0,   // nothing pending
+                 S_ARM  = 2'd1,   // waiting for a trustworthy base
+                 S_ACK  = 2'd2;   // a seek is in flight
+
+reg  [1:0]  state;
+reg  [23:0] tmr;                  // watchdog countdown (frozen while hold_freeze)
+reg  [31:0] tgt_rbn;              // the base, latched ONCE on the issuing cycle
+reg         issue_p;              // 1-cyc: our seek
+reg         dsi_fresh;            // dsi_nv_pck_lbn belongs to a parsed DSI, not to a flush
+
+// Can a re-align be attempted at all? The reader only latches an RBN seek in cell mode or
+// on a seekable linear file, and its VOBU-snap probe is bypassed in the menu domain, so
+// this mirrors the reader's own preconditions rather than inventing new ones. A raw .m2v
+// needs no special case: lin_seek_ok is already low for a bare elementary stream.
+wire possible  = in_title && (dvd_mode || lin_mode) && ~still_active;
+
+// ⚠ dvd_mode is checked FIRST: on a DVD title the linear block is meaningless.
+wire [31:0] base = dvd_mode ? dsi_nv_pck_lbn : lin_blk;
+wire        base_ok  = (dvd_mode && dsi_fresh && ~dsi_stream && ~dsi_commit) || lin_mode;
+wire        can_issue = possible && base_ok && ~hold_freeze;
+
+// An ack only completes the arm if it carried the full trio. A keep_vbuf menu hop did not.
+wire        ack_done = (seek_ack || jump_ack) && ~keep_vbuf;
+
+always @(posedge clk) begin
+    if (~rst_n) begin
+        state       <= S_IDLE;
+        tmr         <= 24'd0;
+        tgt_rbn     <= 32'd0;
+        issue_p     <= 1'b0;
+        mode_switch <= 1'b0;
+        dsi_fresh   <= 1'b0;
+    end else begin
+        issue_p     <= 1'b0;             // both outputs are one-cycle pulses
+        mode_switch <= 1'b0;
+
+        // Freshness of the DSI scalars, shape copied from dvd/dpad_seek.sv.
+        if (nav_flush)       dsi_fresh <= 1'b0;
+        else if (dsi_commit) dsi_fresh <= 1'b1;
+
+        if (start_streaming) begin
+            // A mount supersedes: it fires its own trio AND the decoder soft reset, and
+            // tgt_rbn would belong to the PREVIOUS disc. Cancel silently — emitting the
+            // fallback here would add a second flush on top of the mount's.
+            state <= S_IDLE;
+            tmr   <= 24'd0;
+        end else begin
+            case (state)
+            S_IDLE:
+                // Note only S_IDLE looks at mode_edge: further edges during an arm are
+                // ABSORBED. See the coalescing note in the header.
+                if (mode_edge) begin
+                    if (possible) begin
+                        state <= S_ARM;
+                        tmr   <= WDOG;
+                    end else
+                        mode_switch <= 1'b1;         // fallback: today's in-place trio
+                end
+
+            S_ARM:
+                if (ack_done)             state <= S_IDLE;   // something else already did it
+                else if (scrub_pulse)     state <= S_ACK;    // the user's seek is a superset
+                else if (can_issue) begin
+                    tgt_rbn <= base;                         // latched ONCE
+                    issue_p <= 1'b1;
+                    tmr     <= WDOG;
+                    state   <= S_ACK;
+                end else if (~hold_freeze) begin
+                    // A held scrub is not a timeout: its release issues a seek that
+                    // satisfies this arm, so freeze the budget instead of spending it.
+                    if (tmr == 24'd0) begin
+                        mode_switch <= 1'b1;
+                        state       <= S_IDLE;
+                    end else
+                        tmr <= tmr - 24'd1;
+                end
+
+            S_ACK:
+                if (ack_done)             state <= S_IDLE;
+                else if (tmr == 24'd0) begin
+                    mode_switch <= 1'b1;                     // the seek never landed
+                    state       <= S_IDLE;
+                end else
+                    tmr <= tmr - 24'd1;
+
+            default: state <= S_IDLE;
+            endcase
+        end
+    end
+end
+
+// The scrub ALWAYS wins the mux, so even in a state the FSM does not allow the reader
+// latches the user's target rather than ours; the resulting seek_ack then completes the
+// arm. There is no cycle in which the reader can see a pulse with the wrong target.
+assign seek_rbn_pulse = scrub_pulse | issue_p;
+assign seek_rbn       = scrub_pulse ? scrub_rbn : tgt_rbn;
+assign realign_pend   = (state != S_IDLE);
+
+endmodule
+
+`default_nettype wire

--- a/dvd/mode_realign.sv
+++ b/dvd/mode_realign.sv
@@ -50,6 +50,52 @@
  * trio it needs. Such an ack leaves the arm open; the watchdog then fires the fallback,
  * which is right — by then we are in a menu, where a re-align is not possible anyway.
  *
+ * ★ THE SWITCH BLANK (2026-09-03, user request after the issue #42 HW round). Fixing the
+ * freeze left the ~1 s transient visible, and it is ugly: switching TO Interlaced shows a
+ * full-screen rolling image flashing between black frames (the display losing vertical
+ * lock across the raster change), and switching TO Progressive squishes the picture into
+ * the top half (field-height content in a frame-height DE window). Both are inherent to
+ * changing the raster under in-flight content, so the fix is cosmetic: hold the picture
+ * BLACK until the first frame of the new mode is actually on screen.
+ *
+ * ★ The window needs no new measurement — `video_live` already IS that signal. The
+ * re-align's own load_flush re-arms it (via pickup_hold in resample_addrgen), so it goes
+ * LOW at the flush and HIGH again when the governor picks up the first frame for display.
+ * So: blank on the edge, and clear on the first `video_live` HIGH *after* observing it go
+ * LOW. Requiring the drop first is what makes it robust — at the edge itself video_live is
+ * still high from the OLD content (the flush lands a few ms later), so a naive "clear when
+ * video_live" would clear immediately and blank nothing.
+ *
+ * ⚠ BLANK_MAX is not a nicety, it is load-bearing twice over. (1) In the MENU domain
+ * `video_live` never drops — emu forces the STD mux-lead hold off while `menu_active`
+ * (menus aren't lip-synced), so pickup_hold never rises and nothing re-arms video_live.
+ * The timeout is the ONLY exit there. (2) It bounds the cosmetic fix so it can only ever
+ * hide a TRANSIENT: if the roll or the squish ever outlived the window, the artifact must
+ * come back into view rather than be masked forever.
+ *
+ * ⚠ blank_en (emu wires it to `media_seen`) keeps the blank off until the user has mounted
+ * something. Without it the boot-time mode_edge — il_eff_q resets to 0, so an
+ * Interlaced/Auto-analog rig pulses one at reset release — would black out the idle
+ * screen for the whole timeout, and "nothing on screen after the core loads" is exactly
+ * what the launch-feedback work exists to prevent (docs/idle_screen.md).
+ *
+ * ⛔ "REPEAT THE LAST GOOD FRAME" WAS THE OTHER CANDIDATE AND IS WEAKER, despite the
+ * machinery already existing (the governor's persistence re-scan, repeat_frame=31, as used
+ * by pause and hold_freeze). Three reasons: the Interlaced symptom is a ROLL, i.e. the
+ * display has lost lock, so a held frame rolls too — a rolling still is no better than a
+ * rolling picture, whereas rolling BLACK is invisible; the re-scan goes back through the
+ * same mode-dependent scan path that produces the Progressive squish, and the held image
+ * was built for the OLD mode, so it is not obviously immune to the artifact it is meant to
+ * hide; and it needs the coordinated hold set (watchdog suppression et al.), where
+ * freezing video without audio for ~1 s diverges the timelines the flush just re-anchored.
+ * Blanking acts at the PIN, after every mode-dependent path, so it is immune by
+ * construction. See docs/single_raster_analog.md §7.
+ *
+ * ⚠ emu blanks RGB ONLY, never sync. That is the re_interlace S_HUNT defect
+ * (docs/single_raster_analog.md §3.2): it emitted no sync at all while hunting, costing
+ * 33-67 ms of dead CRT sync per event. Killing sync across a raster change lengthens the
+ * lock-up instead of hiding it.
+ *
  * NOTE ON THE DEFERRAL WINDOW. il_eff is combinational off the OSD bits, so the raster
  * (and VGA_F1, CE_PIXEL, the pixrep overlay inverses) still changes the instant the user
  * commits, exactly as before — only the FLUSH moves, to the moment it can land on a GOP
@@ -63,7 +109,8 @@
 `default_nettype none
 
 module mode_realign #(
-    parameter [23:0] WDOG = 24'd13_500_000       // ~0.5 s @ 27 MHz clk_sys
+    parameter [23:0] WDOG      = 24'd13_500_000, // ~0.5 s @ 27 MHz clk_sys
+    parameter [25:0] BLANK_MAX = 26'd40_500_000  // ~1.5 s: the blank's hard ceiling
 ) (
     input  wire        clk,              // clk_sys (27 MHz)
     input  wire        rst_n,            // core reset_n — NOT pipe_rst_n: the arm has to
@@ -91,6 +138,11 @@ module mode_realign #(
     input  wire        keep_vbuf,        // valid on the ack: 1 = menu hop, load_flush only
     input  wire        start_streaming,  // a new file was mounted => cancel
 
+    // ---- switch blank ----------------------------------------------------------------
+    input  wire        video_live,       // "the display is showing a decoded frame"
+                                         // (re-armed by our own flush, see the header)
+    input  wire        blank_en,         // media_seen: never blank the boot idle screen
+
     // ---- the other producer of the reader's single RBN-seek port ---------------------
     input  wire        scrub_pulse,      // dvd/scrub_ctrl.sv seek_rbn_pulse
     input  wire [31:0] scrub_rbn,        // dvd/scrub_ctrl.sv seek_rbn
@@ -99,7 +151,8 @@ module mode_realign #(
     output wire        seek_rbn_pulse,   // -> dvd_iso_reader (the arbitrated port)
     output wire [31:0] seek_rbn,
     output reg         mode_switch,      // -> flush_ctl: THE IN-PLACE FALLBACK ONLY
-    output wire        realign_pend      // level: an arm is open (debug readout / gating)
+    output wire        realign_pend,     // level: an arm is open (debug readout / gating)
+    output wire        sw_blank          // level: hold the picture black (RGB only!)
 );
 
 localparam [1:0] S_IDLE = 2'd0,   // nothing pending
@@ -192,6 +245,44 @@ always @(posedge clk) begin
         end
     end
 end
+
+// ---------------------------------------------------------------------------------
+// SWITCH BLANK. Deliberately a SEPARATE state machine from the seek arm above: it must
+// cover the raster change, which happens at the OSD edit whichever path the seek takes
+// (re-align or in-place fallback), and it outlives the arm by ~an order of magnitude (the
+// seek lands in ms; the decoder re-locks in ~a second).
+reg         blank_r;
+reg  [25:0] blank_tmr;
+reg         vl_dropped;      // video_live has gone LOW since the blank started
+
+always @(posedge clk) begin
+    if (~rst_n) begin
+        blank_r    <= 1'b0;
+        blank_tmr  <= 26'd0;
+        vl_dropped <= 1'b0;
+    end else if (start_streaming) begin
+        // A mount cuts to black and cold-starts on its own (flush trio + the decoder soft
+        // reset), so it needs no help from here — and holding a blank across it would just
+        // delay the new disc's first frame.
+        blank_r    <= 1'b0;
+        blank_tmr  <= 26'd0;
+        vl_dropped <= 1'b0;
+    end else if (mode_edge && blank_en) begin
+        // Re-triggers if another edge arrives mid-blank: the raster changed again, so the
+        // window restarts. (The SEEK arm coalesces; the blank must not, or a second toggle
+        // would uncover the transient it caused.)
+        blank_r    <= 1'b1;
+        blank_tmr  <= BLANK_MAX;
+        vl_dropped <= 1'b0;
+    end else if (blank_r) begin
+        if (~video_live)              vl_dropped <= 1'b1;
+        if (vl_dropped && video_live) blank_r    <= 1'b0;   // first new-mode frame on screen
+        else if (blank_tmr == 26'd0)  blank_r    <= 1'b0;   // menu path + the safety ceiling
+        else                          blank_tmr  <= blank_tmr - 26'd1;
+    end
+end
+
+assign sw_blank = blank_r;
 
 // The scrub ALWAYS wins the mux, so even in a state the FSM does not allow the reader
 // latches the user's target rather than ours; the resulting seek_ack then completes the

--- a/dvd/pal_detect.sv
+++ b/dvd/pal_detect.sv
@@ -1,0 +1,122 @@
+/*
+ * pal_detect.sv — the PAL/NTSC verdict, hardened against garbage sequence headers
+ *
+ * DVD-FORK (2026-09-03, issue #42 leg 2). Extracted from dvd/emu.sv so the rule is
+ * testbenchable (bench/dvd/pal_detect_tb.sv). It decides ONE bit — "the content is
+ * 50 Hz" — from the decoder's parsed frame height, and that bit is load-bearing far
+ * out of proportion to its size:
+ *
+ *   pal_eff -> the runtime modeline walk (emu.sv): a change RESTARTS THE RASTER, and
+ *              unlike an il_eff change it carries NO pipeline flush
+ *           -> av_sync .refresh_50hz: the STC tick rate
+ *           -> film_det = pal_eff ? det_pal : det_ntsc -> film_want -> filmp_eff,
+ *              which kicks the SAME walk again
+ *           -> the reader's disp_fps, the letterbox geometry, cc_vbi, the SPU pal_mode
+ *
+ * So a wrong verdict is not a cosmetic error: it re-fires the raster while the pipeline
+ * is draining, and through film_det it can re-fire it AGAIN. That is the self-feeding
+ * corruption loop the reverted film-switch attempt died of (docs/film_24p_plan.md §13),
+ * and issue #42's freeze is reached through the same amplifier.
+ *
+ * ★ WHY THE OLD RULE WAS NOT ENOUGH. It was two lines:
+ *
+ *     if (!reset_n)                 pal_detect_dec <= 1'b0;
+ *     else if (vertical_size != 0)  pal_detect_dec <= (vertical_size > 480) || (== 288);
+ *
+ * The `!= 0` guard was added 2026-09-03 for a real bug — vertical_size is a VLD register
+ * on sync_rst, so every watchdog expiry and mount soft reset zeroed it and a PAL disc
+ * read "NTSC" for the gap until the next header. But it only masks ZERO. Any NON-ZERO
+ * garbage height — the 186-wide resolution popups a mid-VOBU flush produces — flipped the
+ * verdict on the spot, from one header, with no way back until the next one.
+ *
+ * ★ THE TWO TERMS THIS ADDS.
+ *
+ * (1) A PLAUSIBILITY BOUND. Outside 64..1152 lines is not a verdict, it is a parse error:
+ *     hold, exactly as zero does. A BOUND and deliberately not a whitelist of
+ *     {240,288,480,576} — the core also plays flat .mpg files, and a whitelist would hold
+ *     the verdict on any unusual-but-real height. 1080 is not a multiple of 16, so do NOT
+ *     "tighten" this with a multiple-of-16 test either.
+ *
+ * (2) A SUSTAINED DISAGREEMENT IS REQUIRED TO *CHANGE* AN ESTABLISHED VERDICT. The first
+ *     plausible header after a mount latches IMMEDIATELY — PAL detection must not be
+ *     delayed at load, or every PAL disc pays a spurious NTSC->PAL walk. After that, a
+ *     disagreeing height must still be the parsed height HOLD_CYC cycles later.
+ *
+ * ⚠ WHY A TIMER AND NOT "N CONSECUTIVE HEADERS" (the design that was tried first and is
+ * WRONG). vertical_size is a REGISTER, not an event: a real disc re-parses a sequence
+ * header every GOP but writes the SAME value, so the register does not change and there
+ * is no observable header event to count. A transition-counting rule can therefore never
+ * reach N for a genuine change — the verdict would freeze forever. Counting time against
+ * the value that is actually in force has neither problem, and it is the right shape
+ * anyway: garbage is TRANSIENT (the next real header overwrites it within a GOP), a real
+ * standard is PERSISTENT. Any change of the parsed height abandons the candidate, so a
+ * burst of DIFFERENT garbage values never accumulates.
+ *
+ * Cost: HOLD_CYC must exceed one GOP comfortably. ~0.5 s at clk_dec (81 MHz) is ~15 GOPs.
+ * A genuine mid-stream standard change is only reachable across a title/VTS jump, which
+ * brings its own flush, so half a second of the old raster there is not a regression.
+ */
+
+`default_nettype none
+
+module pal_detect #(
+    parameter [26:0] HOLD_CYC = 27'd40_500_000   // ~0.5 s @ 81 MHz clk_dec
+) (
+    input  wire        clk,          // clk_dec (the domain vsize is parsed in)
+    input  wire        rst_n,        // core reset_n, async active-low
+    input  wire        mount_arm,    // a new file was mounted: the standard may
+                                     // legitimately differ -> re-arm the immediate latch
+                                     // (2-FF synced mount_flush; MOUNT only, never
+                                     //  load_flush -- that also fires on a mode switch,
+                                     //  i.e. exactly when the parse is least trustworthy)
+    input  wire [13:0] vsize,        // decoder vertical_size_out (0 = no header in force)
+
+    output reg         pal           // the held verdict: 1 = 50 Hz content
+);
+
+// A plausible parsed height, and what it would mean.
+// MPEG-1 PAL SIF is 352x288 (288 = half of 576), which a bare ">480" test misses; MPEG-1
+// NTSC SIF is 240, neither >480 nor 288, so it correctly stays NTSC.
+wire vs_plaus = (vsize >= 14'd64) && (vsize <= 14'd1152);
+wire vs_pal   = (vsize > 14'd480) || (vsize == 14'd288);
+
+reg         pal_init;        // a verdict has been established for this file
+reg  [13:0] cand;            // the disagreeing height being timed
+reg  [26:0] tmr;             // 0 = no candidate armed; else cycles it has held
+
+always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+        pal      <= 1'b0;
+        pal_init <= 1'b0;
+        cand     <= 14'd0;
+        tmr      <= 27'd0;
+    end else if (mount_arm) begin
+        // Re-arm only. `pal` deliberately KEEPS the previous verdict until the new file's
+        // first header: the mount soft reset zeroes vsize, and blanking the verdict here
+        // would read "NTSC" across that gap and fire the very walk this module exists to
+        // prevent. Same reasoning as the `!= 0` hold it replaces.
+        pal_init <= 1'b0;
+        tmr      <= 27'd0;
+    end else if (!pal_init) begin
+        if (vs_plaus) begin
+            pal      <= vs_pal;      // first verdict of the file: latch at once
+            pal_init <= 1'b1;
+            tmr      <= 27'd0;
+        end
+    end else begin
+        if (!vs_plaus || (vs_pal == pal))
+            tmr  <= 27'd0;                                   // no header / already agrees
+        else if ((tmr == 27'd0) || (vsize != cand)) begin
+            cand <= vsize;                                   // arm (or re-arm on a change)
+            tmr  <= 27'd1;
+        end else if (tmr >= HOLD_CYC) begin
+            pal  <= vs_pal;                                  // held long enough: believe it
+            tmr  <= 27'd0;
+        end else
+            tmr  <= tmr + 27'd1;
+    end
+end
+
+endmodule
+
+`default_nettype wire

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -160,6 +160,21 @@ never show this; it depends on the set.
     please [report it](reporting-a-bug.md). See
     [Field alignment](../video/interlaced.md#field-alignment).
 
+### The picture blocks up briefly right after a chapter skip or seek
+
+Known and being tracked
+([issue #45](https://github.com/owenb321/MiSTer_DVD/issues/45)). For roughly six frames —
+about a tenth of a second — the new scene decodes and moves correctly but the old one
+shows through it as a blocky residual, then it clears on its own.
+
+It happens on every disc and on every way of jumping: chapter skip, Fast Fwd / Rewind,
+D-Pad Seek, and entering or leaving a menu. It is a decoder artifact, not a disc or a
+setting, so there is nothing to change and nothing to report unless it lasts appreciably
+longer than that or the picture does not recover.
+
+Changing `Video Output` mid-title produces the same brief glitch on the way back in, for
+the same reason — see [Switching mid-title](../video/interlaced.md).
+
 ### A film disc keeps changing resolution, or judders
 
 Set **`Film 24p Out` = `On`**. The disc is probably **hard-telecined**, meaning the pulldown

--- a/site/content/video/interlaced.md
+++ b/site/content/video/interlaced.md
@@ -76,7 +76,8 @@ everything.
     The screen also **goes black for the changeover** instead of showing the picture
     breaking up while the display re-locks — about a second, and the OSD stays visible
     over it. Sound continues throughout. A brief glitch as the picture comes back is
-    normal, and is the same one a chapter skip produces. If the black lasts noticeably
+    normal, and is the same one a chapter skip produces — see
+    [Troubleshooting](../reference/troubleshooting.md). If the black lasts noticeably
     longer than a second or so, or a mid-title switch still freezes,
     [please report it](../reference/reporting-a-bug.md).
 

--- a/site/content/video/interlaced.md
+++ b/site/content/video/interlaced.md
@@ -71,9 +71,13 @@ everything.
     The current development build fixes that freeze. A mid-title switch now steps playback
     back to the start of the chunk it was reading — up to about a second — and resumes
     from there, so the picture always restarts from a clean point. On a VCD or SVCD the
-    step back can be a little longer. Not yet confirmed on hardware, so if a mid-title
-    switch still freezes on a current build, please
-    [report it](../reference/reporting-a-bug.md).
+    step back can be a little longer.
+
+    The screen also **goes black for the changeover** instead of showing the picture
+    breaking up while the display re-locks — about a second, and the OSD stays visible
+    over it. Sound continues throughout. If the black lasts noticeably longer than that,
+    or a mid-title switch still freezes,
+    [please report it](../reference/reporting-a-bug.md).
 
 ## Field alignment
 

--- a/site/content/video/interlaced.md
+++ b/site/content/video/interlaced.md
@@ -57,16 +57,23 @@ player fed a TV — so a CRT-only setup can simply stay in Interlaced (or Auto) 
 everything.
 
 !!! note "Switching mid-title works, with a brief interruption"
-    Changing `Video Output` during playback fires a full seek-equivalent flush — a short
-    cut to black while the raster and A/V sync re-anchor, like a chapter jump — and then
-    plays on cleanly. Setting the mode before loading just avoids the interruption; it is
-    not required. `Auto` reads the ini bits at boot and while nothing is mounted; it does
-    not change the output mode under a playing disc.
+    Changing `Video Output` during playback interrupts playback briefly — a short cut to
+    black while the raster and A/V sync re-anchor, like a chapter jump — and then plays on
+    cleanly. Setting the mode before loading just avoids the interruption; it is not
+    required. `Auto` reads the ini bits at boot and while nothing is mounted; it does not
+    change the output mode under a playing disc.
 
-    **On a PAL disc this can occasionally freeze the picture** on a malformed frame. It
-    does not recover on its own; **skip a chapter** and playback resumes normally. The
-    same happens on older releases when changing `Analog Out`, so it is not new — it is
-    being tracked. Setting the mode before loading avoids it entirely.
+    On v0.4.0 and earlier this could occasionally **freeze the picture** on a malformed
+    frame instead, on any disc; skipping a chapter recovered it. The same thing happens on
+    older releases when changing `Analog Out`.
+
+!!! info "Unreleased"
+    The current development build fixes that freeze. A mid-title switch now steps playback
+    back to the start of the chunk it was reading — up to about a second — and resumes
+    from there, so the picture always restarts from a clean point. On a VCD or SVCD the
+    step back can be a little longer. Not yet confirmed on hardware, so if a mid-title
+    switch still freezes on a current build, please
+    [report it](../reference/reporting-a-bug.md).
 
 ## Field alignment
 

--- a/site/content/video/interlaced.md
+++ b/site/content/video/interlaced.md
@@ -75,8 +75,9 @@ everything.
 
     The screen also **goes black for the changeover** instead of showing the picture
     breaking up while the display re-locks — about a second, and the OSD stays visible
-    over it. Sound continues throughout. If the black lasts noticeably longer than that,
-    or a mid-title switch still freezes,
+    over it. Sound continues throughout. A brief glitch as the picture comes back is
+    normal, and is the same one a chapter skip produces. If the black lasts noticeably
+    longer than a second or so, or a mid-title switch still freezes,
     [please report it](../reference/reporting-a-bug.md).
 
 ## Field alignment


### PR DESCRIPTION
Fixes #42.

With a disc playing, changing `Video Output` mid-title could freeze the decoder on a
malformed frame with no self-recovery. A chapter seek cleared it. Pre-existing — v0.3.0
does the same on an `Analog Out` change.

## The cause was already written down

`emu.sv`'s `il_switch` block explained it and dismissed it:

> The full flush is exactly what a chapter seek does (HW-confirmed synced); the only
> difference is the reader doesn't jump, so ps_demux re-hunts to the next pack boundary
> within the vbuf re-lock glitch.

That difference **is** the defect. The trio fired but nothing moved the reader, so the
decoder resumed **mid-VOBU with no GOP boundary to re-lock on** — and the reason a chapter
seek cured it is that a seek is the same trio **plus a reader jump**. The workaround was
naming the missing ingredient the whole time.

## "PAL-only" was a wrong constraint, and it shaped the first diagnosis

The report, `CLAUDE.md`, `docs/single_raster_analog.md` and the manual all recorded "NTSC
is unaffected", which pointed straight at the PAL-only `pal_eff` feedback path. It
reproduces on NTSC. The cause is the standard-neutral mid-VOBU resume; `pal_eff` is one of
**two** garbage-header amplifiers and the other (`filmp_eff` via `film_det`) flips on
either standard. All four places corrected, with the correction itself recorded — a symptom
reported as specific to one configuration is a hypothesis, not a measurement.

## What ships

**Leg 1 — `dvd/mode_realign.sv`.** `il_switch` becomes a seek to the playhead's own VOBU;
`seek_ack` drives the trio, making a mode switch byte-identical to a chapter jump.
`flush_ctl.mode_switch` survives as the fallback (menus, raw `.m2v`, a still, no
trustworthy playhead, or an unacknowledged seek), so a mode change can never silently lose
its flush. `flush_ctl.sv` is unchanged.

- The target is the **current** VOBU because `dsi_nv_pck_lbn` already *is* a NAV pack — the
  snap probe hits candidate #1. `iso_reader_seek_tb` TEST9 measures the walk at one read
  per sector over three points (3 / 4 / 8), so the cost model is proven, not claimed.
- **Edges coalesce.** `il_eff` is a level, so N toggles need ONE re-align — that makes the
  repeated-mid-parse-flush loop class structurally unreachable, and is why a future
  `filmp_eff` edge belongs here and never straight in `flush_ctl`.
- `tgt_rbn` is latched **once** and gated on `dsi_fresh`: `nav_dsi` is on `pipe_rst_n`, so
  the re-align's own flush zeroes the playhead and the clamp would jump to the title start
  (the `dpad_seek` stale-table trap).

**Leg 2 — `dvd/pal_detect.sv`.** A verdict change restarts the raster with **no flush**
(the walk keys on `il_eff | pal_eff | filmp_eff`; only `il_eff` carries the trio) and feeds
back through `film_det`. Now a plausibility bound plus a sustained-disagreement requirement
to change an established verdict; the first header after a mount still latches immediately.
⚠ The confirmation is a **timer, not a count of headers** — `vertical_size` is a register,
so a real disc re-parses a header every GOP writing the *same* value, and a
transition-counting rule would freeze the verdict forever. That design was written and
discarded before it shipped.

**Follow-up — the switch blank.** Fixing the freeze left the transient visible (rolling
image to Interlaced, top-half squish to Progressive). `mode_realign` now holds the picture
black from the edge until the first frame of the new mode is on screen. The window needed
no new signal: `video_live` already is it. ⚠ The rule is "clear on the first HIGH *after* a
LOW" — at the edge `video_live` is still high from the old content, so the naive version
blanks nothing. RGB only, never sync. The MiSTer OSD is composited downstream, so the menu
stays visible over the black.

## Test plan

- [x] `bench/dvd/run_mode_realign.sh` green; `--red` reproduces every pre-fix arm
- [x] `mode_realign_chain_tb` over the **real reader**: the bytes after the flush are
      `b0 b0 b0 b0` pre-fix (mid-sector payload) and `00 00 01 BA / BB / BF` fixed
- [x] `mode_realign_tb` 17 scenarios; 15 checks fail on `+realign=0` while both
      "no re-align possible" controls pass in **both** arms
- [x] `pal_detect_tb` counts verdict **edges**, not end states — the pre-fix rule
      self-heals, so an end-state check passed the churn scenarios (RED: 12 walk kicks)
- [x] Blank scenarios **mutation-checked** — five targeted RTL mutations each caught by
      the scenario written for it
- [x] Regressions: `flush_ctl_tb`, `scrub_ctrl_tb`, `iso_reader_seek_tb`,
      `run_dpad_seek.sh`, `run_modeline_boot.sh`, `run_field_parity.sh` (both phases)
- [x] `tools/docs_check.py` + `mkdocs build --strict`
- [x] Fit: SEED 5 first roll both times, clk_dec 93.17 @100C / 91.27 @-40C (gate 86.0),
      88% ALM
- [x] **HW-CONFIRMED** — freeze gone; switch blank confirmed on the follow-up build

## Known residual

~6 frames of macroblocking after **any** seek, on every disc — the new scene decodes and
moves while the old one bleeds through. Root-caused while filing it:
`motcomp_picbuf`'s `prev_i_p_frame_valid` is cleared only by `~rst` or a sequence end,
never by a flush, so reference slots survive a seek still holding the old scene and still
flagged valid. Tracked separately as #45; it is a transport item, not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
