### PR TITLE
Keyboard and TV-remote transport control (fixes #35)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1634,6 +1634,62 @@ worse maintenance burden than targeted in-place edits. So:
   no UDF-only-image support. (Phase-8b TMAP absolute seek: RETIRED 2026-07-10 by user
   decision. The seek UX gained ONE opt-in layer since — `O[45]` D-Pad Seek, below — which
   rides the same `seek_rbn` primitive and does **not** reopen TMAP.)
+- 🔧 **KEYBOARD / TV-REMOTE TRANSPORT (2026-09-03, issue #35, branch
+  `feature/keyboard-controls`) — sim-proven + mutation-checked, ⏳ HW-confirm pending.**
+  Every transport action gained a built-in key: `dvd/kbd_map.sv` decodes `ps2_key` into a
+  17-bit vector in `joystick_0`'s bit order and `emu.sv` ORs it into a new `joy_eff` that
+  every button wire, edge detector, the chapter debounce, the menu walk, the HUD and
+  `vm_entropy_stir` now read — a key and a gamepad button are the same signal by the time
+  anything acts on them, so **no consumer changed**.
+  ★★ **THE BUG WAS IN MAIN, NOT IN US, AND NOT IN THE DISC: MiSTer's "Define buttons"
+  CANNOT BIND `Enter` OR `Esc` TO ANY BUTTON.** `input.cpp:3276` guards the capture block
+  with `!((mapping_type < 2 || !mapping_button) && (cancel || enter))` and a keyboard
+  session is `mapping_type == 0`, so both keys are excluded for *every* button — and
+  `Enter`, being the OSD's own confirm key, additionally reaches `menu.cpp:4419` and **ends
+  and saves the mapping session**, which is exactly why a user reports it "registered" and
+  then does nothing. ✅ Reproduced on a stock MiSTer with a plain USB keyboard (a mapped
+  `Enter` will not activate a highlighted DVD-menu button while the gamepad's Select does,
+  same menu). ⚠ The first two diagnoses were wrong and both were disc-shaped — a nav bundle
+  was nearly requested. **On a console dock remote `OK` and `Exit` ARE those two keys**, so
+  its two most important buttons were the two MiSTer refuses to map.
+  ★ **HDMI-CEC remotes could drive NOTHING here before this** — Main injects CEC presses as
+  keyboard events (`hdmi_cec.cpp:290-319`) and never runs them through the joystick mapper,
+  so scancodes were their only route. ⚠ CEC's own Root Menu/Exit is unreachable
+  (`menu_present() ? KEY_BACK : KEY_MENU`; during playback that is `KEY_MENU` = the OSD
+  toggle, and `KEY_BACK` has `NONE` in the PS/2 table), hence Menu/Title/Audio/Subtitle ride
+  the CEC **colour keys** `F1`-`F4`.
+  ★★ **KEYBOARD FAST FWD / REWIND GO TO `dvd/dpad_seek.sv`, NOT `scrub_ctrl`'s
+  hold-to-scrub — and that is the whole reason `kbd_map` has NO LEVELS.** MEASURED: Retro
+  Remake's SuperDock receiver firmware (`Retro-Remake/DockIR`, `src/main.c`) sends
+  `key-down -> 80 ms -> key-up` PER NEC REPEAT FRAME, ~110 ms apart, so an IR "hold" is ~9
+  discrete taps a second. `scrub_ctrl`'s accumulate tick is 60 ms, so each 80 ms tap leaves
+  `pending_off != 0` and every release issues a REAL seek = ~9 flush/re-locks per second,
+  the regime HW rounds 1-2 recorded as fatal. Second hazard: a stuck level leaves
+  `hold_freeze` high forever (frozen picture, no seek) and the reflex recovery — tap again —
+  releases with `pending_off` at the title span = **one seek to the END OF THE TITLE**.
+  Both vanish with pulses. `scrub_ctrl.sv` and `dpad_seek.sv` are **unmodified**; `emu.sv`
+  masks `kbd_joy[14:13]` out of `joy_eff`, ties `dpad_seek.en` to 1 (it is read in exactly
+  one place) and moves the `O[45]` gate onto the four D-PAD edges, so keyboard seek is
+  ungated — `O[45]` exists to stop the *D-pad* fighting a game disc, which a dedicated seek
+  key cannot do.
+  ⚠ **The extended bit is load-bearing:** six codes are bit-identical to numpad digits and
+  differ only by `E0` (`75`/np-8, `72`/np-2, `6B`/np-4, `74`/np-6, `7D`/np-9, `7A`/np-3).
+  The pre-existing digit block requires `!ps2_key[8]`; `kbd_map` requires `ps2_key[8]` for
+  exactly those six, and decodes **no digits at all**.
+  ⛔ **No OSD option (user decision 2026-09-03):** CEC is opt-in and OFF by default in
+  `MiSTer.ini` (`memset` + no default; `hdmi_cec.cpp:1268`), a user's own mapping already
+  shadows the built-in keys (Main returns early, `input.cpp:3807-3821`, so a key is a
+  joystick bit OR a scancode, never both — which is also why OR-ing cannot double-fire), and
+  a core-side switch could only be all-or-nothing because **a CEC press is indistinguishable
+  from a keyboard press on the wire**. `O[46]` stays free; appending it later is
+  forward-compatible so `"v,2"` would not need bumping.
+  Gate: `bench/dvd/run_kbd.sh` — `kbd_map_tb` is **mutation-checked** (5 targeted RTL
+  mutations each caught; level assertions on a decoder are exactly the shape that passes
+  without proving anything), `dpad_seek_tb` **T19a/T19b** replay the IR burst and prove ONE
+  `jump_fire`, and `scrub_ctrl_tb` passing **unchanged** is the gate that the gamepad scrub
+  was untouched. ⚠ `emu.sv`'s `joy_eff` substitution has NO sim gate (no emu-level bench) —
+  review-only plus Quartus elaboration; `joy_prev <= joy_eff` is the line that silently
+  breaks everything if missed. Detail: **`docs/dvd_nav.md` "Keyboard / CEC input"**.
 - ✅ **D-PAD FIXED-TIME SEEK (`O[45]`, default Off) — HW-CONFIRMED 2026-08-27
   (PR #15; user report; SEED 7, clk_dec 90.97 @100C / 89.5 @-40C).** VLC-style jumps on the D-pad
   while a title plays: **Left/Right ∓10 s, Down/Up ∓60 s**. Presses inside ~400 ms coalesce

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1658,6 +1658,18 @@ worse maintenance burden than targeted in-place edits. So:
   (`menu_present() ? KEY_BACK : KEY_MENU`; during playback that is `KEY_MENU` = the OSD
   toggle, and `KEY_BACK` has `NONE` in the PS/2 table), hence Menu/Title/Audio/Subtitle ride
   the CEC **colour keys** `F1`-`F4`.
+  ⚠⚠ **BUT CEC DOES NOT WORK ON THE MAINTAINER'S BOARD, so it is NOT a supported path and
+  must NOT gate this feature.** MEASURED 2026-09-04: I2C to the ADV7513 is fine, but the
+  clock probe reports `TX elapsed=150 finished=0` -> `CEC: no clock detected.` ->
+  `CEC: init failed.` — the chip's CEC engine never completes a frame. ⛔ `hdmi_cec_clock=`
+  CANNOT fix it (that suggestion was made once and was wrong): the ini value is only
+  consulted AFTER a successful probe TX (`hdmi_cec.cpp:559`), so it picks between clock
+  rates rather than starting an engine. It fails cleanly (`cfg.hdmi_cec = 0`, no retry
+  loop). ★★ The recommended remote is a **USB IR receiver presenting as a HID keyboard**
+  (Flirc / MCE dongle / a dock's own receiver) — same `ps2_key` path, no CEC, no ini.
+  ⚠ **Main discards its own log by default** (`cfg.cpp:452`) — a CEC diagnosis needs
+  `debug=2` under `[MiSTer]` then `/tmp/debug.txt`, and raw button codes are printed
+  **only in the menu core** (`hdmi_cec.cpp:276`).
   ★★ **KEYBOARD FAST FWD / REWIND GO TO `dvd/dpad_seek.sv`, NOT `scrub_ctrl`'s
   hold-to-scrub — and that is the whole reason `kbd_map` has NO LEVELS.** MEASURED: Retro
   Remake's SuperDock receiver firmware (`Retro-Remake/DockIR`, `src/main.c`) sends

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1634,8 +1634,16 @@ worse maintenance burden than targeted in-place edits. So:
   no UDF-only-image support. (Phase-8b TMAP absolute seek: RETIRED 2026-07-10 by user
   decision. The seek UX gained ONE opt-in layer since — `O[45]` D-Pad Seek, below — which
   rides the same `seek_rbn` primitive and does **not** reopen TMAP.)
-- 🔧 **KEYBOARD / TV-REMOTE TRANSPORT (2026-09-03, issue #35, branch
-  `feature/keyboard-controls`) — sim-proven + mutation-checked, ⏳ HW-confirm pending.**
+- ✅ **KEYBOARD / TV-REMOTE TRANSPORT (2026-09-03, issue #35, branch
+  `feature/keyboard-controls`) — sim-proven + mutation-checked and ✅ HW-CONFIRMED
+  2026-09-04** (build `DVD_kbdmap_20260904_0226.rbf`, SEED 5 first roll, clk_dec
+  92.70/90.14): **the issue #35 case itself** (with no Define-buttons mapping, `Enter`
+  activates the highlighted button in a disc menu), menu navigation + the transport keys,
+  the keyboard 10 s seek, and **the gamepad unregressed** (hold-to-scrub still ramps and
+  lands — the one thing only HW could gate, since the `joy_eff` substitution has no bench).
+  ⏳ **STILL UNGATED, and neither is chaseable on the maintainer's rig:** HDMI-CEC (that
+  board's CEC engine does not run at all — see below) and the tap-repeating IR remote burst
+  (no receiver to hand; covered in sim by `dpad_seek_tb` T19a).
   Every transport action gained a built-in key: `dvd/kbd_map.sv` decodes `ps2_key` into a
   17-bit vector in `joystick_0`'s bit order and `emu.sv` ORs it into a new `joy_eff` that
   every button wire, edge detector, the chapter debounce, the menu walk, the HUD and

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -823,4 +823,16 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # ★ The cold corner RECOVERED to 93.11 from the 87.84 of the previous netlist, which the
 # 2026-09-03h entry had flagged as the thinnest margin in this ledger -- more evidence that
 # 87.84 was fit variance rather than anything structural, since this build ADDS logic.
+# 2026-09-04 (feature/keyboard-controls, issue #35 -- dvd/kbd_map.sv added: a combinational
+# scancode->one-hot case plus one 17-bit pulse register and a toggle latch, and emu.sv's
+# joy_eff OR/mask feeding the existing button wires and edge detectors; the dpad_seek `en`
+# gate moved onto the four D-pad edges): SEED 5 held FIRST roll -- clk_dec 92.70 @100C /
+# 90.14 @-40C (gate 86.0, PASS both corners) at 90% ALM (37,653), RAM 498/553 and DSP 92/112
+# both UNCHANGED from the previous entry. NINETEENTH consecutive first-roll fit.
+# Build DVD_kbdmap_20260904_0226.rbf (4326 KB).
+# ★ Essentially ALM-neutral against the timeline netlist (37,846 -> 37,653, i.e. slightly
+# SMALLER): the decoder is a case statement and 18 flops, and it ADDED no consumers -- every
+# button wire, edge detector and the D-pad seek path already existed and simply re-source
+# from joy_eff. That is the fit evidence for the design claim that OR-ing into one vector
+# costs nothing over parallel pulse plumbing.
 set_global_assignment -name SEED 5

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -114,6 +114,9 @@ set_global_assignment -name SYSTEMVERILOG_FILE dvd/nav_pci.sv
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/nav_dsi.sv
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/scrub_ctrl.sv
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/dpad_seek.sv
+# DVD-FORK (issue #35): keyboard / TV-remote transport. See docs/dvd_nav.md
+# "Keyboard / CEC input".
+set_global_assignment -name SYSTEMVERILOG_FILE dvd/kbd_map.sv
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/lin_rate.sv
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/seek_time.sv
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/secs_bcd.sv

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ know. It is not an endorsement of the approach — draw your own conclusions.
 - **[Closed captions](https://owenb321.github.io/MiSTer_DVD/video/closed-captions/)** re-modulated onto line 21 of the
   analog output for your television to decode, exactly as a real player does.
 - **[Video CD / SVCD](https://owenb321.github.io/MiSTer_DVD/formats/vcd-svcd/)** — bin/cue rips play directly.
+- **Gamepad, keyboard or infrared remote** — every transport action has a
+  [built-in key](https://owenb321.github.io/MiSTer_DVD/playback/controls/), so a USB IR receiver
+  turns any remote you already own into a DVD remote with nothing to configure.
 
 Everything runs in FPGA fabric: no HPS-side daemon, no Linux helper process. The ARM only
 serves SD blocks through the standard framework interface.

--- a/bench/dvd/dpad_seek_tb.sv
+++ b/bench/dvd/dpad_seek_tb.sv
@@ -402,6 +402,43 @@ module dpad_seek_tb;
             errors = errors + 1; end
         tick(COAL + 3000);
 
+        // ---- T19: the TAP-REPEATING REMOTE burst (issue #35 keyboard path) --
+        // dvd/emu.sv now ORs the keyboard/remote Fast Fwd + Rewind keys onto
+        // rt_edge/lf_edge instead of scrub_ctrl's held levels, precisely because
+        // an IR receiver does not send a hold: Retro Remake's SuperDock firmware
+        // (DockIR src/main.c) emits key-down -> 80 ms -> key-up PER NEC REPEAT
+        // FRAME, ~110 ms apart, so a long press is ~9 discrete taps a second.
+        // Against scrub_ctrl that is ~9 complete seek gestures a second (its
+        // accumulate tick is 60 ms, so each 80 ms tap leaves pending_off != 0 and
+        // every release issues a real seek) -- the rapid flush/re-lock regime the
+        // headers of scrub_ctrl.sv and dpad_seek.sv record as fatal. Here the
+        // identical burst must produce EXACTLY ONE jump.
+        // Spacing is scaled like the window: ~110/400 of COALESCE.
+        arm;
+        for (i = 0; i < 9; i = i + 1) begin press(2'd0); tick(COAL/4); end
+        tick(120);      // let the MM:SS subtract loop settle
+        if (pend_min !== 7'd1 || pend_sec !== 3'd3) begin
+            $display("FAIL T19a readout %0d:%0d0 want 1:30", pend_min, pend_sec);
+            errors = errors + 1; end
+        // 9 units = 6 + 3 -> fwda[1] + fwda[2] = 15000 + 7500
+        expect_fire("T19a 9-tap IR burst = ONE seek", 32'd22500, 1'b1, LBN0);
+
+        // ---- T19b: ...and the window really does close ---------------------
+        // The bound on T17a: taps spaced WIDER than the window are separate
+        // gestures, so coalescing cannot silently swallow a deliberate second
+        // press. Two isolated taps = two seeks.
+        arm;
+        press(2'd0); tick(COAL + 400);
+        press(2'd0); tick(COAL + 400);
+        if (fires !== 2) begin
+            $display("FAIL T19b: expected 2 fires from 2 spaced taps, got %0d", fires);
+            errors = errors + 1;
+        end else if (f_off !== 32'd2500) begin
+            $display("FAIL T19b: last off=%0d want 2500 (one 10 s rung)", f_off);
+            errors = errors + 1;
+        end else
+            $display("PASS T19b: spaced taps stay separate (2 fires, off=%0d)", f_off);
+
         if (errors == 0) $display("DPAD_SEEK_TB: ALL TESTS PASSED");
         else begin $display("DPAD_SEEK_TB: %0d FAILURE(S)", errors); $fatal(1); end
         $finish;

--- a/bench/dvd/kbd_map_tb.sv
+++ b/bench/dvd/kbd_map_tb.sv
@@ -1,0 +1,222 @@
+// ============================================================================
+// bench/dvd/kbd_map_tb.sv -- unit tests for dvd/kbd_map.sv
+// ============================================================================
+//   iverilog -g2012 -o /tmp/kbd_sim dvd/kbd_map.sv bench/dvd/kbd_map_tb.sv \
+//     && vvp /tmp/kbd_sim
+//
+// The contracts worth defending here are not "the case statement is typed
+// correctly" -- they are the three properties the rest of the design leans on:
+//
+//   * EVERY bit is a one-cycle pulse, including [14:13]. emu.sv feeds those two
+//     to dpad_seek, where a held request would coalesce forever, and the other
+//     fifteen go to edge detectors that must see exactly one edge per press.
+//   * The extended bit DISCRIMINATES. Six of our scancodes are bit-identical to
+//     numpad digits and differ only by the E0 prefix; emu.sv's "NUMPAD MENU
+//     INPUT" block owns the non-extended forms, so any leak here would make one
+//     keypress both pick a menu button and fire a transport action.
+//   * NO digit produces output at all -- the same rule from the other side.
+// ============================================================================
+`timescale 1ns/1ps
+`default_nettype none
+
+module kbd_map_tb;
+
+    reg clk = 1'b0;
+    always #18.5 clk = ~clk;            // ~27 MHz
+
+    reg         rst_n = 1'b0;
+    reg  [10:0] ps2 = 11'd0;
+    wire [16:0] joy;
+
+    kbd_map dut (.clk(clk), .rst_n(rst_n), .ps2_key(ps2), .joy(joy));
+
+    integer errors = 0;
+
+    // Observed pulse activity since the last clear: which bits fired, and the
+    // WIDEST run of consecutive cycles any bit stayed high (the pulse contract).
+    reg [16:0] seen  = 17'd0;
+    integer    width = 0;
+    integer    run   = 0;
+    always @(posedge clk) begin
+        seen <= seen | joy;
+        if (joy != 17'd0) begin
+            run = run + 1;
+            if (run > width) width = run;
+        end else run = 0;
+    end
+
+    task clr; begin seen = 17'd0; width = 0; run = 0; end endtask
+    task tick(input integer n); begin repeat (n) @(negedge clk); end endtask
+
+    // One key event: flip the toggle, hold the word (as hps_io does -- it stays
+    // put for thousands of cycles until the next event).
+    task key(input ext, input [7:0] code, input pressed, input integer hold);
+        begin
+            @(negedge clk);
+            ps2 = {~ps2[10], pressed, ext, code};
+            tick(hold);
+        end
+    endtask
+
+    task expect_bit(input [80*8-1:0] lbl, input integer b);
+        begin
+            if (seen !== (17'd1 << b)) begin
+                $display("FAIL %0s: joy=%b want only bit %0d", lbl, seen, b);
+                errors = errors + 1;
+            end else if (width != 1) begin
+                $display("FAIL %0s: pulse was %0d cycles wide, want 1", lbl, width);
+                errors = errors + 1;
+            end else
+                $display("PASS %0s -> bit %0d", lbl, b);
+        end
+    endtask
+
+    task expect_none(input [80*8-1:0] lbl);
+        begin
+            if (seen !== 17'd0) begin
+                $display("FAIL %0s: joy=%b, want all-zero", lbl, seen);
+                errors = errors + 1;
+            end else
+                $display("PASS %0s -> nothing", lbl);
+        end
+    endtask
+
+    // press-and-release, checking the PRESS produced bit b and the RELEASE
+    // produced nothing at all.
+    task tap_bit(input [80*8-1:0] lbl, input ext, input [7:0] code, input integer b);
+        begin
+            clr(); key(ext, code, 1'b1, 12); expect_bit(lbl, b);
+            clr(); key(ext, code, 1'b0, 12); expect_none({lbl, " (break)"});
+        end
+    endtask
+
+    task tap_none(input [80*8-1:0] lbl, input ext, input [7:0] code);
+        begin
+            clr(); key(ext, code, 1'b1, 12);
+            clr2_check(lbl);
+            clr(); key(ext, code, 1'b0, 12); expect_none({lbl, " (break)"});
+        end
+    endtask
+    task clr2_check(input [80*8-1:0] lbl); begin expect_none(lbl); end endtask
+
+    integer i;
+    reg [7:0] digits [0:19];
+
+    initial begin
+        tick(4); rst_n = 1'b1; tick(4);
+
+        // ---- T1/T2/T3: every mapped key, one-hot, one cycle, break silent ----
+        $display("== T1-T3: per-key one-hot + pulse width + silent break");
+        tap_bit("Up",        1'b1, 8'h75, 3);
+        tap_bit("Down",      1'b1, 8'h72, 2);
+        tap_bit("Left",      1'b1, 8'h6B, 1);
+        tap_bit("Right",     1'b1, 8'h74, 0);
+        tap_bit("Space",     1'b0, 8'h29, 4);
+        tap_bit("PageUp",    1'b1, 8'h7D, 5);
+        tap_bit("P",         1'b0, 8'h4D, 5);
+        tap_bit("PageDown",  1'b1, 8'h7A, 6);
+        tap_bit("N",         1'b0, 8'h31, 6);
+        tap_bit("Enter",     1'b0, 8'h5A, 7);
+        tap_bit("F1",        1'b0, 8'h05, 8);
+        tap_bit("M",         1'b0, 8'h3A, 8);
+        tap_bit("X",         1'b0, 8'h22, 8);
+        tap_bit("G",         1'b0, 8'h34, 9);
+        tap_bit("F3",        1'b0, 8'h04, 10);
+        tap_bit("A",         1'b0, 8'h1C, 10);
+        tap_bit("F4",        1'b0, 8'h0C, 11);
+        tap_bit("S",         1'b0, 8'h1B, 11);
+        tap_bit("D",         1'b0, 8'h23, 12);
+        tap_bit("F2",        1'b0, 8'h06, 15);
+        tap_bit("T",         1'b0, 8'h2C, 15);
+        tap_bit("Esc",       1'b0, 8'h76, 16);
+        tap_bit("B",         1'b0, 8'h32, 16);
+
+        // ---- T4: Fast Fwd / Rewind pulse like everything else ---------------
+        // These are the two bits emu.sv routes to dpad_seek. A LEVEL here would
+        // hold the coalesce window open forever, so the pulse is the contract.
+        $display("== T4: FF/REW are pulses, not levels");
+        tap_bit("Tab (FF)",       1'b0, 8'h0D, 13);
+        tap_bit("F (FF)",         1'b0, 8'h2B, 13);
+        tap_bit("Backspace (REW)",1'b0, 8'h66, 14);
+        tap_bit("R (REW)",        1'b0, 8'h2D, 14);
+
+        // Hold one for a long time with no further events: still ONE pulse.
+        clr(); key(1'b0, 8'h0D, 1'b1, 5000);
+        if (seen !== (17'd1 << 13) || width != 1) begin
+            $display("FAIL T4-hold: seen=%b width=%0d (want one 1-cycle pulse on 13)",
+                     seen, width);
+            errors = errors + 1;
+        end else $display("PASS T4-hold: 5000-cycle hold = exactly one pulse");
+        clr(); key(1'b0, 8'h0D, 1'b0, 12); expect_none("T4-hold release");
+
+        // ---- T5: extended discrimination (the numpad collision) -------------
+        // Non-extended 75/72/6B/74/7D/7A are numpad 8/2/4/6/9/3 and belong to
+        // emu.sv's digit path. They must produce NOTHING here.
+        $display("== T5: non-extended arrow/page codes are numpad digits");
+        tap_none("numpad8 (75)", 1'b0, 8'h75);
+        tap_none("numpad2 (72)", 1'b0, 8'h72);
+        tap_none("numpad4 (6B)", 1'b0, 8'h6B);
+        tap_none("numpad6 (74)", 1'b0, 8'h74);
+        tap_none("numpad9 (7D)", 1'b0, 8'h7D);
+        tap_none("numpad3 (7A)", 1'b0, 8'h7A);
+
+        // ---- T6: no digit, either bank, produces anything --------------------
+        $display("== T6: all 20 digit scancodes are inert");
+        digits[0]=8'h45; digits[1]=8'h16; digits[2]=8'h1E; digits[3]=8'h26;
+        digits[4]=8'h25; digits[5]=8'h2E; digits[6]=8'h36; digits[7]=8'h3D;
+        digits[8]=8'h3E; digits[9]=8'h46;                    // top row 0..9
+        digits[10]=8'h70; digits[11]=8'h69; digits[12]=8'h72; digits[13]=8'h7A;
+        digits[14]=8'h6B; digits[15]=8'h73; digits[16]=8'h74; digits[17]=8'h6C;
+        digits[18]=8'h75; digits[19]=8'h7D;                  // numpad 0..9
+        for (i = 0; i < 20; i = i + 1) begin
+            clr(); key(1'b0, digits[i], 1'b1, 8);
+            if (seen !== 17'd0) begin
+                $display("FAIL T6: digit scancode %02h produced joy=%b", digits[i], seen);
+                errors = errors + 1;
+            end
+            clr(); key(1'b0, digits[i], 1'b0, 8);
+        end
+        $display("PASS T6: no digit scancode reaches the transport map");
+
+        // ---- T7: Enter and KP-Enter both mean Select ------------------------
+        $display("== T7: Enter / KP-Enter");
+        tap_bit("KP-Enter", 1'b1, 8'h5A, 7);
+
+        // ---- T8: no toggle flip = no event ----------------------------------
+        // hps_io holds the word between events; only bit 10 changing is an event.
+        $display("== T8: repeated word without a toggle flip is inert");
+        @(negedge clk); ps2 = {~ps2[10], 1'b1, 1'b0, 8'h29};   // Space press
+        tick(8);
+        clr(); tick(200);                                       // same word held
+        expect_none("Space held, no new event");
+
+        // ---- T9: reset clears -----------------------------------------------
+        $display("== T9: reset");
+        @(negedge clk); ps2 = {~ps2[10], 1'b1, 1'b0, 8'h5A};
+        @(negedge clk); rst_n = 1'b0;
+        clr(); tick(20);
+        if (joy !== 17'd0 || seen !== 17'd0) begin
+            $display("FAIL T9: joy=%b seen=%b under reset", joy, seen);
+            errors = errors + 1;
+        end else $display("PASS T9: held in reset");
+        @(negedge clk); rst_n = 1'b1; tick(4);
+
+        // ---- T10: keys Main eats must never be bound ------------------------
+        // F12 opens the MiSTer OSD, KEY_PAUSE (E1) has no break code, E2 is a
+        // prefix. Executable form of the "never bind" rule in the module header.
+        $display("== T10: never-bind keys");
+        tap_none("F12 (07)",       1'b0, 8'h07);
+        tap_none("KEY_PAUSE (E1)", 1'b0, 8'hE1);
+        tap_none("prefix (E2)",    1'b0, 8'hE2);
+        tap_none("CapsLock (58)",  1'b0, 8'h58);
+
+        if (errors == 0) $display("KBD_MAP_TB: ALL TESTS PASSED");
+        else begin $display("KBD_MAP_TB: %0d FAILURE(S)", errors); $fatal(1); end
+        $finish;
+    end
+
+    initial begin #20_000_000; $display("KBD_MAP_TB: TIMEOUT"); $fatal(1); end
+
+endmodule
+
+`default_nettype wire

--- a/bench/dvd/run_kbd.sh
+++ b/bench/dvd/run_kbd.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# run_kbd.sh — keyboard / TV-remote transport control (issue #35) suite.
+#
+# Why each suite is here:
+#
+#   1. kbd_map_tb     — the decoder itself. The three contracts that matter are
+#                       (a) EVERY bit is a one-cycle pulse, including [14:13]
+#                       which emu.sv feeds to dpad_seek (a held request would
+#                       hold the coalesce window open forever); (b) the E0 bit
+#                       DISCRIMINATES, because six of our scancodes are
+#                       bit-identical to numpad digits; (c) no digit produces
+#                       output at all. Mutation-checked: five targeted RTL
+#                       mutations (level-not-pulse, numpad-8 leak, fire-on-break,
+#                       digit leak, Esc unbound) are each caught.
+#   2. dpad_seek_tb   — where the keyboard's Fast Fwd/Rewind keys actually land.
+#                       T19a replays a SuperDock IR long-press (9 taps a second,
+#                       measured from Retro Remake's DockIR firmware) and proves
+#                       it resolves to ONE seek; T19b proves the window still
+#                       closes, so coalescing cannot swallow a deliberate second
+#                       press. T0-T18 unchanged = the shipped D-Pad Seek gate.
+#   3. nav_pci_tb     — T10 is the numpad digit -> menu button path. emu.sv's
+#                       digit block and kbd_map now share the set-2 scancode
+#                       space, so this is the guard that the two stay disjoint.
+#   4. scrub_ctrl_tb  — must pass COMPLETELY UNCHANGED. That is the gate proving
+#                       the gamepad's hold-to-scrub was not touched: this feature
+#                       deliberately modifies neither scrub_ctrl.sv nor
+#                       dpad_seek.sv, only what drives their inputs.
+#   5. transport_hud_tb / seek_bar_tb — the HUD readout and position bar a
+#                       keyboard-initiated seek now pops, unregressed.
+#
+# ⚠ NOT covered by any bench, by construction: emu.sv's joy_eff substitution and
+# the `joy_prev <= joy_eff` line. There is no emu-level testbench, so those are
+# review-only plus Quartus elaboration. Diff that region deliberately.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+rc=0
+run() {
+    local name=$1; shift
+    echo "== $name =="
+    iverilog -g2012 -o "bench/dvd/${name}_sim" "$@" "bench/dvd/${name}.sv"
+    vvp "bench/dvd/${name}_sim" | tail -4 || rc=1
+}
+
+run kbd_map_tb       dvd/kbd_map.sv
+run dpad_seek_tb     dvd/dpad_seek.sv dvd/nav_dsi.sv
+run nav_pci_tb       dvd/nav_pci.sv
+run scrub_ctrl_tb    dvd/scrub_ctrl.sv
+run transport_hud_tb dvd/transport_hud.sv
+run seek_bar_tb      dvd/seek_bar.sv
+
+if [ $rc -eq 0 ]; then echo "RUN_KBD: ALL SUITES PASSED"; else echo "RUN_KBD: FAILURES"; fi
+exit $rc

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -801,6 +801,124 @@ interactive cell** instead of falling off the end.
   group 1). Still deferred: `btn_se_e_ptm` auto-deselect + CHG_COLCON, JumpTT
   unresolved (needs TT_SRPT-at-jump; Phase 4/6).
 
+## Keyboard / CEC input
+
+Two independent decoders share the `ps2_key` scancode space, and keeping them disjoint is
+a standing constraint: the **digit** path below (menu button by number, shipped 2026-07-27)
+and the **transport** map in `dvd/kbd_map.sv` (issue #35, 2026-09-03).
+
+### Transport: `dvd/kbd_map.sv` — ⏳ HW-confirm pending
+
+**Why it exists.** MiSTer's own *Define buttons* already maps keys onto a core's `J1`
+buttons, so a built-in keymap looks redundant — until you find that **Main refuses to bind
+`Enter` or `Esc` to any button at all.** `input.cpp:3276` guards the capture block with
+`!((mapping_type < 2 || !mapping_button) && (cancel || enter))`, and a keyboard session is
+`mapping_type == 0` (`input.cpp:3353`), so those two keys are excluded for *every* button.
+They are not merely dropped, either: `Enter` is the OSD's own confirm key, so it reaches
+`menu.cpp:4419` (`else if (select || menu || …) finish_map_setting(...)`) and **ends and
+saves the mapping session** — which is exactly why a user reports that it "registered" and
+then does nothing. `start_map_setting()` even calls `user_io_kbd(KEY_ENTER, 0)` to un-stick
+Enter on entry (`input.cpp:1772`), confirming which key drives that UI.
+
+★ **That was the whole of issue #35**, and it was reproduced on a stock MiSTer with a plain
+USB keyboard: a mapped `Enter` does not activate a highlighted DVD-menu button while the
+gamepad's own Select does, in the same menu. The disc and the core were both blameless. It
+matters far beyond one report — on a console dock remote `OK` and `Exit` **are** Enter and
+Esc, i.e. its two most important buttons are precisely the two MiSTer will not map.
+
+★ **And for HDMI-CEC this is the only path that exists.** Main injects CEC button presses as
+KEYBOARD events (`hdmi_cec.cpp:290-319`) and never runs them through the joystick mapping,
+so before this a TV remote could drive nothing here except menu digits. The key choices are
+therefore led by CEC's fixed table, which is the constrained resource; keyboard aliases
+follow DVD-remote/VLC convention afterwards.
+⚠ **CEC's own Root Menu / Exit is unreachable and cannot be fixed here:** it maps to
+`menu_present() ? KEY_BACK : KEY_MENU`, and `menu_present()` means "the OSD is on screen
+right now" (`menu.cpp:8137`) — so during playback it is `KEY_MENU`, which Main eats as the
+OSD toggle, while `KEY_BACK` has `NONE` in the PS/2 table. Hence Menu/Title/Audio/Subtitle
+ride the CEC **colour keys** (`F1`–`F4`). Verified against `hdmi_cec.cpp` as of 2026-09.
+
+**Shape.** `kbd_map` emits a 17-bit vector in `joystick_0`'s own bit order and `emu.sv` ORs
+it in: `joy_eff = joystick_0 | {15'd0, kbd_joy & ~17'h0_6000}`. Every button wire, edge
+detector, the chapter debounce, the menu walk, the HUD and `vm_entropy_stir` then read
+`joy_eff`, so a key and a gamepad button are the same signal by the time anything acts on
+them and **no consumer had to change**. Four substitution sites, of which
+`joy_prev <= joy_eff` is the one that silently breaks everything if missed (a pulse would
+produce a phantom edge every cycle it is high).
+
+★ **OR-ing cannot double-fire**, which is what makes this safe: Main hands a key to the
+joystick mapper *or* to the PS/2 stream, never both — `input.cpp:3807-3821` matches the
+user's map and **returns**, so the scancode is never sent. A user's own mapping therefore
+shadows the built-in one, which can only fire on keys that would otherwise have done
+nothing. Enter and Esc are the exception that motivated the feature, and they can never be
+shadowed because they can never be mapped.
+
+★ **Every bit is a one-cycle PULSE; there is no level anywhere in the module.** Main drops
+keyboard auto-repeat (`user_io.cpp:4059`, `if (press > 1 && !use_ps2ctl) return;` — this
+core does not set `use_ps2ctl`), so a held key is one make and one break and a level would
+buy nothing except failure modes. A lost release becomes a non-event, and a stuck key is
+structurally impossible. (An all-levels design has a subtler trap too: a stuck bit swallows
+the *next* press, because there is no rising edge left to detect, and the key looks dead.)
+
+★★ **`[14:13]` Fast Fwd / Rewind are masked out of `joy_eff` and go to `dvd/dpad_seek.sv`,
+not to `dvd/scrub_ctrl.sv`'s hold-to-scrub.** They are the design's only LEVEL consumers
+(`scrub_ctrl.sv:84`), and a keyboard-like device cannot drive a level safely, for two
+reasons that are measured rather than argued:
+
+1. **Tap-repeating IR remotes turn a hold into a burst of seeks.** Retro Remake's SuperDock
+   receiver firmware (`Retro-Remake/DockIR`, `src/main.c`) sends `key-down → 80 ms →
+   key-up` **per NEC repeat frame**, ~110 ms apart — a long press is ~9 discrete taps a
+   second, not a hold. `scrub_ctrl`'s accumulate tick is 60 ms (`TICK = 1_620_000` @
+   27 MHz), so an 80 ms tap leaves `pending_off != 0` and *every* release issues a real
+   seek: ~9 flush/re-locks per second, precisely the regime HW rounds 1-2 recorded as fatal
+   (headers of `scrub_ctrl.sv` and `dpad_seek.sv`). Under coalescing the identical burst
+   builds ONE jump — `dpad_seek_tb` **T19a** replays it and measures exactly one `jump_fire`.
+2. **A stuck level hangs the picture.** `held_right` stuck with `in_title` leaves `want`
+   high forever → `hold_freeze` → frozen video with the bar up and no seek issued (the seek
+   happens on *release*), and the reflex recovery — tap it again — delivers a break with
+   `pending_off` already ramped to the title span, i.e. **one seek straight to the end of
+   the title**.
+
+The gamepad's hold-to-scrub is untouched: neither `scrub_ctrl.sv` nor `dpad_seek.sv` is
+modified by this feature. `dpad_seek`'s `en` is read in exactly one place
+(`seek_ok = en && in_title && (dvd_mode || lin_mode)`, `dpad_seek.sv:170`), so `emu.sv` ties
+it to 1 and applies the `O[45]` gate to the four **D-pad edges** instead, leaving the
+keyboard's Fast Fwd/Rewind ungated — `O[45]` exists solely to stop the *D-pad* fighting a
+game disc that wants directional input, and a dedicated seek key has no such conflict.
+Keyboard seek needs a `kbd_joy[13]|kbd_joy[14]` term of its own in the pause-clear chain,
+for the same two reasons (masked out of `joy_eff`, and not gated on `O[45]`).
+⚠ Known gap: `dpad_seek` needs DSI tables or a measured linear rate, so keyboard seek is
+inert on a bare `.m2v` where the gamepad scrub still works.
+
+**Keymap.** PS/2 **set 2** throughout (what Main sends — confirmed by the digit decoder
+below): arrows `E0 75/72/6B/74`; `Enter 5A` and `E0 5A` → Select; `Space 29` → Pause;
+`E0 7D`/`P 4D` → Prev Chapter; `E0 7A`/`N 31` → Next Chapter; `F1 05`/`M 3A`/`X 22` → Menu;
+`G 34` → Angle; `F3 04`/`A 1C` → Audio; `F4 0C`/`S 1B` → Subtitle; `D 23` → Display;
+`Tab 0D`/`F 2B` → Fast Fwd; `Backspace 66`/`R 2D` → Rewind; `F2 06`/`T 2C` → Title;
+`Esc 76`/`B 32` → Return. `X` is bound to Menu because it is the SuperDock remote's only
+spare key and that remote's own Menu button is `F12` = the MiSTer OSD. `Esc` is bound
+deliberately: CEC's real back button is unreachable, so without it a CEC user has no way up
+a menu level, and GoUp is a harmless no-op where the disc authors no parent.
+
+⚠ **Never bind**, all verified against Main: `F12` (`07`) and `KEY_MENU` (OSD toggle),
+`KEY_PAUSE` (`E1`, no break code at all), `KEY_SYSRQ`, NumLock/ScrollLock (Main's
+`EMU_SWITCH_1/2`), Alt/Meta.
+
+⚠ **The extended bit is load-bearing.** Six of the codes above are bit-identical to numpad
+digits and differ ONLY by the `E0` prefix — `75`/numpad-8, `72`/numpad-2, `6B`/numpad-4,
+`74`/numpad-6, `7D`/numpad-9, `7A`/numpad-3. The digit block requires `!ps2_key[8]`;
+`kbd_map` requires `ps2_key[8]` for exactly those six. `5A` is the one code accepted with
+either polarity (Enter and KP-Enter both mean OK). **Digits are not decoded in `kbd_map` at
+all** — all twenty scancodes belong to the digit path, and binding them twice would make one
+keypress do two things.
+
+**Gate: `bench/dvd/run_kbd.sh`.** `kbd_map_tb` is mutation-checked — five targeted RTL
+mutations (level-instead-of-pulse, numpad-8 leak, fire-on-break, digit leak, Esc unbound)
+are each caught by their own scenario, because level assertions on a decoder are exactly the
+shape that passes without proving anything. `dpad_seek_tb` T19a/T19b own the IR-burst
+routing. `scrub_ctrl_tb` must pass **completely unchanged** — that is the gate proving the
+gamepad scrub was not touched. ⚠ `emu.sv`'s `joy_eff` substitution has **no** simulation
+gate (there is no emu-level bench); it is review-only plus Quartus elaboration.
+
 ### Numpad input: keyboard digit = select+activate — ✅ HW-CONFIRMED (PR fj#134)
 
 The DVD-remote **number-key shortcut**: with a menu HLI armed, pressing a keyboard

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -837,6 +837,33 @@ right now" (`menu.cpp:8137`) — so during playback it is `KEY_MENU`, which Main
 OSD toggle, while `KEY_BACK` has `NONE` in the PS/2 table. Hence Menu/Title/Audio/Subtitle
 ride the CEC **colour keys** (`F1`–`F4`). Verified against `hdmi_cec.cpp` as of 2026-09.
 
+⚠⚠ **CEC IS NOT AVAILABLE ON EVERY BOARD, AND THE MAINTAINER'S IS ONE IT FAILS ON — do NOT
+treat it as a supported path or gate this feature on it.** MEASURED 2026-09-04: I2C to the
+ADV7513 is fine (no `main register setup failed`), but the clock probe reports
+`clock probe TX elapsed=150 finished=0` → `CEC: no clock detected.` → `CEC: init failed.`
+The chip's CEC transmitter never completes a frame, i.e. its CEC engine has no working clock
+(or the CEC line is not routed/pulled up, so arbitration never sees the bus idle). Either
+way it is a board fact, not a configuration one.
+⛔ **`hdmi_cec_clock=` DOES NOT FIX IT — and that wrong suggestion was already made once.**
+`cec_detect_clock` takes the ini value as `proposed_clock` and only consults it in the
+`else if (proposed_clock)` branch (`hdmi_cec.cpp:559`), which is reached **after** a
+successful probe TX. A failing probe fails identically whatever is configured: the setting
+picks *between* clock rates once the engine is known to run, it cannot start one.
+★ It fails CLEANLY, worth knowing before anyone chases a startup hang: `cec_can_try` is set
+true only *after* `cec_clock()` succeeds (`hdmi_cec.cpp:1060`), so a clock failure prints
+`CEC: init failed.`, sets `cfg.hdmi_cec = 0` and gives up — no 3 s retry loop, just a one-off
+~300 ms probe. `hdmi_cec=0` skips even that.
+★★ **The recommended remote route is a USB IR receiver that presents as a HID keyboard**
+(Flirc, a generic MCE dongle, or a console dock's own receiver): no CEC, no ini, and it lands
+on exactly the `ps2_key` path this module already decodes. The manual leads with that and
+files CEC under "worth trying".
+⚠ **Main discards its own log by default** (`cfg.cpp:452`:
+`stdout = (cfg.debug == 2) ? debug_file : cfg.debug ? orig_stdout : dev_null`), so any CEC
+diagnosis starts with `debug=2` under `[MiSTer]` and reading `/tmp/debug.txt`. Raw button
+codes are logged **only in the menu core** (`if (is_menu())`, `hdmi_cec.cpp:276`), so "is the
+TV sending anything at all?" has to be tested from the MiSTer main menu, not from inside the
+player.
+
 **Shape.** `kbd_map` emits a 17-bit vector in `joystick_0`'s own bit order and `emu.sv` ORs
 it in: `joy_eff = joystick_0 | {15'd0, kbd_joy & ~17'h0_6000}`. Every button wire, edge
 detector, the chapter debounce, the menu walk, the HUD and `vm_entropy_stir` then read

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -807,7 +807,15 @@ Two independent decoders share the `ps2_key` scancode space, and keeping them di
 a standing constraint: the **digit** path below (menu button by number, shipped 2026-07-27)
 and the **transport** map in `dvd/kbd_map.sv` (issue #35, 2026-09-03).
 
-### Transport: `dvd/kbd_map.sv` — ⏳ HW-confirm pending
+### Transport: `dvd/kbd_map.sv` — ✅ HW-CONFIRMED 2026-09-04
+
+Confirmed on the board (build `DVD_kbdmap_20260904_0226.rbf`): the issue #35 case itself
+(`Enter` activates the highlighted button in a disc menu with no Define-buttons mapping in
+place), menu navigation and the transport keys, the keyboard 10 s seek, and the **gamepad
+unregressed** — that last one being the only gate the `joy_eff` substitution has, since
+there is no emu-level bench. ⏳ Still ungated: **HDMI-CEC** (the maintainer's board cannot
+run CEC at all, see the ⚠⚠ note below) and the **tap-repeating IR remote burst** (no
+receiver available; covered in sim by `dpad_seek_tb` T19a).
 
 **Why it exists.** MiSTer's own *Define buttons* already maps keys onto a core's `J1`
 buttons, so a built-in keymap looks redundant — until you find that **Main refuses to bind

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2068,7 +2068,7 @@ Downside: makes the whole share read-only to MiSTer, breaking cores that write s
 the `.iso` and its errno. Keep that trick for any future "core won't load a file" mystery: the
 framework's file syscalls (open mode + errno) are the ground truth the RTL side can't see.
 
-## ✅ DONE: full keyboard + TV-remote transport control (issue #35) — ⏳ HW-confirm pending
+## ✅ DONE: full keyboard + TV-remote transport control (issue #35) — ✅ HW-CONFIRMED 2026-09-04
 
 Every transport action now has a built-in key. `dvd/kbd_map.sv` decodes `ps2_key` into a
 17-bit vector in `joystick_0`'s bit order and `emu.sv` ORs it into a new `joy_eff` that every
@@ -2092,8 +2092,12 @@ keyboard press. `O[46]` stays free and appending it later is forward-compatible.
 
 Gate: `bench/dvd/run_kbd.sh` (`kbd_map_tb` mutation-checked; `dpad_seek_tb` T19a/T19b own the
 IR-burst routing; `scrub_ctrl_tb` unchanged is the gate that the gamepad scrub was untouched).
-**HW gate:** with no Define-buttons mapping in place, `Enter` activates the highlighted button
-in a DVD menu; a dock remote's held Fast Fwd produces one jump, not a burst of seeks. Design:
+**✅ HW-CONFIRMED 2026-09-04** (`DVD_kbdmap_20260904_0226.rbf`): the #35 case (`Enter` selects
+in a disc menu with no mapping in place), menu nav + transport keys, the keyboard 10 s seek,
+and the gamepad unregressed. ⏳ Ungated: **CEC** — the maintainer's board reports
+`CEC: no clock detected` / `init failed`, so it cannot be tested there and is documented as
+board-dependent with a USB-IR receiver as the recommended remote — and the **IR tap-burst**
+(no receiver available; sim-covered by `dpad_seek_tb` T19a). Design:
 **`docs/dvd_nav.md` "Keyboard / CEC input"**.
 
 ## ✅ DONE: numeric button entry via keyboard (easter eggs / direct chapter select) — ✅ HW-CONFIRMED (PR fj#134)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2068,6 +2068,34 @@ Downside: makes the whole share read-only to MiSTer, breaking cores that write s
 the `.iso` and its errno. Keep that trick for any future "core won't load a file" mystery: the
 framework's file syscalls (open mode + errno) are the ground truth the RTL side can't see.
 
+## ✅ DONE: full keyboard + TV-remote transport control (issue #35) — ⏳ HW-confirm pending
+
+Every transport action now has a built-in key. `dvd/kbd_map.sv` decodes `ps2_key` into a
+17-bit vector in `joystick_0`'s bit order and `emu.sv` ORs it into a new `joy_eff` that every
+button wire, edge detector and consumer reads — so a key and a gamepad button are the same
+signal by the time anything acts on them, and no consumer changed.
+
+**The bug that forced it:** MiSTer's own *Define buttons* **cannot bind `Enter` or `Esc` to
+any button** (`input.cpp:3276`), and `Enter` additionally *ends and saves* the mapping
+session, which is why it looks like it registered. Reproduced on a stock MiSTer with a plain
+USB keyboard. On a console dock remote `OK` and `Exit` **are** those two keys. HDMI-CEC
+remotes are affected doubly: their presses only ever arrive as scancodes, never as joystick
+bits, so before this a TV remote could drive nothing here but menu digits.
+
+★ Keyboard **Fast Fwd / Rewind go to `dvd/dpad_seek.sv`** (±10 s per press, coalescing), not
+to `scrub_ctrl`'s hold-to-scrub — an IR remote's "hold" is really ~9 taps a second, which
+against the hold path is ~9 flush/re-locks a second. `scrub_ctrl.sv` and `dpad_seek.sv` are
+both unmodified. **No OSD option** (2026-09-03, user decision): CEC is already opt-in and off
+by default in `MiSTer.ini`, a user's own mapping already shadows the built-in keys, and a
+core-side switch could only be all-or-nothing because a CEC press is indistinguishable from a
+keyboard press. `O[46]` stays free and appending it later is forward-compatible.
+
+Gate: `bench/dvd/run_kbd.sh` (`kbd_map_tb` mutation-checked; `dpad_seek_tb` T19a/T19b own the
+IR-burst routing; `scrub_ctrl_tb` unchanged is the gate that the gamepad scrub was untouched).
+**HW gate:** with no Define-buttons mapping in place, `Enter` activates the highlighted button
+in a DVD menu; a dock remote's held Fast Fwd produces one jump, not a burst of seeks. Design:
+**`docs/dvd_nav.md` "Keyboard / CEC input"**.
+
 ## ✅ DONE: numeric button entry via keyboard (easter eggs / direct chapter select) — ✅ HW-CONFIRMED (PR fj#134)
 
 **Shipped + HW-CONFIRMED (2026-07-27, PR fj#134). Confirmed on HW by unlocking the T2

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -566,7 +566,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "dev-main"
+`define CORE_VERSION "dev-keyboard"
 
 parameter CONF_STR = {
     "DVD;;",
@@ -796,13 +796,17 @@ parameter CONF_STR = {
     // migration, so audit the index-0 label of every option when bumping.
     "v,2;",   // v2: 2026-09-02 Video Output consolidation relayout (O[10:9] re-enumerated, O[27:26] retired)
     // Gamepad transport (dvd/dvd_iso_reader seek + presentation-clock pause) +
-    // disc-menu nav (Phase 2). The J1 list names buttons B1..B11 for the MiSTer
-    // "Define buttons" menu (bits 4..14 of joystick_0; D-pad = bits 3:0). The
+    // disc-menu nav (Phase 2). The J1 list names buttons B1..B13 for the MiSTer
+    // "Define buttons" menu (bits 4..16 of joystick_0; D-pad = bits 3:0). The
     // HOLD-to-seek time scrub (accelerating 10->30->60->120 s via
     // dvd/scrub_ctrl.sv) rides its OWN buttons B10 "Fast Fwd" / B11 "Rewind"
     // while a TITLE plays, so the D-pad is ALWAYS free for directional
     // navigation (menu/game button walk) and never conflicts with a game that
     // wants left/right input over seekable video. See docs/dvd_nav.md.
+    // ⚠ These names are ALSO the "Define buttons" prompt list (Main walks this
+    // string, capped at 28 names), so the order is user-visible -- and MiSTer
+    // will NOT bind Enter or Esc to any of them (issue #35). dvd/kbd_map.sv
+    // gives every one of them a built-in key that bypasses that mapper.
     "J1,Pause,Prev Chapter,Next Chapter,Select,Menu,Angle,Audio,Subtitle,Display,Fast Fwd,Rewind,Title,Return;",
     "V,",`CORE_VERSION," ",`BUILD_DATE,";"
 };
@@ -1242,25 +1246,63 @@ wire hud_dbg   = status[2];                         // O[2]: HUD shows reader PG
 wire dpad_seek_en = status[45];                     // O[45]: D-pad fixed-time seek
 // effective subpicture routing/decode enable: subtitles OR a menu is up
 wire sp_route_en;                                  // (assigned at the SPU block)
-wire joy_pause = joystick_0[4];                    // B1 "Pause"
-wire joy_next  = joystick_0[6];                    // B3 "Next Chapter"
-wire joy_prevc = joystick_0[5];                    // B2 "Prev Chapter"
-wire joy_sel   = joystick_0[7];                    // B4 "Select"
-wire joy_menu  = joystick_0[8];                    // B5 "Menu"
-wire joy_angle = joystick_0[9];                    // B6 "Angle"
-wire joy_audio = joystick_0[10];                   // B7 "Audio"     (Phase 10)
-wire joy_sub   = joystick_0[11];                   // B8 "Subtitle"  (Phase 10)
-wire joy_disp  = joystick_0[12];                   // B9 "Display"   (Phase 11 HUD)
+// =========================================================================
+// KEYBOARD / TV-REMOTE TRANSPORT (2026-09-03, issue #35)
+// =========================================================================
+// dvd/kbd_map.sv turns the framework's ps2_key stream into a VIRTUAL JOYSTICK
+// VECTOR in joystick_0's own bit order, and joy_eff below is what every button
+// wire, edge detector and consumer in this file reads from here on. So a key
+// and a gamepad button are the same signal by the time anything acts on them --
+// no parallel pulse plumbing, and no consumer had to change.
+//
+// ★ OR-ing CANNOT DOUBLE-FIRE. Main hands a key to the joystick mapper OR to
+// the PS/2 stream, never both: input.cpp:3807-3821 matches the user's Define-
+// buttons map and RETURNS, so the scancode is never sent. A user's own mapping
+// therefore shadows our built-in one, which can only ever fire on keys that
+// would otherwise have done nothing. (Enter and Esc are the exception that
+// motivated the feature -- Main refuses to bind those two at all, so our
+// bindings for them always apply. See dvd/kbd_map.sv's header, and issue #35.)
+//
+// ★ kbd_joy[14:13] (Fast Fwd / Rewind) ARE MASKED OUT HERE. They are the only
+// LEVEL consumers in the design (scrub_ctrl's held_right/held_left) and a
+// keyboard-like device cannot drive a level safely -- a tap-repeating IR remote
+// turns a held button into ~9 complete seek gestures a second, and a swallowed
+// release freezes the picture. They go to dvd/dpad_seek.sv instead (+/-10 s per
+// press, coalescing into ONE seek), wired at the dpad_seek instance below. The
+// gamepad's hold-to-scrub is untouched. Full reasoning: dvd/kbd_map.sv header.
+wire [16:0] kbd_joy;
+
+kbd_map kbd_map_inst (
+    .clk     (clk_sys),
+    .rst_n   (reset_n),
+    .ps2_key (ps2_key),
+    .joy     (kbd_joy)
+);
+
+wire [31:0] joy_eff = joystick_0 | {15'd0, (kbd_joy & ~17'h0_6000)};
+
+wire joy_pause = joy_eff[4];                       // B1 "Pause"
+wire joy_next  = joy_eff[6];                       // B3 "Next Chapter"
+wire joy_prevc = joy_eff[5];                       // B2 "Prev Chapter"
+wire joy_sel   = joy_eff[7];                       // B4 "Select"
+wire joy_menu  = joy_eff[8];                       // B5 "Menu"
+wire joy_angle = joy_eff[9];                       // B6 "Angle"
+wire joy_audio = joy_eff[10];                      // B7 "Audio"     (Phase 10)
+wire joy_sub   = joy_eff[11];                      // B8 "Subtitle"  (Phase 10)
+wire joy_disp  = joy_eff[12];                      // B9 "Display"   (Phase 11 HUD)
 // Dedicated seek buttons: the HOLD-to-seek time scrub lives on its OWN buttons
 // (B10 Fast Fwd = seek forward, B11 Rewind = seek backward) so the D-pad is
 // never claimed by the scrub. This keeps left/right free for directional menu /
 // game navigation even when the underlying video is seekable (the conflict this
 // split resolves). scrub_ctrl reads the HELD levels; ff_edge/rew_edge below only
 // clear pause when a scrub begins.
-wire joy_ff    = joystick_0[13];                   // B10 "Fast Fwd" (held scrub fwd)
-wire joy_rew   = joystick_0[14];                   // B11 "Rewind"   (held scrub bwd)
-wire joy_title = joystick_0[15];                   // B12 "Title"    (VMGM Top Menu)
-wire joy_ret   = joystick_0[16];                   // B13 "Return"   (GoUp)
+// ⚠ GAMEPAD-ONLY BY CONSTRUCTION: joy_eff masks kbd_joy[14:13] out, so a
+// keyboard/remote can never assert these two LEVELS -- its Fast Fwd/Rewind keys
+// go to dpad_seek instead (see the joy_eff comment above).
+wire joy_ff    = joy_eff[13];                      // B10 "Fast Fwd" (held scrub fwd)
+wire joy_rew   = joy_eff[14];                      // B11 "Rewind"   (held scrub bwd)
+wire joy_title = joy_eff[15];                      // B12 "Title"    (VMGM Top Menu)
+wire joy_ret   = joy_eff[16];                      // B13 "Return"   (GoUp)
 wire pause_edge = joy_pause & ~joy_prev[4];
 // Phase 8: B2/B3 = CHAPTER prev/next (program_map); B10/B11 (Fast Fwd/Rewind) =
 // HOLD-to-seek TIME SCRUB (dvd/scrub_ctrl.sv, accelerating 10->30->60->120 s the
@@ -1301,10 +1343,10 @@ wire ret_edge   = joy_ret   & ~joy_prev[16];       // Return press  (GoUp)
 // dvd/dpad_seek.sv for VLC-style fixed-time jumps -- but only where the nav
 // layer has NOT claimed them (see the menu_nav / in_title_menu gates below),
 // so the no-conflict property above is preserved by construction.
-wire up_edge    = joystick_0[3] & ~joy_prev[3];
-wire dn_edge    = joystick_0[2] & ~joy_prev[2];
-wire lf_edge    = joystick_0[1] & ~joy_prev[1];
-wire rt_edge    = joystick_0[0] & ~joy_prev[0];
+wire up_edge    = joy_eff[3] & ~joy_prev[3];
+wire dn_edge    = joy_eff[2] & ~joy_prev[2];
+wire lf_edge    = joy_eff[1] & ~joy_prev[1];
+wire rt_edge    = joy_eff[0] & ~joy_prev[0];
 
 // nav_pci interface (Phase 3)
 wire        hl_btns_armed;
@@ -1383,7 +1425,7 @@ always @(posedge clk_sys or negedge reset_n) begin
         key_title_p  <= 1'b0;
         key_return_p <= 1'b0;
     end else begin
-        joy_prev     <= joystick_0;
+        joy_prev     <= joy_eff;
         seek_pulse   <= 1'b0;             // default: one-cycle pulses
         chap_pulse   <= 1'b0;
         angle_pulse  <= 1'b0;
@@ -1401,7 +1443,12 @@ always @(posedge clk_sys or negedge reset_n) begin
         else if (pause_edge)      pause_q <= ~pause_q;
         // a title-mode Fast Fwd/Rewind time scrub resumes playback (the scrub FSM
         // below issues the actual seek_rbn)
-        else if ((cell_ready || lin_seek_ok_w) && !menu_active && !in_title_menu && (ff_edge || rew_edge)) pause_q <= 1'b0;
+        // A KEYBOARD Fast Fwd/Rewind press must resume too, and it needs its own
+        // term: kbd_joy[14:13] are masked out of joy_eff (so ff_edge/rew_edge
+        // never see them) and the D-pad clause below is gated on O[45], which a
+        // dedicated seek key is deliberately NOT.
+        else if ((cell_ready || lin_seek_ok_w) && !menu_active && !in_title_menu &&
+                 (ff_edge || rew_edge || kbd_joy[13] || kbd_joy[14])) pause_q <= 1'b0;
         // a D-pad fixed-time seek likewise resumes playback (dvd/dpad_seek.sv
         // issues the jump when the coalesce window closes)
         else if (dpad_seek_en && (cell_ready || lin_seek_ok_w) && !menu_active &&
@@ -1660,7 +1707,13 @@ dpad_seek dpad_seek_inst (
     .clk            (clk_sys),
     .rst_n          (reset_n),                  // NOT pipe_rst_n: the gesture
                                                 // must survive its own seek
-    .en             (dpad_seek_en),
+    // ★ `en` is read in exactly ONE place inside dpad_seek
+    // (seek_ok = en && in_title && (dvd_mode || lin_mode)), so the O[45] gate is
+    // applied to the D-PAD EDGES instead and the module needs no change. That is
+    // what lets the keyboard's Fast Fwd/Rewind keys in unconditionally:
+    // O[45] exists solely to stop the D-PAD fighting a game disc that wants
+    // directional input, and a dedicated Fast Fwd key has no such conflict.
+    .en             (1'b1),
     .in_title       ((cell_ready || lin_seek_ok_w) && !menu_active &&
                      !in_title_menu && !menu_nav),
     .dvd_mode       (cell_ready),               // DSI tables available
@@ -1670,10 +1723,15 @@ dpad_seek dpad_seek_inst (
     // zero step through, so a tap in the ~0.5 s before the estimate arms does
     // nothing instead of firing a jump resolved against nothing.
     .lin_mode       (lin_mode_w && lin_blk10_ok_w),
-    .up_edge        (up_edge),
-    .dn_edge        (dn_edge),
-    .lf_edge        (lf_edge),
-    .rt_edge        (rt_edge),
+    .up_edge        (dpad_seek_en & up_edge),
+    .dn_edge        (dpad_seek_en & dn_edge),
+    // Keyboard/remote Fast Fwd + Rewind ride the COALESCING fixed-time path
+    // rather than scrub_ctrl's hold-to-scrub: a tap-repeating IR remote turns a
+    // held button into ~9 complete seek gestures a second, and a swallowed
+    // release freezes the picture. Here the same burst builds ONE jump.
+    // (dvd/kbd_map.sv header carries the measurements.)
+    .lf_edge        ((dpad_seek_en & lf_edge) | kbd_joy[14]),   // Rewind   key = -10 s
+    .rt_edge        ((dpad_seek_en & rt_edge) | kbd_joy[13]),   // Fast Fwd key = +10 s
     .cancel         (jump_ack | chap_pulse | start_streaming | hold_freeze),
     .nav_flush      (load_flush),               // nav_dsi's own reset condition
     .dsi_commit     (dsi_commit),
@@ -1748,7 +1806,7 @@ always @(posedge clk_sys) begin
         sec_tick <= 1'b0;
     end
 end
-wire vm_entropy_stir = |(joystick_0 ^ joy_prev);   // any gamepad edge = user timing
+wire vm_entropy_stir = |(joy_eff ^ joy_prev);      // any gamepad/key edge = user timing
 // Seed = mount-instant counter XOR the wall clock (both halves of it, so a
 // 16-bit seed still moves with the high word). srand(time()) parity.
 wire [15:0] vm_rnd_seed = entropy_ctr[15:0] ^

--- a/dvd/kbd_map.sv
+++ b/dvd/kbd_map.sv
@@ -1,0 +1,179 @@
+// ============================================================================
+// dvd/kbd_map.sv -- keyboard / TV-remote transport control
+// ============================================================================
+// Decodes the framework's ps2_key stream into a VIRTUAL JOYSTICK VECTOR with
+// exactly the bit layout of hps_io's joystick_0[16:0] (D-pad = [3:0], the J1
+// CONF_STR buttons B1..B13 = [4]..[16]), which dvd/emu.sv ORs into joy_eff.
+// Every transport action therefore gains a key for free -- edge detection,
+// chapter coalescing, the menu button walk, the HUD and vm_entropy_stir all
+// consume joy_eff and need no change.
+//
+// ★ WHY THIS EXISTS AT ALL, when MiSTer already maps keys to buttons
+// (issue #35). Main's "Define buttons" REFUSES to bind Enter or Esc:
+// input.cpp:3276 guards the capture block with
+//     !((mapping_type < 2 || !mapping_button) && (cancel || enter))
+// and a keyboard session is mapping_type == 0 (input.cpp:3353), so those two
+// keys are excluded for EVERY button. Worse, they are not merely dropped --
+// Enter is the OSD's own confirm key, so it reaches menu.cpp:4419 and ENDS AND
+// SAVES the mapping session, which is exactly why a user reports that it
+// "registered" and then does nothing. Reproduced on a stock MiSTer: a mapped
+// Enter does not activate a highlighted DVD-menu button while the gamepad's
+// own Select does, in the same menu. Reading the scancode here bypasses Main's
+// mapper entirely -- and since those two keys can never be mapped, our bindings
+// for them can never be shadowed by a user's own.
+//
+// ★ AND FOR HDMI-CEC THIS IS THE ONLY PATH THAT EXISTS. Main injects CEC button
+// presses as KEYBOARD events (hdmi_cec.cpp:290-319) and never runs them through
+// the joystick mapping, so before this module a TV remote could drive nothing
+// here except menu digits. The key choices below are led by that fixed CEC
+// table, because it is the constrained resource; keyboard aliases follow
+// DVD-remote / VLC convention afterwards.
+// ⚠ CEC's own Root Menu / Exit is UNREACHABLE and that is not fixable here:
+// it maps to `menu_present() ? KEY_BACK : KEY_MENU` and menu_present() means
+// "the OSD is on screen right now" (menu.cpp:8137), so during playback it is
+// KEY_MENU -- which Main eats as the OSD toggle -- while KEY_BACK has NONE in
+// the PS/2 table. Hence Menu/Title/Audio/Subtitle ride the CEC COLOUR keys.
+//
+// ★ EVERY OUTPUT BIT IS A ONE-CYCLE PULSE ON THE PRESS. Break events are
+// ignored and no level is held anywhere in this module, so a lost release is a
+// non-event and a stuck key is structurally impossible. (An all-levels design
+// has a subtler failure too: a stuck bit swallows the NEXT press, because there
+// is no rising edge left to detect, and the key just looks dead.) The cost is
+// no key-repeat from holding a direction in a menu -- but the gamepad behaves
+// identically today, and Main drops keyboard auto-repeat anyway
+// (user_io.cpp:4059, `if (press > 1 && !use_ps2ctl) return;`), so a held key
+// was never going to repeat.
+//
+// ★ [14:13] FAST FWD / REWIND ARE PULSES TOO, AND emu.sv MASKS THEM OUT OF
+// joy_eff -- they drive dvd/dpad_seek.sv (+/-10 s per press, coalescing) rather
+// than dvd/scrub_ctrl.sv's hold-to-scrub. They are the design's ONLY level
+// consumers (scrub_ctrl.sv:84) and a keyboard-like device cannot drive a level
+// safely, for two measured reasons:
+//   1. TAP-REPEATING IR REMOTES TURN A HOLD INTO A BURST OF SEEKS. Retro
+//      Remake's own SuperDock receiver firmware (DockIR, src/main.c) sends
+//      key-down -> 80 ms -> key-up PER NEC REPEAT FRAME, ~110 ms apart: a long
+//      press is ~9 discrete taps a second, not a hold. scrub_ctrl's accumulate
+//      tick is 60 ms (TICK = 1_620_000 @ 27 MHz), so an 80 ms tap leaves
+//      pending_off != 0 and each release issues a REAL seek -- ~9 flush and
+//      re-locks per second, which is precisely the regime HW rounds 1-2
+//      recorded as fatal (see the headers of scrub_ctrl.sv and dpad_seek.sv).
+//      Under coalescing that identical burst builds ONE large jump instead.
+//   2. A STUCK LEVEL HANGS THE PICTURE. held_right stuck with in_title leaves
+//      `want` high forever -> hold_freeze -> frozen video with the bar up and
+//      no seek issued (the seek happens on RELEASE), and the reflex recovery --
+//      tap it again -- delivers a break with pending_off already ramped to the
+//      title span, i.e. one seek straight to the END OF THE TITLE.
+// The gamepad's hold-to-scrub is untouched by any of this; scrub_ctrl.sv is not
+// modified. See docs/dvd_nav.md "Keyboard / CEC input".
+//
+// ⚠ DIGITS 0-9 ARE DELIBERATELY NOT DECODED HERE. All twenty scancodes (top row
+// and numpad) belong to emu.sv's "NUMPAD MENU INPUT" block, where a digit
+// selects AND activates menu button N -- the DVD-remote idiom, HW-confirmed by
+// the T2 "82997" easter egg (PR fj#134). Binding them to a transport action as
+// well would make one keypress do two things.
+//
+// ⚠ EXTENDED-BIT COLLISIONS ARE THE WHOLE REASON ps2_key[8] IS PART OF THE
+// DECODE KEY. In PS/2 set 2 the arrow and page keys are bit-identical to numpad
+// digits and differ ONLY by the E0 prefix:
+//     E0 75 Up   / 75 numpad-8      E0 72 Down / 72 numpad-2
+//     E0 6B Left / 6B numpad-4      E0 74 Rght / 74 numpad-6
+//     E0 7D PgUp / 7D numpad-9      E0 7A PgDn / 7A numpad-3
+// The digit block already requires !ps2_key[8]; this one requires ps2_key[8]
+// for exactly those six. Enter is the one key accepted with EITHER polarity
+// (5A and E0 5A = Enter and KP-Enter, both "OK").
+//
+// ⚠ NEVER BIND, all verified against Main: F12 (07) and KEY_MENU are eaten as
+// the OSD toggle; KEY_PAUSE (E1) has no break code at all; NumLock/ScrollLock
+// are Main's EMU_SWITCH_1/2 keyboard-emulation toggles; Alt/Meta are passed
+// through specially so they cannot stick.
+// ============================================================================
+
+`default_nettype none
+
+module kbd_map (
+    input  wire        clk,        // clk_sys (27 MHz)
+    input  wire        rst_n,
+
+    // hps_io "ps2 alternative interface": {toggle, pressed, extended, code}.
+    // Bit 10 flips on every new key event; bit 9 is make/break; bit 8 is E0.
+    input  wire [10:0] ps2_key,
+
+    // One-cycle pulse per PRESS, in joystick_0[16:0] bit order.
+    output reg  [16:0] joy
+);
+
+    // ---- scancode -> bit index (combinational) -----------------------------
+    // hit is a one-hot vector, not an index, because emu.sv wants the vector
+    // and several keys share a destination (M / X / F1 all mean Menu).
+    reg [16:0] hit;
+    always @(*) begin
+        hit = 17'd0;
+        if (ps2_key[8]) begin
+            // ---- E0-extended --------------------------------------------
+            case (ps2_key[7:0])
+            8'h75: hit[3]  = 1'b1;   // Up          -> D-pad Up      (CEC)
+            8'h72: hit[2]  = 1'b1;   // Down        -> D-pad Down    (CEC)
+            8'h6B: hit[1]  = 1'b1;   // Left        -> D-pad Left    (CEC)
+            8'h74: hit[0]  = 1'b1;   // Right       -> D-pad Right   (CEC)
+            8'h7D: hit[5]  = 1'b1;   // Page Up     -> B2  Prev Chapter (CEC)
+            8'h7A: hit[6]  = 1'b1;   // Page Down   -> B3  Next Chapter (CEC)
+            8'h5A: hit[7]  = 1'b1;   // KP-Enter    -> B4  Select
+            default: ;
+            endcase
+        end else begin
+            // ---- plain set-2 --------------------------------------------
+            case (ps2_key[7:0])
+            8'h5A: hit[7]  = 1'b1;   // Enter       -> B4  Select    (CEC OK)
+            8'h29: hit[4]  = 1'b1;   // Space       -> B1  Pause     (CEC Play/Pause)
+            8'h4D: hit[5]  = 1'b1;   // P           -> B2  Prev Chapter
+            8'h31: hit[6]  = 1'b1;   // N           -> B3  Next Chapter
+            8'h05: hit[8]  = 1'b1;   // F1          -> B5  Menu      (CEC Blue)
+            8'h3A: hit[8]  = 1'b1;   // M           -> B5  Menu
+            8'h22: hit[8]  = 1'b1;   // X           -> B5  Menu      (SuperDock "Cancel":
+                                     //   its only spare key, and the dock's ONLY route to
+                                     //   the disc menu -- its Menu button is F12 = the OSD)
+            8'h34: hit[9]  = 1'b1;   // G           -> B6  Angle
+            8'h04: hit[10] = 1'b1;   // F3          -> B7  Audio     (CEC Green)
+            8'h1C: hit[10] = 1'b1;   // A           -> B7  Audio
+            8'h0C: hit[11] = 1'b1;   // F4          -> B8  Subtitle  (CEC Yellow)
+            8'h1B: hit[11] = 1'b1;   // S           -> B8  Subtitle
+            8'h23: hit[12] = 1'b1;   // D           -> B9  Display
+            8'h0D: hit[13] = 1'b1;   // Tab         -> B10 Fast Fwd  (CEC FF)
+            8'h2B: hit[13] = 1'b1;   // F           -> B10 Fast Fwd
+            8'h66: hit[14] = 1'b1;   // Backspace   -> B11 Rewind    (CEC Rewind)
+            8'h2D: hit[14] = 1'b1;   // R           -> B11 Rewind
+            8'h06: hit[15] = 1'b1;   // F2          -> B12 Title     (CEC Red)
+            8'h2C: hit[15] = 1'b1;   // T           -> B12 Title
+            8'h76: hit[16] = 1'b1;   // Esc         -> B13 Return    (CEC Stop, dock "Exit").
+                                     //   Bound deliberately: CEC's real back button is
+                                     //   unreachable (see header), so without Esc a CEC
+                                     //   user has no way up a menu level. GoUp is a
+                                     //   harmless no-op where the disc authors no parent.
+            8'h32: hit[16] = 1'b1;   // B           -> B13 Return
+            default: ;
+            endcase
+        end
+    end
+
+    // ---- event edge -> one-cycle pulse -------------------------------------
+    // Registered, NOT combinational off ps2_key: that word stays put for
+    // thousands of cycles between events, so a combinational "pulse" would be a
+    // level and every downstream edge detector would see one edge but the
+    // wrong width -- and bits [14:13] would land in dpad_seek as a held request.
+    reg ps2_tgl_q;
+
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            joy       <= 17'd0;
+            ps2_tgl_q <= 1'b0;
+        end else begin
+            joy       <= 17'd0;                 // default: one-cycle pulse
+            ps2_tgl_q <= ps2_key[10];
+            // new key event (toggle flipped) + PRESSED (break events ignored)
+            if ((ps2_key[10] ^ ps2_tgl_q) && ps2_key[9]) joy <= hit;
+        end
+    end
+
+endmodule
+
+`default_nettype wire

--- a/site/content/getting-started/what-you-need.md
+++ b/site/content/getting-started/what-you-need.md
@@ -14,6 +14,7 @@ that when something does not play, you can tell which piece is missing.
 | **Bitstream passthrough over optical S/PDIF** | ✓ | ✓ | ✓ |
 | **Bitstream passthrough over HDMI** — *DD/DTS 5.1, no I/O board* | — | ✓ | ✓ |
 | Analog/CRT output, closed captions, HUD, seeking | ✓ | ✓ | ✓ |
+| Gamepad, keyboard or IR-remote control *(unreleased)* | ✓ | ✓ | ✓ |
 | **Physical disc — unencrypted** | — | ✓ | ✓ |
 | **Physical disc — CSS-encrypted** *(most commercial discs)* | — | — | ✓ |
 | **CSS-encrypted ISO** — *no optical drive needed* | — | — | ✓ |

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -46,8 +46,8 @@ a display-refresh-locked frame-rate governor.
 disc's authored menus work: First Play, root and title menus, PCI/HLI button highlights,
 D-pad navigation following the authored link graph, subpictures, chapters via the PTT
 tables, multi-angle, seamless-branch interleaved cells, still frames, and
-audio/subtitle/angle/language selection. Transport is on the gamepad with an on-screen HUD
-and seek bar.
+audio/subtitle/angle/language selection. Transport runs from a gamepad, a USB keyboard or an
+infrared remote, with an on-screen HUD and seek bar.
 
 **Audio** — AC-3 and MPEG-1 Layer II decoded entirely in fabric (every AC-3 channel mode,
 downmixed to stereo) to HDMI; 48 kHz LPCM; AC-3 and DTS as

--- a/site/content/playback/controls.md
+++ b/site/content/playback/controls.md
@@ -47,6 +47,9 @@ itself to MiSTer as a keyboard counts, which is how a **remote** drives the play
 
 ## Using a remote
 
+!!! info "Unreleased"
+    Needs the keyboard support above; not in v0.3.0.
+
 The reliable way is an **infrared receiver that presents itself as a USB keyboard** — a
 Flirc, a generic MCE-style USB IR dongle, or the receiver built into a console dock. It
 learns whatever remote you already own, emits ordinary keystrokes, and needs no setting up

--- a/site/content/playback/controls.md
+++ b/site/content/playback/controls.md
@@ -51,9 +51,15 @@ HDMI-CEC TV remote, or a console dock's infrared remote.
 - **++f12++ and a remote's Menu button open the MiSTer OSD**, always. They can never be
   given a disc function.
 - While the OSD is open, **no key reaches the player**.
-- On a **CEC remote, Exit / Root Menu also opens the MiSTer OSD** rather than the disc menu.
-  Use the **colour keys** instead: blue = Menu, red = Title, green = Audio, yellow =
-  Subtitle.
+- On a **CEC remote, Menu / Exit is the MiSTer OSD button**, not the disc menu. It is a
+  proper toggle: pressing it again steps back a level and closes the OSD at the top, so it
+  is how you get in and out. **Stop** also closes the OSD from any level. To reach the
+  *disc's* menus, use the **colour keys**: blue = Menu, red = Title, green = Audio,
+  yellow = Subtitle.
+
+    Which physical button sends which code is up to the TV, not MiSTer — most sets send
+    Exit for Back/Return and Root Menu for Home/Menu while a source is selected, and some
+    pass only a few keys through CEC at all.
 
 !!! note "Turning CEC on, and off again"
     CEC is off unless you asked for it — MiSTer needs `hdmi_cec=1` in `MiSTer.ini` before a

--- a/site/content/playback/controls.md
+++ b/site/content/playback/controls.md
@@ -1,7 +1,8 @@
 # Controls
 
-Playback is driven from the gamepad. The button numbers below are MiSTer's standard
-numbering — whatever you mapped B1 to in the MiSTer menu is what "B1" means here.
+Playback is driven from a gamepad, a USB keyboard, or a TV or set-top remote — all three
+work at once, and none of them needs setting up. The button numbers below are MiSTer's
+standard numbering — whatever you mapped B1 to in the MiSTer menu is what "B1" means here.
 
 | Button | Action | | Button | Action |
 |---|---|---|---|---|
@@ -13,8 +14,74 @@ numbering — whatever you mapped B1 to in the MiSTer menu is what "B1" means he
 | B6 | Angle (cycle) | | B13 | Return (go up) |
 | B7 | Audio (cycle) | | D-pad | Menu navigation |
 
+Every one of those actions also has a **[keyboard and remote key](#keyboard-and-tv-remote)**.
 A USB keyboard's **number keys select menu buttons directly**, which is often quicker than
 walking a menu with the D-pad.
+
+## Keyboard and TV remote
+
+!!! info "Unreleased"
+    Available in development builds; not in v0.3.0.
+
+Nothing to configure — plug in a keyboard, or point a remote at the receiver, and these keys
+work. Anything that presents itself to MiSTer as a keyboard counts: a USB keyboard, an
+HDMI-CEC TV remote, or a console dock's infrared remote.
+
+| Key | Action | | Key | Action |
+|---|---|---|---|---|
+| ↑ ↓ ← → | Menu navigation | | ++"A"++ | Audio (cycle) |
+| ++enter++ | Select | | ++"S"++ | Subtitle (cycle) |
+| ++space++ | Pause | | ++"G"++ | Angle (cycle) |
+| ++page-up++ / ++"P"++ | Prev Chapter | | ++"D"++ | Display (toggle status line) |
+| ++page-down++ / ++"N"++ | Next Chapter | | ++tab++ / ++"F"++ | Fast Fwd (10 s per press) |
+| ++"M"++ / ++"X"++ | Menu | | ++backspace++ / ++"R"++ | Rewind (10 s per press) |
+| ++"T"++ | Title menu | | ++esc++ / ++"B"++ | Return (go up) |
+| ++0++ – ++9++ | Select menu button by number | | | |
+
+!!! warning "Fast Fwd and Rewind work differently here"
+    On a gamepad you *hold* them to scrub. On a keyboard or remote each press jumps **10
+    seconds**, and presses add up the same way [D-pad seek](#d-pad-seek) does — six quick
+    taps is one minute, and one seek happens when you stop. That is deliberate: a remote's
+    "hold" is really a rapid stream of taps, which a scrub would turn into dozens of
+    separate seeks. This works whether or not D-Pad Seek is switched on. Files with no seek
+    information — a bare `.m2v` — have no keyboard seek.
+
+### Things MiSTer keeps for itself
+
+- **++f12++ and a remote's Menu button open the MiSTer OSD**, always. They can never be
+  given a disc function.
+- While the OSD is open, **no key reaches the player**.
+- On a **CEC remote, Exit / Root Menu also opens the MiSTer OSD** rather than the disc menu.
+  Use the **colour keys** instead: blue = Menu, red = Title, green = Audio, yellow =
+  Subtitle.
+
+!!! note "Turning CEC on, and off again"
+    CEC is off unless you asked for it — MiSTer needs `hdmi_cec=1` in `MiSTer.ini` before a
+    TV remote reaches any core. To stop a TV remote controlling playback without giving up
+    CEC's power-on and standby handling, set `hdmi_cec_input_mode=0` instead. There is no
+    setting for this in the player's own menu, because a CEC keypress arrives as an
+    ordinary keystroke — the core cannot tell it apart from a USB keyboard.
+- The [support bundle chord](#support-bundle-chord) is **gamepad-only** — it is handled
+  outside the core, so the keyboard's Audio and Subtitle keys cannot trigger it.
+
+### Rebinding
+
+Use MiSTer's own **Define buttons**, which maps any key onto any of the buttons in the first
+table. A key you map there takes over completely, so it replaces whatever the built-in list
+above gave it.
+
+!!! note "++enter++ and ++esc++ cannot be rebound"
+    MiSTer reserves both as its own confirm and cancel keys and will not assign them to a
+    button — pressing ++enter++ during Define buttons *ends* the session rather than
+    capturing it, which looks like it worked. That is exactly why the player reads them
+    itself, and it is why a dock remote's **OK** and **Exit** buttons now work at all.
+
+### Console dock remotes
+
+A dock's infrared remote usually sends only a handful of keys — on a SuperStation One
+SuperDock, the arrows plus **OK** (++enter++), **Exit** (++esc++), **Cancel** (++"X"++) and
+one function key. That is enough to walk a disc's menus and pick a title. **Cancel** is
+mapped to Menu precisely because that remote's own Menu button belongs to the MiSTer OSD.
 
 ## In a menu
 

--- a/site/content/playback/controls.md
+++ b/site/content/playback/controls.md
@@ -14,7 +14,7 @@ standard numbering — whatever you mapped B1 to in the MiSTer menu is what "B1"
 | B6 | Angle (cycle) | | B13 | Return (go up) |
 | B7 | Audio (cycle) | | D-pad | Menu navigation |
 
-Every one of those actions also has a **[keyboard and remote key](#keyboard-and-tv-remote)**.
+Every one of those actions also has a **[keyboard or remote key](#keyboard-and-tv-remote)**.
 A USB keyboard's **number keys select menu buttons directly**, which is often quicker than
 walking a menu with the D-pad.
 
@@ -23,9 +23,8 @@ walking a menu with the D-pad.
 !!! info "Unreleased"
     Available in development builds; not in v0.3.0.
 
-Nothing to configure — plug in a keyboard, or point a remote at the receiver, and these keys
-work. Anything that presents itself to MiSTer as a keyboard counts: a USB keyboard, an
-HDMI-CEC TV remote, or a console dock's infrared remote.
+Nothing to configure — plug in a keyboard and these keys work. Anything that presents
+itself to MiSTer as a keyboard counts, which is how a **remote** drives the player too.
 
 | Key | Action | | Key | Action |
 |---|---|---|---|---|
@@ -46,31 +45,84 @@ HDMI-CEC TV remote, or a console dock's infrared remote.
     separate seeks. This works whether or not D-Pad Seek is switched on. Files with no seek
     information — a bare `.m2v` — have no keyboard seek.
 
-### Things MiSTer keeps for itself
+## Using a remote
+
+The reliable way is an **infrared receiver that presents itself as a USB keyboard** — a
+Flirc, a generic MCE-style USB IR dongle, or the receiver built into a console dock. It
+learns whatever remote you already own, emits ordinary keystrokes, and needs no setting up
+on the MiSTer side at all: the keys in the table above simply work.
+
+That is also what a console dock does. A dock remote usually sends only a handful of keys —
+on a SuperStation One SuperDock, the arrows plus **OK** (++enter++), **Exit** (++esc++),
+**Cancel** (++"X"++) and one function key — which is enough to walk a disc's menus and start
+a title. **Cancel** is mapped to Menu precisely because that remote's own Menu button
+belongs to the MiSTer OSD.
+
+### Using your TV's remote over HDMI-CEC
+
+A TV remote can drive the player over CEC instead, with no extra hardware — **but whether
+CEC works at all depends on your board**, so treat it as worth trying rather than as a
+supported path.
+
+Enable it under `[MiSTer]` in `MiSTer.ini`:
+
+```ini
+hdmi_cec=1
+```
+
+Then map the colour keys to the disc's own menus: **blue** = Menu, **red** = Title,
+**green** = Audio, **yellow** = Subtitle. You need those because the remote's Menu / Exit
+button belongs to the MiSTer OSD (see below).
+
+!!! failure "If nothing happens, check the log before changing anything else"
+    MiSTer throws its own log away by default. Add `debug=2` under `[MiSTer]`, reboot, and
+    read `/tmp/debug.txt`:
+
+    ```
+    grep -i cec /tmp/debug.txt
+    ```
+
+    | What you see | What it means |
+    |---|---|
+    | `CEC: no clock detected` then `CEC: init failed.` | **Your board's CEC hardware is not usable.** Nothing in the ini changes this — see below. |
+    | `CEC: main register setup failed` | The HDMI transmitter could not be reached at all. |
+    | `CEC: no EDID and power-on disabled` | Set `hdmi_cec_power_on=1`. |
+    | `CEC: logical=… physical=1.0.0.0` | CEC is working. If the remote still does nothing, the **TV** is not routing it — usually because MiSTer is not the selected input. |
+    | *no `CEC:` lines at all* | `hdmi_cec=1` is not being read. It must be under `[MiSTer]`, not below another core's section heading. |
+
+    To see whether the TV sends anything at all, press keys **from the MiSTer main menu**
+    rather than inside the player — button codes are only logged there, as
+    `CEC button: 0x09, pressed=1`.
+
+!!! warning "`no clock detected` cannot be fixed in the ini"
+    It means the HDMI transmitter's CEC engine never completed a transmission, which is a
+    wiring or clock-source question on the board itself. In particular **`hdmi_cec_clock=`
+    does not help**: that setting only chooses between clock rates *after* a successful
+    probe, so it cannot revive an engine that is not running. Set `hdmi_cec=0` to skip the
+    probe and its startup delay, and use a USB infrared receiver instead — it gives you the
+    same remote control and does not involve the HDMI transmitter at all.
+
+!!! note "Turning CEC off again"
+    `hdmi_cec=0` disables the whole thing. To stop a TV remote controlling playback while
+    keeping CEC's power-on and standby handling, set `hdmi_cec_input_mode=0` instead. There
+    is no setting for either in the player's own menu, because a CEC keypress arrives as an
+    ordinary keystroke — the core cannot tell it apart from a USB keyboard.
+
+## Things MiSTer keeps for itself
 
 - **++f12++ and a remote's Menu button open the MiSTer OSD**, always. They can never be
   given a disc function.
 - While the OSD is open, **no key reaches the player**.
 - On a **CEC remote, Menu / Exit is the MiSTer OSD button**, not the disc menu. It is a
   proper toggle: pressing it again steps back a level and closes the OSD at the top, so it
-  is how you get in and out. **Stop** also closes the OSD from any level. To reach the
-  *disc's* menus, use the **colour keys**: blue = Menu, red = Title, green = Audio,
-  yellow = Subtitle.
-
-    Which physical button sends which code is up to the TV, not MiSTer — most sets send
-    Exit for Back/Return and Root Menu for Home/Menu while a source is selected, and some
-    pass only a few keys through CEC at all.
-
-!!! note "Turning CEC on, and off again"
-    CEC is off unless you asked for it — MiSTer needs `hdmi_cec=1` in `MiSTer.ini` before a
-    TV remote reaches any core. To stop a TV remote controlling playback without giving up
-    CEC's power-on and standby handling, set `hdmi_cec_input_mode=0` instead. There is no
-    setting for this in the player's own menu, because a CEC keypress arrives as an
-    ordinary keystroke — the core cannot tell it apart from a USB keyboard.
+  is how you get in and out. **Stop** also closes the OSD from any level. Which physical
+  button sends which code is up to the TV, not MiSTer — most sets send Exit for Back/Return
+  and Root Menu for Home/Menu while a source is selected, and some pass only a few keys
+  through CEC at all.
 - The [support bundle chord](#support-bundle-chord) is **gamepad-only** — it is handled
   outside the core, so the keyboard's Audio and Subtitle keys cannot trigger it.
 
-### Rebinding
+## Rebinding
 
 Use MiSTer's own **Define buttons**, which maps any key onto any of the buttons in the first
 table. A key you map there takes over completely, so it replaces whatever the built-in list
@@ -81,13 +133,6 @@ above gave it.
     button — pressing ++enter++ during Define buttons *ends* the session rather than
     capturing it, which looks like it worked. That is exactly why the player reads them
     itself, and it is why a dock remote's **OK** and **Exit** buttons now work at all.
-
-### Console dock remotes
-
-A dock's infrared remote usually sends only a handful of keys — on a SuperStation One
-SuperDock, the arrows plus **OK** (++enter++), **Exit** (++esc++), **Cancel** (++"X"++) and
-one function key. That is enough to walk a disc's menus and pick a title. **Cancel** is
-mapped to Menu precisely because that remote's own Menu button belongs to the MiSTer OSD.
 
 ## In a menu
 

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -266,6 +266,47 @@ with zero contrast, which is intentional on their part.
     at full resolution and may reach into the black bars — see
     [Analog and CRT output](../video/analog-crt.md#analog-aspect).
 
+## Controls
+
+### My keyboard does nothing
+
+!!! info "Unreleased"
+    Keyboard control arrived after v0.3.0; on that release only the number keys work, and
+    only inside a menu.
+
+Check the [key list](../playback/controls.md#keyboard-and-tv-remote) — the keys are fixed,
+not derived from your gamepad mapping. Two things reasonably often explain it:
+
+- **A key you mapped in MiSTer's *Define buttons* takes over**, and is doing whatever you
+  mapped it to instead. That is how you rebind, but it can surprise you if you forgot.
+- **The MiSTer OSD is open.** No key reaches the player while it is up.
+
+### My TV remote does nothing over HDMI-CEC
+
+CEC has to be switched on (`hdmi_cec=1` under `[MiSTer]` in `MiSTer.ini`), and **it does not
+work on every board**. Before changing anything else, get the log — MiSTer discards its own
+output unless you ask for it. Add `debug=2` under `[MiSTer]`, reboot, and read it:
+
+```
+grep -i cec /tmp/debug.txt
+```
+
+If that says `CEC: no clock detected` followed by `CEC: init failed.`, your board's CEC
+hardware is not usable and **no `MiSTer.ini` setting will change it** — including
+`hdmi_cec_clock`, which only chooses between clock rates once CEC is already working. Set
+`hdmi_cec=0` and use an infrared receiver that presents itself as a USB keyboard instead
+(a Flirc or a generic MCE dongle); that path does not involve CEC at all and gives you the
+same control.
+
+The full table of log lines and what each one means is on the
+[controls page](../playback/controls.md#using-your-tvs-remote-over-hdmi-cec).
+
+### My remote's Menu button opens the MiSTer menu instead of the disc menu
+
+That is MiSTer claiming it, and it cannot be reassigned. Use the **blue** colour key for the
+disc's menu, **red** for its title menu. The Menu button is still useful — it is a toggle, so
+it also closes the OSD again.
+
 ## Navigation
 
 ### A menu option does the wrong thing, or `LINK FAIL`


### PR DESCRIPTION
## What this fixes

[#35](https://github.com/owenb321/MiSTer_DVD/issues/35) — a user mapped their remote's OK button (which arrives as `Enter`) to `Select` in MiSTer's *Define buttons*, it appeared to register, and it did nothing in a disc menu while the gamepad's own Select worked in the same menu.

**The cause is in Main, not in this core and not in the disc.** `input.cpp:3276` guards the button-capture block with

```c
!((mapping_type < 2 || !mapping_button) && (cancel || enter))
```

and a Define-buttons session over a keyboard is `mapping_type == 0`, so `KEY_ENTER` and `KEY_ESC` are excluded from capture for *every* button. They are not merely dropped either: `Enter` is the OSD's own confirm key, so it reaches `menu.cpp:4419` and **ends and saves the mapping session** — which is exactly why it looks like it registered. Reproduced on a stock MiSTer with a plain USB keyboard.

That matters well beyond one report: on a console dock remote, **`OK` and `Exit` *are* those two keys**.

## What it does

`dvd/kbd_map.sv` decodes `ps2_key` into a 17-bit vector in `joystick_0`'s own bit order, and `emu.sv` ORs it into a new `joy_eff` that every button wire, edge detector, the chapter debounce, the menu walk, the HUD and `vm_entropy_stir` now read. A key and a gamepad button are therefore the same signal by the time anything acts on them, and **no consumer changed**.

| Key | Action | | Key | Action |
|---|---|---|---|---|
| ↑ ↓ ← → | Menu navigation | | `A` | Audio |
| `Enter` | Select | | `S` | Subtitle |
| `Space` | Pause | | `G` | Angle |
| `PageUp` / `P` | Prev Chapter | | `D` | Display |
| `PageDown` / `N` | Next Chapter | | `Tab` / `F` | Fast Fwd |
| `M` / `X` | Menu | | `Backspace` / `R` | Rewind |
| `T` | Title menu | | `Esc` / `B` | Return |

Digits 0–9 are untouched — they keep their existing meaning (select menu button N).

This is also the only path HDMI-CEC remotes have ever had: Main injects CEC presses as keyboard events and never runs them through the joystick mapping, so a TV remote previously could drive nothing here except menu digits.

## Three design points

**OR-ing cannot double-fire.** Main hands a key to the joystick mapper *or* to the PS/2 stream, never both (`input.cpp:3807-3821` matches and returns), so a user's own mapping shadows ours and ours only fires on keys that would otherwise have done nothing. `Enter`/`Esc` are the exception that motivated the feature — unmappable, therefore never shadowed.

**Every bit is a one-cycle pulse; there are no levels.** Main drops keyboard auto-repeat, so a held key is one make and one break and a level would buy nothing but failure modes.

**Fast Fwd/Rewind route to `dpad_seek`, not to `scrub_ctrl`'s hold-to-scrub.** An IR remote's "hold" is not one: Retro Remake's SuperDock firmware sends `key-down → 80 ms → key-up` per NEC repeat frame, ~110 ms apart — ~9 discrete taps a second. `scrub_ctrl`'s accumulate tick is 60 ms, so each tap would leave `pending_off != 0` and every release would issue a real seek: ~9 flush/re-locks a second, the regime HW rounds 1-2 recorded as fatal. Coalescing turns the same burst into one jump. A stuck level is the other hazard — frozen picture, and the reflex recovery seeks to the end of the title. Both vanish with pulses.

`dvd/scrub_ctrl.sv` and `dvd/dpad_seek.sv` are **unmodified**.

## No OSD option

CEC is opt-in and off by default in `MiSTer.ini`, a user's own mapping already shadows the built-in keys, and a core-side switch could only be all-or-nothing because a CEC press is indistinguishable from a keyboard press on the wire. `O[46]` stays free and appending it later is forward-compatible.

## Test plan

- [x] `bench/dvd/run_kbd.sh` — all suites pass
- [x] `kbd_map_tb` **mutation-checked**: five targeted RTL mutations (level-not-pulse, numpad-8 leak, fire-on-break, digit leak, Esc unbound) each caught by their own scenario
- [x] `dpad_seek_tb` **T19a** replays the SuperDock IR burst and measures exactly one `jump_fire`; **T19b** proves the coalesce window still closes
- [x] `scrub_ctrl_tb` passes **unchanged** — the gate that the gamepad scrub was untouched
- [x] `bench/dvd/run_dpad_seek.sh` in full, `nav_pci_tb`, `dvd_vm_tb`, `iso_reader_vm_tb`, `iso_reader_menu_tb`
- [x] `tools/docs_check.py` and `mkdocs build --strict`
- [x] Fit: pinned SEED 5, first roll, clk_dec 92.70 @100C / 90.14 @-40C (gate 86.0), 90% ALM
- [x] **HW-CONFIRMED** (`DVD_kbdmap_20260904_0226.rbf`): the #35 case itself, menu navigation and transport keys, the keyboard 10 s seek, and **the gamepad unregressed**
- [ ] HDMI-CEC — **untestable on the maintainer's board**, which reports `CEC: no clock detected` / `init failed`. Documented as board-dependent, with a USB IR receiver as the recommended remote route
- [ ] Tap-repeating IR remote burst on real hardware — no receiver available; covered in sim by `dpad_seek_tb` T19a

## Docs

`site/content/playback/controls.md` gains the key table, a `Using a remote` section led by USB-IR receivers, and a CEC section framed as board-dependent with a log-line diagnosis table. `reference/troubleshooting.md` gains a Controls section. `index.md`, `README.md` and `what-you-need.md` no longer imply transport is gamepad-only. Engineering rationale in `docs/dvd_nav.md` "Keyboard / CEC input".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
