### PR TITLE
Re-align the decoder's references after a seek (#45)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,17 +366,8 @@ worse maintenance burden than targeted in-place edits. So:
   jump**; once it is, it cannot carry a class of artifact a chapter seek does not. So a
   symptom that matches a chapter skip is the goal being MET, and it relocates the remaining
   work. ⚠ Do NOT re-chase it under issue #42.
-  Likely mechanism, for whoever picks it up: the trio discards BUFFERED data but leaves the
-  decode pipeline (`vld`/`getbits`/`motcomp`/`picbuf` are on `sync_rst`; `mount_flush` is
-  MOUNT-ONLY, *"NEVER on seeks/jumps/mode switches"*), so across any seek the in-flight
-  picture completes on the new stream's first start code (one truncated frame) and the old
-  references stay valid for an open-GOP VOBU's first B-frames. ★ **The blank changes the
-  argument for this path only:** the stated reason not to soft-reset on a seek is *display
-  continuity*, and during a blanked mode switch there is none to protect — so adding the
-  mode-switch/re-align acks to `mount_flush` is now arguable. ⚠ It would gate the modeline
-  walk via `dec_ready`/`sync_rst` (§3.2's boot race — the regfile survives on `hard_rst`,
-  but TB it in `modeline_boot_tb` first), and it would leave chapter skips untouched, i.e.
-  fix one path and leave the class open. Detail: `docs/single_raster_analog.md` §6.8. Fixes: a mid-title `Video Output` change
+  ✅ **ISSUE #45 IS NOW FIXED — see the POST-SEEK REFERENCE RE-ALIGN bullet below**
+  (`docs/seek_realign.md`); the mechanism guessed here was confirmed exactly. Fixes: a mid-title `Video Output` change
   could freeze the decoder on a malformed frame with no self-recovery; a chapter seek
   cleared it. Pre-existing (v0.3.0 does it on `Analog Out`).
   ★★ **THE FIX WAS WRITTEN IN THE EXISTING COMMENT AND HAD BEEN READ AS HARMLESS FOR
@@ -443,6 +434,69 @@ worse maintenance burden than targeted in-place edits. So:
   freezes, the remaining suspect is the raster restart** and the next step is to gate
   `il_out` on `~realign_pend` — one behavioural delta per round
   (`docs/single_raster_analog.md` §3.9). Detail: `docs/single_raster_analog.md` §6.
+- 🔧 **POST-SEEK REFERENCE RE-ALIGN (2026-09-03, issue #45, branch
+  `fix/seek-reference-realign`) — sim-proven RED/GREEN, ⏳ HW-confirm pending.**
+  Every seek (chapter skip, scrub release, D-Pad Seek, menu → Play) showed **~6 frames
+  (~100 ms)** of macroblocking. ★ **The detail that identified it was in the report:**
+  *"the target chapter is decoding and in motion during this macroblocking, but it has the
+  residual image overlayed"* — new content building correctly AND MOVING exonerates the
+  reader, the demux and the landing point; only the PREDICTION is wrong. A corrupt picture
+  would be one still-wrong frame, not a burst with coherent new motion.
+  **Root cause:** `flush_vbuf_eff` reaches exactly three sinks (`vbuf_rst`,
+  `frame_drop_ctl.flush`, `framestore.vb_flush`) and the decode pipeline is on `sync_rst`,
+  so `motcomp_picbuf`'s reference slots survive a seek holding the PRE-SEEK scene — and
+  those slots carry **no valid bit at all** (`forward/backward_reference_frame` are pure
+  pointers `motcomp_addrgen` reads unconditionally), so stale CONTENT is invisible to the
+  decoder by construction.
+  ★ **TWO anchors, not one, and the rotation is why:** picbuf assigns
+  `current_frame <= forward_reference_frame` while fwd/bwd swap, so the first post-flush I
+  only establishes the BACKWARD reference — forward still points at the old scene, which is
+  exactly what an open GOP's leading B's read; only the SECOND anchor overwrites that slot.
+  Two coded pictures × 3:2 ≈ the reported 6 display frames.
+  **Fix = `rtl/mpeg2/vld.v`** (one new input, `vbuf_flush` from `flush_vbuf_eff` — already
+  clk_dec, no new CDC): drop every non-I picture until the first I, then B's until the
+  second anchor, through the EXISTING governor suppression legs, so picbuf never sees them
+  and the display **actually holds** the last frame — which is what `flush_ctl.sv` always
+  claimed a seek did.
+  ★ **THE ARM MUST SIT BEFORE THE `clk_en` TERM.** `vld.clk_en` is `vld_en`, and
+  `motcomp.v:257-272` freezes the VLD at EVERY picture header until picbuf's display
+  handshake — **up to a whole display frame (~1.5 M clk_dec cycles)** — while the flush
+  level is ~192 clk_dec cycles. A `clk_en`-gated capture would miss it ROUTINELY, not
+  occasionally. Level-dominant for the window also coalesces repeated flushes for free.
+  ★ **Anchors are counted off the SAME node picbuf rotates on** (`hdr_upd_slot`, factored
+  out of `update_picture_buffers`): "count an anchor exactly when picbuf rotates" is then
+  true by construction, a field-coded I frame (two I field pictures) counts ONCE, and it
+  adds no new fan-out on `picture_structure` — the register physical synthesis mangled in
+  the Thayer `drops=0` round. No sibling pair-arm is needed: the predicate is identical at
+  both field headers, so pair atomicity is structural.
+  ★ **The ledger split is not hygiene:** `drop_this_picture` latches either reason but a new
+  `drop_gov_picture` feeds `drop_pic_ack`, else 2–3 unrequested credits per seek drive
+  `frame_drop_ctl` to `DEBT_FLOOR = -4` and the governor needs 6 lates before it may drop
+  again — during the post-seek re-lock, when it is most likely to be late.
+  ⛔ **`closed_gop` is REJECTED, not overlooked** (parsed at `vld.v:1477`, consumed by
+  nothing): it is a bit the ENCODER wrote, not a measurement — the `progressive_frame`
+  failure class again; a disc that lies would leave the defect present AND unfalsifiable.
+  ⛔ **The picbuf `prev_i_p_frame_valid` clear (issue #45's own "fix direction 1") is
+  INSUFFICIENT and was not done:** it suppresses the display of one stale anchor and does
+  nothing to `forward_reference_frame`. ★★ **And the durable rule it earned: anything that
+  must correct an `update_picture_buffers` decision either RIDES the mvec FIFO or is decided
+  in the vld — it cannot bypass the FIFO and arrive on time.** A direct wire can be re-set
+  by a queued PRE-flush anchor's update, and no bounded level defeats that (the queue can
+  take a whole field to drain because picbuf blocks on the display handshake).
+  ⚠ **Known residual, WRITTEN DOWN BEFORE THE BUILD:** the picture in flight at the flush
+  is truncated, owns a slot, and is displayed once — now held ~4 picture times instead of
+  ~1. Net trade: ~6 frames of macroblocked MOTION → ~1 torn frame held longer. **The HW
+  question is binary: is the old scene still visible IN MOTION as residual?**
+  **Gate: `bench/dvd/run_seek_realign.sh`** — real `vld` + `getbits` + `motcomp_picbuf` over
+  TWO cuts of a real title with a real reader jump at the flush, measuring **slot
+  provenance** (a shadow tag per picbuf slot; a post-flush picture predicting from a
+  pre-flush-tagged slot is a violation). Names no signal in the fix, so it cannot become a
+  golden model that agrees with its RTL. RED (`-Pseek_realign_tb.SEEK_REALIGN=0`) measures
+  `viol == meta[3]` = the fixture's leading-B count and reproduces a pristine-RTL run byte
+  for byte; GREEN is `viol == 0` AND `realign_drops == meta[3]` — asserted EXACTLY, because
+  dropping too much costs display frames at every seek. `tools/seek_fixture.py` REFUSES a
+  cut whose landing GOP is closed or has no leading B's (that fixture would make RED
+  measure zero and the gate vacuous). Detail: **`docs/seek_realign.md`**.
 - ✅ **FIELD-PARITY CORRECTOR REPAIRED AND RE-ENABLED (2026-09-03, issue #41, branch
   `fix/field-parity-corrector`) — sim-proven RED/GREEN and ✅ HW-CONFIRMED: round 1 gave
   the CRT ("always gets the fields right on the TV" where PR #40 was a coin flip) and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,7 +496,13 @@ worse maintenance burden than targeted in-place edits. So:
   for byte; GREEN is `viol == 0` AND `realign_drops == meta[3]` — asserted EXACTLY, because
   dropping too much costs display frames at every seek. `tools/seek_fixture.py` REFUSES a
   cut whose landing GOP is closed or has no leading B's (that fixture would make RED
-  measure zero and the gate vacuous). Detail: **`docs/seek_realign.md`**.
+  measure zero and the gate vacuous). Arms include a **menu still** landing
+  (`hp_still_i.hex` as cut B): a still is `SEQ GOP PIC:I SEQ_END`, ONE I and no B's, so a
+  rule that dropped an I would mean the menu never appears — measured `realign_drops=0`.
+  ★ **Scope note: menu→menu hops are structurally untouched** — `flush_ctl` gates
+  `seek_flush` on `~keep_vbuf`, so the Phase-5 rule is inherited for free and only menu
+  ENTRY/EXIT (which were always two of issue #45's four paths) re-align.
+  Detail: **`docs/seek_realign.md`**.
 - ✅ **FIELD-PARITY CORRECTOR REPAIRED AND RE-ENABLED (2026-09-03, issue #41, branch
   `fix/field-parity-corrector`) — sim-proven RED/GREEN and ✅ HW-CONFIRMED: round 1 gave
   the CRT ("always gets the fields right on the TV" where PR #40 was a coin flip) and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,6 +358,15 @@ worse maintenance burden than targeted in-place edits. So:
   still is not. Gate: `mode_realign_tb` [12]–[17], **mutation-checked** (5 targeted RTL
   mutations, each caught by its own scenario — these are cheap level assertions, exactly
   the shape that passes without proving anything).
+  ⚠ **STILL OPEN on this path, and it is NEITHER of the two fixed bugs: A/V SYNC after a
+  `Video Output` change.** User report 2026-09-03 (on the seek-realign build): *"Many video
+  output changes can cause sync issues, but that is existing behavior and is cleared by a
+  chapter skip."* Not the freeze (fixed, §6) and not the stale-reference macroblocking
+  (fixed, `docs/seek_realign.md`) — it is lip-sync drift cured by a RE-ANCHOR. ★ That cure
+  is the diagnosis: a chapter skip re-anchors the STC, so suspect `av_sync`'s refresh
+  accounting across a refresh-rate change (`TICKS_PER_REFRESH`/`refresh_50hz` are picked
+  from the mode), NOT the raster or the flush — the switch already fires the full trio plus
+  a re-align seek. Detail: `docs/single_raster_analog.md` §7.
   ★★ **THE RESIDUAL IS NOW A TRANSPORT ITEM (tracked as issue #45), NOT A MODE-SWITCH
   ONE, and the user's own
   report is what establishes that:** *"still some visible glitches but I think these are
@@ -434,8 +443,19 @@ worse maintenance burden than targeted in-place edits. So:
   freezes, the remaining suspect is the raster restart** and the next step is to gate
   `il_out` on `~realign_pend` — one behavioural delta per round
   (`docs/single_raster_analog.md` §3.9). Detail: `docs/single_raster_analog.md` §6.
-- 🔧 **POST-SEEK REFERENCE RE-ALIGN (2026-09-03, issue #45, branch
-  `fix/seek-reference-realign`) — sim-proven RED/GREEN, ⏳ HW-confirm pending.**
+- ✅ **POST-SEEK REFERENCE RE-ALIGN (2026-09-03, issue #45, branch
+  `fix/seek-reference-realign`) — sim-proven RED/GREEN and ✅ HW-CONFIRMED 2026-09-03**
+  (build `DVD_seekrealign_20260903_1901.rbf`, SEED 5 first roll, clk_dec 91.10/88.28).
+  ★★ **THE HW REPORT MATCHED THE WRITTEN PREDICTION TO THE FRAME:** *"the old scene is not
+  in motion, it's frozen and we jump to the target seek position with ~1 frame of a
+  misaligned image."* Three claims, each mapping onto a piece of the design — the leading
+  B's are no longer displayed (the reported defect, GONE); the display now genuinely HOLDS
+  the last frame (what `flush_ctl.sv` always claimed a seek did and did not); and the one
+  remaining bad frame is the truncated in-flight picture, predicted below and unchanged.
+  ★ **Writing the residual down BEFORE the build is what made the round cheap** — the
+  report read as a confirmation, not a surprise, and no time went into re-opening the
+  anchor accounting to explain a frame already accounted for. Same discipline as
+  `docs/single_raster_analog.md` §3.9, which cost five rounds to learn.
   Every seek (chapter skip, scrub release, D-Pad Seek, menu → Play) showed **~6 frames
   (~100 ms)** of macroblocking. ★ **The detail that identified it was in the report:**
   *"the target chapter is decoding and in motion during this macroblocking, but it has the
@@ -483,10 +503,15 @@ worse maintenance burden than targeted in-place edits. So:
   in the vld — it cannot bypass the FIFO and arrive on time.** A direct wire can be re-set
   by a queued PRE-flush anchor's update, and no bounded level defeats that (the queue can
   take a whole field to drain because picbuf blocks on the display handshake).
-  ⚠ **Known residual, WRITTEN DOWN BEFORE THE BUILD:** the picture in flight at the flush
-  is truncated, owns a slot, and is displayed once — now held ~4 picture times instead of
-  ~1. Net trade: ~6 frames of macroblocked MOTION → ~1 torn frame held longer. **The HW
-  question is binary: is the old scene still visible IN MOTION as residual?**
+  ⚠ **Residual, PREDICTED BEFORE THE BUILD AND CONFIRMED BY IT:** the picture in flight at
+  the flush is truncated, owns a slot, and is displayed once — held ~4 picture times
+  instead of ~1. Net trade: ~6 frames of macroblocked MOTION → **~1 misaligned frame**.
+  That is now the ONLY thing left of issue #45 and it is a different defect class (one
+  corrupt picture, not stale prediction). ★ The HW shape — freeze, then cut to the new
+  scene with one bad frame between — **weakens the v1 argument against blanking a seek**:
+  that argument was written when the alternative was six frames of visible garbage, and
+  blanking one frame of an already-hard cut costs almost no display continuity. See
+  `docs/seek_realign.md` §5.1.
   **Gate: `bench/dvd/run_seek_realign.sh`** — real `vld` + `getbits` + `motcomp_picbuf` over
   TWO cuts of a real title with a real reader jump at the flush, measuring **slot
   provenance** (a shadow tag per picbuf slot; a post-flush picture predicting from a

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -767,4 +767,17 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # ⚠ The added mux level sits in the ALREADY-REGISTERED output stage (reg -> pin), which is
 # why a blank on the pixel path costs nothing in clk_dec: that stage was retimed in
 # 2026-06-28 precisely to make it a short hop.
+# 2026-09-03f (fix/seek-reference-realign, issue #45 -- the post-seek reference re-align:
+# rtl/mpeg2/vld.v gains ra_active / ra_anchors[1:0] / ra_hdrs[5:0] / drop_gov_picture, ten
+# registers plus a handful of LUTs, and mpeg2video routes flush_vbuf_eff to the new vld
+# input): SEED 5 held FIRST roll -- clk_dec 91.10 @100C / 88.28 @-40C (gate 86.0, PASS both
+# corners) at 88% ALM (36,843, DOWN 184 from the switch-blank netlist's 37,027), RAM 494/553
+# and DSP 92/112 both unchanged. FIFTEENTH consecutive first-roll fit. Build
+# DVD_seekrealign_20260903_1901.rbf (4293 KB).
+# ⚠ The ALM count going DOWN while logic was ADDED is fit variance on a fresh netlist, not a
+# reclaim -- the same caution the 2026-09-03e entry records in the opposite direction, where
+# clk_dec improved on a build that only added logic. Do not read either as a logic delta.
+# The new logic sits entirely in the once-per-picture STATE_PICTURE_HEADER decision cone,
+# which has cycles of slack; the only pre-existing path it touches is update_picture_buffers,
+# where an inverted term replaced an inlined comparison of the same width.
 set_global_assignment -name SEED 5

--- a/bench/dvd/cc_extract_tb.sv
+++ b/bench/dvd/cc_extract_tb.sv
@@ -104,7 +104,8 @@ module cc_extract_tb;
     .dbg_drop_probe(),
     .flags_commit(),
     .cc_pair_valid(cc_pair_valid), .cc_pair(cc_pair), .cc_pair_field(cc_pair_field),
-    .mpeg1()
+    .mpeg1(),
+    .vbuf_flush(1'b0)   // DVD-FORK FIX (seek realign, issue #45): not exercised here
   );
 
   // ---- check every emitted pair against the golden stream, in order ----

--- a/bench/dvd/film_evidence_tb.sv
+++ b/bench/dvd/film_evidence_tb.sv
@@ -112,7 +112,8 @@ module film_evidence_tb;
     .flags_commit(),
     .pic_informative(pic_informative), .informative_commit(informative_commit),
     .cc_pair_valid(), .cc_pair(), .cc_pair_field(),
-    .mpeg1()
+    .mpeg1(),
+    .vbuf_flush(1'b0)   // DVD-FORK FIX (seek realign, issue #45): not exercised here
   );
 
   // The counter measures from STATE_PICTURE_HEADER to the terminating start

--- a/bench/dvd/run_seek_realign.sh
+++ b/bench/dvd/run_seek_realign.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# run_seek_realign.sh -- post-seek reference re-align (GitHub issue #45).
+#
+# The defect: a VBUF flush discards the buffered bitstream and nothing else, so
+# motcomp_picbuf's reference slots survive a seek still holding the PRE-SEEK
+# scene. The landing GOP's leading B-pictures motion-compensate against them,
+# which on hardware reads as ~6 frames of the new chapter decoding IN MOTION
+# with the old image overlaid as residual. Fix: rtl/mpeg2/vld.v drops pictures
+# until two post-flush anchors have re-established the references.
+# Design: docs/seek_realign.md
+#
+# The fixture is cut from a real disc (nothing here is synthetic): set
+# DVD_ISO_DIR to a library of decrypted DVD-Video rips. Without it every arm
+# SKIPs loudly rather than passing on an empty array.
+#
+#   ./bench/dvd/run_seek_realign.sh          # GREEN arms + the vld regressions
+#   ./bench/dvd/run_seek_realign.sh --red    # also the RED arm first (must FAIL
+#                                            # to find the defect -- it PASSES by
+#                                            # asserting the pre-fix violation count)
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+ISO_DIR="${DVD_ISO_DIR:-$HOME/dvd-isos}"
+FIX=bench/dvd/test_vobs/seek_realign
+IV="iverilog -g2012 -D__IVERILOG__ -I rtl/mpeg2"
+RTL="rtl/mpeg2/vld.v rtl/mpeg2/getbits.v rtl/mpeg2/motcomp_picbuf.v"
+rc=0
+
+# ---- fixture -----------------------------------------------------------------
+if [ ! -f "$FIX.hex" ]; then
+  SRC=$(ls "$ISO_DIR"/*.iso "$ISO_DIR"/*.ISO 2>/dev/null | head -1 || true)
+  if [ -n "$SRC" ]; then
+    echo "== cutting fixture from $(basename "$SRC") (two cuts + a seek between them) =="
+    # seek_fixture.py REFUSES a landing whose first GOP is closed or has no
+    # leading B's: such a cut would make the RED arm measure zero and the whole
+    # gate vacuous. Walk the title until one qualifies.
+    for f in 0.60 0.40 0.75 0.25 0.85; do
+      if python3 tools/seek_fixture.py "$SRC" --cut-b-frac "$f" --out "$FIX"; then break; fi
+    done
+  fi
+fi
+if [ ! -f "$FIX.hex" ]; then
+  echo "== seek_realign: SKIPPED -- set DVD_ISO_DIR to a library of decrypted rips =="
+  exit 0
+fi
+
+# ---- RED: the same TB with the fix's input tied low --------------------------
+if [ "${1:-}" = "--red" ]; then
+  echo "== RED (SEEK_REALIGN=0): must MEASURE the defect, exactly meta[3] violations =="
+  $IV -Pseek_realign_tb.SEEK_REALIGN=0 -o bench/dvd/seek_realign_red_sim $RTL bench/dvd/seek_realign_tb.sv
+  vvp bench/dvd/seek_realign_red_sim | grep -vE '^WARNING' || rc=1
+fi
+
+$IV -o bench/dvd/seek_realign_sim $RTL bench/dvd/seek_realign_tb.sv
+
+echo "== [1] control -- no flush: the re-align must be completely inert =="
+vvp bench/dvd/seek_realign_sim +NOFLUSH=1 | grep -vE '^WARNING' || rc=1
+
+echo "== [2] seek, flush mid-slice (the reported case) =="
+vvp bench/dvd/seek_realign_sim | grep -vE '^WARNING' || rc=1
+
+echo "== [3] seek, flush at a picture header =="
+vvp bench/dvd/seek_realign_sim +FLUSHDLY=0 | grep -vE '^WARNING' || rc=1
+
+echo "== [4] two flushes on one seek -- the second must RESTART, not be swallowed =="
+vvp bench/dvd/seek_realign_sim +REFLUSH=400 | grep -vE '^WARNING' || rc=1
+
+echo "== [5] display-blocked (+DRAIN): the flush window sits inside a vld freeze,"
+echo "==     so this is what proves the arm is not gated by clk_en =="
+vvp bench/dvd/seek_realign_sim +DRAIN=4000 +FLUSHDLY=20 | grep -vE '^WARNING' || rc=1
+
+echo "== [6] RA_CAP give-up: decoding must resume on a stream that never re-anchors =="
+$IV -Pseek_realign_tb.RA_CAP=2 -o bench/dvd/seek_realign_cap_sim $RTL bench/dvd/seek_realign_tb.sv
+vvp bench/dvd/seek_realign_cap_sim +CAPARM=1 | grep -vE '^WARNING' || rc=1
+
+# ---- regressions on the shared vld edits -------------------------------------
+# vld_drop_rff_tb is the ledger-split gate: drop_pic_ack must still fire for the
+# governor's drops and ONLY for those.
+echo "== regression: vld_drop_rff_tb (governor drop ack ledger) =="
+$IV -o bench/dvd/vld_drop_rff_sim $RTL bench/dvd/vld_drop_rff_tb.sv
+vvp bench/dvd/vld_drop_rff_sim +ES=$FIX.hex +MAXPIC=18 | tail -3 || rc=1
+
+[ $rc -eq 0 ] && echo "== ALL GREEN ==" || echo "== FAILURES (rc=$rc) =="
+exit $rc

--- a/bench/dvd/run_seek_realign.sh
+++ b/bench/dvd/run_seek_realign.sh
@@ -28,8 +28,8 @@ RTL="rtl/mpeg2/vld.v rtl/mpeg2/getbits.v rtl/mpeg2/motcomp_picbuf.v"
 rc=0
 
 # ---- fixture -----------------------------------------------------------------
+SRC=$(ls "$ISO_DIR"/*.iso "$ISO_DIR"/*.ISO 2>/dev/null | head -1 || true)
 if [ ! -f "$FIX.hex" ]; then
-  SRC=$(ls "$ISO_DIR"/*.iso "$ISO_DIR"/*.ISO 2>/dev/null | head -1 || true)
   if [ -n "$SRC" ]; then
     echo "== cutting fixture from $(basename "$SRC") (two cuts + a seek between them) =="
     # seek_fixture.py REFUSES a landing whose first GOP is closed or has no
@@ -63,7 +63,7 @@ vvp bench/dvd/seek_realign_sim | grep -vE '^WARNING' || rc=1
 echo "== [3] seek, flush at a picture header =="
 vvp bench/dvd/seek_realign_sim +FLUSHDLY=0 | grep -vE '^WARNING' || rc=1
 
-echo "== [4] two flushes on one seek -- the second must RESTART, not be swallowed =="
+echo "== [4] two flushes on one seek -- they must COALESCE onto one re-align =="
 vvp bench/dvd/seek_realign_sim +REFLUSH=400 | grep -vE '^WARNING' || rc=1
 
 echo "== [5] display-blocked (+DRAIN): the flush window sits inside a vld freeze,"
@@ -71,15 +71,43 @@ echo "==     so this is what proves the arm is not gated by clk_en =="
 vvp bench/dvd/seek_realign_sim +DRAIN=4000 +FLUSHDLY=20 | grep -vE '^WARNING' || rc=1
 
 echo "== [6] RA_CAP give-up: decoding must resume on a stream that never re-anchors =="
-$IV -Pseek_realign_tb.RA_CAP=2 -o bench/dvd/seek_realign_cap_sim $RTL bench/dvd/seek_realign_tb.sv
+$IV -Pseek_realign_tb.RA_CAP=1 -o bench/dvd/seek_realign_cap_sim $RTL bench/dvd/seek_realign_tb.sv
 vvp bench/dvd/seek_realign_cap_sim +CAPARM=1 | grep -vE '^WARNING' || rc=1
+
+# A menu still is SEQ GOP PIC:I SEQ_END -- one I picture, no B's. Entering or
+# leaving a menu is a FLUSHING jump (flush_ctl gates seek_flush on ~keep_vbuf, so
+# only menu->menu hops are exempt), so the re-align arms there like any seek. If
+# it ever dropped that I the menu would never appear. Cut B here is
+# bench/dvd/test_vobs/hp_still_i.hex, a real still cut from the Harry Potter
+# interactive disc for the picbuf slot-alias fix.
+if [ -f bench/dvd/test_vobs/hp_still_i.hex ]; then
+  echo "== [7] menu still as the landing: nothing may be dropped =="
+  python3 tools/seek_fixture.py "$SRC" --cut-b-hex bench/dvd/test_vobs/hp_still_i.hex \
+      --out bench/dvd/test_vobs/seek_still >/dev/null 2>&1 || true
+  if [ -f bench/dvd/test_vobs/seek_still.hex ]; then
+    vvp bench/dvd/seek_realign_sim +STILLARM=1 \
+        +ES=bench/dvd/test_vobs/seek_still.hex \
+        +META=bench/dvd/test_vobs/seek_still.meta.hex | grep -vE '^WARNING' || rc=1
+  else
+    echo "  SKIPPED -- could not build the still fixture"
+  fi
+fi
 
 # ---- regressions on the shared vld edits -------------------------------------
 # vld_drop_rff_tb is the ledger-split gate: drop_pic_ack must still fire for the
 # governor's drops and ONLY for those.
-echo "== regression: vld_drop_rff_tb (governor drop ack ledger) =="
+# The ledger split (drop_gov_picture) must leave the governor's drop accounting
+# BIT-IDENTICAL. Measured against the pre-fix vld on this same fixture
+# (2026-09-03, commit 0509f25): drops=11 ack_rff1=5 ack_rff0=6 over 18 pictures.
+echo "== regression: vld_drop_rff_tb -- the governor's ack ledger must not move =="
 $IV -o bench/dvd/vld_drop_rff_sim $RTL bench/dvd/vld_drop_rff_tb.sv
-vvp bench/dvd/vld_drop_rff_sim +ES=$FIX.hex +MAXPIC=18 | tail -3 || rc=1
+BASE="SUMMARY: pictures=18 drops=11 ack_rff1=5 ack_rff0=6 vld_err=0"
+GOT=$(vvp bench/dvd/vld_drop_rff_sim +ES=$FIX.hex +MAXPIC=18 | grep '^SUMMARY:' || true)
+if [ "$GOT" = "$BASE" ]; then
+  echo "  ledger unchanged: $GOT"
+else
+  echo "  FAIL: ledger moved"; echo "    want: $BASE"; echo "    got:  $GOT"; rc=1
+fi
 
 [ $rc -eq 0 ] && echo "== ALL GREEN ==" || echo "== FAILURES (rc=$rc) =="
 exit $rc

--- a/bench/dvd/seek_realign_tb.sv
+++ b/bench/dvd/seek_realign_tb.sv
@@ -51,6 +51,11 @@
  *       bench/dvd/seek_realign_tb.sv
  *   vvp bench/dvd/seek_realign_sim [+FLUSHPIC=n] [+FLUSHDLY=k] [+FLUSHW=w]
  *                                  [+DRAIN=n] [+NOFLUSH=1] [+REFLUSH=k]
+ *
+ * +REFLUSH=k fires a SECOND flush k cycles after the first. Inside the landing
+ * window the two must COALESCE onto one re-align (ra_anchors is a level, not an
+ * edge count) -- the repeated-mid-parse-flush loop that killed the film-mode
+ * edge is structurally unreachable here for the same reason.
  */
 `timescale 1ns/1ps
 `include "vld_codes.v"
@@ -215,7 +220,6 @@ module seek_realign_tb;
 
   // ---- the seek: flush level + reader jump --------------------------------
   localparam [7:0] VS_PICTURE_HEADER  = 8'h02;
-  localparam [7:0] VS_SEQUENCE_HEADER = 8'h06;
   localparam [3:0] PB_UPDATE          = 4'h1;
 
   always @(posedge clk) cyc = cyc + 1;
@@ -223,8 +227,9 @@ module seek_realign_tb;
   integer flushpic = 3;        // flush during cut A's picture #3
   integer flushdly = 400;      // cycles after that header: >0 = mid-slice
   integer flushw   = 192;      // flush level width (dvd/flush_ctl.sv: ~64 clk_sys)
-  integer reflush  = 0;        // >0: fire a SECOND flush this many cycles later
+  integer reflush  = 0;        // >0: a SECOND flush this many cycles later (must coalesce)
   reg     caparm   = 1'b0;     // RA_CAP arm: the give-up path, not the normal one
+  reg     stillarm = 1'b0;     // MENU STILL arm: cut B is one I picture, nothing may drop
   reg     noflush  = 1'b0;     // control arm: no flush, no reader jump
 
   integer npic = -1;                       // coded picture index over the whole feed
@@ -232,8 +237,7 @@ module seek_realign_tb;
   integer arm_t = 0, wnd_end = 0, re_t = 0;
   reg     re_pend = 0;
   integer vlden_in_window = 0;             // vld_en cycles inside the flush window
-  reg     seq_after_flush = 0;             // a sequence header was parsed post-flush
-  reg     pic_after_flush = 0;
+  integer flush_edges = 0;                 // how many times the level was asserted
 
   always @(posedge clk) if (rst) begin
     jump_now <= 1'b0;
@@ -243,16 +247,14 @@ module seek_realign_tb;
         arm   <= 1'b1;
         arm_t  = cyc + flushdly;
       end
-      if (flushed_seen) pic_after_flush <= 1'b1;
     end
-    if (vld_en && (vld.state == VS_SEQUENCE_HEADER) && flushed_seen && !pic_after_flush)
-      seq_after_flush <= 1'b1;
 
     if (arm && (cyc >= arm_t)) begin
       arm          <= 1'b0;
       flush_lvl    <= 1'b1;
       jump_now     <= 1'b1;                // the reader lands on cut B
       flushed_seen <= 1'b1;
+      flush_edges   = flush_edges + 1;
       wnd_end       = cyc + flushw;
       if (reflush > 0) begin re_pend <= 1'b1; re_t = cyc + reflush; end
     end
@@ -263,9 +265,10 @@ module seek_realign_tb;
     // a second flush landing on the same seek (scrub / double chapter skip):
     // it must RESTART the window, not be swallowed by the first.
     if (re_pend && (cyc >= re_t)) begin
-      re_pend   <= 1'b0;
-      flush_lvl <= 1'b1;
-      wnd_end    = cyc + flushw;
+      re_pend     <= 1'b0;
+      flush_lvl   <= 1'b1;
+      flush_edges  = flush_edges + 1;
+      wnd_end      = cyc + flushw;
     end
   end
 
@@ -335,6 +338,7 @@ module seek_realign_tb;
       integer nf;
       if ($value$plusargs("NOFLUSH=%d", nf)) noflush = nf[0];
       if ($value$plusargs("CAPARM=%d", nf)) caparm = nf[0];
+      if ($value$plusargs("STILLARM=%d", nf)) stillarm = nf[0];
     end
     $readmemh(esf, es);
     $readmemh(mtf, meta);
@@ -403,19 +407,29 @@ module seek_realign_tb;
         $display("FAIL: the flush never fired - cut A has fewer than %0d pictures", flushpic + 1);
         errors = errors + 1;
       end
-      if (upds_b < 8) begin
+      if (!stillarm && (upds_b < 8)) begin
         $display("FAIL: only %0d post-flush pictures reached picbuf (need >= 8) - 'drop everything forever' would score zero violations", upds_b);
         errors = errors + 1;
       end
-      if (anchors_b < 2) begin
+      if (!stillarm && (anchors_b < 2)) begin
         $display("FAIL: only %0d post-flush anchors decoded (need >= 2) - the run never reached the point where the references are re-established", anchors_b);
         errors = errors + 1;
       end
-      if (!seq_after_flush) begin
-        $display("FAIL: no sequence header parsed between the flush and the first post-flush picture header - the cut-A/cut-B tagging is not trustworthy");
+      /* Tagging trustworthiness. getbits keeps a 129-bit window, so up to 16
+       * bytes of cut A survive the jump and are consumed as the truncated
+       * picture's payload -- which is also why cut B's own sequence header is
+       * usually eaten and NOT re-parsed (sequence_header_seen is already set
+       * from cut A). The property that does establish trust is the count: one
+       * leaked cut-A picture header would make this 15, not 14. */
+      if (!field_b && (hdr_b != pics_b)) begin
+        $display("FAIL: %0d post-flush frame headers, but the fixture says cut B has %0d pictures - a cut-A header leaked into the post-flush tag", hdr_b, pics_b);
         errors = errors + 1;
       end
-      if (lead_b == 0) begin
+      if (reflush > 0 && flush_edges != 2) begin
+        $display("FAIL: the second flush never fired (%0d edge(s)) - this arm proves nothing", flush_edges);
+        errors = errors + 1;
+      end
+      if (!stillarm && (lead_b == 0)) begin
         $display("FAIL: fixture reports zero leading B's - it cannot tell a working re-align from one wired off");
         errors = errors + 1;
       end
@@ -432,11 +446,35 @@ module seek_realign_tb;
         $display("FAIL: control arm only decoded %0d pictures - it proves nothing", upds_b);
         errors = errors + 1;
       end
+    end else if (stillarm) begin
+      /* MENU STILL. A menu still is a whole stream -- SEQ GOP PIC:I SEQ_END --
+       * carrying exactly ONE I picture and no B's. Entering or leaving a menu
+       * IS a flushing jump (flush_ctl gates seek_flush on ~keep_vbuf, so only
+       * menu->menu hops are exempt), so the re-align arms here like any seek.
+       * If it ever dropped that I the menu would simply never appear, which is
+       * the worst failure this change could have. It must drop NOTHING. */
+      if (realign_drops != 0) begin
+        $display("FAIL: the menu still lost %0d picture(s) - a still is one I frame, and dropping it means the menu never appears", realign_drops);
+        errors = errors + 1;
+      end
+      if (upds_b < 1) begin
+        $display("FAIL: the still's I never reached picbuf");
+        errors = errors + 1;
+      end
+      if (anchors_b < 1) begin
+        $display("FAIL: the still's I was not accepted as an anchor");
+        errors = errors + 1;
+      end
     end else if (caparm) begin
       // RA_CAP arm: the give-up must fire and decoding must RESUME. If the cap
       // were dead code this arm would look exactly like the normal one.
+      /* The give-up clears ra_active but realign_now_comb is combinational off
+       * the PRE-clear value, so the header that trips the cap is still judged
+       * normally: the cap shortens the window by one picture. RA_CAP must
+       * therefore be small enough that fewer than lead_b pictures are dropped,
+       * or "the cap fired" and "the cap is dead code" look identical. */
       if (realign_drops >= lead_b) begin
-        $display("FAIL: RA_CAP=%0d arm dropped %0d picture(s) - the give-up never fired", RA_CAP, realign_drops);
+        $display("FAIL: RA_CAP=%0d arm dropped %0d picture(s), same as an uncapped run (%0d) - the give-up never fired", RA_CAP, realign_drops, lead_b);
         errors = errors + 1;
       end
       if (upds_b < 8) begin

--- a/bench/dvd/seek_realign_tb.sv
+++ b/bench/dvd/seek_realign_tb.sv
@@ -1,0 +1,477 @@
+/*
+ * seek_realign_tb.sv -- after a seek, does any displayed picture still predict
+ * from a reference slot holding the PRE-SEEK scene?  (Issue #45.)
+ *
+ * The field report is unambiguous about the signature: the new chapter decodes
+ * correctly AND IS IN MOTION while the old scene bleeds through as residual,
+ * for ~6 frames (~100 ms) on a 60 Hz HDMI recording. That is motion
+ * compensation against stale references, not a corrupt or truncated picture --
+ * so the thing to measure is not "does the picture look wrong" but "which slot
+ * did this picture predict FROM, and what was written into that slot".
+ *
+ * WHAT THIS BENCH MEASURES
+ *   Two elementary-stream cuts from different points of a real title are fed
+ *   through the REAL getbits_fifo + vld + motcomp_picbuf. Partway through cut A
+ *   the bench does what hardware does on a seek: asserts the VBUF flush level
+ *   and jumps the read pointer to cut B. getbits is deliberately NOT reset --
+ *   its 129-bit window keeps up to 16 bytes of cut A, so the in-flight picture
+ *   truncates and completes on cut B's first start code, exactly as on hardware.
+ *
+ *   A shadow slot_tag[] records, for each of picbuf's frame slots, which CUT
+ *   last wrote it. Every picture that reaches picbuf is then checked against
+ *   the slots it actually predicts from (fwd for P, fwd+bwd for B; I is intra).
+ *   A post-flush picture reading a slot tagged A is a VIOLATION.
+ *
+ *   That is a property of the byte stream and of picbuf's own pointers. It
+ *   names no signal in the fix, so it cannot degenerate into a golden model
+ *   that agrees with its RTL by construction (memory: bench-that-cannot-fail).
+ *
+ * RED / GREEN
+ *   The RED arm is a TESTBENCH parameter, not an RTL one: SEEK_REALIGN=0 ties
+ *   the vld's vbuf_flush input low, which reverts update_picture_buffers and
+ *   drop_this_picture to their byte-identical pre-fix expressions. So the same
+ *   binary proves both that the defect is real and that the added logic is
+ *   inert when unarmed.
+ *     RED   : viol == meta[3] (the leading-B count of cut B's first GOP)
+ *     GREEN : viol == 0  AND  realign_drops == meta[3]
+ *   The GREEN count is asserted EXACTLY, not as ">= 1": dropping too much is a
+ *   failure too (it costs display frames at every seek).
+ *
+ * FIDELITY NOTE -- do not "improve" this into the full motcomp path.
+ *   In the real decoder update_picture_buffers reaches picbuf through the mvec
+ *   FIFO; here it is a direct pulse plus the motcomp.v freeze interlock. That
+ *   is faithful FOR THIS MEASUREMENT because the fix lives entirely in the vld
+ *   and the freeze already serialises header-vs-rotation ordering. It is NOT
+ *   faithful for anything that tries to correct picbuf from outside the vld --
+ *   see docs/seek_realign.md on the mvec-FIFO ordering hazard.
+ *
+ * Build (see bench/dvd/run_seek_realign.sh):
+ *   iverilog -g2012 -D__IVERILOG__ -I rtl/mpeg2 -o bench/dvd/seek_realign_sim \
+ *       rtl/mpeg2/vld.v rtl/mpeg2/getbits.v rtl/mpeg2/motcomp_picbuf.v \
+ *       bench/dvd/seek_realign_tb.sv
+ *   vvp bench/dvd/seek_realign_sim [+FLUSHPIC=n] [+FLUSHDLY=k] [+FLUSHW=w]
+ *                                  [+DRAIN=n] [+NOFLUSH=1] [+REFLUSH=k]
+ */
+`timescale 1ns/1ps
+`include "vld_codes.v"
+
+module seek_realign_tb;
+
+  // SEEK_REALIGN=0 ties the fix's input low -> pre-fix behaviour (the RED arm).
+  parameter SEEK_REALIGN = 1;
+  // RA_CAP is forwarded to the vld so the give-up path can be reached inside a
+  // short fixture; the shipped default (48) never is.
+  parameter RA_CAP = 6'd48;
+
+  reg clk = 0; always #5 clk = ~clk;
+  reg rst = 0;
+
+  // ---- ES feed: behavioral vbuf-read fifo (64-bit, big-endian words) -------
+  // Sized to the fixture, not to a round power of two: an oversized TB array is
+  // an Icarus compile cliff, not free headroom.
+  localparam MAXW = 70000;
+  reg [63:0] es [0:MAXW-1];
+  integer    es_words = 0;
+  integer    rd_ptr   = 0;
+
+  reg [31:0] meta [0:6];
+  integer    b_word, pics_a, first_ct, lead_b, closed_b, pics_b, field_b;
+
+  wire        vid_in_rd_en;
+  reg         vid_in_rd_valid = 0;
+  reg  [63:0] vid_in = 64'h0;
+  reg         jump_now = 0;               // 1-cycle: reader lands on cut B
+
+  always @(posedge clk) begin
+    vid_in_rd_valid <= 1'b0;
+    if (jump_now) rd_ptr <= b_word;
+    else if (rst && vid_in_rd_en && (rd_ptr < es_words)) begin
+      vid_in          <= es[rd_ptr];
+      vid_in_rd_valid <= 1'b1;
+      rd_ptr          <= rd_ptr + 1;
+    end
+  end
+
+  // ---- DUT: getbits_fifo + vld + motcomp_picbuf (all real RTL) ------------
+  wire  [4:0] advance;
+  wire        align, wait_state;
+  wire [23:0] getbits;
+  wire        signbit, getbits_valid, vld_en;
+  wire        motcomp_busy;
+
+  getbits_fifo getbits_fifo (
+    .clk(clk), .clk_en(1'b1), .rst(rst),
+    .vid_in(vid_in), .vid_in_rd_en(vid_in_rd_en), .vid_in_rd_valid(vid_in_rd_valid),
+    .advance(advance), .align(align), .wait_state(wait_state),
+    .rld_wr_almost_full(1'b0), .mvec_wr_almost_full(1'b0),
+    .motcomp_busy(motcomp_busy),
+    .getbits(getbits), .signbit(signbit),
+    .getbits_valid(getbits_valid), .vld_en(vld_en)
+  );
+
+  reg  flush_lvl = 1'b0;                  // the ~192 clk_dec VBUF flush level
+  wire drop_pic_ack;
+  integer cyc = 0;
+  integer vld_err_cnt = 0;
+  reg     flushed_seen = 0;               // 1 once the flush has fired
+  wire update_picture_buffers, flags_commit, last_frame, second_field;
+  wire pic_informative, informative_commit;
+  wire [2:0] picture_coding_type;
+  wire [1:0] picture_structure;
+  wire repeat_first_field, top_field_first, progressive_frame, progressive_sequence;
+  wire vld_err;
+
+  vld #(.RA_CAP(RA_CAP)) vld (
+    .clk(clk), .clk_en(vld_en), .rst(rst),
+    .getbits(getbits), .signbit(signbit),
+    .advance(advance), .align(align), .wait_state(wait_state),
+    .quant_wr_data(), .quant_wr_addr(), .quant_rst(),
+    .wr_intra_quant(), .wr_non_intra_quant(),
+    .wr_chroma_intra_quant(), .wr_chroma_non_intra_quant(),
+    .rld_wr_en(), .rld_cmd(), .dct_coeff_run(), .dct_coeff_signed_level(),
+    .dct_coeff_end(), .alternate_scan(), .q_scale_type(), .quantiser_scale_code(),
+    .macroblock_intra(), .intra_dc_precision(), .matrix_coefficients(),
+    .horizontal_size(), .vertical_size(),
+    .display_horizontal_size(), .display_vertical_size(),
+    .aspect_ratio_information(), .frame_rate_code(),
+    .frame_rate_extension_n(), .frame_rate_extension_d(),
+    .picture_coding_type(picture_coding_type), .picture_structure(picture_structure),
+    .motion_type(), .dct_type(), .macroblock_address(),
+    .macroblock_motion_forward(), .macroblock_motion_backward(),
+    .mb_width(), .mb_height(),
+    .motion_vert_field_select_0_0(), .motion_vert_field_select_0_1(),
+    .motion_vert_field_select_1_0(), .motion_vert_field_select_1_1(),
+    .second_field(second_field), .update_picture_buffers(update_picture_buffers),
+    .last_frame(last_frame), .chroma_format(), .motion_vector_valid(),
+    .pmv_0_0_0(), .pmv_0_0_1(), .pmv_1_0_0(), .pmv_1_0_1(),
+    .pmv_0_1_0(), .pmv_0_1_1(), .pmv_1_1_0(), .pmv_1_1_1(),
+    .dmv_0_0(), .dmv_0_1(), .dmv_1_0(), .dmv_1_1(),
+    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame),
+    .top_field_first(top_field_first), .repeat_first_field(repeat_first_field),
+    .vld_err(vld_err),
+    .drop_pic_req(1'b0),                  // governor OFF: every drop here is a realign drop
+    .drop_pic_ack(drop_pic_ack), .drop_pic_rff(), .drop_pic_field(),
+    .dbg_drop_probe(),
+    .flags_commit(flags_commit),
+    .pic_informative(pic_informative), .informative_commit(informative_commit),
+    .cc_pair_valid(), .cc_pair(), .cc_pair_field(), .mpeg1(),
+    .vbuf_flush(SEEK_REALIGN ? flush_lvl : 1'b0)
+  );
+
+  // motcomp.v's freeze interlock, replicated (see the fidelity note above).
+  wire picbuf_busy;
+  reg  flush_pend;
+  always @(posedge clk)
+    if (~rst) flush_pend <= 1'b0;
+    else if (update_picture_buffers) flush_pend <= 1'b1;
+    else if (picbuf_busy) flush_pend <= 1'b0;
+  assign motcomp_busy = flush_pend || picbuf_busy;
+
+  wire [2:0] fwd, bwd, cur_slot, output_frame;
+  wire       output_frame_valid;
+  reg        output_frame_rd;
+
+  motcomp_picbuf picbuf (
+    .clk(clk), .clk_en(1'b1), .rst(rst),
+    .source_select(3'd0),
+    .picture_coding_type(picture_coding_type),
+    .progressive_sequence(progressive_sequence), .progressive_frame(progressive_frame),
+    .top_field_first(top_field_first), .repeat_first_field(repeat_first_field),
+    .last_frame(last_frame),
+    .pic_informative(pic_informative), .informative_commit(informative_commit),
+    .update_picture_buffers(update_picture_buffers), .flags_commit(flags_commit),
+    .forward_reference_frame(fwd), .backward_reference_frame(bwd),
+    .current_frame(cur_slot),
+    .output_frame(output_frame), .output_frame_valid(output_frame_valid),
+    .output_frame_rd(output_frame_rd),
+    .output_progressive_sequence(), .output_progressive_frame(),
+    .output_top_field_first(), .output_repeat_first_field(), .output_informative(),
+    .picbuf_busy(picbuf_busy)
+  );
+
+  // ---- governor stub (resample's pickup handshake) + optional display block -
+  integer emits = 0, drain = 0, drain_cnt = 0;
+  integer last_emit_t = 0, max_gap = 0, gap_from = -1;
+  reg gov_ack;
+  always @(posedge clk)
+    if (~rst) begin output_frame_rd <= 1'b0; gov_ack <= 1'b0; drain_cnt <= 0; end
+    else begin
+      output_frame_rd <= 1'b0;
+      if (~gov_ack && output_frame_valid) begin
+        if (drain_cnt < drain) drain_cnt <= drain_cnt + 1;
+        else begin
+          drain_cnt <= 0;
+          emits = emits + 1;
+          if (flushed_seen && (gap_from >= 0) && ((cyc - last_emit_t) > max_gap))
+            max_gap = cyc - last_emit_t;
+          last_emit_t = cyc;
+          if (flushed_seen && (gap_from < 0)) gap_from = cyc;
+          output_frame_rd <= 1'b1;
+          gov_ack <= 1'b1;
+        end
+      end else if (gov_ack && ~output_frame_valid)
+        gov_ack <= 1'b0;
+    end
+
+  // ---- the seek: flush level + reader jump --------------------------------
+  localparam [7:0] VS_PICTURE_HEADER  = 8'h02;
+  localparam [7:0] VS_SEQUENCE_HEADER = 8'h06;
+  localparam [3:0] PB_UPDATE          = 4'h1;
+
+  always @(posedge clk) cyc = cyc + 1;
+
+  integer flushpic = 3;        // flush during cut A's picture #3
+  integer flushdly = 400;      // cycles after that header: >0 = mid-slice
+  integer flushw   = 192;      // flush level width (dvd/flush_ctl.sv: ~64 clk_sys)
+  integer reflush  = 0;        // >0: fire a SECOND flush this many cycles later
+  reg     caparm   = 1'b0;     // RA_CAP arm: the give-up path, not the normal one
+  reg     noflush  = 1'b0;     // control arm: no flush, no reader jump
+
+  integer npic = -1;                       // coded picture index over the whole feed
+  reg     arm = 0;
+  integer arm_t = 0, wnd_end = 0, re_t = 0;
+  reg     re_pend = 0;
+  integer vlden_in_window = 0;             // vld_en cycles inside the flush window
+  reg     seq_after_flush = 0;             // a sequence header was parsed post-flush
+  reg     pic_after_flush = 0;
+
+  always @(posedge clk) if (rst) begin
+    jump_now <= 1'b0;
+    if (vld_en && (vld.state == VS_PICTURE_HEADER)) begin
+      npic = npic + 1;
+      if (!noflush && !arm && !flushed_seen && (npic == flushpic)) begin
+        arm   <= 1'b1;
+        arm_t  = cyc + flushdly;
+      end
+      if (flushed_seen) pic_after_flush <= 1'b1;
+    end
+    if (vld_en && (vld.state == VS_SEQUENCE_HEADER) && flushed_seen && !pic_after_flush)
+      seq_after_flush <= 1'b1;
+
+    if (arm && (cyc >= arm_t)) begin
+      arm          <= 1'b0;
+      flush_lvl    <= 1'b1;
+      jump_now     <= 1'b1;                // the reader lands on cut B
+      flushed_seen <= 1'b1;
+      wnd_end       = cyc + flushw;
+      if (reflush > 0) begin re_pend <= 1'b1; re_t = cyc + reflush; end
+    end
+    if (flush_lvl) begin
+      if (vld_en) vlden_in_window = vlden_in_window + 1;
+      if (cyc >= wnd_end) flush_lvl <= 1'b0;
+    end
+    // a second flush landing on the same seek (scrub / double chapter skip):
+    // it must RESTART the window, not be swallowed by the first.
+    if (re_pend && (cyc >= re_t)) begin
+      re_pend   <= 1'b0;
+      flush_lvl <= 1'b1;
+      wnd_end    = cyc + flushw;
+    end
+  end
+
+  // ---- the measurement: slot provenance ------------------------------------
+  // 0 = never written, 1 = cut A (pre-seek), 2 = cut B (post-seek).
+  reg  [1:0] slot_tag [0:7];
+  reg        upd_seg;                      // segment of the picture owning this update
+  reg  [3:0] pb_state_d;
+  integer    viol = 0, upds_b = 0, anchors_b = 0, hdr_b = 0, k;
+  integer    lastf_upds = 0;
+
+  always @(posedge clk) pb_state_d <= picbuf.state;
+
+  // The freeze interlock guarantees at most one update in flight, so a single
+  // latch carries the owning picture's segment to the rotation cycle.
+  always @(posedge clk)
+    if (~rst) upd_seg <= 1'b0;
+    else if (update_picture_buffers) upd_seg <= flushed_seen;
+
+  // Post-flush FRAME slots seen at the header (a field pair is one frame slot,
+  // matching the condition update_picture_buffers itself uses).
+  wire in_zone = noflush ? 1'b1 : flushed_seen;   // control arm counts the whole run
+  always @(posedge clk)
+    if (rst && vld_en && (vld.state == VS_PICTURE_HEADER) && in_zone &&
+        ((picture_structure == FRAME_PICTURE) || second_field))
+      hdr_b = hdr_b + 1;
+
+  always @(posedge clk)
+    if (~rst) begin
+      for (k = 0; k < 8; k = k + 1) slot_tag[k] <= 2'd0;
+    end else if ((pb_state_d == PB_UPDATE) && ~picbuf.vld_last_frame) begin
+      // Sampled one cycle AFTER STATE_UPDATE, so fwd/bwd/current_frame carry
+      // the values this picture actually decodes and predicts with.
+      slot_tag[cur_slot] <= (upd_seg || noflush) ? 2'd2 : 2'd1;   // control arm: everything is "post"
+      if (upd_seg || noflush) begin
+        upds_b = upds_b + 1;
+        if (picbuf.vld_picture_coding_type != B_TYPE) anchors_b = anchors_b + 1;
+        case (picbuf.vld_picture_coding_type)
+          P_TYPE: if (slot_tag[fwd] == 2'd1) begin
+                    viol = viol + 1;
+                    $display("  VIOL pic=%0d P slot=%0d predicts fwd=%0d (cut A)", npic, cur_slot, fwd);
+                  end
+          B_TYPE: if ((slot_tag[fwd] == 2'd1) || (slot_tag[bwd] == 2'd1)) begin
+                    viol = viol + 1;
+                    $display("  VIOL pic=%0d B slot=%0d predicts fwd=%0d(%0d) bwd=%0d(%0d) -- cut A residual",
+                             npic, cur_slot, fwd, slot_tag[fwd], bwd, slot_tag[bwd]);
+                  end
+          default: ;                       // I_TYPE is intra: nothing to check
+        endcase
+      end
+    end else if ((pb_state_d == PB_UPDATE) && picbuf.vld_last_frame)
+      lastf_upds = lastf_upds + 1;
+
+  // ---- drive ---------------------------------------------------------------
+  integer errors = 0, guard = 0, realign_drops = 0;
+  string  esf, mtf;
+
+  initial begin
+    if (!$value$plusargs("ES=%s", esf))   esf = "bench/dvd/test_vobs/seek_realign.hex";
+    if (!$value$plusargs("META=%s", mtf)) mtf = "bench/dvd/test_vobs/seek_realign.meta.hex";
+    void'($value$plusargs("FLUSHPIC=%d", flushpic));
+    void'($value$plusargs("FLUSHDLY=%d", flushdly));
+    void'($value$plusargs("FLUSHW=%d",   flushw));
+    void'($value$plusargs("DRAIN=%d",    drain));
+    void'($value$plusargs("REFLUSH=%d",  reflush));
+    begin : noflush_arg
+      integer nf;
+      if ($value$plusargs("NOFLUSH=%d", nf)) noflush = nf[0];
+      if ($value$plusargs("CAPARM=%d", nf)) caparm = nf[0];
+    end
+    $readmemh(esf, es);
+    $readmemh(mtf, meta);
+    begin : count_words
+      integer j;
+      j = 0;
+      while (j < MAXW && es[j] !== 64'hx) j = j + 1;
+      es_words = j;
+    end
+    b_word   = meta[0]; pics_a   = meta[1]; first_ct = meta[2]; lead_b = meta[3];
+    closed_b = meta[4]; pics_b   = meta[5]; field_b  = meta[6];
+
+    if (es_words == 0 || meta[0] === 32'hx) begin
+      $display("SKIP: seek_realign_tb - fixture missing; run bench/dvd/run_seek_realign.sh");
+      $finish;
+    end
+    if (es_words >= MAXW) begin
+      $display("FAIL: fixture (%0d words) fills the TB array (MAXW=%0d) - it was truncated", es_words, MAXW);
+      $fatal(1);
+    end
+    $display("seek_realign_tb: SEEK_REALIGN=%0d RA_CAP=%0d  ES %0d words, cut B at word %0d",
+             SEEK_REALIGN, RA_CAP, es_words, b_word);
+    $display("  fixture: cut A %0d pics, cut B %0d pics, leading B's %0d, closed=%0d, field=%0d",
+             pics_a, pics_b, lead_b, closed_b, field_b);
+    $display("  arm: flushpic=%0d flushdly=%0d flushw=%0d drain=%0d reflush=%0d noflush=%0d",
+             flushpic, flushdly, flushw, drain, reflush, noflush);
+
+    rst = 0;
+    repeat (8) @(posedge clk);
+    rst = 1;
+
+    // Run to completion, not to a fixed delay: clocks x timescale overflows
+    // 32-bit integer arithmetic on a fixture this size, and the bench then
+    // either stops early (testing almost nothing) or never stops at all.
+    guard = 0;
+    while ((rd_ptr < es_words - 1) && (guard < (es_words * 192 + drain * 4096))) begin
+      @(posedge clk);
+      guard = guard + 1;
+    end
+    repeat (4000) @(posedge clk);          // let the tail drain through picbuf
+
+    if (guard >= (es_words * 192 + drain * 4096)) begin
+      $display("FAIL: watchdog expired at word %0d/%0d - the run did not complete", rd_ptr, es_words);
+      errors = errors + 1;
+    end
+
+    realign_drops = hdr_b - upds_b;
+
+    /* The DRAIN arm exists to prove ONE design decision: the flush arm inside
+     * the vld is not gated by clk_en. With the display blocked, motcomp's
+     * freeze holds vld_en low across the whole flush window, so a clk_en-gated
+     * capture would miss the level entirely and the violations would come back.
+     * This counter is the anti-vacuity guard on that: if the drain was not deep
+     * enough the window was not actually a freeze and the arm proves nothing. */
+    if (drain > 0 && !noflush) begin
+      $display("  drain arm: vld_en high for %0d of the %0d flush-window cycles", vlden_in_window, flushw);
+      if (vlden_in_window != 0) begin
+        $display("FAIL: the flush window was not inside a vld freeze (+DRAIN too small or +FLUSHDLY misplaced) - this arm cannot test the ungated capture");
+        errors = errors + 1;
+      end
+    end
+
+    // ---- anti-vacuity: a bench that drops everything must not pass ---------
+    if (!noflush) begin
+      if (!flushed_seen) begin
+        $display("FAIL: the flush never fired - cut A has fewer than %0d pictures", flushpic + 1);
+        errors = errors + 1;
+      end
+      if (upds_b < 8) begin
+        $display("FAIL: only %0d post-flush pictures reached picbuf (need >= 8) - 'drop everything forever' would score zero violations", upds_b);
+        errors = errors + 1;
+      end
+      if (anchors_b < 2) begin
+        $display("FAIL: only %0d post-flush anchors decoded (need >= 2) - the run never reached the point where the references are re-established", anchors_b);
+        errors = errors + 1;
+      end
+      if (!seq_after_flush) begin
+        $display("FAIL: no sequence header parsed between the flush and the first post-flush picture header - the cut-A/cut-B tagging is not trustworthy");
+        errors = errors + 1;
+      end
+      if (lead_b == 0) begin
+        $display("FAIL: fixture reports zero leading B's - it cannot tell a working re-align from one wired off");
+        errors = errors + 1;
+      end
+    end
+    if (vld_err_cnt > 0)
+      $display("  note: %0d vld_err cycles (a truncated in-flight picture is expected)", vld_err_cnt);
+
+    // ---- verdict -----------------------------------------------------------
+    if (noflush) begin
+      if (realign_drops != 0) begin
+        $display("FAIL: control arm dropped %0d picture(s) - the re-align is not inert in steady state", realign_drops); errors = errors + 1;
+      end
+      if (upds_b < 8) begin
+        $display("FAIL: control arm only decoded %0d pictures - it proves nothing", upds_b);
+        errors = errors + 1;
+      end
+    end else if (caparm) begin
+      // RA_CAP arm: the give-up must fire and decoding must RESUME. If the cap
+      // were dead code this arm would look exactly like the normal one.
+      if (realign_drops >= lead_b) begin
+        $display("FAIL: RA_CAP=%0d arm dropped %0d picture(s) - the give-up never fired", RA_CAP, realign_drops);
+        errors = errors + 1;
+      end
+      if (upds_b < 8) begin
+        $display("FAIL: RA_CAP arm decoded only %0d pictures - the give-up did not restore decoding", upds_b);
+        errors = errors + 1;
+      end
+    end else if (SEEK_REALIGN == 0) begin
+      if (viol != lead_b) begin
+        $display("FAIL: RED arm measured %0d violation(s), fixture says %0d leading B's",
+                 viol, lead_b); errors = errors + 1;
+      end
+      if (realign_drops != 0) begin
+        $display("FAIL: RED arm dropped %0d picture(s) - vbuf_flush is tied low, the re-align must be completely inert", realign_drops); errors = errors + 1;
+      end
+    end else begin
+      if (viol != 0) begin
+        $display("FAIL: %0d picture(s) predicted from a pre-seek slot", viol); errors = errors + 1;
+      end
+      if (realign_drops != lead_b) begin
+        $display("FAIL: re-align dropped %0d picture(s), fixture says %0d leading B's - dropping too much costs display frames at every seek",
+                 realign_drops, lead_b); errors = errors + 1;
+      end
+    end
+
+    $display("SUMMARY: viol=%0d realign_drops=%0d post-flush{hdr=%0d upd=%0d anchors=%0d} emits=%0d max_post_flush_emit_gap=%0d cyc", viol, realign_drops,
+             hdr_b, upds_b, anchors_b, emits, max_gap);
+
+    if (errors == 0) $display("PASS: seek_realign_tb");
+    else begin
+      $display("FAIL: seek_realign_tb - %0d error(s)", errors);
+      $fatal(1);
+    end
+    $finish;
+  end
+
+  always @(posedge clk) if (rst && vld_en && vld_err) vld_err_cnt = vld_err_cnt + 1;
+
+endmodule

--- a/bench/dvd/vld_drop_rff_tb.sv
+++ b/bench/dvd/vld_drop_rff_tb.sv
@@ -77,7 +77,8 @@ module vld_drop_rff_tb;
   );
 
   reg  drop_pic_req = 1'b1;
-  wire drop_pic_ack, drop_pic_rff;
+  wire drop_pic_ack, drop_pic_rff, drop_pic_field;
+  wire pic_informative, informative_commit;
   wire update_picture_buffers, flags_commit;
   wire [2:0] picture_coding_type;
   wire repeat_first_field, top_field_first, progressive_frame, progressive_sequence;
@@ -115,7 +116,17 @@ module vld_drop_rff_tb;
     .drop_pic_req(drop_pic_req),
     .drop_pic_ack(drop_pic_ack),
     .drop_pic_rff(drop_pic_rff),
-    .flags_commit(flags_commit)
+    .drop_pic_field(drop_pic_field),
+    .dbg_drop_probe(),
+    .flags_commit(flags_commit),
+    // ports added to vld since this bench was written (2026-09-03 repair):
+    // outputs may dangle, but picbuf's pic_informative/informative_commit are
+    // INPUTS and were floating to z -- connect them from the real vld.
+    .pic_informative(pic_informative),
+    .informative_commit(informative_commit),
+    .cc_pair_valid(), .cc_pair(), .cc_pair_field(),
+    .mpeg1(),
+    .vbuf_flush(1'b0)   // DVD-FORK FIX (seek realign, issue #45): not exercised here
   );
 
   // ---- REAL motcomp_picbuf + the motcomp.v freeze interlock (round 11) ----
@@ -150,6 +161,9 @@ module vld_drop_rff_tb;
     .last_frame(1'b0),
     .update_picture_buffers(update_picture_buffers),
     .flags_commit(flags_commit),
+    .pic_informative(pic_informative),
+    .informative_commit(informative_commit),
+    .output_informative(),
     .forward_reference_frame(), .backward_reference_frame(), .current_frame(),
     .output_frame(output_frame),
     .output_frame_valid(output_frame_valid),
@@ -231,7 +245,9 @@ module vld_drop_rff_tb;
   // ---- drive ----
   string esf;
   initial begin
-    if (!$value$plusargs("ES=%s", esf)) esf = "bench/dvd/mib6.hex";
+    // bench/dvd/mib6.hex was never committed and no longer exists; default to a
+    // fixture the repo's own tooling regenerates (bench/dvd/run_seek_realign.sh).
+    if (!$value$plusargs("ES=%s", esf)) esf = "bench/dvd/test_vobs/seek_realign.hex";
     void'($value$plusargs("MAXPIC=%d", maxpic));
     void'($value$plusargs("DRAIN=%d", drain));
     begin : req_arg
@@ -247,6 +263,10 @@ module vld_drop_rff_tb;
     end
     $display("ES: %0d words (%0d bytes), drop_pic_req=%0d, maxpic=%0d",
              es_words, es_words * 8, drop_pic_req, maxpic);
+    if (es_words == 0) begin
+      $display("SKIP: vld_drop_rff_tb - fixture %0s missing; run bench/dvd/run_seek_realign.sh", esf);
+      $finish;
+    end
     rst = 0;
     repeat (8) @(posedge clk);
     rst = 1;

--- a/bench/dvd/vld_mpeg1_tb.sv
+++ b/bench/dvd/vld_mpeg1_tb.sv
@@ -143,7 +143,8 @@ module vld_mpeg1_tb;
     .drop_pic_rff(drop_pic_rff),
     .drop_pic_field(drop_pic_field),
     .flags_commit(flags_commit),
-    .mpeg1(mpeg1_flag)
+    .mpeg1(mpeg1_flag),
+    .vbuf_flush(1'b0)   // DVD-FORK FIX (seek realign, issue #45): not exercised here
   );
 
   // ---- REAL motcomp_picbuf + the motcomp.v freeze interlock ----

--- a/docs/seek_realign.md
+++ b/docs/seek_realign.md
@@ -1,6 +1,9 @@
 # Post-seek reference re-align (issue #45)
 
-> **Status: 🔧 fixed in fabric, sim-proven RED/GREEN, ⏳ HW-confirm pending.**
+> **Status: ✅ FIXED and HW-CONFIRMED 2026-09-03** (build
+> `DVD_seekrealign_20260903_1901.rbf`, SEED 5 first roll, clk_dec 91.10/88.28).
+> Sim-proven RED/GREEN first; the hardware round then reported exactly the predicted
+> outcome — see §5.
 > Branch `fix/seek-reference-realign`. RTL: `rtl/mpeg2/vld.v` (+ one port connection
 > in `rtl/mpeg2/mpeg2video.v`). Gate: `bench/dvd/run_seek_realign.sh`.
 > Engineering note — the user-facing statement lives in
@@ -215,12 +218,35 @@ update. **With the leading B's dropped it is now held for ~4 picture times inste
 
 Net trade: **~6 frames of macroblocked *motion* → ~1 torn frame held longer.** That is
 better, and the *signature* the field report identifies is gone, but it is not clean. The
-HW round's question is therefore binary and falsifiable:
+HW round's question was therefore binary and falsifiable:
 
 > **Is the old scene still visible in motion as residual?**
 
-If no, v1 succeeded and the remaining held frame is a separate item. If yes, the anchor
-accounting is wrong and the bench's slot-tag arms are where to look — not the display path.
+### ✅ HW round, 2026-09-03 — the prediction held, to the frame
+
+> *"this looks good. the old scene is not in motion, it's frozen and we jump to the target
+> seek position with ~1 frame of a misaligned image."*
+
+Three separable claims in one sentence, and each maps onto a specific piece of the design:
+
+- **"the old scene is not in motion"** — the leading B's are no longer decoded and
+  displayed. That is the defect issue #45 reported, and it is gone.
+- **"it's frozen"** — `output_frame_valid` now stays on the last good frame across the
+  landing, because picbuf never sees the dropped pictures. This is the behaviour
+  `flush_ctl.sv` claimed a seek already had (§2) and did not.
+- **"~1 frame of a misaligned image"** — the truncated in-flight picture, predicted above
+  and unchanged by this fix. One frame, not a burst.
+
+★ **Writing the residual down *before* the build is what made this round cheap.** The
+report is a confirmation rather than a surprise, and no time was spent re-opening the
+anchor accounting to explain a frame that was already accounted for. Had the answer been
+"yes, still moving", the next place to look was named in advance (the bench's slot-tag
+arms, not the display path) — which is the same discipline `docs/single_raster_analog.md`
+§3.9 earned the hard way over five rounds.
+
+The remaining single frame is the v2 item costed in §5.1. It is now the *only* thing left
+of issue #45, and it is a different defect class: one corrupt picture, not stale
+prediction.
 
 ### 5.1 Why the display side was left alone (and what v2 would have to be)
 
@@ -254,6 +280,13 @@ the hold, reuses mutation-checked machinery, and lives entirely in `dvd/`. The
 counter-argument is `docs/single_raster_analog.md` §6.8's own reason not to blank a seek —
 display continuity — which is weaker than it looks when the thing being held is torn. **A
 UX call, deferred by user decision (2026-09-03): one behavioural delta this round.**
+
+⚠ **The HW round sharpens the cost/benefit for this one.** What the screen now does at a
+landing is *freeze, then cut to the new scene with one bad frame in between* — which is
+already close to a hard cut, so blanking that single frame would cost very little display
+continuity and would make the transition clean. The v1 argument for leaving it (never blank
+a seek) was written when the alternative was six frames of visible garbage; it is a weaker
+argument against blanking one.
 
 ## 6. The gate
 

--- a/docs/seek_realign.md
+++ b/docs/seek_realign.md
@@ -151,6 +151,46 @@ forever. It is a `parameter` so the bench can reach the path inside a short fixt
 (arm [6], `-Pseek_realign_tb.RA_CAP=2`); the shipped value never is, which would otherwise
 make it untested dead code.
 
+### 3.5 Scope: which menu transitions this touches
+
+The re-align arms on `flush_vbuf_eff`, and `dvd/flush_ctl.sv` gates `seek_flush` on
+`~keep_vbuf`:
+
+```verilog
+wire jump_flush     = jump_ack && ~keep_vbuf;
+wire seek_flush_now = seek_ack && ~keep_vbuf;
+```
+
+So the split is the Phase-5 menu-transition rule, unchanged and inherited for free:
+
+| transition | `keep_vbuf` | flush | re-align |
+|---|---|---|---|
+| menu → menu (submenu, page, `next_pgcn` advance) | 1 | none | **never arms** |
+| title → menu (Menu key) | 0 | trio | arms, like a seek |
+| menu → title (Play) | 0 | trio | arms, like a seek |
+| chapter skip / scrub / D-Pad Seek | 0 | trio | arms |
+| `Video Output` change | — (`mode_switch`) | trio | arms |
+
+Menu→menu hops — the ones that carry an authored transition animation, and that
+`keep_vbuf` exists to protect — are **structurally untouched**: no flush reaches the
+decoder, so `ra_active` never sets. Entering and leaving a menu *is* a flushing jump and
+was always one of the four paths issue #45 named, so it gets the same treatment as a
+chapter skip.
+
+⚠ **The failure mode worth measuring is a menu STILL**, because it is the shape that would
+break catastrophically. A still is a whole stream — `SEQ GOP PIC:I SEQ_END` — carrying
+**one** I picture and no B's, so if the re-align ever dropped an I the menu would simply
+never appear. It does not: an I is always accepted at `ra_anchors == 0`, and bench arm [7]
+measures it over `bench/dvd/test_vobs/hp_still_i.hex` (a real still, cut from the Harry
+Potter interactive disc for the picbuf slot-alias fix) landed as cut B:
+`realign_drops=0, post-flush{hdr=1 upd=1 anchors=1}`.
+
+A second-order effect worth knowing: after a still, `ra_active` stays armed (a still yields
+one anchor, never two) until the next anchor or `RA_CAP`. If the user then makes a
+`keep_vbuf` hop to a *motion* menu, that menu's leading B's are dropped — which is the
+right answer anyway, since they predict from the previous menu's frame. The cost is one
+extra held frame at a menu transition, bounded by `RA_CAP`.
+
 ## 4. Rejected alternatives
 
 **`closed_gop`** (parsed at `vld.v:1477`, consumed by nothing before or after this change)
@@ -236,28 +276,67 @@ closed first GOP or no leading B's — either would make the RED arm measure zer
 whole gate vacuous — and refuses a cut A containing a sequence end, which would pre-clear
 the references for free.
 
-| | measured |
-|---|---|
-| **RED** (`-Pseek_realign_tb.SEEK_REALIGN=0`, the fix's input tied low) | `viol == meta[3]` — the exact leading-B count, and `realign_drops == 0` (the added logic is provably inert when unarmed) |
-| **GREEN** | `viol == 0` **and** `realign_drops == meta[3]` — asserted **exactly**, because dropping too much costs display frames at every seek |
+| | asserted | measured (Matrix Revolutions VTS01, `lead_b = 2`) |
+|---|---|---|
+| **RED** (`-Pseek_realign_tb.SEEK_REALIGN=0`, the fix's input tied low) | `viol == meta[3]`, `realign_drops == 0` | `viol=2` — both leading B's predicting `fwd = slot 1`, tagged cut A |
+| **GREEN** | `viol == 0` **and** `realign_drops == meta[3]` | `viol=0 realign_drops=2 post-flush{hdr=14 upd=12 anchors=5}` |
+
+The GREEN drop count is asserted **exactly**, not as `>= 1`: dropping too much is a failure
+too, because it costs display frames at every seek.
 
 The RED arm is a *testbench* parameter, not an RTL one, so the shipped RTL has no
 feature-off path and the same binary proves both halves. Its numbers reproduce a run
-against pristine, unmodified `vld.v` byte for byte (`viol=2`, `emits=18`, identical emit
-gap), which is what makes it a legitimate stand-in for the pre-fix build.
+against pristine, unmodified `vld.v` **byte for byte** (`viol=2`, `emits=18`, emit gap
+285962 cycles), which is what makes it a legitimate stand-in for a pre-fix build.
 
-Arms: [1] control, no flush (the re-align must be completely inert over a whole stream);
-[2] flush mid-slice — the reported case; [3] flush at a picture header; [4] two flushes on
-one seek (the second must restart the window); [5] `+DRAIN` display-blocked — §3.1; [6]
-`RA_CAP=2` — the give-up must fire and decoding must resume. Anti-vacuity on every arm:
-≥ 8 post-flush pictures must reach picbuf and ≥ 2 post-flush anchors must decode, or
-"drop everything forever" would score zero violations and pass.
+All eight arms green (`bench/dvd/run_seek_realign.sh --red`, 2026-09-03).
 
-Regression: `vld_drop_rff_tb` guards the ledger split (§3.3). It was **stale** — its `vld`
-and `motcomp_picbuf` instances predated `pic_informative` / `informative_commit` /
-`drop_pic_field` / `mpeg1` / `cc_pair*`, so picbuf's two evidence *inputs* were floating,
-and its default fixture no longer existed — and was repaired in the same branch before
-being trusted as a baseline.
+**Arms.** [1] control, no flush — the re-align must be inert over a whole stream
+(`realign_drops=0` over 19 pictures); [2] flush mid-slice, the reported case; [3] flush at
+a picture header; [4] two flushes on one seek — they must **coalesce** onto one re-align,
+which is structural because `ra_active`/`ra_anchors` are a level rather than an edge count
+(the same property that makes the repeated-mid-parse-flush loop which killed the film-mode
+edge unreachable here); [5] `+DRAIN=4000` display-blocked — §3.1; [6] `RA_CAP=1`, the
+give-up; [7] a **menu still** as the landing — §3.5.
+
+Anti-vacuity on every arm: ≥ 8 post-flush pictures must reach picbuf and ≥ 2 post-flush
+anchors must decode, or "drop everything forever" would score zero violations and pass.
+
+Three things the arms taught, all worth keeping:
+
+- ⚠ **The truncated in-flight picture EATS cut B's sequence header.** The bench originally
+  asserted that a sequence header must be parsed between the flush and the first post-flush
+  picture header, as a guard that the cut-A/cut-B tagging was trustworthy. Arms [3] and [5]
+  failed it on correct RTL: the truncated picture consumes the new stream's opening bytes
+  as its own payload, and since `sequence_header_seen` is already set from cut A the vld
+  simply decodes on. The guard is now a **count** — post-flush frame headers must equal the
+  fixture's cut-B picture count (14 = 14); one leaked cut-A header would make it 15.
+- ⚠ **`RA_CAP` must be small enough to shorten the window by more than one picture.** The
+  give-up clears `ra_active`, but `realign_now_comb` is combinational off the *pre*-clear
+  value, so the header that trips the cap is still judged normally. At `RA_CAP=2` the arm
+  measured `realign_drops=2` — identical to an uncapped run, i.e. "the cap fired" and "the
+  cap is dead code" were indistinguishable. `RA_CAP=1` separates them.
+- ★ **The give-up arm measures `viol=1`, and that is the design, not a miss.** Cutting the
+  window short lets one leading B through to predict from the stale slot. The cap trades a
+  bounded amount of the very artifact this change fixes for a guarantee that video can
+  never freeze on a stream that stops delivering anchors. `RA_CAP=48` is far beyond any
+  real GOP, so the trade is never taken on a real disc — but the arm shows exactly what it
+  costs when it is.
+- The `+DRAIN` arm's own guard reports `vld_en high for 0 of the 192 flush-window cycles` —
+  the freeze really did cover the whole window, so the arm genuinely exercised §3.1.
+
+**Regression: the governor's ack ledger must not move.** `vld_drop_rff_tb` measured
+`pictures=18 drops=11 ack_rff1=5 ack_rff0=6` against the **pre-fix** vld on this fixture,
+and the same numbers after the split — asserted as a literal string by the runner. That
+bench was **stale** and had to be repaired before it could be trusted as a baseline: its
+`vld` and `motcomp_picbuf` instances predated `pic_informative` / `informative_commit` /
+`drop_pic_field` / `mpeg1` / `cc_pair*` (two of which are picbuf *inputs*, so they were
+floating to `z`), and its default fixture no longer existed — `$readmemh` on a missing file
+leaves the array all-X, so it would have "passed" having decoded nothing.
+
+Other benches over the shared `vld`, all green: `film_evidence_tb` (35/35 pictures, every
+verdict matches golden), `cc_extract_tb` (180/180 caption pairs byte-exact), `vld_mpeg1_tb`
+(115 pictures, 0 errors), `motcomp_picbuf_tb` (50 release-point checks, 0 fails).
 
 ## 7. Fit
 

--- a/docs/seek_realign.md
+++ b/docs/seek_realign.md
@@ -1,0 +1,267 @@
+# Post-seek reference re-align (issue #45)
+
+> **Status: 🔧 fixed in fabric, sim-proven RED/GREEN, ⏳ HW-confirm pending.**
+> Branch `fix/seek-reference-realign`. RTL: `rtl/mpeg2/vld.v` (+ one port connection
+> in `rtl/mpeg2/mpeg2video.v`). Gate: `bench/dvd/run_seek_realign.sh`.
+> Engineering note — the user-facing statement lives in
+> `site/content/reference/troubleshooting.md`.
+
+## 1. The report, and the one detail that identifies it
+
+Every seek — chapter skip (B2/B3), Fast Fwd / Rewind scrub release, D-Pad Seek (`O[45]`),
+menu → Play — shows a short burst of macroblocking as playback resumes. Measured from a
+60 Hz HDMI recording: **~6 frames (~100 ms)**. From the same recording:
+
+> *"The macroblocks are a mix of the previous scene and the one we're seeking to. Worth
+> noting that the target chapter is decoding and in motion during this macroblocking, but
+> it has the residual image overlayed."*
+
+★ **That is the whole diagnosis.** The new content decoding *and moving* rules out the
+reader, the demux and the landing point: the stream is correct and the picture is being
+built. Only the **prediction** is wrong. A corrupt or truncated picture would be a single
+still-wrong frame, not a burst with coherent new motion. So the artefact is motion
+compensation against reference frames from where we *were*, and the question is why the
+decoder still has them.
+
+Scope: all four transport paths, every disc tried. Not authoring-dependent, so it belongs
+to the shared flush contract rather than to any one path.
+
+## 2. Root cause
+
+`flush_vbuf_eff` (`rtl/mpeg2/mpeg2video.v:865`) reaches exactly three sinks:
+
+| sink | line | what it clears |
+|---|---|---|
+| `vbuf_rst` | :870 | the circular video buffer's write/read FIFOs |
+| `frame_drop_ctl.flush` | :1095 | the governor's carried drop debt |
+| `framestore.vb_flush` | :1811 | the DDR circular-buffer pointers |
+
+**Nothing else.** `vld` / `getbits` / `motcomp` / `motcomp_picbuf` are on `sync_rst`, and
+`mount_flush` (the decoder soft reset) has been MOUNT-ONLY since 2026-08-28. So the flush
+discards *buffered bytes* and leaves every bit of decode state standing — including the
+reference slots.
+
+`motcomp_picbuf` has **no valid bit on the reference slots at all**:
+`forward_reference_frame` / `backward_reference_frame` are pure pointers, and
+`motcomp_addrgen` reads them unconditionally for any macroblock with
+`macroblock_motion_forward/backward`. Stale *content* is therefore invisible to the
+decoder by construction. (`prev_i_p_frame_valid`, which issue #45 originally named, is a
+*display* flag — see §5.)
+
+### 2.1 Why the leading B's, and why TWO anchors are needed
+
+`motcomp_picbuf.v:281-291` and `:371-383` — at a non-B `STATE_UPDATE` the module assigns
+`current_frame <= forward_reference_frame` while fwd and bwd swap. Trace it across a seek:
+
+| picture | current | fwd after | bwd after | predicts from |
+|---|---|---|---|---|
+| pre-flush anchor → slot 1 | 1 | 0 | 1 | — |
+| **I0** — first post-flush anchor | 0 | 1 | 0 | intra, safe |
+| B1, B2 — the open GOP's leading pictures | aux 2/3 | 1 | 0 | fwd = slot 1 = **PRE-FLUSH** |
+| **P3** — second post-flush anchor | **1** | 0 | 1 | fwd = I0 ✓, and it *overwrites* slot 1 |
+| B4, B5 … | aux | 0 | 1 | both post-flush ✓ |
+
+The first anchor only establishes the **backward** reference. Forward still points at the
+slot the old scene lives in, and an open GOP's leading B-pictures — coded after the I,
+displayed before it — are precisely the pictures that read it. Only the **second** anchor's
+`current_frame <= forward_reference_frame` overwrites that slot. Two coded pictures at
+~24–30 fps, expanded by 3:2, is ~6 display frames: the reported number.
+
+⚠ **The rationale `flush_ctl.sv` gave for not soft-resetting on a seek was not being
+achieved.** It said a seek is *"where the display must hold the last frame and the
+reference frames are same-file valid"*. Same-**file** is not same-**position**, and MPEG
+prediction cares about position; and the display was not holding — it was showing ~6
+corrupt frames, because `output_frame_valid` stays high straight through a flush.
+
+## 3. The fix
+
+`rtl/mpeg2/vld.v` gains one input, `vbuf_flush` (driven from `flush_vbuf_eff` — already
+clk_dec, already 2-FF synced in `dvd/emu.sv`, so no new CDC), and a small state machine:
+
+- `ra_anchors == 0` → drop every picture that is **not an I**.
+- `ra_anchors == 1` → drop **B** pictures.
+- the second accepted anchor clears `ra_active`.
+
+Dropping happens through the decoder's existing, HW-proven suppression legs — the same
+ones the frame-drop governor uses — so the dropped pictures are invisible downstream:
+slices routed to `STATE_NEXT_START_CODE` (`vld.v:721`), `update_picture_buffers` suppressed
+so picbuf never allocates or rotates for them, `flags_commit` and `informative_commit`
+gated. picbuf therefore never emits them and the display **genuinely holds** the last frame
+until the new scene's references are real — which is what `flush_ctl.sv` always claimed a
+seek did.
+
+Non-I pictures are dropped before the first I because a title seek lands on a VOBU/GOP
+boundary but a flat `.mpg`/`.VOB` seek only hunts a pack and may land anywhere. There, the
+pre-fix behaviour was garbage until the next I; now it is a held frame until the next I.
+
+### 3.1 ★ The arm must sit BEFORE the `clk_en` term
+
+`vld.clk_en` is `vld_en`, and `rtl/mpeg2/motcomp.v:257-272` freezes the VLD at **every**
+picture header until picbuf has processed the update — picbuf waits there on the display
+handshake, i.e. **up to a whole display frame (~1.5 M clk_dec cycles at 93 MHz / 60 Hz)**.
+The flush level is ~64 clk_sys cycles ≈ **192 clk_dec cycles**. A `clk_en`-gated capture
+would therefore miss the level *routinely*, not occasionally.
+
+The arm is level-dominant for the whole window, which also coalesces repeated flushes for
+free: a scrub or a double chapter skip restarts the window instead of being swallowed —
+the same property `mode_realign` needed (`docs/single_raster_analog.md` §6).
+
+Bench arm [5] (`+DRAIN=4000`) is the one that proves this, and it carries its own
+anti-vacuity guard: it asserts the vld was frozen for the entire flush window
+(`vld_en` high for 0 of its cycles), because otherwise the arm would pass without ever
+exercising the case.
+
+### 3.2 Anchors are counted off the node picbuf rotates on
+
+`update_picture_buffers`'s header condition is factored out as `hdr_upd_slot`, and the
+anchor counter keys on the same wire. Two reasons this is not just tidiness:
+
+- **Correct by construction.** The rule becomes "count an anchor exactly when picbuf
+  rotates". In particular a **field-coded I frame is two I field pictures** and must count
+  ONCE — it does, because `second_field` reads 1 only at a field pair's *first* header (the
+  seq/gop preset convention that `drop_now_comb` already relies on). Writing the condition
+  out a second time is how that gets silently wrong.
+- **No new fan-out on `picture_structure`** — the register physical synthesis mangled in
+  the Thayer `drops=0` round (`vld.v` `drop_ps_lat` note). The new logic reads the same
+  node the HW-proven `update_picture_buffers` path reads.
+
+MPEG-1 comes free: `picture_structure` is forced to `FRAME_PICTURE` in mpeg1 mode.
+
+No sibling pair-arm latch is needed. The governor needs `drop_pair_arm` because its
+predicate is deliberately restricted to a field pair's first field; this predicate is a
+pure function of `getbits[13:11]` and `ra_anchors`, identical at both field headers, so
+field-pair atomicity is **structural**.
+
+### 3.3 The ledger split — not hygiene, a real regression if omitted
+
+`drop_this_picture` now latches *either* reason, but a new `drop_gov_picture` latch (the
+governor's alone) feeds `drop_slice_hit` and therefore `drop_pic_ack`.
+
+Without the split, 2–3 realign drops on every seek pay credit into `frame_drop_ctl`, whose
+`DEBT_FLOOR` is `-4` (`dvd/frame_drop_ctl.sv:120,136`). With `DROP_THRESHOLD = 2` the
+governor would then need **6 accrued lates before it could drop again** — exactly during
+the post-seek re-lock, when it is most likely to be late. `drop_pic_rff` / `drop_pic_field`
+would also export the realign-dropped picture's flags into `drop_cost`, and
+`frames_dropped_cnt` telemetry would be polluted.
+
+### 3.4 The give-up cap
+
+`RA_CAP = 48` picture headers. A stream that never delivers an I must not freeze video
+forever. It is a `parameter` so the bench can reach the path inside a short fixture
+(arm [6], `-Pseek_realign_tb.RA_CAP=2`); the shipped value never is, which would otherwise
+make it untested dead code.
+
+## 4. Rejected alternatives
+
+**`closed_gop`** (parsed at `vld.v:1477`, consumed by nothing before or after this change)
+would let a genuinely-safe leading B through. **Not honoured, deliberately:** it is a bit
+the *encoder wrote*, not a measurement — the same failure class as `progressive_frame` in
+the film-evidence gate (`docs/film_24p_plan.md` §14), where an encoder's meaningless
+default was being counted as evidence. A disc that lies `closed_gop=1` would leave issue
+#45 present **and unfalsifiable on that disc**. It can only ever make the fix weaker, and
+it buys two pictures at a landing the user already expects to re-lock.
+
+**Extending `mount_flush` (the decoder soft reset) to seeks** — the blunt version. It
+asserts `sync_rst`, which drops `dec_ready` and gates the modeline walk (the boot race in
+`docs/single_raster_analog.md` §3.2), and it trades a glitch for a black cut on every
+chapter skip. Retained only as the fallback if the re-align proves insufficient on HW.
+
+## 5. What this does NOT fix — a prediction, written before the build
+
+The picture in flight when the flush lands already had its `update_picture_buffers` fire:
+it owns a slot, its remaining slices decode against a discarded buffer, and it completes on
+the new stream's first start code. It is displayed once at the first post-flush anchor's
+update. **With the leading B's dropped it is now held for ~4 picture times instead of ~1.**
+
+Net trade: **~6 frames of macroblocked *motion* → ~1 torn frame held longer.** That is
+better, and the *signature* the field report identifies is gone, but it is not clean. The
+HW round's question is therefore binary and falsifiable:
+
+> **Is the old scene still visible in motion as residual?**
+
+If no, v1 succeeded and the remaining held frame is a separate item. If yes, the anchor
+accounting is wrong and the bench's slot-tag arms are where to look — not the display path.
+
+### 5.1 Why the display side was left alone (and what v2 would have to be)
+
+Issue #45's own "fix direction 1" was to clear `prev_i_p_frame_valid` on a flush. Two
+findings against doing it in this round:
+
+1. **Insufficient alone.** It suppresses the *display* of one stale anchor and does nothing
+   to `forward_reference_frame`, so the leading B's — the reported symptom — still predict
+   from the stale slot.
+2. **An ordering hazard no bounded level defeats.** picbuf's `update_picture_buffers`
+   arrives through the **mvec FIFO** (`motcomp.v:280` packs it into `mvec_wr_dta[1]`;
+   `motcomp_addrgen.v:379` drives picbuf from `mvec_rd_update_picture_buffers`). A flush
+   wire routed *directly* to picbuf can clear the flag and then have a queued **pre-flush**
+   anchor's update re-set it from `current_frame_valid` (which is never cleared except by
+   reset). Holding the level for the whole ~192-cycle window does not help: the queued
+   update can take a whole field to drain, because picbuf itself blocks on the display
+   handshake.
+
+★ **The durable rule:** anything that must correct an `update_picture_buffers` decision
+either **rides the mvec FIFO** or is **decided in the vld**. It cannot bypass the FIFO and
+arrive on time.
+
+So the designed v2, if the residual is judged worth it, is a per-picture `pic_realigned`
+flag widened into `mvec_wr_dta` (188 → 189 bits) so picbuf clears the flag *in order*, by
+construction. Costed, not built — it is a second, independent behavioural delta on an
+87–88 % ALM design.
+
+A cheaper v2 candidate with no decoder change at all: extend `mode_realign`'s existing
+switch blank to fire on `seek_ack`/`jump_ack && ~keep_vbuf`. It blanks the torn frame and
+the hold, reuses mutation-checked machinery, and lives entirely in `dvd/`. The
+counter-argument is `docs/single_raster_analog.md` §6.8's own reason not to blank a seek —
+display continuity — which is weaker than it looks when the thing being held is torn. **A
+UX call, deferred by user decision (2026-09-03): one behavioural delta this round.**
+
+## 6. The gate
+
+`bench/dvd/seek_realign_tb.sv`, driven by `bench/dvd/run_seek_realign.sh`. Real
+`getbits_fifo` + real `vld` + real `motcomp_picbuf` over **two cuts from different points
+of a real title**. Partway through cut A the bench does what hardware does: asserts the
+flush level *and* jumps the read pointer to cut B. `getbits` is deliberately **not** reset,
+so its 129-bit window keeps up to 16 bytes of cut A and the in-flight picture truncates
+exactly as on hardware.
+
+**The measurement is slot provenance, not a restatement of the fix.** A shadow `slot_tag[]`
+records which *cut* last wrote each of picbuf's frame slots; every picture that reaches
+picbuf is then checked against the slots it actually predicts from (fwd for P, fwd+bwd for
+B; I is intra). A post-flush picture reading a slot tagged with the pre-flush cut is a
+violation. That names no signal in the fix, so it cannot degenerate into a golden model
+that agrees with its RTL by construction (memory `bench-that-cannot-fail`).
+
+Fixture: `tools/seek_fixture.py`, which **refuses** to emit a fixture whose cut B has a
+closed first GOP or no leading B's — either would make the RED arm measure zero and the
+whole gate vacuous — and refuses a cut A containing a sequence end, which would pre-clear
+the references for free.
+
+| | measured |
+|---|---|
+| **RED** (`-Pseek_realign_tb.SEEK_REALIGN=0`, the fix's input tied low) | `viol == meta[3]` — the exact leading-B count, and `realign_drops == 0` (the added logic is provably inert when unarmed) |
+| **GREEN** | `viol == 0` **and** `realign_drops == meta[3]` — asserted **exactly**, because dropping too much costs display frames at every seek |
+
+The RED arm is a *testbench* parameter, not an RTL one, so the shipped RTL has no
+feature-off path and the same binary proves both halves. Its numbers reproduce a run
+against pristine, unmodified `vld.v` byte for byte (`viol=2`, `emits=18`, identical emit
+gap), which is what makes it a legitimate stand-in for the pre-fix build.
+
+Arms: [1] control, no flush (the re-align must be completely inert over a whole stream);
+[2] flush mid-slice — the reported case; [3] flush at a picture header; [4] two flushes on
+one seek (the second must restart the window); [5] `+DRAIN` display-blocked — §3.1; [6]
+`RA_CAP=2` — the give-up must fire and decoding must resume. Anti-vacuity on every arm:
+≥ 8 post-flush pictures must reach picbuf and ≥ 2 post-flush anchors must decode, or
+"drop everything forever" would score zero violations and pass.
+
+Regression: `vld_drop_rff_tb` guards the ledger split (§3.3). It was **stale** — its `vld`
+and `motcomp_picbuf` instances predated `pic_informative` / `informative_commit` /
+`drop_pic_field` / `mpeg1` / `cc_pair*`, so picbuf's two evidence *inputs* were floating,
+and its default fixture no longer existed — and was repaired in the same branch before
+being trusted as a baseline.
+
+## 7. Fit
+
+Ten registers (`ra_active`, `ra_anchors[1:0]`, `ra_hdrs[5:0]`, `drop_gov_picture`) plus a
+few LUTs, all inside the once-per-picture `STATE_PICTURE_HEADER` decision cone, which has
+enormous slack. It should not move the limiter — but the netlist changes, so the pinned
+fitter SEED is a fresh roll regardless. See the `DVD.qsf` ledger entry.

--- a/docs/single_raster_analog.md
+++ b/docs/single_raster_analog.md
@@ -508,15 +508,24 @@ observation that relocates the remaining work. (It is an observation of appearan
 measurement — but it is the right shape, and it is the same reasoning that closed §3.9:
 when a build changes X and the symptom persists unchanged, X is exonerated.)
 
-**The residual is now tracked as [issue #45](https://github.com/owenb321/MiSTer_DVD/issues/45)**
-— *"Macroblocking for ~6 frames after any seek: reference frames survive the VBUF flush"*.
-Measured there from a 60 Hz HDMI recording: ~6 frames (~100 ms), on all four transport
-paths and every disc tried, with the target chapter decoding and in motion while the old
-scene bleeds through as residual. That last detail is what identifies it — motion
-compensation against stale references, not a corrupt picture. Root cause confirmed in the
-RTL: `motcomp_picbuf`'s `prev_i_p_frame_valid` is cleared only by `~rst` or a sequence end,
-never by a flush, so the reference slots survive a seek still holding the old scene and
-still flagged valid.
+**The residual was tracked as [issue #45](https://github.com/owenb321/MiSTer_DVD/issues/45)**
+— *"Macroblocking for ~6 frames after any seek: reference frames survive the VBUF flush"* —
+and is **🔧 FIXED (2026-09-03, branch `fix/seek-reference-realign`, sim-proven RED/GREEN,
+⏳ HW-confirm pending): `docs/seek_realign.md`.** Measured there from a 60 Hz HDMI
+recording: ~6 frames (~100 ms), on all four transport paths and every disc tried, with the
+target chapter decoding and in motion while the old scene bleeds through as residual. That
+last detail is what identifies it — motion compensation against stale references, not a
+corrupt picture.
+
+⚠ **This note originally named `motcomp_picbuf`'s `prev_i_p_frame_valid` as the root
+cause. That is only the DISPLAY half, and it is the smaller one.** The slots themselves
+carry **no valid bit at all** — `forward_reference_frame` / `backward_reference_frame` are
+pure pointers that `motcomp_addrgen` reads unconditionally — so what produced the reported
+*moving* residual is the landing GOP's leading B-pictures predicting from the surviving
+slot, which clearing a display flag does nothing about. The fix is one layer up, in
+`rtl/mpeg2/vld.v`: drop the landing GOP's leading predicted pictures until two post-flush
+anchors have re-established the references. Why *two*, and why the picbuf-side clear cannot
+be made to work from outside the mvec FIFO, are both in `docs/seek_realign.md`.
 
 **The original note, kept because it is the reasoning that got there:** `flush_ctl`'s trio discards
 *buffered* data but deliberately leaves the decode pipeline's state — `vld`/`getbits`/
@@ -529,17 +538,21 @@ first B-frames against frames from the *old* position. Same mechanism as the mid
 garbage (`docs/av_sync.md`), just bounded, because within one title the references are at
 least same-file.
 
-★ **And the switch blank changes the cost/benefit for the mode-switch case specifically.**
-The stated reason not to soft-reset on a seek is *display continuity* — the screen must
-hold the last frame while the decoder re-locks. During a blanked mode switch there is no
-display continuity to protect: the screen is black by design. So adding `mode_switch` (the
-fallback leg) **and** the re-align's `seek_ack` to `mount_flush` is now arguable for this
-path alone, and would remove the truncated frame and the stale references. ⚠ Two things to
-design against before trying it: the soft reset asserts `sync_rst`, which drops `dec_ready`
-and gates the modeline walk (§3.2's boot race) — the regfile is on `hard_rst` so the walk's
-writes survive, but the interaction wants a `modeline_boot_tb` phase before a build; and
-chapter skips would still be untouched, so it fixes the symptom on one path while leaving
-the class open. Not attempted; recorded so the next session starts from here.
+⛔ **SUPERSEDED (2026-09-03) — the proposal below was to extend `mount_flush` to the mode
+switch. Issue #45 was fixed in the vld instead, which covers all four transport paths
+rather than this one. Retained as the FALLBACK if the re-align proves insufficient on
+hardware.** ★ *The switch blank changes the cost/benefit for the mode-switch case
+specifically.* The stated reason not to soft-reset on a seek is *display continuity* — the
+screen must hold the last frame while the decoder re-locks. During a blanked mode switch
+there is no display continuity to protect: the screen is black by design. So adding
+`mode_switch` (the fallback leg) **and** the re-align's `seek_ack` to `mount_flush` is
+arguable for this path alone, and would remove the truncated frame as well as the stale
+references. ⚠ Two things to design against before trying it: the soft reset asserts
+`sync_rst`, which drops `dec_ready` and gates the modeline walk (§3.2's boot race) — the
+regfile is on `hard_rst` so the walk's writes survive, but the interaction wants a
+`modeline_boot_tb` phase before a build; and chapter skips would still be untouched, so it
+fixes the symptom on one path while leaving the class open. **That last objection is
+exactly what sent the fix to the vld:** the class is shared, so the fix should be too.
 
 ## 7. Follow-ups
 - **✅ Blank the video during a `Video Output` switch — IMPLEMENTED 2026-09-03 (user

--- a/docs/single_raster_analog.md
+++ b/docs/single_raster_analog.md
@@ -510,8 +510,11 @@ when a build changes X and the symptom persists unchanged, X is exonerated.)
 
 **The residual was tracked as [issue #45](https://github.com/owenb321/MiSTer_DVD/issues/45)**
 — *"Macroblocking for ~6 frames after any seek: reference frames survive the VBUF flush"* —
-and is **🔧 FIXED (2026-09-03, branch `fix/seek-reference-realign`, sim-proven RED/GREEN,
-⏳ HW-confirm pending): `docs/seek_realign.md`.** Measured there from a 60 Hz HDMI
+and is **✅ FIXED and HW-CONFIRMED 2026-09-03 (branch `fix/seek-reference-realign`, build
+`DVD_seekrealign_20260903_1901.rbf`): `docs/seek_realign.md`.** What remains at a landing
+is a freeze followed by ~1 misaligned frame — the truncated in-flight picture, which was
+predicted before the build and is a different defect class from the stale prediction this
+fixed. Measured there from a 60 Hz HDMI
 recording: ~6 frames (~100 ms), on all four transport paths and every disc tried, with the
 target chapter decoding and in motion while the old scene bleeds through as residual. That
 last detail is what identifies it — motion compensation against stale references, not a
@@ -555,6 +558,20 @@ fixes the symptom on one path while leaving the class open. **That last objectio
 exactly what sent the fix to the vld:** the class is shared, so the fix should be too.
 
 ## 7. Follow-ups
+- ⚠ **A/V SYNC after a `Video Output` change — OPEN, pre-existing, NOT from issue #42 or
+  #45.** Reported on the 2026-09-03 seek-realign round: *"Many video output changes can
+  cause sync issues, but that is existing behavior and is cleared by a chapter skip."*
+  Note what this is **not**: not the mode-switch FREEZE (§6, fixed and HW-confirmed), and
+  not the stale-reference macroblocking (`docs/seek_realign.md`, fixed and HW-confirmed on
+  the same build). It is lip-sync drift that survives the switch and is cured by a
+  re-anchor. ★ **That "cured by a chapter skip" detail is the diagnosis pointing at
+  `av_sync`, not at the raster:** a chapter skip re-anchors the STC, so the switch is
+  leaving the STC on a timeline the new raster no longer matches. The mode switch already
+  fires the full trio plus a re-align seek, so the suspect is the refresh-rate change
+  itself — `TICKS_PER_REFRESH` / `refresh_50hz` are picked from the mode, and an
+  Interlaced↔Progressive change alters how many refreshes a displayed frame costs. Not
+  investigated; recorded so the next session starts from the right layer.
+
 - **✅ Blank the video during a `Video Output` switch — IMPLEMENTED 2026-09-03 (user
   request after the issue #42 HW round; ⏳ HW-confirm pending).** See §6.8. The proposal
   that was recorded here is now the shipped design; the reasoning that survived is in §6.8

--- a/dvd/flush_ctl.sv
+++ b/dvd/flush_ctl.sv
@@ -169,8 +169,7 @@ end
 // watchdog-equivalent soft reset (mpeg2video.soft_flush -> reset.soft_rst_n). The
 // flush trio above discards BUFFERED data but deliberately leaves the decode
 // pipeline's state (the upstream "trick play" flush resets only the VBUF FIFOs;
-// vld/getbits/motcomp/picbuf are all on sync_rst) — right for seeks, where the
-// display must hold the last frame and the reference frames are same-file valid.
+// vld/getbits/motcomp/picbuf are all on sync_rst).
 // A NEW FILE must not inherit any of it: the in-flight picture "completes" on the
 // new file's first start code (one truncated garbage frame), and the old file's
 // reference frames stay flagged valid, so an open-GOP-leading new file (common for
@@ -179,6 +178,22 @@ end
 // all of it while the regfile/modeline (hard_rst) survive — the exact recovery
 // path a watchdog expiry exercises routinely on HW — so a warm load starts as
 // black and clean as a core reload. NEVER on seeks/jumps/mode switches.
+//
+// ⚠ CORRECTED 2026-09-03 (issue #45). This comment used to justify the
+// mount-only rule as "right for seeks, where the display must hold the last
+// frame and the reference frames are same-file valid". BOTH halves were wrong,
+// and the conflation IS the bug: same-FILE is not same-POSITION, and MPEG
+// prediction cares about position, so a seek's surviving references are exactly
+// as stale as a mount's; and the display was NOT holding — output_frame_valid
+// stays high straight through a flush, so ~6 frames of the landing GOP's
+// leading B-pictures were displayed motion-compensated against the scene we
+// just left. THE RULE ITSELF STANDS, unchanged: a seek still must not soft-reset
+// (sync_rst drops dec_ready and gates the modeline walk, and a black cut on
+// every chapter skip is worse than a held frame). The reference staleness is
+// fixed one layer down instead — rtl/mpeg2/vld.v drops the landing GOP's
+// leading predicted pictures until two post-flush anchors have re-established
+// the references, so the display holds the last frame for real.
+// See docs/seek_realign.md.
 reg [6:0] mount_flush_cnt = 7'd0;
 assign    mount_flush = mount_flush_cnt != 7'd0;
 always @(posedge clk) begin

--- a/rtl/mpeg2/mpeg2video.v
+++ b/rtl/mpeg2/mpeg2video.v
@@ -1028,7 +1028,14 @@ module mpeg2video(clk, mem_clk, dot_clk, dot_ce,
     .drop_pic_ack(drop_pic_ack),                             // DVD-FORK (frame-drop O[19]): to frame_drop_ctl
     .drop_pic_rff(drop_pic_rff),                             // DVD-FORK (film-aware drop cost): dropped pic's rff
     .drop_pic_field(drop_pic_field),                         // DVD-FORK (field-pair drop): dropped pic was a field
-    .dbg_drop_probe(dbg_drop_probe)                          // DVD-FORK DEBUG (2026-08-05): in-vld drop-path probe
+    .dbg_drop_probe(dbg_drop_probe),                         // DVD-FORK DEBUG (2026-08-05): in-vld drop-path probe
+    /* DVD-FORK FIX (seek realign, issue #45): the same flush that discards the
+     * buffered bitstream now also tells the vld that motcomp_picbuf's reference
+     * slots are stale, so it can drop the landing GOP's leading predicted
+     * pictures instead of displaying them motion-compensated against the scene
+     * we just left. Already clk_dec and already 2-FF synced upstream
+     * (dvd/emu.sv vbuf_flush_dec) — no new CDC. See docs/seek_realign.md. */
+    .vbuf_flush(flush_vbuf_eff)
     );
 
   /* DVD-FORK (frame-drop governor, O[19]): catch-up credit controller. Banks a "drop

--- a/rtl/mpeg2/vld.v
+++ b/rtl/mpeg2/vld.v
@@ -55,7 +55,8 @@ module vld(clk, clk_en, rst,
   flags_commit,                                                                             // DVD-FORK (round 11): per-picture display flags are valid (coding ext parsed)
   pic_informative, informative_commit,                                                      // DVD-FORK (film evidence gate): this picture carried real evidence
   cc_pair_valid, cc_pair, cc_pair_field,                                                    // DVD-FORK (line-21 CC): EIA-608 byte pairs sniffed out of user_data
-  mpeg1                                                                                     // DVD-FORK FIX (mpeg1): stream is MPEG-1 (no sequence extension) — to rld via the rld fifo
+  mpeg1,                                                                                    // DVD-FORK FIX (mpeg1): stream is MPEG-1 (no sequence extension) — to rld via the rld fifo
+  vbuf_flush                                                                                // DVD-FORK FIX (seek realign, issue #45): a VBUF flush happened — the references are now stale
   );
 
   input            clk;                           // clock
@@ -282,6 +283,24 @@ module vld(clk, clk_en, rst,
    * slice-routing gate can bypass every slice of the dropped B. */
   wire             drop_now_comb;   // assigned below, after picture_structure is declared
   (* preserve *) reg drop_this_picture;   // DVD-FORK FIX (2026-08-05): see drop_now_comb hardening note
+  /* DVD-FORK FIX (seek realign, issue #45): drop_this_picture now latches EITHER
+   * reason, but only the governor's may pay into the frame-drop ledger — see the
+   * realign block below and drop_gov_picture at the ack. */
+  (* preserve *) reg drop_gov_picture;
+  wire             realign_now_comb; // assigned below, beside drop_now_comb
+  wire             hdr_upd_slot;     // assigned below, at update_picture_buffers
+
+  /* DVD-FORK FIX (seek realign, issue #45): a VBUF flush is a DISCONTINUITY.
+   * flush_vbuf_eff (mpeg2video.v) discards the buffered bitstream and nothing
+   * else: vld/getbits/motcomp/picbuf are on sync_rst, so motcomp_picbuf's
+   * reference slots survive a seek still holding the PRE-SEEK scene. An open
+   * GOP's leading B-pictures then motion-compensate against them, which is the
+   * reported "new chapter decoding and in motion with the old image overlaid",
+   * measured at ~6 frames on a 60 Hz capture.
+   *
+   * ~192 clk_dec-cycle LEVEL (dvd/flush_ctl.sv issues ~64 clk_sys cycles; the
+   * 2-FF CDC into clk_dec is in dvd/emu.sv). Level, not pulse — see the arm. */
+  input            vbuf_flush;
 
   /* in sequence header */
   output wire[13:0]horizontal_size;
@@ -393,6 +412,75 @@ module vld(clk, clk_en, rst,
       // sibling's own header re-evaluates this with second_field=0 -> cleared.
       drop_pair_arm <= drop_now_comb && drop_ps_field && second_field;
     else drop_pair_arm <= drop_pair_arm;
+
+  /* DVD-FORK FIX (seek realign, issue #45) — POST-FLUSH REFERENCE RE-ALIGN.
+   *
+   * WHY TWO ANCHORS. Trace motcomp_picbuf's rotation (:281-291 and :371-383):
+   * at a non-B update it assigns current_frame <= forward_reference_frame while
+   * fwd/bwd swap, so the FIRST anchor after a flush only establishes the
+   * BACKWARD reference — forward still points at the pre-flush slot, and that
+   * is exactly what the leading B's read. Only the SECOND anchor's
+   * current_frame <= forward_reference_frame overwrites the stale slot:
+   *
+   *   pre-flush anchor -> slot 1                fwd=0 bwd=1
+   *   I0  (1st post-flush anchor) -> slot 0     fwd=1 bwd=0   intra, safe
+   *   B1,B2 (open-GOP leading)    -> aux        fwd=1 = PRE-FLUSH  <- the defect
+   *   P3  (2nd post-flush anchor) -> slot 1     fwd=0 bwd=1   overwrites it
+   *   B4,B5 ...                                 both post-flush, clean
+   *
+   * So: while ra_anchors == 0 drop every picture that is not an I (a seek lands
+   * on a VOBU/GOP boundary, but a flat-file seek hunts a pack and may not);
+   * while ra_anchors == 1 drop B's; the second accepted anchor ends it. The
+   * dropped pictures use the existing, HW-proven suppression legs, so the
+   * display simply HOLDS the last frame until the new scene's references are
+   * real — which is what flush_ctl.sv always claimed a seek did.
+   *
+   * ★ THE ARM MUST SIT BEFORE THE clk_en TERM. clk_en here is vld_en, and
+   * motcomp.v:257-272 freezes the VLD at EVERY picture header until picbuf has
+   * processed the update — picbuf waits there on the display handshake, i.e.
+   * up to a whole display frame (~1.5 M clk_dec cycles at 93 MHz / 60 Hz).
+   * The flush level is only ~192 clk_dec cycles. A clk_en-gated capture would
+   * miss it routinely, not occasionally. Level-dominant for the whole window
+   * also coalesces repeated flushes for free (a scrub or double chapter skip
+   * restarts the window instead of being swallowed).
+   *
+   * ⚠ closed_gop (parsed at STATE_GROUP_HEADER0, consumed by nothing) is
+   * deliberately NOT honoured: it is a bit the ENCODER wrote, not a
+   * measurement — the same failure class as progressive_frame in the film
+   * evidence gate. A disc that lies would leave the defect present AND
+   * unfalsifiable. It could only ever make this weaker, and it buys two
+   * pictures at a landing the user already expects to re-lock.
+   *
+   * RA_CAP is the give-up: a stream that never delivers an I must not freeze
+   * video forever. It is a parameter so bench/dvd/seek_realign_tb.sv can reach
+   * the path inside a short fixture; the shipped value never is. */
+  parameter [5:0] RA_CAP = 6'd48;
+  (* preserve *) reg       ra_active;   // references not yet re-established
+  (* preserve *) reg [1:0] ra_anchors;  // post-flush frame anchors accepted (saturating)
+                 reg [5:0] ra_hdrs;     // picture headers seen while active (give-up)
+  (* keep *) wire ra_hdr_is_i = (getbits[13:11] == I_TYPE);
+  assign realign_now_comb = ra_active && (state == STATE_PICTURE_HEADER) &&
+                            ((ra_anchors == 2'd0) ? ~ra_hdr_is_i : drop_hdr_is_b);
+  /* No pair-arm sibling latch is needed. The governor needs one because its
+   * predicate is restricted to a field pair's FIRST field; this predicate is a
+   * pure function of getbits[13:11] and ra_anchors, identical at both field
+   * headers of a frame, so field-pair atomicity is structural. */
+  always @(posedge clk)
+    if (~rst)
+      begin ra_active <= 1'b0; ra_anchors <= 2'd0; ra_hdrs <= 6'd0; end
+    else if (vbuf_flush)                                   // ★ ungated: see above
+      begin ra_active <= 1'b1; ra_anchors <= 2'd0; ra_hdrs <= 6'd0; end
+    else if (clk_en && ra_active && (state == STATE_PICTURE_HEADER))
+      begin
+        ra_hdrs <= ra_hdrs + 6'd1;
+        if (ra_hdrs >= RA_CAP) ra_active <= 1'b0;          // give up, never freeze
+        else if (hdr_upd_slot && ~drop_hdr_is_b && ~realign_now_comb)
+          begin                                            // an ACCEPTED anchor
+            ra_anchors <= 2'd1;
+            if (ra_anchors == 2'd1) ra_active <= 1'b0;     // second one: done
+          end
+      end
+
   // DVD-FORK DEBUG (2026-08-05): in-vld drop-path probe — see the port comment.
   (* preserve *) reg [3:0] dbg_hdr_cnt;
   (* preserve *) reg [3:0] dbg_dropnow_cnt;
@@ -2245,9 +2333,18 @@ module vld(clk, clk_en, rst,
   // picbuf for a picture that never delivers data. Combinational off the same getbits
   // field the drop test reads (the loadreg only latches this cycle).
   wire hdr_is_d_m1 = mpeg1 && (getbits[13:11] == D_TYPE);
+  /* DVD-FORK FIX (seek realign, issue #45): factored so the realign's anchor
+   * counter keys on the SAME node picbuf's rotation does. "Count an anchor
+   * exactly when picbuf rotates" is then true by construction — in particular a
+   * field-coded I frame (two I field pictures) counts ONCE, because
+   * second_field reads 1 only at the first field's header. It also adds no new
+   * fan-out on picture_structure, the register physical synthesis mangled in
+   * the Thayer drops=0 round (see drop_ps_lat above). MPEG-1 comes free:
+   * picture_structure is forced to FRAME_PICTURE in mpeg1 mode. */
+  assign hdr_upd_slot = (state == STATE_PICTURE_HEADER) && ((picture_structure == FRAME_PICTURE) || second_field) && ~hdr_is_d_m1;
   always @(posedge clk)
     if (~rst) update_picture_buffers <= 1'b0;
-    else if (clk_en) update_picture_buffers <= ((state == STATE_PICTURE_HEADER) && ((picture_structure == FRAME_PICTURE) || second_field) && ~drop_now_comb && ~hdr_is_d_m1) // emit frame at picture header
+    else if (clk_en) update_picture_buffers <= (hdr_upd_slot && ~drop_now_comb && ~realign_now_comb) // emit frame at picture header
                                                || ((state == STATE_SEQUENCE_END) && ~last_frame); // emit last frame
     else update_picture_buffers <= 1'b0;
 
@@ -2273,10 +2370,23 @@ module vld(clk, clk_en, rst,
    * skipped that would have displayed). */
   always @(posedge clk)
     if (~rst) drop_this_picture <= 1'b0;
-    else if (clk_en && (state == STATE_PICTURE_HEADER)) drop_this_picture <= drop_now_comb;
+    else if (clk_en && (state == STATE_PICTURE_HEADER)) drop_this_picture <= drop_now_comb || realign_now_comb;
     else drop_this_picture <= drop_this_picture;
 
-  wire drop_slice_hit = (state == STATE_START_CODE) && drop_this_picture &&
+  /* DVD-FORK FIX (seek realign, issue #45): the ACK ledger must see the
+   * governor's drops only. A realign drop was not requested by frame_drop_ctl,
+   * so paying it a credit drives debt to DEBT_FLOOR (-4, dvd/frame_drop_ctl.sv)
+   * — the governor would then need 6 accrued lates before it could drop again,
+   * exactly during the post-seek re-lock where it is most likely to be late —
+   * and drop_pic_rff/drop_pic_field would export the realign-dropped picture's
+   * flags into drop_cost. Every SUPPRESSION leg keys on drop_this_picture (both
+   * reasons); only the ack keys on this. */
+  always @(posedge clk)
+    if (~rst) drop_gov_picture <= 1'b0;
+    else if (clk_en && (state == STATE_PICTURE_HEADER)) drop_gov_picture <= drop_now_comb;
+    else drop_gov_picture <= drop_gov_picture;
+
+  wire drop_slice_hit = (state == STATE_START_CODE) && drop_gov_picture &&
                         (getbits[7:0] >= 8'h01) && (getbits[7:0] <= 8'haf);
   (* preserve *) reg drop_acked;   // one ack per dropped picture (many slices are skipped); preserved per the drop_now_comb hardening note
 

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -162,18 +162,28 @@ never show this; it depends on the set.
 
 ### The picture blocks up briefly right after a chapter skip or seek
 
-Known and being tracked
-([issue #45](https://github.com/owenb321/MiSTer_DVD/issues/45)). For roughly six frames —
-about a tenth of a second — the new scene decodes and moves correctly but the old one
-shows through it as a blocky residual, then it clears on its own.
+!!! info "Unreleased"
+    Fixed in the development build; not in v0.3.0. On a release build you will still see
+    the artifact described below.
 
-It happens on every disc and on every way of jumping: chapter skip, Fast Fwd / Rewind,
-D-Pad Seek, and entering or leaving a menu. It is a decoder artifact, not a disc or a
-setting, so there is nothing to change and nothing to report unless it lasts appreciably
-longer than that or the picture does not recover.
+On v0.3.0, for roughly six frames — about a tenth of a second — the new scene decodes and
+moves correctly but the old one shows through it as a blocky residual, then it clears on
+its own. It happens on every disc and on every way of jumping: chapter skip, Fast Fwd /
+Rewind, D-Pad Seek, and entering or leaving a menu.
 
-Changing `Video Output` mid-title produces the same brief glitch on the way back in, for
-the same reason — see [Switching mid-title](../video/interlaced.md).
+It is a decoder artifact, not a disc or a setting: the player was still predicting each new
+picture from the scene it had just left ([issue
+#45](https://github.com/owenb321/MiSTer_DVD/issues/45)). The development build discards
+those pictures instead of showing them, so the last frame simply holds until the new scene
+is ready.
+
+**What remains on the development build** is much shorter: a single frame at the landing
+point can look torn, and it is held a little longer than a normal frame while the picture
+comes back. Report it if you see the old scene moving through the new one, if the blocking
+lasts appreciably longer than that, or if the picture does not recover on its own.
+
+Changing `Video Output` mid-title goes through the same landing sequence — see
+[Switching mid-title](../video/interlaced.md).
 
 ### A film disc keeps changing resolution, or judders
 

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -177,10 +177,11 @@ picture from the scene it had just left ([issue
 those pictures instead of showing them, so the last frame simply holds until the new scene
 is ready.
 
-**What remains on the development build** is much shorter: a single frame at the landing
-point can look torn, and it is held a little longer than a normal frame while the picture
-comes back. Report it if you see the old scene moving through the new one, if the blocking
-lasts appreciably longer than that, or if the picture does not recover on its own.
+**What remains on the development build** is much shorter, and confirmed on hardware: the
+picture freezes on the last frame, then cuts to the new position with about **one**
+misaligned frame in between. Report it if you see the old scene *moving* through the new
+one, if the blocking lasts appreciably longer than a frame, or if the picture does not
+recover on its own.
 
 Changing `Video Output` mid-title goes through the same landing sequence — see
 [Switching mid-title](../video/interlaced.md).

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -76,6 +76,19 @@ language — the fault is likely in how the disc maps tracks to soundtracks, whi
 its navigation tables. A [repro bundle](reporting-a-bug.md) captures those, so that report
 can be reproduced without the disc.
 
+### Sound is out of sync after changing `Video Output` mid-title
+
+**Skip a chapter.** That re-anchors the audio to the picture and clears it.
+
+Changing the output mode under a playing disc restarts the raster and the A/V timing
+together, and the audio does not always come back on the picture's timeline. It is
+long-standing behaviour on every release. Setting `Video Output` before loading the disc
+avoids it entirely. See [Video Output](../video/interlaced.md).
+
+If sound drifts out of sync **without** a mode change, that is a different problem — try
+`A/V Offset` on the debug page first, and [report it](reporting-a-bug.md) with the disc and
+roughly how far into the title it started.
+
 ### Menu audio went silent
 
 You changed the audio track while the menu was open. It comes back when you leave the menu.

--- a/site/content/video/interlaced.md
+++ b/site/content/video/interlaced.md
@@ -58,10 +58,15 @@ everything.
 
 !!! note "Switching mid-title works, with a brief interruption"
     Changing `Video Output` during playback interrupts playback briefly — a short cut to
-    black while the raster and A/V sync re-anchor, like a chapter jump — and then plays on
-    cleanly. Setting the mode before loading just avoids the interruption; it is not
-    required. `Auto` reads the ini bits at boot and while nothing is mounted; it does not
-    change the output mode under a playing disc.
+    black while the raster and A/V sync re-anchor, like a chapter jump. Setting the mode
+    before loading just avoids the interruption; it is not required. `Auto` reads the ini
+    bits at boot and while nothing is mounted; it does not change the output mode under a
+    playing disc.
+
+    **Sound can come back out of sync**, and often does. This is long-standing behaviour on
+    every release, not something the recent fixes introduced. **Skip a chapter to clear
+    it** — that re-anchors the audio to the picture. Setting the mode before loading avoids
+    it entirely.
 
     On v0.4.0 and earlier this could occasionally **freeze the picture** on a malformed
     frame instead, on any disc; skipping a chapter recovered it. The same thing happens on
@@ -77,8 +82,9 @@ everything.
     breaking up while the display re-locks — about a second, and the OSD stays visible
     over it. Sound continues throughout. A brief glitch as the picture comes back is
     normal, and is the same one a chapter skip produces — see
-    [Troubleshooting](../reference/troubleshooting.md). If the black lasts noticeably
-    longer than a second or so, or a mid-title switch still freezes,
+    [Troubleshooting](../reference/troubleshooting.md). The lip-sync caveat above still
+    applies: that one is not fixed. If the black lasts noticeably longer than a second or
+    so, or a mid-title switch still freezes,
     [please report it](../reference/reporting-a-bug.md).
 
 ## Field alignment

--- a/tools/seek_fixture.py
+++ b/tools/seek_fixture.py
@@ -122,6 +122,14 @@ def main():
     ap.add_argument('--require-still', action='store_true',
                     help="cut B must be a still cell (I pictures only, terminated "
                          "by a sequence end) -- the menu arm")
+    ap.add_argument('--cut-b-hex', metavar='FILE',
+                    help="take cut B from an existing 64-bit-word ES fixture instead of "
+                         "from the disc. Used for the MENU STILL arm: a menu still is a "
+                         "whole stream (SEQ GOP PIC:I SEQ_END) with ONE I picture and no "
+                         "B's, which is the shape that would break catastrophically -- the "
+                         "menu would never appear -- if the re-align ever dropped an I. "
+                         "bench/dvd/test_vobs/hp_still_i.hex is exactly that, cut from a "
+                         "real disc for the picbuf slot-alias fix.")
     ap.add_argument('--out', required=True, help='fixture stem, no extension')
     a = ap.parse_args()
 
@@ -138,7 +146,12 @@ def main():
         return None
 
     es_a = cut(nav, sector_at, int(total * a.cut_a_frac), a.sectors_a)
-    es_b = cut(nav, sector_at, int(total * a.cut_b_frac), a.sectors_b)
+    if a.cut_b_hex:
+        raw = bytes.fromhex(''.join(l.strip() for l in open(a.cut_b_hex)))
+        sh = raw.find(b'\x00\x00\x01\xb3')
+        es_b = raw[sh:] if sh >= 0 else b''
+    else:
+        es_b = cut(nav, sector_at, int(total * a.cut_b_frac), a.sectors_b)
     if not es_a:
         return die("no sequence header in cut A -- move --cut-a-frac")
     if not es_b:
@@ -152,7 +165,10 @@ def main():
         return es, pics
 
     es_a, pics_a = trim(es_a, a.pics_a)
-    es_b, pics_b = trim(es_b, a.pics_b)
+    if not a.cut_b_hex:
+        es_b, pics_b = trim(es_b, a.pics_b)   # a supplied cut B is used whole
+    else:
+        pics_b = parse_pictures(es_b)
     if not pics_a or not pics_b:
         return die("a cut decoded to zero pictures -- widen --sectors-a/--sectors-b")
 
@@ -165,13 +181,21 @@ def main():
                    "references; move --cut-a-frac or shorten --sectors-a")
 
     n_lead, closed, first_gop = leading_bs(pics_b, gop_headers(es_b))
-    if first_gop and first_gop[0]['ct'] != I_TYPE:
+    if a.cut_b_hex:
+        # A still has no leading B's BY DEFINITION -- that is the whole point of
+        # the arm, so the checks below (which exist to stop a vacuous RED) would
+        # reject exactly the fixture we want. The bench gets lead_b = 0 and its
+        # own verdict: nothing may be dropped at all.
+        if any(q['ct'] != I_TYPE for q in pics_b):
+            return die(f"{a.cut_b_hex} is not a still: it contains non-I pictures")
+        n_lead, closed = 0, False
+    elif first_gop and first_gop[0]['ct'] != I_TYPE:
         return die(f"cut B's first picture is type {first_gop[0]['ct']}, not I -- "
                    "a seek always lands on a VOBU/GOP boundary; move --cut-b-frac")
-    if closed:
+    if (not a.cut_b_hex) and closed:
         return die("cut B's first GOP is CLOSED -- its leading B's do not predict "
                    "across the boundary, so the defect cannot appear; move --cut-b-frac")
-    if n_lead == 0:
+    if (not a.cut_b_hex) and n_lead == 0:
         return die("cut B's first GOP has no leading B-pictures -- the RED arm "
                    "would measure zero and the gate would be vacuous; move --cut-b-frac")
 

--- a/tools/seek_fixture.py
+++ b/tools/seek_fixture.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# =============================================================================
+# seek_fixture.py -- build the RTL fixture for the post-seek reference re-align
+#                    (issue #45, bench/dvd/seek_realign_tb.sv)
+#
+# A seek is a DISCONTINUITY in the bitstream: the VBUF is flushed, the reader
+# jumps, and the decoder resumes at a VOBU boundary somewhere else in the title.
+# The bug being measured is that the decoder's REFERENCE FRAMES survive that
+# discontinuity, so the landing GOP's leading B-pictures motion-compensate
+# against the OLD scene.
+#
+# To reproduce it faithfully the bench needs two elementary-stream cuts from
+# DIFFERENT points of a real title, plus enough structural metadata to know
+# what the correct answer is:
+#
+#   <stem>.hex       cut A words, then cut B words -- 64-bit big-endian, one
+#                    hex word per line, the format getbits_fifo's shift order
+#                    expects (first stream byte in bits [63:56]).
+#   <stem>.meta.hex  seven 32-bit words, $readmemh'd into a small TB array.
+#
+# Each cut starts at a SEQUENCE HEADER (00 00 01 B3): the vld refuses picture
+# start codes until sequence_header_seen, so a cut beginning mid-GOP would make
+# the bench and the disc disagree about which picture index they are on. Cut A
+# is padded to an 8-byte boundary before cut B is appended, so cut B starts on
+# a whole word index -- that index is the bench's jump target. The file ends
+# with 00 00 01 B7 plus filler because getbits reads whole 64-bit words through
+# a 129-bit window: without bytes BEHIND the last picture the pipeline starves
+# and that picture never commits (same reason tools/cc_scan.py pads).
+#
+# VALIDATION IS THE POINT, not a nicety. The bench asserts an exact violation
+# count, so a fixture whose cut B has a CLOSED first GOP -- or no leading B's
+# at all -- would make the RED arm measure zero and the whole gate vacuous.
+# Those cases exit 1 here, naming the flag to move, rather than producing a
+# fixture that passes for the wrong reason.
+#
+# Usage:
+#   tools/seek_fixture.py <iso> [--vts N] \
+#       [--cut-a-frac 0.10] [--sectors-a 120] \
+#       [--cut-b-frac 0.60] [--sectors-b 200] \
+#       [--require-field] [--require-still] \
+#       --out bench/dvd/test_vobs/seek_realign
+# =============================================================================
+import sys, os, argparse
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from dvd_vm_ref import IsoNav                       # noqa: E402
+from video_cadence_census import video_payload      # noqa: E402
+from film_evidence_probe import parse_pictures      # noqa: E402
+
+SEC = 2048
+I_TYPE, P_TYPE, B_TYPE = 1, 2, 3
+
+
+def gop_headers(buf):
+    """Offset -> closed_gop for every group_start_code in the cut.
+
+    The GOP header is 00 00 01 B8 then 27 bits: 25 of time_code, then
+    closed_gop, then broken_link. So closed_gop is bit 6 of the fourth payload
+    byte, counting from the MSB (ISO 13818-2 6.2.2.6).
+    """
+    out, i = {}, buf.find(b'\x00\x00\x01\xb8')
+    while i >= 0:
+        if i + 8 <= len(buf):
+            out[i] = (buf[i + 7] >> 6) & 1
+        i = buf.find(b'\x00\x00\x01\xb8', i + 4)
+    return out
+
+
+def leading_bs(pics, gops):
+    """(count, closed_gop) for the FIRST GOP of a cut.
+
+    "Leading" B-pictures are the ones an OPEN GOP codes after its I but
+    displays BEFORE it -- temporal_reference below the I's. They are exactly
+    the pictures whose forward reference lies in the previous GOP, i.e. the
+    ones that read a stale slot after a seek. Everything else in the GOP
+    predicts from anchors decoded after the landing and is safe.
+    """
+    first = [p for p in pics if p['gop'] == pics[0]['gop']]
+    if not first or first[0]['ct'] != I_TYPE:
+        return 0, None, first
+    i_tr = first[0]['tr']
+    n = 0
+    for p in first[1:]:
+        if p['ct'] != B_TYPE or p['tr'] >= i_tr:
+            break
+        n += 1
+    off = min((o for o in gops), default=None)
+    return n, (gops[off] if off is not None else None), first
+
+
+def cut(nav, sector_at, start, count):
+    es = b''.join(d for d in (video_payload(nav.sec(sector_at(start + k)))
+                              for k in range(count)
+                              if sector_at(start + k) is not None) if d)
+    sh = es.find(b'\x00\x00\x01\xb3')
+    return es[sh:] if sh >= 0 else b''
+
+
+def die(msg):
+    print(f"seek_fixture: {msg}", file=sys.stderr)
+    return 1
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('iso')
+    ap.add_argument('--vts', type=int, default=None)
+    ap.add_argument('--cut-a-frac', type=float, default=0.10)
+    ap.add_argument('--sectors-a', type=int, default=400)
+    ap.add_argument('--cut-b-frac', type=float, default=0.60)
+    ap.add_argument('--sectors-b', type=int, default=400)
+    # Sector counts are a SEARCH width (a sequence header must fall inside one);
+    # picture counts are what the fixture actually keeps. Trimming matters:
+    # Icarus compiles the TB's ES array as flops, so an oversized fixture is a
+    # compile cliff, not free headroom (memory: icarus-large-array-compile-cliff).
+    ap.add_argument('--pics-a', type=int, default=5)
+    ap.add_argument('--pics-b', type=int, default=14)
+    ap.add_argument('--require-field', action='store_true',
+                    help="cut B must be FIELD-coded (exercises the once-per-frame "
+                         "anchor count; a field-coded I frame is two I pictures)")
+    ap.add_argument('--require-still', action='store_true',
+                    help="cut B must be a still cell (I pictures only, terminated "
+                         "by a sequence end) -- the menu arm")
+    ap.add_argument('--out', required=True, help='fixture stem, no extension')
+    a = ap.parse_args()
+
+    nav = IsoNav(a.iso)
+    vts = a.vts if a.vts is not None else nav.best_vts
+    runs = [(ext, dl // SEC) for ext, dl in nav.groups[vts]]
+    total = sum(n for _, n in runs)
+
+    def sector_at(idx):
+        for ext, n in runs:
+            if idx < n:
+                return ext + idx
+            idx -= n
+        return None
+
+    es_a = cut(nav, sector_at, int(total * a.cut_a_frac), a.sectors_a)
+    es_b = cut(nav, sector_at, int(total * a.cut_b_frac), a.sectors_b)
+    if not es_a:
+        return die("no sequence header in cut A -- move --cut-a-frac")
+    if not es_b:
+        return die("no sequence header in cut B -- move --cut-b-frac")
+
+    def trim(es, keep):
+        pics = parse_pictures(es)
+        if len(pics) > keep:
+            es = es[:pics[keep]['off']]
+            pics = parse_pictures(es)
+        return es, pics
+
+    es_a, pics_a = trim(es_a, a.pics_a)
+    es_b, pics_b = trim(es_b, a.pics_b)
+    if not pics_a or not pics_b:
+        return die("a cut decoded to zero pictures -- widen --sectors-a/--sectors-b")
+
+    # Cut A must not end its own sequence before the flush: a 00 00 01 B7 sends
+    # the vld down STATE_LAST_FRAME, which CLEARS prev_i_p_frame_valid and
+    # rotates the slots -- i.e. it re-aligns the references for free and the
+    # bench would be measuring the wrong discontinuity.
+    if b'\x00\x00\x01\xb7' in es_a:
+        return die("cut A contains a sequence end -- it would pre-clear the "
+                   "references; move --cut-a-frac or shorten --sectors-a")
+
+    n_lead, closed, first_gop = leading_bs(pics_b, gop_headers(es_b))
+    if first_gop and first_gop[0]['ct'] != I_TYPE:
+        return die(f"cut B's first picture is type {first_gop[0]['ct']}, not I -- "
+                   "a seek always lands on a VOBU/GOP boundary; move --cut-b-frac")
+    if closed:
+        return die("cut B's first GOP is CLOSED -- its leading B's do not predict "
+                   "across the boundary, so the defect cannot appear; move --cut-b-frac")
+    if n_lead == 0:
+        return die("cut B's first GOP has no leading B-pictures -- the RED arm "
+                   "would measure zero and the gate would be vacuous; move --cut-b-frac")
+
+    field_b = 1 if any(p['pstruct'] != 3 for p in pics_b) else 0
+    if a.require_field and not field_b:
+        return die("cut B is frame-coded; --require-field wants a field-coded VTS")
+    if a.require_still and any(p['ct'] != I_TYPE for p in pics_b):
+        return die("cut B is not a still cell; --require-still wants I pictures only")
+
+    # Assemble. Cut A padded to a word boundary so cut B's start is a word index.
+    es_a += b'\x00' * (-len(es_a) % 8)
+    b_word = len(es_a) // 8
+    es = es_a + es_b
+    es += b'\x00\x00\x01\xb7' + b'\x00' * 64          # let the last picture commit
+    es += b'\x00' * (-len(es) % 8)
+
+    with open(a.out + '.hex', 'w') as fh:
+        for i in range(0, len(es), 8):
+            fh.write(es[i:i + 8].hex() + '\n')
+
+    meta = [b_word, len(pics_a), first_gop[0]['ct'], n_lead,
+            1 if closed else 0, len(pics_b), field_b]
+    with open(a.out + '.meta.hex', 'w') as fh:
+        for w in meta:
+            fh.write(f"{w & 0xFFFFFFFF:08x}\n")
+
+    print(f"{os.path.basename(a.iso)}  VTS{vts:02d}")
+    print(f"  {a.out}.hex       {len(es)} B  (cut A {len(es_a)} B / {len(pics_a)} pics, "
+          f"cut B {len(es_b)} B / {len(pics_b)} pics)")
+    print(f"  {a.out}.meta.hex  b_word={b_word} lead_b={n_lead} closed={closed} "
+          f"field={field_b}")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Closes #45.

Every seek showed ~6 frames (~100 ms) of macroblocking in which the new chapter decoded
correctly **and moved** while the old scene bled through as residual. That detail from the
report is the diagnosis: new content building and moving exonerates the reader, the demux
and the landing point, so only the *prediction* was wrong.

## Root cause

`flush_vbuf_eff` reaches exactly three sinks — `vbuf_rst`, `frame_drop_ctl.flush`,
`framestore.vb_flush` — and the decode pipeline is on `sync_rst`, so `motcomp_picbuf`'s
reference slots survive a seek still holding the pre-seek scene. Those slots carry **no
valid bit at all** (`forward/backward_reference_frame` are pure pointers `motcomp_addrgen`
reads unconditionally), so stale *content* is invisible to the decoder by construction.

**Two anchors, not one**, because of picbuf's rotation: a non-B update assigns
`current_frame <= forward_reference_frame` while fwd/bwd swap, so the first post-flush I
only establishes the *backward* reference. Forward still points at the old scene — exactly
what an open GOP's leading B's read — and only the second anchor overwrites that slot.
Two coded pictures through 3:2 is about the six display frames reported.

## The fix

`rtl/mpeg2/vld.v` gains one input (`vbuf_flush` from `flush_vbuf_eff`, already clk_dec, no
new CDC) and drops every non-I picture until the first I, then B's until the second anchor,
through the **existing** governor suppression legs. picbuf never sees them, so the display
holds the last frame — which is what `flush_ctl.sv` always claimed a seek did.

Three things worth knowing:

- **The flush arm sits before the `clk_en` term.** `clk_en` is `vld_en`, and `motcomp.v`
  freezes the VLD at every picture header until picbuf's display handshake — up to a whole
  display frame — while the flush level is ~192 clk_dec cycles. A gated capture would miss
  it routinely, not occasionally. Being level-dominant also coalesces repeated flushes.
- **Anchors are counted off the same node picbuf rotates on** (`hdr_upd_slot`, factored out
  of `update_picture_buffers`), so a field-coded I frame counts once and no new fan-out
  lands on `picture_structure`.
- **The ledger is split.** `drop_this_picture` latches either reason but a new
  `drop_gov_picture` feeds `drop_pic_ack`; without it, unrequested credits drive
  `frame_drop_ctl` to `DEBT_FLOOR = -4` during the post-seek re-lock.

`closed_gop` is **rejected**, not overlooked: it is a bit the encoder wrote, not a
measurement, so a disc that lies would leave the defect present *and unfalsifiable*.
Rationale, the rotation trace and the costed v2 are in `docs/seek_realign.md`.

## Test plan

- [x] RED on unmodified RTL: `viol=2`, exactly the fixture's leading-B count, both B's
      predicting from a cut-A-tagged slot
- [x] GREEN: `viol=0 realign_drops=2` — asserted *exactly*, so dropping too much fails too
- [x] RED arm reproduces a pristine-RTL run byte for byte (`emits=18`, same emit gap)
- [x] [1] control, no flush — re-align provably inert over 19 pictures
- [x] [3] flush at a picture header · [4] two flushes coalesce
- [x] [5] `+DRAIN` display-blocked — `vld_en` high for 0 of the 192 window cycles
- [x] [6] `RA_CAP=1` give-up fires and decoding resumes
- [x] [7] menu still as the landing — `realign_drops=0`, the I is never dropped
- [x] Governor ack ledger bit-identical to the pre-fix vld
      (`drops=11 ack_rff1=5 ack_rff0=6`), asserted literally
- [x] `film_evidence_tb` 35/35 · `cc_extract_tb` 180/180 · `vld_mpeg1_tb` 115 pics ·
      `motcomp_picbuf_tb` 0 fails
- [x] Build: SEED 5 first roll, clk_dec 91.10 @100C / 88.28 @-40C (gate 86.0), 88% ALM
- [x] **HW-CONFIRMED**: *"the old scene is not in motion, it's frozen and we jump to the
      target seek position with ~1 frame of a misaligned image"*
- [x] `tools/docs_check.py` + `mkdocs build --strict`

## Scope

Menu→menu hops are structurally untouched — `flush_ctl` gates `seek_flush` on
`~keep_vbuf`, so the Phase-5 rule is inherited for free. Menu entry/exit re-align, as they
were always two of issue #45's four paths.

## Known residual, predicted before the build

The picture in flight at the flush is truncated, owns a slot, and is displayed once — now
held ~4 picture times instead of ~1. Net trade: ~6 frames of macroblocked *motion* → **~1
misaligned frame**. A different defect class, with a costed v2 in `docs/seek_realign.md`
§5.1. Not addressed here.

Also recorded as **open and separate**: A/V sync drift after a `Video Output` change,
pre-existing on every release, cleared by a chapter skip. The manual now states it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
