### PR TITLE
Dev builds name their feature; CI assembles release artifacts from a draft

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Cut and publish a GitHub release of the MiSTer DVD core — build the timing-clean .rbf and the MiSTer_DVDcss Main, assemble the ready-to-extract zip, gather release notes from every PR merged since the previous release, publish with the right assets, and bump CORE_VERSION. Use when the user asks to cut, make, or publish a release.
+description: Cut and publish a GitHub release of the MiSTer DVD core — gather release notes from every PR merged since the previous release, land the one release commit that sets CORE_VERSION and reconciles the manual, build the timing-clean .rbf, create the draft that CI packages (Main + install zip), smoke-test it, publish, and set the version back to dev-main. Use when the user asks to cut, make, or publish a release.
 ---
 
 # Cutting a DVD core release
@@ -9,12 +9,17 @@ Publishes a GitHub release for `owenb321/MiSTer_DVD`. Two build outputs (FPGA `.
 Quartus, `MiSTer_DVDcss` Main via the ARM toolchain) plus a packaged zip, with notes drawn
 from the PRs merged since the last release.
 
-## Versioning — semver, with one hard exception
+## Versioning — the one-commit invariant
 
-- **`CORE_VERSION` in `dvd/emu.sv` = semver `MAJOR.MINOR.PATCH`** (e.g. `0.2.0`). Shown in
-  the OSD as `` v`CORE_VERSION` `BUILD_DATE` ``. Bump it the **moment a release publishes**,
-  so no dev build ever advertises a version that already exists on the releases page.
-- **Release tag = `v<semver>`** (e.g. `v0.2.0`); title = `v<semver> — <headline>`.
+> A bare semver lives in **exactly one commit per release** — the release commit. Any
+> build whose OSD shows `v0.4.0` came from that commit and no other.
+
+- **`CORE_VERSION` in `dvd/emu.sv`** carries `dev-<slug>` on a feature branch and
+  `dev-main` on `main`. Step 0 below sets it to `v<semver>` for the release; the last step
+  sets it back to `dev-main`. Shown in the OSD as `` `CORE_VERSION` `BUILD_DATE` ``.
+  `build_release.sh` refuses a `dev-` string on a publishable `--release` build and refuses
+  a bare semver on a dev build, so the invariant is mechanical rather than remembered.
+- **Release tag = `v<semver>`** (e.g. `v0.4.0`); title = `v<semver> — <headline>`.
   (This replaces the older `v<version>-<yyyymmdd>` tag format — pure semver now.)
 - **Zip = `MiSTer_DVD_v<semver>.zip`** (produced by `tools/package_release.sh`).
 - **★ The `.rbf` filename stays `DVD_YYYYMMDD.rbf` — date only, NEVER a version.** This is
@@ -23,8 +28,10 @@ from the PRs merged since the last release.
   detection. `build_release.sh --release` already produces this name. Date and semver never
   collide: date lives in the filename (for MiSTer), semver lives in the tag/zip/OSD (for
   humans).
-- `BUILD_DATE` (`yymmdd`) is regenerated per compile; do not extend it — it is part of
-  `CONF_STR`, so any change re-rolls the fitter seed lottery.
+- `BUILD_DATE` (`yymmdd`) is regenerated per compile; do not extend it. Both it and
+  `CORE_VERSION` are part of `CONF_STR` = part of the netlist, so either changing re-rolls
+  the fitter seed lottery — which is why the version edit rides in ONE commit with the docs
+  sweep, so the release needs exactly one compile.
 
 ## Preconditions
 
@@ -33,8 +40,10 @@ from the PRs merged since the last release.
 - **The manual matches what is shipping.** `python3 tools/docs_check.py` and
   `mkdocs build --strict` both pass. If a release note would claim something the manual
   does not say, fix the manual first — it is the published contract.
-- `CORE_VERSION` is AHEAD of the latest published tag (`gh release list`). If it still
-  equals a published version, bump it first and commit.
+- `CORE_VERSION` currently reads `dev-main` (it is set to the semver by step 0, not
+  before). Decide the number against the **whole** unreleased delta on `main`, not the last
+  branch merged — several patch-looking merges can add up to a minor release. The
+  patch/minor/major rules are in `CLAUDE.md` "Versioning and publishing releases".
 
 ## gh auth
 
@@ -47,59 +56,73 @@ export GH_TOKEN=$(printf "host=github.com\nprotocol=https\n\n" | git credential 
 
 ## Steps
 
-1. **Build the core (timing-clean).** Quartus, in the pinned container:
+In execution order. Steps 1-2 come before any build because the version number depends on
+what the notes say, and because `CORE_VERSION` is part of the netlist — deciding it late
+would cost a second compile.
+
+1. **Gather the notes.** Every PR merged since the last release (recipe in "Release notes"
+   below), grouped into human sentences. Then run the `docs-sweep` skill over
+   `<prev_tag>..HEAD`: you have just read every PR, so asking of each one "does this change
+   controls, an OSD option, an on-screen message, install steps, or compatibility?" is
+   nearly free. Fix the owning page in `site/content/` for anything stale.
+   The headline you write here decides the version (patch / minor / major — see `CLAUDE.md`).
+
+2. **Land ONE release commit** on `main`, containing the docs-sweep edits **and**:
+   - `CORE_VERSION` in `dvd/emu.sv` → `"v<semver>"` (from `"dev-main"`).
+   - `extra.released_version` in `mkdocs.yml` → `<semver>` (no `v`). The release workflow
+     **refuses to package** if this disagrees with the tag: it drives the "latest release is
+     vX.Y.Z" banner on every manual page.
+   - the "Current as of **vX.Y.Z**" line in `site/content/reference/compatibility.md`.
+   - sweep out `!!! info "Unreleased"` admonitions for anything this release ships.
+
+   **One commit, one netlist, one compile.** `CORE_VERSION` lives in `CONF_STR`, so
+   splitting the bump from the docs commit buys a second netlist and a second seed decision
+   for nothing. Push it — the workflow checks out this exact commit, so anything uncommitted
+   would silently not be in the released Main, Scripts or `DVD_INSTALL.txt`.
+   Verify locally first: `python3 tools/docs_check.py && mkdocs build --strict`.
+
+3. **Build the core (timing-clean).** Quartus, in the pinned container:
    ```bash
-   USE_DOCKER=1 ./build_release.sh --release --compile   # -> releases/DVD_YYYYMMDD.rbf
+   USE_DOCKER=1 ./build_release.sh --release --compile   # -> releases/DVD_YYYYMMDD.rbf + .rbf.json
    ```
-   The `--release` gate refuses to pack a timing-marginal netlist. **Never ship a
-   `_MARGINAL_` .rbf.** If it comes back marginal, re-roll the seed (`tools/seed_sweep.sh`)
-   until clean. (Long compile — run in the background and report the result.)
+   `--release` refuses to pack a timing-marginal netlist, and now also refuses to build at
+   all unless `CORE_VERSION` is the release semver. **Never ship a `_MARGINAL_` .rbf** — if
+   it comes back marginal, re-roll with `tools/seed_sweep.sh` until clean. (Long compile —
+   run it in the background and report the result.) It writes a provenance manifest beside
+   the `.rbf`; the workflow needs both files.
 
-2. **Build the Main:**
+4. **Record the fit in `DVD.qsf`'s seed ledger.** `jq . releases/DVD_YYYYMMDD.rbf.json` has
+   every number the entry quotes (seed, both clk_dec corners, ALM/RAM/DSP), and the workflow
+   reprints them as a table in its run summary.
+
+5. **Create the draft and package it:**
    ```bash
-   USE_DOCKER=1 ./main/build_main.sh                      # -> main/.build/MiSTer_DVDcss
+   ./tools/publish_draft.sh v<semver> --notes /tmp/relnotes.md --title "v<semver> — <headline>"
    ```
+   It pre-flights locally (version matches the tag, tree clean and pushed, core
+   non-marginal, manifest matches the `.rbf`), creates the **draft** with the `.rbf` +
+   manifest attached, and dispatches `.github/workflows/package.yml`. CI validates the core,
+   builds `MiSTer_DVDcss`, re-runs `docs_check.py` + `mkdocs --strict`, packages the zip and
+   attaches the four assets it owns.
 
-3. **Assemble the package:**
+   ⚠ **A draft cannot trigger a workflow** (GitHub does not fire `release:created` for
+   drafts) and **has no git tag** — hence the explicit dispatch, and hence the workflow
+   checking out the SHA from the manifest rather than `refs/tags/`. Do not "simplify" it to
+   `on: release`.
+
+6. **Smoke-test the draft, then publish.** This is the point of drafting: download the zip
+   CI attached, flash the `.rbf`, confirm the core boots, mounts a disc and plays, and that
+   the OSD About line reads `DVD v<semver> <yymmdd>`.
    ```bash
-   ./tools/package_release.sh                             # -> releases/MiSTer_DVD_v<ver>.zip
+   gh release view v<semver> --web        # confirm all five assets are attached
+   gh release edit v<semver> --draft=false
    ```
-   It picks the newest non-MARGINAL `DVD_*.rbf` (or pass `--rbf`), bundles the Main and
-   both `Scripts/` tools (`install_dvdcss.sh`, `set_dvd_region.sh`), and **prints the exact
-   files to attach**.
+   Publishing creates the tag. The `/releases/latest` URL the README links to updates
+   automatically — no README edit per release.
 
-4. **Draft release notes from the PRs since the last release** (see the section below).
-
-4b. **Reconcile the manual against the notes.** You have just read every PR in the range,
-   so this is nearly free. Invoke the `docs-sweep` skill over `<prev_tag>..HEAD`. For each
-   PR ask: does it change controls, an OSD option, an on-screen message, install steps, or
-   compatibility? Confirm the owning page in `site/content/` is current.
-
-   Then, in the same commit:
-   - Update `extra.released_version` in `mkdocs.yml` to the version being cut — it drives
-     the "latest release is vX.Y.Z" banner on every page.
-   - Update the "Current as of **vX.Y.Z**" line in `site/content/reference/compatibility.md`.
-   - Sweep out `!!! info "Unreleased"` admonitions for anything this release ships.
-
-   **Commit these to `main` BEFORE tagging.** The Pages deploy is triggered by that push,
-   so the manual goes live as the release is announced rather than after it.
-
-5. **Publish** (attach the zip AND the bare components — most users want only the `.rbf`):
-   ```bash
-   gh release create v<semver> \
-     --title "v<semver> — <headline>" \
-     --notes-file /tmp/relnotes.md \
-     releases/MiSTer_DVD_v<semver>.zip \
-     releases/DVD_YYYYMMDD.rbf \
-     main/.build/MiSTer_DVDcss \
-     main/Scripts/install_dvdcss.sh \
-     main/Scripts/set_dvd_region.sh
-   ```
-   The `/releases/latest` URL the README links to updates automatically — no README edit
-   needed per release.
-
-6. **Bump `CORE_VERSION`** in `dvd/emu.sv` to the next planned version and commit (so the
-   next dev build's OSD line is already distinct from what you just shipped).
+7. **Set `CORE_VERSION` back to `"dev-main"`** in `dvd/emu.sv` and commit. This is what
+   preserves the invariant: the semver now exists in exactly one commit, so no later dev
+   build can advertise a released version.
 
 ## Release assets (attach all five)
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -170,7 +170,7 @@ jobs:
             + "| commit | `\(.git.sha[0:12])` on `\(.git.branch)`\(if .git.dirty then " **(dirty)**" else "" end) |\n"
             + "| fitter seed | \(.fit.seed) |\n"
             + "| clk_dec Fmax | \(.timing.clk_dec_100c_mhz) MHz @100C / \(.timing.clk_dec_m40c_mhz) MHz @-40C (gate \(.timing.threshold_mhz)) |\n"
-            + "| utilization | \(.fit.alm) ALM, \(.fit.ram_blocks) RAM, \(.fit.dsp_blocks) DSP |\n"
+            + "| utilization | ALM \(.fit.alm) · RAM \(.fit.ram_blocks) · DSP \(.fit.dsp_blocks) |\n"
             + "| toolchain | \(.toolchain.quartus) |\n"
             + "| image | `\(.toolchain.image)` |"' incoming/*.rbf.json >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,286 @@
+name: package release
+
+# Assembles the distributable artifacts around an .rbf the maintainer has ALREADY
+# built and uploaded to a release DRAFT: validates the core, builds the
+# MiSTer_DVDcss Main, packages the install zip, and attaches everything back to
+# the draft. The maintainer then downloads it, flashes, smoke-tests, and publishes.
+#
+# ⚠ WHY workflow_dispatch AND NOT `on: release: types: [created]`:
+# GitHub does not run workflows for the created/edited/deleted activity types on
+# DRAFT releases — only `published` fires for a draft, which is after the point of
+# no return. The whole design here is smoke-test-THEN-publish, so a draft cannot
+# be the trigger. A draft also has NO GIT TAG, which is why nothing below checks
+# out refs/tags/$TAG; the tree comes from the SHA in the build manifest instead.
+# Do not "fix" either of these.
+#
+# ⚠ QUARTUS IS NOT RUN HERE, and cannot be. raetro/quartus:mister is 17 GB
+# unpacked / 6 GB pulled against a hosted runner's ~14 GB of free disk, the fitter
+# peaks ~6 GB RAM, and a fit that lands timing-MARGINAL needs a human-judged seed
+# sweep (DVD.qsf's ledger). The .rbf is always built locally with
+# `USE_DOCKER=1 ./build_release.sh --release --compile`.
+#
+# Usage — normally via tools/publish_draft.sh, which does both steps:
+#   gh release create v0.4.0 --draft --notes-file notes.md \
+#       releases/DVD_YYYYMMDD.rbf releases/DVD_YYYYMMDD.rbf.json
+#   gh workflow run package.yml -f tag=v0.4.0
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag of the release draft holding the .rbf (e.g. v0.4.0)'
+        required: true
+        type: string
+      rbf_asset:
+        description: 'Which DVD_*.rbf asset to package (only if the draft holds more than one)'
+        required: false
+        type: string
+  # Safety net only: catch a release published without ever having been packaged.
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+# Never cancel a run mid-upload: a half-uploaded asset set is worse than a queue.
+concurrency:
+  group: package-${{ inputs.tag || github.event.release.tag_name }}
+  cancel-in-progress: false
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  GH_REPO: ${{ github.repository }}
+  TAG: ${{ inputs.tag || github.event.release.tag_name }}
+
+jobs:
+  # ------------------------------------------------------------------ validate
+  validate:
+    name: Validate the uploaded core
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.check.outputs.sha }}
+      rbf: ${{ steps.check.outputs.rbf }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      # No checkout — a draft has no tag, so there is nothing to check out yet.
+      - name: Download the .rbf and its provenance manifest
+        run: |
+          set -euo pipefail
+          mkdir -p incoming
+          # `gh release view` finds a DRAFT by its pending tag name (it falls back
+          # to GraphQL for exactly this case), so the whole gh half works on drafts.
+          if ! gh release view "$TAG" --json isDraft,assets > rel.json 2>/dev/null; then
+            echo "::error::No release or draft tagged '$TAG' in $GH_REPO."
+            exit 1
+          fi
+          echo "Assets currently on '$TAG':"
+          jq -r '.assets[].name | "  " + .' rel.json
+          PAT='${{ inputs.rbf_asset }}'
+          [ -n "$PAT" ] || PAT='DVD_*.rbf'
+          if ! gh release download "$TAG" --dir incoming --clobber \
+                 --pattern "$PAT" --pattern "$PAT.json"; then
+            echo "::error::'$TAG' has no $PAT asset. Build the core and upload it first:"
+            echo "::error::  USE_DOCKER=1 ./build_release.sh --release --compile"
+            echo "::error::  gh release upload $TAG releases/DVD_YYYYMMDD.rbf releases/DVD_YYYYMMDD.rbf.json"
+            exit 1
+          fi
+
+      - name: Validate the core and its manifest
+        id: check
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          rbfs=(incoming/DVD_*.rbf); mans=(incoming/*.rbf.json)
+          if [ ${#rbfs[@]} -ne 1 ]; then
+            echo "::error::Expected exactly one DVD_*.rbf asset, found ${#rbfs[@]}. Pass rbf_asset to disambiguate."
+            exit 1
+          fi
+          if [ ${#mans[@]} -ne 1 ]; then
+            echo "::error::Missing the .rbf.json provenance manifest. build_release.sh emits it beside the .rbf; upload both."
+            exit 1
+          fi
+          RBF="${rbfs[0]}"; MAN="${mans[0]}"; BASE="$(basename "$RBF")"
+
+          # 1. MiSTer's core browser and update scripts parse YYYYMMDD out of the
+          #    filename to decide which build is newest, so the name is date-only,
+          #    never a version — and never a _MARGINAL tag.
+          if [[ ! "$BASE" =~ ^DVD_[0-9]{8}\.rbf$ ]]; then
+            echo "::error::'$BASE' is not DVD_YYYYMMDD.rbf. MiSTer parses that date to rank builds; a version or a _MARGINAL tag there breaks update detection."
+            exit 1
+          fi
+
+          # 2. The manifest must describe THIS file, and describe a clean fit.
+          want=$(jq -r '.rbf.sha256' "$MAN"); got=$(sha256sum "$RBF" | cut -d' ' -f1)
+          if [ "$want" != "$got" ]; then
+            echo "::error::sha256 mismatch — manifest says $want, asset is $got. The manifest belongs to a different build."
+            exit 1
+          fi
+          if [ "$(jq -r '.rbf.marginal' "$MAN")" = "true" ] || [ "$(jq -r '.timing.pass' "$MAN")" != "true" ]; then
+            echo "::error::This is a TIMING-MARGINAL build ($(jq -r '.timing.clk_dec_100c_mhz' "$MAN") MHz @100C / $(jq -r '.timing.clk_dec_m40c_mhz' "$MAN") MHz @-40C, gate $(jq -r '.timing.threshold_mhz' "$MAN")). Never ship one — re-roll with tools/seed_sweep.sh."
+            exit 1
+          fi
+
+          # 3. Size band. An UNCOMPRESSED pack is ~7 MB and silently fails to
+          #    configure the FPGA (no video at all) — that is what this catches.
+          #    The band is deliberately wide: shipped releases measure 4.44-4.56 MB,
+          #    so a 4.5 MB ceiling would have rejected v0.1a.
+          sz=$(stat -c%s "$RBF")
+          if [ "$sz" -lt 3500000 ] || [ "$sz" -gt 5000000 ]; then
+            echo "::error::.rbf is $sz bytes, outside the 3.5-5.0 MB band. An uncompressed pack (~7 MB) does not configure the FPGA."
+            exit 1
+          fi
+          [ "$sz" -le 4500000 ] || echo "::warning::.rbf is $sz bytes (> 4.5 MB) — larger than typical for this core."
+
+          # 4. BUILD_DATE vs the filename date. WARNING, not an error, and the
+          #    reason is a real trap: BUILD_DATE is generated by sys/build_id.tcl
+          #    inside the Quartus container (UTC) while the filename comes from
+          #    `date` in whichever context ran the pack. They agree when both run
+          #    under USE_DOCKER, but a native pack of a container-built .sof can
+          #    legitimately straddle UTC midnight. A real mismatch still means
+          #    something worth seeing: an old .sof packed under today's name.
+          fdate=$(echo "$BASE" | sed 's/DVD_\([0-9]*\)\.rbf/\1/')
+          bdate="20$(jq -r '.build_date' "$MAN")"
+          [ "$bdate" = "$fdate" ] || echo "::warning::manifest BUILD_DATE $bdate != filename date $fdate (timezone straddle, or a stale .sof was packed)."
+
+          # 5. The version in the bitstream IS the tag. This is the invariant:
+          #    a bare semver lives in exactly one commit per release.
+          VER=$(jq -r '.core_version' "$MAN")
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag '$TAG' must be vMAJOR.MINOR.PATCH."
+            exit 1
+          fi
+          if [ "$VER" != "$TAG" ]; then
+            echo "::error::The core was built with CORE_VERSION '$VER' but this release is '$TAG'. Set it in dvd/emu.sv on the release commit and rebuild — the OSD would otherwise advertise the wrong version."
+            exit 1
+          fi
+
+          [ "$(jq -r '.git.dirty' "$MAN")" = "false" ] || \
+            echo "::warning::Built from a DIRTY working tree — the shipped artifacts may not match any commit."
+
+          { echo "version=$VER"; echo "rbf=$BASE"; echo "sha=$(jq -r '.git.sha' "$MAN")"; } >> "$GITHUB_OUTPUT"
+          echo "OK: $BASE, $VER, $(jq -r '.git.sha' "$MAN" | cut -c1-12)"
+
+      # Paste-able into the release notes and into DVD.qsf's seed ledger, whose
+      # entries quote exactly these numbers.
+      - name: Provenance summary
+        run: |
+          jq -r '"### Build provenance\n\n| | |\n|---|---|\n"
+            + "| version | `\(.core_version) \(.build_date)` |\n"
+            + "| commit | `\(.git.sha[0:12])` on `\(.git.branch)`\(if .git.dirty then " **(dirty)**" else "" end) |\n"
+            + "| fitter seed | \(.fit.seed) |\n"
+            + "| clk_dec Fmax | \(.timing.clk_dec_100c_mhz) MHz @100C / \(.timing.clk_dec_m40c_mhz) MHz @-40C (gate \(.timing.threshold_mhz)) |\n"
+            + "| utilization | \(.fit.alm) ALM, \(.fit.ram_blocks) RAM, \(.fit.dsp_blocks) DSP |\n"
+            + "| toolchain | \(.toolchain.quartus) |\n"
+            + "| image | `\(.toolchain.image)` |"' incoming/*.rbf.json >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: incoming
+          path: incoming/
+          retention-days: 7
+
+  # ------------------------------------------------------------------ assemble
+  assemble:
+    name: Build the Main and package
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      # The MANIFEST's SHA, not refs/tags/$TAG: a draft has no tag, and this
+      # guarantees the Main, the Scripts and DVD_INSTALL.txt come from the exact
+      # tree the .rbf was synthesised from.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: incoming
+          path: incoming
+
+      - name: The source at this commit agrees with the manifest
+        run: |
+          set -euo pipefail
+          got=$(sed -n 's/.*`define CORE_VERSION "\([^"]*\)".*/\1/p' dvd/emu.sv | head -1)
+          if [ "$got" != "${{ needs.validate.outputs.version }}" ]; then
+            echo "::error::dvd/emu.sv at ${{ needs.validate.outputs.sha }} says CORE_VERSION '$got', the manifest says '${{ needs.validate.outputs.version }}'."
+            exit 1
+          fi
+          # The manual's release banner is built from main and read by every user.
+          rv=$(sed -n 's/^ *released_version: *"\(.*\)".*/\1/p' mkdocs.yml | head -1)
+          if [ "v$rv" != "$TAG" ]; then
+            echo "::error::mkdocs.yml extra.released_version is '$rv' but this release is '$TAG'. The manual would announce the wrong version on every page."
+            exit 1
+          fi
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: site/requirements.txt
+
+      - run: pip install -r site/requirements.txt
+
+      # The manual is the published contract, and a release is exactly when it
+      # must be true. Same two commands as docs.yml and as the local pre-commit.
+      - name: The manual matches the OSD definition
+        run: |
+          python3 tools/docs_check.py
+          mkdocs build --strict
+
+      # ~4-6 min on a cold runner: main/docker_reexec.sh builds the pinned ARM
+      # toolchain image from main/docker/Dockerfile on first use. build_main.sh
+      # needs no CI-specific changes — it already pins MAIN_MISTER_REF and clones
+      # stock Main itself.
+      - name: Build MiSTer_DVDcss
+        run: USE_DOCKER=1 ./main/build_main.sh
+
+      - name: Package the install zip
+        run: ./tools/package_release.sh --rbf "incoming/${{ needs.validate.outputs.rbf }}"
+
+      - name: Attach the assets to the draft
+        run: |
+          set -euo pipefail
+          zip=$(ls -t releases/MiSTer_DVD_*.zip | head -1)
+          # --clobber makes re-runs idempotent. The .rbf and its manifest are
+          # already on the release (the maintainer uploaded them); these are the
+          # four this workflow owns.
+          gh release upload "$TAG" --clobber \
+            "$zip" \
+            main/.build/MiSTer_DVDcss \
+            main/Scripts/install_dvdcss.sh \
+            main/Scripts/set_dvd_region.sh
+          {
+            echo ""
+            echo "### Packaged"
+            echo ""
+            echo "Attached \`$(basename "$zip")\` + \`MiSTer_DVDcss\` + 2 Scripts to **$TAG**."
+            echo ""
+            echo "Next: download, flash, smoke-test, then publish with"
+            echo '```'
+            echo "gh release edit $TAG --draft=false"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # -------------------------------------------------------------- safety net
+  published-check:
+    name: Published release has its assets
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      # Nothing can be fixed automatically at this point — the release is public.
+      # This exists so "published a draft that was never packaged" is loud rather
+      # than discovered by the first user who downloads it.
+      - name: Check the asset set
+        run: |
+          set -euo pipefail
+          names=$(gh release view "$TAG" --json assets --jq '.assets[].name')
+          echo "$names"
+          missing=""
+          echo "$names" | grep -q '^MiSTer_DVD_.*\.zip$'  || missing="$missing install-zip"
+          echo "$names" | grep -q '^DVD_[0-9]\{8\}\.rbf$' || missing="$missing core-rbf"
+          echo "$names" | grep -q '^MiSTer_DVDcss$'       || missing="$missing MiSTer_DVDcss"
+          if [ -n "$missing" ]; then
+            echo "::error::Release $TAG is missing:$missing. It was published without being packaged — run: gh workflow run package.yml -f tag=$TAG (assets can still be added to a published release)."
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ bench/dvd/prefetch_sweep_fine.txt
 
 # --- Built cores (huge; keep out of git — use build_release.sh, archive to releases-old/) ---
 releases/*.rbf
+releases/*.rbf.json
 releases/*.zip
 !releases/.gitkeep
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2122,11 +2122,12 @@ giveaway for a bad pack). A correct compressed `.rbf` for this device is
 ./build_release.sh --name DVD_foo  # override the release base name
 ```
 
-**★ Always name builds uniquely (`--name`).** Every build MUST get a distinct,
-descriptive `--name DVD_<feature>` tied to the feature/branch (e.g.
-`--compile --name DVD_ilauto`) — never leave the generic default, which produces a
-meaningless name like `DVD_ps_demux_<date>.rbf` that collides across features and can't be
-told apart on the SD card. The date/time suffix is appended automatically.
+**★ Builds name themselves (`--name` is now optional).** A dev build's name defaults to
+the `dev-<slug>` in `` `CORE_VERSION `` — `dev-seekrealign` gives
+`releases/DVD_seekrealign_<date>_<time>.rbf` — so the OSD line, the `.rbf` and the zip all
+name the same thing without anyone remembering a flag. (This replaces the old "always pass
+`--name`" rule and the meaningless `DVD_ps_demux` default it existed to work around.) Pass
+`--name` only to override.
 
 The script always passes `-o bitstream_compression=on` and warns if the output
 exceeds ~4 MB. Copy the resulting `releases/*.rbf` to the SD card to load it.
@@ -2135,23 +2136,42 @@ exceeds ~4 MB. Copy the resulting `releases/*.rbf` to the SD card to load it.
 
 Two identifiers, deliberately at different granularities:
 
-- **`` `CORE_VERSION `` in `dvd/emu.sv`** — the series (`0.1b`), shown in the OSD as
-  ``v`CORE_VERSION` `BUILD_DATE` `` (e.g. `v0.1b 260825`). **Bump it the moment a release
-  is PUBLISHED, not when the next one is cut**, so no dev build ever advertises a version
-  that already exists on the releases page — that line is the only thing a bug report can
-  quote. Keeping the next version open also means the latest `.rbf` already matches the
-  tag when you decide to release, instead of forcing a rebuild (and a possible fitter
-  re-sweep) at release time.
-  **★ Corollary — check at the START of every feature branch (instituted 2026-08-26, by
-  user decision):** before building a new feature, verify `` `CORE_VERSION `` is AHEAD of
-  the latest published release (`gh release list`); if it still equals a published tag,
-  bump it as the branch's first commit. The point is that ANY feature build must be
-  publishable as-is as the next release — its version line already distinct from
-  everything on the releases page. This costs nothing extra in the seed lottery: a
-  feature branch changes the netlist anyway, and folding the bump into the branch means
-  ONE re-roll instead of a second one at release time. (The saved-settings `"v,N;"`
-  config version is a SEPARATE, coarser counter — bump that one only on an incompatible
-  `O[..]` relayout, see `docs/idle_screen.md`.)
+- **`` `CORE_VERSION `` in `dvd/emu.sv`** — shown in the OSD as
+  `` `CORE_VERSION` `BUILD_DATE` `` (e.g. `v0.4.0 260910`). **★ THE INVARIANT (revised
+  2026-09-04, by user decision):**
+
+  > A bare semver lives in **exactly one commit per release** — the release commit. Any
+  > build whose OSD shows `v0.4.0` came from that commit and no other.
+
+  | Where | `` `CORE_VERSION `` | OSD line |
+  |---|---|---|
+  | feature branch | `dev-<slug>` | `DVD dev-seekrealign 260903` |
+  | `main` between releases | `dev-main` | `DVD dev-main 260903` |
+  | the release commit, only | `v0.4.0` | `DVD v0.4.0 260903` |
+
+  Set `dev-<slug>` as the **first commit of a feature branch**, named after the feature.
+  `build_release.sh` **gates this mechanically** before the compile (so a wrong value costs
+  a second, not 40 minutes): a bare semver on a dev build and a `dev-` string on a
+  publishable `--release` build are both refused.
+  **⛔ This REPLACES the retired 2026-08-26 rule ("bump `` `CORE_VERSION `` to the
+  speculated next semver at the start of every feature branch").** That rule made every
+  pre-release test build advertise a version that did not exist yet: a build sent out for
+  testing showed `v0.4.0`, testers and the sessions reading their reports called it 0.4.0,
+  and the real 0.4.0 shipped far ahead of it. **Its stated payoff was illusory** — "the
+  latest `.rbf` already matches the tag, avoiding a rebuild and re-sweep at release time"
+  is only true if a release is cut from one branch's exact tree, and it never is: a release
+  is cut from `main` after N branches merge, so the release build is a fresh netlist and a
+  fresh seed decision regardless. Do not reinstate it.
+  **Two hard limits on the string**, both measured against stock Main and both enforced by
+  `build_release.sh`:
+  - **≤ 18 characters.** `menu.cpp`'s About screen (`MENU_ABOUT2`) truncates the whole
+    `"DVD <ver> <date>"` line at 30, and `"DVD "` + `" "` + `"260903"` already uses 12.
+  - **No `,` `;` `"`.** `CONF_STR` delimits entries on `;`, and `user_io.cpp`'s `p[0]=='V'`
+    arm calls `substrcpy(...,1)`, which splits on commas — either character **silently
+    truncates** the version rather than failing.
+
+  (The saved-settings `"v,N;"` config version is a SEPARATE, coarser counter — bump that
+  one only on an incompatible `O[..]` relayout, see `docs/idle_screen.md`.)
   **★ HOW FAR to bump (instituted 2026-08-31, by user decision — the rule existed only
   as precedent until someone had to ask):**
   - **patch** (`0.2.0` → `0.2.1`) — bug fixes, doc-only changes, internal rework with no
@@ -2168,15 +2188,56 @@ Two identifiers, deliberately at different granularities:
   ⚠ Judge the bump against the WHOLE unreleased delta on `main`, not just the branch in
   hand — several patch-looking merges can add up to a minor release.
 - **`BUILD_DATE`** — `yymmdd`, regenerated per compile by `sys/build_id.tcl`. ⚠ Do NOT
-  extend it with a time or a git SHA to separate same-day builds: it is part of
-  `CONF_STR`, hence part of the netlist, so every compile would become a new netlist and
-  re-roll the fitter seed lottery (see `DVD.qsf`'s seed ledger). Same-day dev builds are
-  told apart by their `build_release.sh --name` filename, which already carries
-  `<date>_<time>`.
+  extend it with a time or a git SHA to separate same-day builds. Same-day dev builds are
+  told apart by their `build_release.sh --name` filename (which carries `<date>_<time>`),
+  and a second build sent to testers on one day appends a digit to the slug
+  (`dev-seekrealign2`).
+  ⚠ `BUILD_DATE` is generated **inside the Quartus container, in UTC**, while the `.rbf`
+  filename comes from `date` wherever the pack ran. They agree when both run under
+  `USE_DOCKER=1`; a native pack of a container-built `.sof` can straddle UTC midnight and
+  disagree by a day. That is why the release workflow warns rather than fails on it.
 
-Publishing (GitHub, `gh`): tag `v<version>-<yyyymmdd>` (the first release was
-`v0.1a-20260825`), title `<version> (<date>) — <headline>`, attach the **timing-clean**
-`.rbf` only — never a `_MARGINAL_` one. Then bump `` `CORE_VERSION `` in the same session.
+**⚠ BOTH `` `CORE_VERSION `` AND `BUILD_DATE` ARE INSIDE `CONF_STR` = INSIDE THE NETLIST.**
+Either one changing re-rolls `DVD.qsf`'s pinned fitter `SEED` — measured, not theoretical:
+the ledger records `"0.1a"`→`"0.1b"` alone dropping SEED 8 below the hot-corner gate. So
+`` `CORE_VERSION `` may change **once per branch** (free — the branch changes the netlist
+anyway) and **never per commit**. Never derive either from a git SHA, a branch name read at
+build time, or a timestamp: every compile would become a new netlist, and the seed ledger's
+hand-written measurements would stop describing the thing that was built.
+
+**Publishing** — see `.claude/skills/release/SKILL.md`. It is the single source of truth
+for the tag format, the asset list and the draft→smoke-test→publish flow; this file
+deliberately does not restate it, because the copy that used to live here went stale (it
+still described the retired `v<version>-<yyyymmdd>` tag scheme long after v0.2.0 moved to
+plain semver). In outline: build the core locally, `tools/publish_draft.sh v<semver>`
+creates the draft and dispatches `.github/workflows/package.yml`, which validates the core
+and attaches the Main + install zip; flash and smoke-test the draft; then publish.
+
+### Sending a build to testers
+
+Pre-release builds go out to testers directly (Discord); they are deliberately **not**
+GitHub releases, so the releases page shows only real releases. Traceability comes from the
+version string instead — two commands, no flags:
+
+```bash
+USE_DOCKER=1 ./build_release.sh --compile     # --name defaults to the dev-<slug>
+USE_DOCKER=1 ./main/build_main.sh             # only if the Main also changed
+./tools/package_release.sh                    # -> MiSTer_DVD_dev-<slug>_<date>.zip
+```
+
+The OSD line, the `.rbf` name and the zip name all carry the same slug and date, so a report
+saying *"I'm on dev-seekrealign 260903"* names exactly one build:
+
+| | |
+|---|---|
+| OSD | `DVD dev-seekrealign 260903` |
+| `.rbf` (inside the zip, name unchanged for MiSTer's core browser) | `DVD_20260903.rbf` |
+| zip | `MiSTer_DVD_dev-seekrealign_20260903.zip` |
+| `dvd_report` bundle manifest | `core_version: "dev-seekrealign 260903"` |
+
+Sending a **second** build from the same branch on the same day: append a digit to the slug
+(`dev-seekrealign2`), or the two are indistinguishable in the OSD. The `.rbf.json` beside
+each pack records the exact commit, seed and timing if a build ever needs identifying later.
 
 > **Always build after completing a requested feature.** When an RTL/feature change is
 > finished (committed, PR opened), run `./build_release.sh --compile` to produce a fresh
@@ -2282,6 +2343,12 @@ long markdown with backticks and checklists does not survive shell quoting relia
 ```bash
 gh pr merge <number> --merge        # or --squash / --rebase
 ```
+
+**★ After the merge, reset `` `CORE_VERSION `` to `"dev-main"`** in `dvd/emu.sv` on `main`
+(a one-line commit) if the merged branch left its own `dev-<slug>` there. Otherwise a build
+made from `main` advertises the last-merged feature's slug while containing much more than
+that feature. It costs nothing: `main` is not compiled between merges, so the netlist change
+is absorbed by whichever build comes next. See "Versioning and publishing releases".
 
 ### Updating a PR description
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,12 @@ Steps 2 and 3 are one-time — **updating later is just the new zip.**
 Requires **Quartus 17.0.2 exactly** — newer versions break MiSTer project compatibility.
 
 ```bash
-./build_release.sh --compile --name DVD_myfeature              # native Quartus
-USE_DOCKER=1 ./build_release.sh --compile --name DVD_myfeature # pinned container
+./build_release.sh --compile              # native Quartus
+USE_DOCKER=1 ./build_release.sh --compile # pinned container
 ```
+
+The build names itself after the `dev-<slug>` in `CORE_VERSION`, so the `.rbf`, the zip
+and the OSD line all identify the same build.
 
 Always use `build_release.sh` rather than `quartus_cpf` directly: MiSTer's loader needs a
 *compressed* `.rbf` (~4.3 MB). An uncompressed one (~7 MB) silently fails to configure —

--- a/build_release.sh
+++ b/build_release.sh
@@ -58,7 +58,8 @@ done
 # CONF_STR = part of the synthesis netlist, so it changes at most ONCE PER BRANCH
 # (see CLAUDE.md "Versioning"). Recorded in the provenance manifest below, and
 # gated for shape further down.
-CORE_VERSION="$(sed -n 's/.*`define CORE_VERSION "\([^"]*\)".*/\1/p' dvd/emu.sv | head -1)"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CORE_VERSION="$(sed -n 's/.*`define CORE_VERSION "\([^"]*\)".*/\1/p' "$HERE/dvd/emu.sv" | head -1)"
 if [[ -z "$CORE_VERSION" ]]; then
     echo "ERROR: no \`define CORE_VERSION found in dvd/emu.sv." >&2
     exit 1
@@ -218,21 +219,21 @@ fi
 MANIFEST="${OUT}.json"
 FIT_SUMMARY="output_files/${PROJECT}.fit.summary"
 # `Key : value` lookup in the fitter summary. Keys contain ( ) which are literal in BRE.
-fitval() { sed -n "s/^$1 : *//p" "$FIT_SUMMARY" 2>/dev/null | head -1 | sed 's/[[:space:]]*$//'; }
+fitval() { sed -n "s/^$1 : *//p" "$FIT_SUMMARY" 2>/dev/null | head -1 | sed 's/[[:space:]]*$//' || true; }
 # The pinned fitter seed. quartus_fit --seed=N writes this assignment back into the
 # qsf, so the LAST one is what actually built this netlist.
-SEED_V=$(sed -n 's/^set_global_assignment -name SEED  *//p' "${PROJECT}.qsf" 2>/dev/null | tail -1)
+SEED_V=$(sed -n 's/^set_global_assignment -name SEED  *//p' "$HERE/${PROJECT}.qsf" 2>/dev/null | tail -1 || true)
 # From "clk_dec Restricted Fmax: 94.06 MHz @100C, 93.11 MHz @-40C (target 86.0)".
 F100=$(printf '%s' "$FMAX_LINE" | sed -n 's/.*Fmax: *\([0-9.]*\) MHz @100C.*/\1/p')
 FM40=$(printf '%s' "$FMAX_LINE" | sed -n 's/.*, *\([0-9.]*\) MHz @-40C.*/\1/p')
 FTGT=$(printf '%s' "$FMAX_LINE" | sed -n 's/.*(target *\([0-9.]*\)).*/\1/p')
-BDATE=$(sed -n 's/.*`define BUILD_DATE "\([^"]*\)".*/\1/p' build_id.v 2>/dev/null || true)
+BDATE=$(sed -n 's/.*`define BUILD_DATE "\([^"]*\)".*/\1/p' "$HERE/build_id.v" 2>/dev/null || true)
 RBF_SHA=$(sha256sum "$OUT" 2>/dev/null | cut -d' ' -f1 || true)
 # GIT_* normally arrive from tools/docker_reexec.sh, which resolves them on the
 # host. This fallback covers a direct (non-Docker) run.
 G_BRANCH="${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)}"
 G_SHA="${GIT_SHA:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
-G_DIRTY="${GIT_DIRTY:-$([ -n "$(git status --porcelain 2>/dev/null)" ] && echo true || echo false)}"
+G_DIRTY="${GIT_DIRTY:-$([ -n "$(git -C "$HERE" status --porcelain --untracked-files=no 2>/dev/null)" ] && echo true || echo false)}"
 [[ "$G_DIRTY" == "true" || "$G_DIRTY" == "false" ]] || G_DIRTY=null
 
 cat > "$MANIFEST" <<EOF

--- a/build_release.sh
+++ b/build_release.sh
@@ -64,6 +64,63 @@ if [[ -z "$CORE_VERSION" ]]; then
     exit 1
 fi
 
+# --- Version identity gate --------------------------------------------------
+# Runs BEFORE the compile so a wrong version costs a second, not 40 minutes.
+# The invariant (dvd/emu.sv, CLAUDE.md "Versioning"): a bare semver lives in
+# exactly ONE commit per release; every other commit carries dev-<slug>.
+#
+# "Publishable" is --release WITHOUT --name — the same condition that selects the
+# DVD_YYYYMMDD.rbf naming below. tools/seed_sweep.sh passes --release WITH --name
+# purely for the hard timing gate, so it lands in the dev arm and is unaffected;
+# that is the one non-obvious caller.
+if [[ ${#CORE_VERSION} -gt 18 ]]; then
+    echo "ERROR: CORE_VERSION '$CORE_VERSION' is ${#CORE_VERSION} chars; the limit is 18." >&2
+    echo "       stock menu.cpp (MENU_ABOUT2) truncates the whole 'DVD <ver> <date>'" >&2
+    echo "       About line at 30 chars, and 'DVD ' + ' ' + 'yymmdd' already uses 12." >&2
+    exit 1
+fi
+case "$CORE_VERSION" in
+    *,*|*\;*|*\"*)
+        echo "ERROR: CORE_VERSION '$CORE_VERSION' contains , ; or \" — all three break CONF_STR." >&2
+        echo "       ';' ends the entry and user_io.cpp's V arm splits on commas, so the" >&2
+        echo "       version would be silently TRUNCATED rather than rejected." >&2
+        exit 1 ;;
+esac
+
+if [[ "$RELEASE_GATE" -eq 1 && "$NAME_SET" -eq 0 ]]; then
+    if [[ ! "$CORE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "ERROR: a publishable --release build needs the release semver in dvd/emu.sv," >&2
+        echo "       e.g. \`define CORE_VERSION \"v0.4.0\"  — found \"$CORE_VERSION\"." >&2
+        echo "       Set it on the release commit, together with the mkdocs.yml and manual" >&2
+        echo "       updates, so one commit and one compile carry the whole release." >&2
+        exit 1
+    fi
+else
+    if [[ ! "$CORE_VERSION" =~ ^dev-[a-z0-9][a-z0-9.-]*$ ]]; then
+        echo "ERROR: dev builds must carry a feature-identifying CORE_VERSION 'dev-<slug>'," >&2
+        echo "       e.g. \`define CORE_VERSION \"dev-seekrealign\"  — found \"$CORE_VERSION\"." >&2
+        echo "       A bare semver on a dev build is exactly the bug this gate exists to" >&2
+        echo "       stop: testers quote the OSD line and report it as a released version." >&2
+        exit 1
+    fi
+    # Advisory only — a slug and a branch name legitimately differ, but a slug left
+    # over from ANOTHER branch is a real and easy mistake.
+    _br="${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')}"
+    _brslug="$(printf '%s' "${_br##*/}" | tr -cd 'a-z0-9')"
+    _vslug="$(printf '%s' "${CORE_VERSION#dev-}" | tr -cd 'a-z0-9')"
+    if [[ -n "$_brslug" && "$_brslug" != "main" && "$_brslug" != *"$_vslug"* && "$_vslug" != *"$_brslug"* ]]; then
+        echo "NOTE: CORE_VERSION '$CORE_VERSION' does not resemble branch '$_br' — left over from another branch?" >&2
+    fi
+fi
+
+# The .rbf, the zip and the OSD should all name the same thing, so a dev build's
+# name FOLLOWS the version slug instead of needing --name every time. (This
+# replaces the old "always pass --name" rule, and the meaningless DVD_ps_demux
+# default it existed to work around.) An explicit --name still wins.
+if [[ "$NAME_SET" -eq 0 && "$RELEASE_GATE" -eq 0 ]]; then
+    NAME="${PROJECT}_${CORE_VERSION#dev-}"
+fi
+
 SOF="output_files/${PROJECT}.sof"
 mkdir -p releases
 # Release builds take the MiSTer convention (CoreName_YYYYMMDD.rbf); feature builds keep

--- a/build_release.sh
+++ b/build_release.sh
@@ -54,6 +54,16 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# The OSD version string, read from the single source of truth. It is part of
+# CONF_STR = part of the synthesis netlist, so it changes at most ONCE PER BRANCH
+# (see CLAUDE.md "Versioning"). Recorded in the provenance manifest below, and
+# gated for shape further down.
+CORE_VERSION="$(sed -n 's/.*`define CORE_VERSION "\([^"]*\)".*/\1/p' dvd/emu.sv | head -1)"
+if [[ -z "$CORE_VERSION" ]]; then
+    echo "ERROR: no \`define CORE_VERSION found in dvd/emu.sv." >&2
+    exit 1
+fi
+
 SOF="output_files/${PROJECT}.sof"
 mkdir -p releases
 # Release builds take the MiSTer convention (CoreName_YYYYMMDD.rbf); feature builds keep
@@ -136,6 +146,75 @@ echo ">> Done: ${OUT} ($((SIZE/1024)) KB)"
 if [[ "$SIZE" -gt 4500000 ]]; then
     echo "WARNING: .rbf is larger than expected (~4.2 MB typical). Compression may not have applied." >&2
 fi
+
+# --- Build provenance manifest ---------------------------------------------
+# One JSON sidecar per .rbf, "<rbf>.json". releases/ and build_id.v are BOTH
+# git-ignored, so without this an .rbf found on a tester's SD card months from
+# now is unidentifiable — the filename is its only metadata. Three consumers:
+#   * .github/workflows/package.yml validates the uploaded release asset against
+#     it, and learns WHICH COMMIT to check out (a draft release has no git tag).
+#   * a mystery build: which tree, which seed, what timing.
+#   * DVD.qsf's hand-written seed ledger — its entries quote exactly these
+#     numbers, so this is machine-readable input for that paragraph.
+# Everything here comes from files this script has already produced; nothing is
+# recomputed and there is no python3 dependency inside the Quartus container.
+MANIFEST="${OUT}.json"
+FIT_SUMMARY="output_files/${PROJECT}.fit.summary"
+# `Key : value` lookup in the fitter summary. Keys contain ( ) which are literal in BRE.
+fitval() { sed -n "s/^$1 : *//p" "$FIT_SUMMARY" 2>/dev/null | head -1 | sed 's/[[:space:]]*$//'; }
+# The pinned fitter seed. quartus_fit --seed=N writes this assignment back into the
+# qsf, so the LAST one is what actually built this netlist.
+SEED_V=$(sed -n 's/^set_global_assignment -name SEED  *//p' "${PROJECT}.qsf" 2>/dev/null | tail -1)
+# From "clk_dec Restricted Fmax: 94.06 MHz @100C, 93.11 MHz @-40C (target 86.0)".
+F100=$(printf '%s' "$FMAX_LINE" | sed -n 's/.*Fmax: *\([0-9.]*\) MHz @100C.*/\1/p')
+FM40=$(printf '%s' "$FMAX_LINE" | sed -n 's/.*, *\([0-9.]*\) MHz @-40C.*/\1/p')
+FTGT=$(printf '%s' "$FMAX_LINE" | sed -n 's/.*(target *\([0-9.]*\)).*/\1/p')
+BDATE=$(sed -n 's/.*`define BUILD_DATE "\([^"]*\)".*/\1/p' build_id.v 2>/dev/null || true)
+RBF_SHA=$(sha256sum "$OUT" 2>/dev/null | cut -d' ' -f1 || true)
+# GIT_* normally arrive from tools/docker_reexec.sh, which resolves them on the
+# host. This fallback covers a direct (non-Docker) run.
+G_BRANCH="${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)}"
+G_SHA="${GIT_SHA:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
+G_DIRTY="${GIT_DIRTY:-$([ -n "$(git status --porcelain 2>/dev/null)" ] && echo true || echo false)}"
+[[ "$G_DIRTY" == "true" || "$G_DIRTY" == "false" ]] || G_DIRTY=null
+
+cat > "$MANIFEST" <<EOF
+{
+  "schema": 1,
+  "core_version": "${CORE_VERSION}",
+  "build_date": "${BDATE}",
+  "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "rbf": {
+    "name": "$(basename "$OUT")",
+    "bytes": ${SIZE},
+    "sha256": "${RBF_SHA}",
+    "marginal": $([ -n "$FMAX_TAG" ] && echo true || echo false)
+  },
+  "git": {
+    "branch": "${G_BRANCH}",
+    "sha": "${G_SHA}",
+    "dirty": ${G_DIRTY}
+  },
+  "fit": {
+    "seed": ${SEED_V:-null},
+    "alm": "$(fitval 'Logic utilization (in ALMs)')",
+    "registers": "$(fitval 'Total registers')",
+    "ram_blocks": "$(fitval 'Total RAM Blocks')",
+    "dsp_blocks": "$(fitval 'Total DSP Blocks')"
+  },
+  "timing": {
+    "clk_dec_100c_mhz": ${F100:-null},
+    "clk_dec_m40c_mhz": ${FM40:-null},
+    "threshold_mhz": ${FTGT:-null},
+    "pass": $([ -z "$FMAX_TAG" ] && echo true || echo false)
+  },
+  "toolchain": {
+    "quartus": "$(fitval 'Quartus Prime Version')",
+    "image": "${QUARTUS_DOCKER_IMAGE:-raetro/quartus:mister}"
+  }
+}
+EOF
+echo ">> Manifest: ${MANIFEST}"
 
 # Phone notification (no-op if tools/.notify_url / $NOTIFY_URL unset; NOTIFY_SILENT=1
 # suppresses it, e.g. when seed_sweep.sh sends its own summary instead).

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -533,18 +533,40 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // date matters for a public release: it is the only way a bug report can identify
 // WHICH build the reporter is running.
 `include "build_id.v"
-// VERSIONING (2026-08-25): bump this the moment a release is PUBLISHED, not when
-// the next one is cut. `0.1a` shipped as tag v0.1a-20260825, so every build made
-// after that point must advertise 0.1b or it lies about which build it is - and
-// this OSD line is the only thing a bug report can quote. Keeping the next
-// version open also means the latest .rbf already matches the tag when you decide
-// to release, instead of forcing a rebuild (and a fitter re-sweep) at release
-// time. BUILD_DATE below still separates dev builds within the series.
-// ⚠ Do NOT add a time-of-day or git SHA to BUILD_DATE to separate same-day
-// builds: it is part of CONF_STR = part of the netlist, so every compile would
-// become a new netlist and re-roll the fitter seed lottery (DVD.qsf's ledger).
-// Same-day dev builds are identified by their build_release.sh --name filename.
-`define CORE_VERSION "0.4.0"
+// VERSIONING (revised 2026-09-04). THE INVARIANT:
+//
+//     A bare semver lives in EXACTLY ONE COMMIT per release - the release
+//     commit. Any build whose OSD shows "v0.4.0" came from that commit and no
+//     other.
+//
+//   feature branch       "dev-<slug>"   -> OSD "DVD dev-seekrealign 260903"
+//   main between rels    "dev-main"     -> OSD "DVD dev-main 260903"
+//   the release commit   "v0.4.0"       -> OSD "DVD v0.4.0 260903"
+//
+// This REPLACES the old rule ("bump to the speculated next semver at the start
+// of a feature branch"). That rule made every pre-release test build advertise
+// a version that did not exist yet: testers - and the sessions reading their
+// reports - quoted a build as "0.4.0" when the real 0.4.0 would ship far ahead
+// of it. Its stated payoff, that the release build then needs no CONF_STR
+// change, was illusory: a release is cut from main after N branches merge, so
+// the release build is a fresh netlist and a fresh seed decision regardless.
+// build_release.sh gates the shape and refuses the wrong one for the build type.
+//
+// TWO HARD LIMITS on the string, both measured against stock Main:
+//   * <= 18 chars. menu.cpp's About screen (MENU_ABOUT2) truncates the whole
+//     "DVD <ver> <date>" line at 30, and "DVD " + " " + "260903" already eats 12.
+//   * no ','  ';'  '"'. CONF_STR delimits entries on ';', and user_io.cpp's
+//     p[0]=='V' arm calls substrcpy(...,1), which splits on commas - a comma
+//     silently truncates the version rather than failing.
+//
+// ⚠ CORE_VERSION and BUILD_DATE are both inside CONF_STR = inside the netlist,
+// so either one changing re-rolls DVD.qsf's pinned fitter SEED (measured:
+// DVD.qsf's ledger records "0.1a"->"0.1b" alone dropping SEED 8 below the hot-
+// corner gate). CORE_VERSION may therefore change ONCE PER BRANCH - free, since
+// the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
+// either from a git SHA or a timestamp: every compile would become a new
+// netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
+`define CORE_VERSION "dev-main"
 
 parameter CONF_STR = {
     "DVD;;",
@@ -782,7 +804,7 @@ parameter CONF_STR = {
     // navigation (menu/game button walk) and never conflicts with a game that
     // wants left/right input over seekable video. See docs/dvd_nav.md.
     "J1,Pause,Prev Chapter,Next Chapter,Select,Menu,Angle,Audio,Subtitle,Display,Fast Fwd,Rewind,Title,Return;",
-    "V,v",`CORE_VERSION," ",`BUILD_DATE,";"
+    "V,",`CORE_VERSION," ",`BUILD_DATE,";"
 };
 
 wire [26:0] ioctl_addr;

--- a/main/support/dvd/dvd_report.cpp
+++ b/main/support/dvd/dvd_report.cpp
@@ -224,9 +224,12 @@ static void start(void)
 	const char *cfg = find_cfg(cfgbuf, sizeof(cfgbuf));
 
 	// The core version, without a human having to read it off the OSD and type
-	// it. CONF_STR's "V,v0.4.0 260901" line is appended to the OSD core name at
-	// init (user_io.cpp, the p[0]=='V' arm), so OsdCoreNameGet() reads back
-	// "DVD v0.4.0 260901" and everything after the first space is the version.
+	// it. CONF_STR's "V,<version> <yymmdd>" line is appended to the OSD core name
+	// at init (user_io.cpp, the p[0]=='V' arm), so OsdCoreNameGet() reads back
+	// "DVD v0.4.0 260901" (a release) or "DVD dev-seekrealign 260903" (a test
+	// build), and everything after the FIRST space is the version. The two shapes
+	// are deliberate and distinguishable: a bundle from a pre-release build can
+	// no longer look like one from a release. See dvd/emu.sv "VERSIONING".
 	// This matters more here than on the PC route: there is no reporter in the
 	// loop to supply it, and it is the only thing that identifies a build.
 	const char *ver = 0;

--- a/site/content/about/building.md
+++ b/site/content/about/building.md
@@ -6,8 +6,8 @@ Requires **Quartus 17.0.2 exactly** — newer versions break MiSTer project comp
 Either a native install or the pinned Docker image:
 
 ```bash
-./build_release.sh --compile --name DVD_myfeature              # native Quartus
-USE_DOCKER=1 ./build_release.sh --compile --name DVD_myfeature # pinned container
+./build_release.sh --compile              # native Quartus
+USE_DOCKER=1 ./build_release.sh --compile # pinned container
 ```
 
 The Docker path needs no local Quartus install — it re-executes inside
@@ -21,8 +21,14 @@ running as your own user so build artifacts stay yours.
     which looks like a completely different class of bug. The script always passes the
     compression flag and warns if the output looks too large.
 
-Every build should get a distinct `--name DVD_<feature>`; a date and time suffix is added
-automatically, so builds can be told apart on the SD card.
+Builds name themselves after the `dev-<slug>` in `CORE_VERSION` (`dvd/emu.sv`), with a date
+and time suffix added automatically, so they can be told apart on the SD card **and** match
+the version line the OSD shows. `--name` overrides it.
+
+A development build's version is the feature it came from, never a version number — the OSD
+reads `DVD dev-seekrealign 260903`. A bare semver appears in exactly one commit per release,
+so a build advertising `v0.4.0` can only have come from the v0.4.0 release commit.
+`build_release.sh` refuses to build if the two are mixed up.
 
 ## Simulation
 

--- a/site/content/getting-started/install.md
+++ b/site/content/getting-started/install.md
@@ -140,9 +140,14 @@ or grabbing a single piece:
 
 ## Checking what you are running
 
-The core's version is shown in the OSD as `v0.3.0 260901` — the semantic version followed
-by the build date. Quote that line in any bug report; it is the only thing that identifies
-a build unambiguously.
+The core's version is shown in the OSD as `v0.3.0 260901` — the version followed by the
+build date. Quote that line in any bug report; it is the only thing that identifies a
+build unambiguously.
+
+If you are running a **test build** — one handed out for feedback before a release — the
+line names the feature instead of a version, like `dev-seekrealign 260903`. That is
+correct, not a fault: a test build is not a release and deliberately cannot be mistaken
+for one. Quote it the same way.
 
 ## Updating
 

--- a/site/content/reference/reporting-a-bug.md
+++ b/site/content/reference/reporting-a-bug.md
@@ -10,7 +10,8 @@ problem be reproduced without the disc.
 ## Always include
 
 - The **core version** from the OSD — the `v0.3.0 260901` line. It is the only thing that
-  identifies a build.
+  identifies a build. On a test build handed out before a release it names the feature
+  instead, like `dev-seekrealign 260903`; quote whichever you see, exactly.
 - The **disc title and region**.
 - **What happens, and where** — does it boot, reach a menu, start the feature?
 - Any [on-screen message](../playback/on-screen-messages.md).

--- a/tools/docker_reexec.sh
+++ b/tools/docker_reexec.sh
@@ -52,7 +52,11 @@ maybe_reexec_in_docker() {
     # value already exported by the caller wins, so CI can inject its own.
     export GIT_BRANCH="${GIT_BRANCH:-$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)}"
     export GIT_SHA="${GIT_SHA:-$(git -C "$repo" rev-parse HEAD 2>/dev/null || echo unknown)}"
-    export GIT_DIRTY="${GIT_DIRTY:-$([ -n "$(git -C "$repo" status --porcelain 2>/dev/null)" ] && echo true || echo false)}"
+    # --untracked-files=no on purpose: an untracked scratch file cannot be in the
+    # bitstream (anything that pulls one in is itself tracked and would show as
+    # modified), and counting them marked every build dirty, which made the flag
+    # useless. Only tracked modifications mean "this .rbf matches no commit".
+    export GIT_DIRTY="${GIT_DIRTY:-$([ -n "$(git -C "$repo" status --porcelain --untracked-files=no 2>/dev/null)" ] && echo true || echo false)}"
 
     echo ">> [docker] re-exec in ${image}  (repo ${repo}, uid $(id -u):$(id -g))" >&2
     echo ">> [docker] cancel with: docker stop quartus_$(basename "$self" .sh)_$$" >&2

--- a/tools/docker_reexec.sh
+++ b/tools/docker_reexec.sh
@@ -26,6 +26,9 @@
 #   * Memory is left UNBOUNDED — the fitter peaks ~6 GB; a low --memory OOM-kills it.
 #   * SEEDS/FMAX_MIN/SWEEP_ALL/NOTIFY_* are forwarded so seed_sweep's env knobs and
 #     notifications still work; positional args (--compile, NAME, ...) pass via "$@".
+#   * GIT_* are resolved on the HOST and forwarded: the image may have no git, and
+#     build_release.sh's provenance manifest needs branch/sha/dirty. QUARTUS_DOCKER_IMAGE
+#     rides along so the manifest can record which image actually built the .rbf.
 
 maybe_reexec_in_docker() {
     [ "${USE_DOCKER:-0}" = "1" ] || return 0        # opt-in only
@@ -43,6 +46,14 @@ maybe_reexec_in_docker() {
         exit 1
     fi
 
+    # Git facts for the build provenance manifest (build_release.sh writes
+    # <rbf>.json). Resolved HERE, on the host, because the Quartus image is not
+    # guaranteed to carry a git binary and build_release.sh runs INSIDE it. Any
+    # value already exported by the caller wins, so CI can inject its own.
+    export GIT_BRANCH="${GIT_BRANCH:-$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)}"
+    export GIT_SHA="${GIT_SHA:-$(git -C "$repo" rev-parse HEAD 2>/dev/null || echo unknown)}"
+    export GIT_DIRTY="${GIT_DIRTY:-$([ -n "$(git -C "$repo" status --porcelain 2>/dev/null)" ] && echo true || echo false)}"
+
     echo ">> [docker] re-exec in ${image}  (repo ${repo}, uid $(id -u):$(id -g))" >&2
     echo ">> [docker] cancel with: docker stop quartus_$(basename "$self" .sh)_$$" >&2
     exec docker run --rm \
@@ -50,6 +61,7 @@ maybe_reexec_in_docker() {
         -u "$(id -u):$(id -g)" \
         -e IN_QUARTUS_DOCKER=1 -e HOME=/tmp \
         -e SEEDS -e FMAX_MIN -e SWEEP_ALL -e FIT_TIMEOUT -e NOTIFY_URL -e NOTIFY_SILENT \
+        -e GIT_BRANCH -e GIT_SHA -e GIT_DIRTY -e QUARTUS_DOCKER_IMAGE \
         -v "$repo":"$repo" -w "$repo" \
         "$image" "$self" "$@"
 }

--- a/tools/dvd_report.py
+++ b/tools/dvd_report.py
@@ -77,7 +77,7 @@
 # Usage (reporter, on a PC, with their own rip -- encrypted or decrypted):
 #   python3 dvd_report.py disc.iso
 #   python3 dvd_report.py disc.iso --nav-packs        # menu highlight bugs
-#   python3 dvd_report.py disc.iso --core-version "0.3.0 260830" --no-prompt
+#   python3 dvd_report.py disc.iso --core-version "v0.4.0 260910" --no-prompt
 #
 # Usage (maintainer, on a received bundle):
 #   python3 tools/dvd_report.py info    dvdreport-*.zip
@@ -447,7 +447,8 @@ def cmd_make(args):
         print()
         if not core_version:
             core_version = prompt(
-                "Core version, exactly as shown in the OSD (e.g. 0.3.0 260830)")
+                "Core version, exactly as shown in the OSD "
+                "(e.g. v0.4.0 260910, or dev-seekrealign 260903)")
         if not symptom:
             symptom = prompt("What happened")
         if not expected:
@@ -654,7 +655,8 @@ def main():
         p.add_argument("iso", help="DVD-Video .iso rip (encrypted or decrypted)")
         p.add_argument("-o", "--out", help="output .zip (default: auto-named)")
         p.add_argument("--core-version",
-                       help="core version line from the OSD, e.g. '0.3.0 260830'")
+                       help="core version line from the OSD, e.g. 'v0.4.0 260910' "
+                            "for a release or 'dev-seekrealign 260903' for a test build")
         p.add_argument("--symptom", help="what happened")
         p.add_argument("--expected", help="what you expected")
         p.add_argument("--steps", help="how to reach it")

--- a/tools/package_release.sh
+++ b/tools/package_release.sh
@@ -15,7 +15,8 @@
 # Options:
 #   --rbf PATH    core .rbf to bundle (default: newest releases/DVD_*.rbf, non-MARGINAL)
 #   --main PATH   MiSTer_DVDcss binary (default: main/.build/MiSTer_DVDcss)
-#   --out PATH    output zip (default: releases/MiSTer_DVD_v<CORE_VERSION>.zip)
+#   --out PATH    output zip (default: releases/MiSTer_DVD_<CORE_VERSION>.zip;
+#                 a dev build appends the .rbf date, e.g. dev-seekrealign_20260903)
 
 set -euo pipefail
 

--- a/tools/package_release.sh
+++ b/tools/package_release.sh
@@ -39,7 +39,9 @@ done
 # Normalise "." / "" to "SD root".
 case "$RBF_DIR" in .|"") RBF_DIR="" ;; esac
 
-# Core version from the RTL, for the zip name (falls back to the date).
+# Core version from the RTL, for the zip name (falls back to the date). It now
+# carries its own sigil — "v0.4.0" on a release commit, "dev-<slug>" everywhere
+# else — so nothing here prepends a "v" (see dvd/emu.sv "VERSIONING").
 VER="$(sed -n 's/.*`define CORE_VERSION "\([^"]*\)".*/\1/p' "$REPO/dvd/emu.sv" 2>/dev/null | head -1)"
 [ -n "$VER" ] || VER="$(date +%Y%m%d)"
 
@@ -66,9 +68,20 @@ REGIONTOOL="$REPO/main/Scripts/set_dvd_region.sh"
 
 command -v python3 >/dev/null 2>&1 || { echo "!! 'python3' not found on PATH" >&2; exit 1; }
 
-[ -n "$OUT" ] || OUT="$REPO/releases/MiSTer_DVD_v${VER}.zip"
+# A release zip is MiSTer_DVD_v0.4.0.zip — version alone, since the tag pins the
+# rest. A DEV zip appends the .rbf's date, because a slug is reused across a
+# branch's whole life: "dev-seekrealign_20260903" is exactly what that build's
+# OSD shows ("DVD dev-seekrealign 260903"), so a tester quoting the OSD line
+# names one file and no other.
+case "$VER" in
+    dev-*) RBF_DATE="$(basename "$RBF" | sed -n 's/.*_\([0-9]\{8\}\)\(_[0-9]\{4\}\)\{0,1\}\.rbf$/\1/p')"
+           ZIPVER="${VER}${RBF_DATE:+_$RBF_DATE}" ;;
+    *)     ZIPVER="$VER" ;;
+esac
 
-echo "== packaging MiSTer DVD Player v${VER}"
+[ -n "$OUT" ] || OUT="$REPO/releases/MiSTer_DVD_${ZIPVER}.zip"
+
+echo "== packaging MiSTer DVD Player ${VER}"
 echo "   core : $(basename "$RBF")"
 echo "   main : $(basename "$MAIN_BIN")"
 
@@ -92,7 +105,7 @@ chmod +x "$STAGE/Scripts/dvd_report.py"
 
 RBF_SHOWN="${RBF_DIR:+$RBF_DIR/}$(basename "$RBF")"
 cat > "$STAGE/DVD_INSTALL.txt" <<EOF
-MiSTer DVD Player v${VER}
+MiSTer DVD Player ${VER}
 
 1. Extract this zip to the ROOT of your MiSTer SD card. If you copy files over the
    network (SSH/SFTP) instead of pulling the card, that root is /media/fat. You get:

--- a/tools/publish_draft.sh
+++ b/tools/publish_draft.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# publish_draft.sh — create the GitHub release DRAFT for a built core and kick the
+# packaging workflow, in one step.
+#
+# The .rbf is the one artifact CI cannot produce: raetro/quartus:mister is 17 GB
+# unpacked against a hosted runner's ~14 GB of disk, and a timing-marginal fit needs
+# a human-judged seed sweep. So the split is: build the core here, let
+# .github/workflows/package.yml do everything mechanical around it.
+#
+#   USE_DOCKER=1 ./build_release.sh --release --compile    # -> releases/DVD_YYYYMMDD.rbf (+ .json)
+#   ./tools/publish_draft.sh v0.4.0 --notes /tmp/relnotes.md --title "v0.4.0 — <headline>"
+#   # ...watch the run, download the zip, flash, smoke-test...
+#   gh release edit v0.4.0 --draft=false
+#
+# ⚠ A DRAFT cannot trigger a workflow (GitHub does not fire release:created for
+# drafts) and has no git tag, which is why this dispatches package.yml explicitly
+# and why the workflow reads the commit out of the build manifest.
+#
+# Options:
+#   --notes PATH   release-notes markdown (required unless --notes-inline)
+#   --title TEXT   release title (default: "<tag> — <first heading in the notes>")
+#   --rbf PATH     core to publish (default: newest non-MARGINAL releases/DVD_*.rbf)
+#   --no-dispatch  create the draft only; do not start the packaging workflow
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+cd "$REPO"
+
+TAG=""; NOTES=""; TITLE=""; RBF=""; DISPATCH=1
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --notes)       NOTES="$2"; shift 2 ;;
+        --title)       TITLE="$2"; shift 2 ;;
+        --rbf)         RBF="$2";   shift 2 ;;
+        --no-dispatch) DISPATCH=0; shift ;;
+        -h|--help)     sed -n '2,26p' "$0"; exit 0 ;;
+        -*)            echo "!! unknown option: $1" >&2; exit 1 ;;
+        *)             [ -z "$TAG" ] || { echo "!! unexpected argument: $1" >&2; exit 1; }
+                       TAG="$1"; shift ;;
+    esac
+done
+
+die() { echo "!! $*" >&2; exit 1; }
+
+[ -n "$TAG" ] || die "usage: tools/publish_draft.sh vX.Y.Z --notes PATH [--title TEXT]"
+[[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "tag must be vMAJOR.MINOR.PATCH, got '$TAG'"
+[ -n "$NOTES" ] || die "--notes PATH is required (the workflow never writes the release body)"
+[ -f "$NOTES" ] || die "notes file not found: $NOTES"
+
+# --- Pre-flight, all of it BEFORE touching GitHub --------------------------
+# The invariant this protects: a bare semver lives in exactly one commit, and
+# that commit is the one being released. See dvd/emu.sv "VERSIONING".
+VER="$(sed -n 's/.*`define CORE_VERSION "\([^"]*\)".*/\1/p' dvd/emu.sv | head -1)"
+[ "$VER" = "$TAG" ] || die "dvd/emu.sv says CORE_VERSION \"$VER\" but you are releasing $TAG.
+   Set it on the release commit (together with mkdocs.yml's released_version and the
+   manual sweep) and rebuild — the OSD would otherwise advertise the wrong version."
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+[ "$BRANCH" = "main" ] || echo ">> note: releasing from branch '$BRANCH', not main" >&2
+[ -z "$(git status --porcelain)" ] || die "working tree is dirty — commit or stash first.
+   The workflow checks out the commit named in the build manifest, so uncommitted
+   changes would silently NOT be in the released Main, Scripts or DVD_INSTALL.txt."
+git diff --quiet "@{upstream}" 2>/dev/null || echo ">> note: HEAD differs from its upstream; push before publishing" >&2
+
+if [ -z "$RBF" ]; then
+    RBF="$(ls -t releases/DVD_*.rbf 2>/dev/null | grep -v MARGINAL | head -1 || true)"
+fi
+[ -n "$RBF" ] && [ -f "$RBF" ] || die "no core .rbf found. Build one:
+   USE_DOCKER=1 ./build_release.sh --release --compile"
+BASE="$(basename "$RBF")"
+[[ "$BASE" =~ ^DVD_[0-9]{8}\.rbf$ ]] || die "'$BASE' is not DVD_YYYYMMDD.rbf.
+   MiSTer's core browser parses that date to rank builds; use --release (no --name)."
+
+MAN="${RBF}.json"
+[ -f "$MAN" ] || die "missing the provenance manifest $MAN.
+   build_release.sh emits it beside the .rbf; rebuild, or the workflow cannot
+   determine which commit to check out (a draft release has no git tag)."
+
+# Cheap local mirror of the workflow's gates, so a mistake costs no round trip.
+python3 - "$MAN" "$TAG" "$RBF" <<'PY'
+import json, sys, hashlib, os
+man, tag, rbf = json.load(open(sys.argv[1])), sys.argv[2], sys.argv[3]
+def die(m): sys.exit("!! " + m)
+if man.get("core_version") != tag:
+    die("manifest says the core was built as %r, not %r" % (man.get("core_version"), tag))
+if man["rbf"].get("marginal") or not man["timing"].get("pass"):
+    die("that build is TIMING-MARGINAL (%s/%s MHz, gate %s) — never ship one; re-roll with tools/seed_sweep.sh"
+        % (man["timing"].get("clk_dec_100c_mhz"), man["timing"].get("clk_dec_m40c_mhz"),
+           man["timing"].get("threshold_mhz")))
+h = hashlib.sha256(open(rbf, "rb").read()).hexdigest()
+if man["rbf"].get("sha256") != h:
+    die("manifest sha256 does not match the .rbf — they are from different builds")
+sz = os.path.getsize(rbf)
+if not (3_500_000 <= sz <= 5_000_000):
+    die(".rbf is %d bytes, outside the 3.5-5.0 MB band (an uncompressed pack does not configure the FPGA)" % sz)
+if man["git"].get("dirty"):
+    print(">> note: that core was built from a DIRTY tree", file=sys.stderr)
+print(">> core %s  seed %s  %s/%s MHz  %s"
+      % (man["rbf"]["name"], man["fit"]["seed"], man["timing"]["clk_dec_100c_mhz"],
+         man["timing"]["clk_dec_m40c_mhz"], man["git"]["sha"][:12]))
+PY
+
+# gh is not authenticated on this machine by default; the token lives in the git
+# credential helper (see the gh-cli-not-authenticated memory).
+if [ -z "${GH_TOKEN:-}" ] && ! gh auth status >/dev/null 2>&1; then
+    GH_TOKEN="$(printf 'host=github.com\nprotocol=https\n\n' | git credential fill | sed -n 's/^password=//p')"
+    [ -n "$GH_TOKEN" ] || die "could not obtain a GitHub token from the git credential helper"
+    export GH_TOKEN
+fi
+
+[ -n "$TITLE" ] || TITLE="$TAG — $(sed -n 's/^#\+ *//p' "$NOTES" | head -1)"
+
+echo "== creating DRAFT $TAG"
+echo "   title : $TITLE"
+echo "   core  : $BASE"
+gh release create "$TAG" --draft --title "$TITLE" --notes-file "$NOTES" "$RBF" "$MAN"
+
+if [ "$DISPATCH" -eq 1 ]; then
+    echo "== dispatching package.yml"
+    gh workflow run package.yml -f tag="$TAG"
+    sleep 3
+    echo
+    echo "Watch it:      gh run watch \$(gh run list --workflow=package.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+fi
+echo "Review draft:  gh release view $TAG --web"
+echo "Then publish:  gh release edit $TAG --draft=false"


### PR DESCRIPTION
## Why

The OSD version line is the only thing a bug report can quote, and on dev builds it was
lying. `CORE_VERSION` carried the **speculated next semver**, so a pre-release build handed
to testers showed `DVD v0.4.0 260903` — testers, and the sessions reading their reports,
called it "0.4.0" while the real 0.4.0 will ship far ahead of it.

Separately, releases were assembled entirely by hand.

## The version invariant

> A bare semver lives in **exactly one commit per release** — the release commit. Any build
> whose OSD shows `v0.4.0` came from that commit and no other.

| Where | `CORE_VERSION` | OSD line |
|---|---|---|
| feature branch | `dev-<slug>` | `DVD dev-seekrealign 260903` |
| `main` between releases | `dev-main` | `DVD dev-main 260903` |
| the release commit, only | `v0.4.0` | `DVD v0.4.0 260903` |

`build_release.sh` gates this **before** the compile, so a wrong version costs a second
rather than 40 minutes. Two limits are now enforced rather than assumed, both measured
against stock Main: **18 chars** (`menu.cpp:4499` truncates the whole `"DVD <ver> <date>"`
About line at 30) and **no `,` `;` `"`** (`CONF_STR` delimits on `;` and `user_io.cpp`'s `V`
arm splits on commas — either *silently truncates*).

`--name` now defaults to the slug, so the OSD line, the `.rbf` and the zip agree by
construction. Release zip names are unchanged (`MiSTer_DVD_v0.4.0.zip`).

⛔ This retires the 2026-08-26 "bump to the next semver at branch start" rule. Its stated
payoff — that the release build then needs no `CONF_STR` change — was illusory: a release is
cut from `main` after N branches merge, so the release build is a fresh netlist and a fresh
seed decision regardless.

## Release automation

`.github/workflows/package.yml` (the repo's first non-docs CI) validates a locally-built
core and assembles everything around it. The `.rbf` stays local because
`raetro/quartus:mister` is **17 GB unpacked** against a hosted runner's ~14 GB, the fitter
peaks ~6 GB RAM, and a timing-marginal fit needs a human-judged seed sweep.

Two GitHub facts drive the shape, both **verified against this repo** with a throwaway draft:
- A **draft cannot trigger a workflow** (no `release:created` for drafts; `published` is
  after the point of no return) → `workflow_dispatch`, wrapped in `tools/publish_draft.sh`.
- A **draft has no git tag** — the test draft's URL came back `untagged-9b14708072…` with
  zero matching remote tags → nothing checks out `refs/tags/`; the tree comes from the SHA
  in the new build manifest.

`build_release.sh` now emits `<rbf>.json` beside every pack. `releases/` and `build_id.v`
are both git-ignored, so previously an `.rbf`'s only metadata was its filename.

## Test plan

- [x] Version gate, all arms: semver-on-dev, `v`-semver-on-dev, dev-on-release, >18 chars, comma, and both passing cases
- [x] Zip naming both ways — `MiSTer_DVD_v0.4.0.zip` byte-identical to the old convention; dev → `MiSTer_DVD_dev-<slug>_<date>.zip`
- [x] Manifest end-to-end against a real pack; sha256 cross-checked; git facts cross the container boundary
- [x] Manifest degrades to valid JSON with `fit.summary` absent (was an abort — see below)
- [x] `git.dirty` ignores untracked files, true on tracked modifications
- [x] Gate is cwd-independent
- [x] `gh` behaviour on a **real draft**: create w/ assets, download (byte-identical), pattern disambiguation, `upload --clobber` twice, missing-asset → rc=1
- [x] `docs_check.py` + `mkdocs --strict` after the `CONF_STR` edit
- [x] Workflow YAML parses; all shell scripts `bash -n`
- [x] **Quartus compile: SEED 5 held first roll, clk_dec 96.17 MHz @100C / 92.76 @-40C (gate 86.0), 0 implicit nets**
- [ ] Flash `DVD_versionscheme_20260904_0150.rbf` and confirm the About line reads `DVD dev-main 260904`
- [ ] Exercise `package.yml` on a real draft (needs the workflow on `main` first — `workflow_dispatch` only lists default-branch workflows)

## Bugs found by running things

1. **`set -euo pipefail` aborts on a failing command substitution inside a heredoc** — a
   missing `fit.summary` killed `build_release.sh` *after* a successful pack and announced
   "build FAILED" for a good `.rbf`.
2. **`git.dirty` counted untracked files**, so a stray scratch dir marked every build dirty
   and the flag carried no information.
3. A 4–4.5 MB size band — the obvious choice — **would have rejected v0.1a** (4,556,484 B).
   It is 3.5–5.0 MB with a warning above 4.5.
4. **`BUILD_DATE` is generated in UTC inside the container** while `.rbf` filenames use local
   `date`; they can differ by a day across UTC midnight. That check is a warning, not an error.

## Note on the netlist

The only non-comment RTL change is two lines in `dvd/emu.sv` — the `CORE_VERSION` value and
dropping the hardcoded `v` from `CONF_STR`. `rtl/` and `sys/` are untouched. Worth recording:
`BUILD_DATE` is in `CONF_STR` too, so **the netlist already changes daily** — a version-string
edit costs no more than building tomorrow instead of today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
