### PR TITLE
MGL launch enhancements and hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1935,6 +1935,30 @@ worse maintenance burden than targeted in-place edits. So:
   is the core's data pump. Blocking I/O there is a video artefact, not a latency
   nit.** `dvd_report` already forks for this reason; `crack_title_keys` gets away
   with it only because nothing is playing yet.
+  ★★ **FOURTH ROUND: RETURNING TO THE IDLE SCREEN MUST NOT DEPEND ON THE HPS RESET.**
+  Report: after an MGL launch the OSD **Reset row does nothing**, so neither the
+  button nor an eject reaches the idle screen. ⚠ **The core side CANNOT be
+  launch-dependent** — `status[0]` goes through ONE flip-flop into `reset_n`, and
+  `user_io_status_set()` sends unconditionally with `hps_io` latching `status[15:0]`
+  on the FIRST word of the transaction (so even the OSD row's back-to-back
+  `set(1); set(0)` leaves the bit high for the rest of a transaction = hundreds of
+  clk_sys cycles). Neither end has an MGL dependency, so this half is
+  **INSTRUMENTED, not guessed**: integration step 31 logs every `status[0]` write to
+  `/tmp/dvd_report.log` with the MGL state, which splits "Main never dispatched"
+  from "the core ignored it" — they are fixed in completely different places.
+  ★★ **But the eject path had a defect of its own, and it was MINE from round two:**
+  `img_ejected` is a ONE-CYCLE PULSE and an eject arrives while the last frames are
+  still on screen, so `(img_ejected && !img_streaming && !video_live_s2)` evaluated
+  `video_live_s2` as still HIGH at exactly that instant and threw the clear away
+  every time. **The test was right; sampling it at the pulse was wrong.** New
+  `slot_empty` latches the emptied slot and the clear fires once the picture
+  actually runs out — so the return to idle now depends on nothing but the core.
+  ★ The latch also keeps the original guard honest: a FAILED MOUNT over live content
+  still leaves the old image playing and `media_seen` undisturbed, so `VIDEO_ARX/ARY`
+  does not flip mid-title and Main does not re-init the scaler.
+  ⚠ **Durable shape, and this is the second time this session:** a one-cycle event
+  ANDed with a level that is only settled LATER is a condition that never fires.
+  Latch the event, test the level when it can answer.
   Detail: **`docs/mgl_launch.md`**.
 - ✅ **SEEK-PREVIEW CLOCK + A GENTLER SCRUB RAMP (2026-09-03, branch
   `feature/flat-file-time-seek`) — ✅ HW-CONFIRMED 2026-09-04** (build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1906,6 +1906,30 @@ worse maintenance burden than targeted in-place edits. So:
   disc. ⚠ The module carries exactly ONE `#ifdef DVD_PHYS_TEST`, around
   `open_ready_drive` — a real `/dev/srN` cannot be faked (a regular file opens fine
   and then fails `CDROM_DRIVE_STATUS`).
+  ★★ **AND A THIRD ROUND: THE DRIVE PROBE RUNS ON THE THREAD THAT FEEDS THE
+  DECODER.** Report after the slot-ownership fix: the MGL launch was clean, but
+  ejecting an UNRELATED disc still froze the `.mpg` — **while the OSD kept
+  working**. ★ That last clause IS the diagnosis: Main alive + HandleUI running
+  ⇒ nothing unmounted the file and the core is not in reset, so it is being
+  STARVED. And with the slot fix in place `dvd_phys_tick()` does nothing on that
+  eject, which leaves exactly one thing still touching the drive — the 1 Hz scan
+  itself. `open("/dev/srN", O_NONBLOCK)` + `ioctl(CDROM_DRIVE_STATUS)` is
+  **BLOCKING I/O on the same thread as `user_io_poll()`'s SD block service**, so
+  however long it takes is time the core gets no data. Microseconds on a settled
+  drive; with the **TRAY OPEN** the `sr` driver answers TEST UNIT READY with a
+  media-change unit attention and RETRIES — hundreds of ms, every second, forever,
+  because the state never settles. Fix: a probe over 50 ms doubles the scan period
+  (cap 10 s) and a fast one restores 1 s; while a foreign image owns the slot the
+  floor is 5 s (the scan then exists only to notice an INSERTION). Measured
+  (`dvd_phys_test.cpp` [8], 400 ms probe): **60 blocking calls a minute → 7.**
+  ⚠ **Recorded as a HYPOTHESIS WITH INSTRUMENTATION, not a confirmed root cause** —
+  it fits every observation but has not been measured on the reporter's drive, so
+  `dvd_phys` logs any probe over 50 ms to `/tmp/dvd_report.log` with its duration.
+  No such line at the freeze ⇒ the scan is exonerated and the search moves core-side.
+  ★ **The durable rule, worth applying to any future overlay tick: `user_io_poll()`
+  is the core's data pump. Blocking I/O there is a video artefact, not a latency
+  nit.** `dvd_report` already forks for this reason; `crack_title_keys` gets away
+  with it only because nothing is playing yet.
   Detail: **`docs/mgl_launch.md`**.
 - ✅ **SEEK-PREVIEW CLOCK + A GENTLER SCRUB RAMP (2026-09-03, branch
   `feature/flat-file-time-seek`) — ✅ HW-CONFIRMED 2026-09-04** (build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1922,10 +1922,15 @@ worse maintenance burden than targeted in-place edits. So:
   (cap 10 s) and a fast one restores 1 s; while a foreign image owns the slot the
   floor is 5 s (the scan then exists only to notice an INSERTION). Measured
   (`dvd_phys_test.cpp` [8], 400 ms probe): **60 blocking calls a minute → 7.**
-  ⚠ **Recorded as a HYPOTHESIS WITH INSTRUMENTATION, not a confirmed root cause** —
-  it fits every observation but has not been measured on the reporter's drive, so
-  `dvd_phys` logs any probe over 50 ms to `/tmp/dvd_report.log` with its duration.
-  No such line at the freeze ⇒ the scan is exonerated and the search moves core-side.
+  ✅ **HW-CONFIRMED 2026-09-04** (*"ejecting during .mpg playback works now"*). It
+  shipped as a hypothesis with instrumentation and the instrument STAYS: any probe
+  over 50 ms is logged to `/tmp/dvd_report.log` with its duration, which is the
+  fastest way to tell a slow drive from a core-side stall next time.
+  ★★ **THE DIAGNOSIS CAME FROM ONE CLAUSE IN THE REPORT — "the OSD still works".**
+  Main alive + HandleUI running rules out every unmount/reset hypothesis at a stroke
+  and leaves starvation as the only shape that fits. **Ask it explicitly next time:
+  "is the PICTURE frozen or is the MACHINE frozen" separates the HPS side from the
+  core side before a line of code is read.**
   ★ **The durable rule, worth applying to any future overlay tick: `user_io_poll()`
   is the core's data pump. Blocking I/O there is a video artefact, not a latency
   nit.** `dvd_report` already forks for this reason; `crack_title_keys` gets away

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1853,9 +1853,22 @@ worse maintenance burden than targeted in-place edits. So:
   and always serves it; the real `hps_io` picks requests up by polling cmd `'h16` at
   Main's poll rate, so a request withdrawn in between is LOST. Without a polling mock the
   "mount over an in-flight read" arm is a bench that cannot fail.
-  ⚠ **Residual (not fixed):** an MGL launch runs with the OSD DISABLED (`menu.cpp` calls
-  `OsdDisable()`), so a CSS-encrypted `.iso` mounted by an MGL cracks its keys with the
-  `ProgressMessage` bar invisible. Keys cache, so it is once per disc.
+  ★ **The CSS progress bar survives an MGL launch on a PHYSICAL disc, and the reason is
+  worth knowing because the obvious one is wrong:** `ProgressMessage` → `InfoMessage`, and
+  `InfoMessage` calls `OsdEnable(OSD_MSG)` ITSELF, so the `OsdDisable()` an MGL performs
+  does not hide it. The gate is `if (menustate <= MENU_INFO)`. A physical disc mounts on
+  the VERY FIRST `user_io_poll()` (before HandleUI has run at all, and long before a
+  `delay=N` MGL fires) with `menustate` still at its `MENU_NONE1` initialiser ⇒ bar
+  visible. ⚠ **Residual (not fixed):** only an encrypted `.iso` that the MGL ITSELF mounts
+  loses the bar, because that mount runs inside `MENU_GENERIC_IMAGE_SELECTED` and the
+  guard fails. Keys cache, so it is once per disc.
+  ⚠ **And that same crack is why the watchdog measures TICKS, NOT WALL CLOCK:**
+  `crack_title_keys()` is synchronous inside `user_io_file_mount()` and blocks
+  `user_io_poll()` for MINUTES on an uncached disc, so wall-clock timing would read a
+  physical disc's first-play crack as an MGL stall and destroy a healthy auto-load — the
+  watchdog killing the thing it was added to protect. `dvd_launch_tick()` discounts gaps
+  between its own invocations: a gap means the loop was not running, so it cannot be time
+  the MGL spent stuck.
   Detail: **`docs/mgl_launch.md`**.
 - ✅ **SEEK-PREVIEW CLOCK + A GENTLER SCRUB RAMP (2026-09-03, branch
   `feature/flat-file-time-seek`) — ✅ HW-CONFIRMED 2026-09-04** (build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1959,6 +1959,28 @@ worse maintenance burden than targeted in-place edits. So:
   ⚠ **Durable shape, and this is the second time this session:** a one-cycle event
   ANDed with a level that is only settled LATER is a condition that never fires.
   Latch the event, test the level when it can answer.
+  ★★ **FIFTH ROUND: THE `delay` WAS BEING CONSUMED BEFORE IT WAS SET.** Report: the
+  clip plays immediately with `delay="5"`. The log settled it in three lines —
+  `MGL pending -- delay=5s, 5000 ms remaining` … `mount result: slot 0 OK` …
+  `MGL finished after ~0s`. The timer was armed CORRECTLY and the mount still
+  happened inside the same second, so `CheckTimer` was never the gate: the FSM had
+  been advanced past `case 0` before the main loop even started.
+  ★★ **`CheckTimer(t)` is `(!t) || (GetTimer(0) >= t)` — AN UNARMED TIMER READS AS
+  AN EXPIRED ONE.** `mgl_parse()` memsets the struct, so `mgl->timer` is 0 from the
+  parse (`user_io_init` ~1516) until the arming at that function's very END (~1760);
+  anything re-entering `HandleUI()` in that window runs `case 0` with
+  `CheckTimer(0) == true`. **`user_io_file_tx()` ends with
+  `ProgressMessage(0,0,0,0)` → `MenuHide()` → `HandleUI()`, so a `boot.rom` transfer
+  does exactly that — and this fork ships a `boot.rom` for the idle logo.** Fixed at
+  the invariant: `if (mgl->timer && CheckTimer(mgl->timer))` (integration step 32,
+  the FIRST edit outside `user_io.cpp`; new `replace_once()` helper fails loudly if
+  the anchor moves). ⚠ `delay="0"` still works — that yields `GetTimer(0)`, a live
+  millisecond count, never literally zero.
+  ★★★ **THE PATTERN ACROSS ALL FIVE ROUNDS, AND IT IS THE MOST REUSABLE THING HERE:
+  the stock mechanism was fine every time, and THIS CORE'S OWN ADDITIONS are what
+  tipped it over** — our `InfoMessage` pumps froze the MGL FSM, our drive scan
+  starved the decoder, our `boot.rom` ate the delay. **Ask what THIS core does that
+  a stock core does not, before reading stock code for a defect.**
   Detail: **`docs/mgl_launch.md`**.
 - ✅ **SEEK-PREVIEW CLOCK + A GENTLER SCRUB RAMP (2026-09-03, branch
   `feature/flat-file-time-seek`) — ✅ HW-CONFIRMED 2026-09-04** (build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1869,6 +1869,43 @@ worse maintenance burden than targeted in-place edits. So:
   watchdog killing the thing it was added to protect. `dvd_launch_tick()` discounts gaps
   between its own invocations: a gap means the loop was not running, so it cannot be time
   the MGL spent stuck.
+  ★★ **FOLLOW-UP (same branch, from the HW round): THE OPTICAL DRIVE FIGHTS FOR THE
+  SAME SLOT.** Report: an MGL for a `.mpg` worked, but with a disc in the drive it
+  waited for key extraction first, and removing that disc froze the `.mpg` and left
+  the core unable to reach the idle screen. Both are `dvd_phys.cpp` treating slot 0
+  as its own when it shares it with every image the user can load. (1)
+  `dvd_phys_tick()` auto-mounted on the VERY FIRST poll, and an MGL's `<file>` lands
+  `delay` seconds later — so the drive won that race every time, and on an encrypted
+  disc that is minutes of `crack_title_keys()` (SYNCHRONOUS, blocking
+  `user_io_poll()`) for a disc the MGL then replaces anyway. (2) `mounted` meant "we
+  mounted a disc at some point", NOT "we still own the slot", so after any later
+  mount an eject still ran the teardown: `user_io_file_mount("", 0)` closed the file
+  that WAS playing (the reader starves = the freeze) and pulsed `status[0]`.
+  ⚠ **Note (2) is INDEPENDENT of MGL** — auto-mount a disc, then pick a file from
+  the OSD, then eject: same bug, and it predates all of this.
+  Fix = new `dvd_phys_note_mount(path, index)` from `user_io_file_mount()`
+  (integration step 30). ★ **Every reason not to mount is now checked BEFORE
+  `dvd_video_probe()`**, the first thing that actually reads the disc — "no disc
+  operations when launched to play a file" has to mean no READS, not just no mount,
+  or a spinning drive is probed once a second all session. ★ **An insertion EDGE
+  (not the level) clears the `foreign` latch:** putting a disc in is deliberate and
+  the auto-mount is the only way to play one, so an insertion still wins, while a
+  disc merely SITTING there never takes the slot back from an image the user chose.
+  Readiness is the edge, so it costs one ioctl and reads nothing. ⚠ **Pass the
+  INDEX** — Main mounts `boot*.vhd` across slots 0-3 at init and the drive only ever
+  binds slot 0; without it a `boot.vhd` in `games/DVD/` would silently disable
+  physical-disc playback. ⚠ Still open, and a candidate if "Reset does nothing" is
+  ever reported: the eject path's `reset_release_at` releases `status[0]`
+  unconditionally ~1 s later, so an OSD Reset pressed inside that window is
+  cancelled by it.
+  **Gate: `main/tests/run_tests.sh`** — HOST-side (plain `g++`, no MiSTer, no ARM
+  toolchain, no Docker), the overlay's first such test. `dvd_phys_test.cpp` includes
+  the module and stubs the rest of Main at link time, so it exercises the real
+  logic; RED against the pre-fix module reproduces BOTH field symptoms. [4]-[6] are
+  controls, because every one of these bugs is trivially "fixed" by never mounting a
+  disc. ⚠ The module carries exactly ONE `#ifdef DVD_PHYS_TEST`, around
+  `open_ready_drive` — a real `/dev/srN` cannot be faked (a regular file opens fine
+  and then fails `CDROM_DRIVE_STATUS`).
   Detail: **`docs/mgl_launch.md`**.
 - ✅ **SEEK-PREVIEW CLOCK + A GENTLER SCRUB RAMP (2026-09-03, branch
   `feature/flat-file-time-seek`) — ✅ HW-CONFIRMED 2026-09-04** (build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1759,6 +1759,104 @@ worse maintenance burden than targeted in-place edits. So:
   `bench/dvd/dpad_seek_tb.sv` (24 scenarios incl. the trap), `scrub_ctrl_tb` T9–T12,
   `transport_hud_tb` T18–T20, all under `bench/dvd/run_dpad_seek.sh`. Design:
   **`docs/dvd_nav.md` §2b**.
+- 🔧 **MGL LAUNCH (issue #48, 2026-09-04, branch `fix/mgl-launch`) — sim-proven
+  RED/GREEN, ⏳ HW-confirm pending.** Report: launching the core from an MGL shortcut
+  gave "a grey or green screen" and a MiSTer that was "completely unresponsive" and had
+  to be restarted, while the same `.mpg` played when picked by hand from Load Video.
+  ★★ **THE UNRESPONSIVENESS WAS OUR OWN `InfoMessage` PUMPS, and the coupling is worth
+  knowing before writing ANY Main-side tick:** while `mgl->done == 0`, `HandleUI()` takes
+  the MGL branch and **never calls `menu_key_get()`** — the SOLE source of every input
+  event (keyboard menu key, gamepad menu key, the physical OSD button, and the core's own
+  virtual one; the `KEY_F12|UPSTROKE` synthesis lives inside it). The MGL's only forward
+  edge out of state 1 requires `menustate == MENU_NONE2` **exactly**, states 1/2 have no
+  handler in the MGL switch, and there is **no timeout**. `InfoMessage()` pins
+  `menustate = MENU_INFO`. Two overlay pumps call it once a second from `user_io_poll()`,
+  BEFORE `HandleUI` runs — `dvd_css_tick` (8 s) and `dvd_hdmi_audio`'s `report_pump`
+  (6 s per arm, **re-armed on every stage transition**, and the stage moves with the
+  scaler re-init a mount itself provokes). A `delay="5"` MGL fires squarely inside them:
+  nothing mounted, nothing responded. **That is why MGL misbehaved on THIS core and not on
+  stock ones.** ⚠ **The rule, now in `INTEGRATION.md` and `docs/mgl_launch.md`: never
+  raise `Info`/`InfoMessage`/`ProgressMessage` from a poll tick while
+  `mgl_get()->done == 0` — check `dvd_launch_ui_busy()` and DEFER (push the window
+  forward, don't spend it).** New `main/support/dvd/dvd_launch.{h,cpp}` (steps 27-29) also
+  adds a 20 s MGL watchdog — a floor under the fix, not the fix: a stall we haven't
+  thought of now costs a failed load, not a reboot.
+  ⚠ **Two comments in those files said `InfoMessage` "no-ops"/"is dropped" when the menu
+  FSM is busy. For the IDLE case that is exactly backwards, and believing it is what let
+  this ship.** Both corrected in place. Same class: `docs/idle_screen.md` claimed Main
+  skips `boot.rom` for an MGL launch — it does not (an MGL leaves `path` empty, so
+  boot.rom downloads normally and the `<file>` mount arrives seconds later by another
+  route).
+  ★ **The MGL dispatch itself was SOUND for this core** — `type="s" index="0"` matches the
+  `S0` row at `selentry 0`, `user_io_ext_idx` resolves `.mpg` to extension 0, the index
+  byte is `0x01` in BOTH flows, `make_fullpath` passes an absolute path through. Nothing
+  about the MGL format needed changing; ruling that out first is what left the real
+  asymmetry visible (the MGL flow is the one that opens a COLD path — the manual flow
+  always walks the directory with `ScanDirectory` first, warming the CIFS cache).
+  ★★ **COLOUR IS A DIAGNOSTIC and it is measurable, not folklore** (traced through
+  `yuv2rgb.v`, SMPTE-170M, `cy=38155`): **black** (0,0,0) = nothing scanning at all
+  (`mixer` emits Y=16,U=V=128 when not displaying) = reader wedged; **green** (0,136,0) =
+  a framestore slot being scanned that was NEVER WRITTEN (Y=Cb=Cr=0); **grey**
+  (130,130,130) = an intra picture DECODED OUT OF MIS-FRAMED BYTES (MPEG-2 resets the
+  intra DC predictor to 128 per slice) ⇒ suspect `ps_demux` framing. Splits three bugs
+  apart before any instrumentation. ⚠ `mode_realign`'s switch blank is NOT a candidate for
+  any of them — hard ~1.5 s `BLANK_MAX`, cleared on `start_streaming`, gated off before
+  the first mount, and it produces black.
+  **Core-side, three defects the launch exposed** (none MGL-specific in mechanism):
+  (1) **A MOUNT WITH NO MEDIA WAS TREATED AS A MOUNT.** Main sends `UIO_SET_SDSTAT` even
+  when the open FAILED (size zeroed) and `hps_io` raises `img_mounted` for an all-zero
+  word — which is also how an EJECT arrives — so the pulse means "the slot changed", not
+  "there is media". `disc_ever` always guarded on `img_size != 0`; `start_streaming` and
+  `media_seen` did not, so a failed mount killed the idle logo AND its file picker,
+  flipped `VIDEO_ARX`, and started the reader on a zero-length image, where
+  `total_blocks == 0` took the "< 17 sectors" branch and `S_STREAM`'s
+  `strm_blk + 1 == ext_blocks_q` terminator can NEVER be satisfied ⇒ an unbounded walk of
+  LBA 0,1,2,… of an empty slot. ⚠ **And it could not be reported: `img_unplayable`'s
+  window only advances while `img_streaming`, so a reader that requests and receives
+  nothing SILENCES the one notice that would have named it.** Fixed in three places on
+  purpose (`start_streaming` gated on size; a new `img_ejected` clears `media_seen`,
+  itself guarded on the delivery/picture signals `logo_vis` uses so a failed mount can't
+  flip `VIDEO_ARX` under live content; `S_INIT` → `S_DONE` on zero blocks; terminator
+  relaxed to `>=`).
+  (2) **`ps_demux`'s `S_ES_PASS` WAS A ONE-WAY DOOR.** The raw-ES verdict is taken on the
+  first start code after a pipe reset and `ever_seen_pack` is cleared by EVERY
+  `load_flush`, so it is retaken after each one — and a flush does not always land on a
+  pack boundary (the in-place `mode_switch` fallback flushes without moving the reader,
+  and is chosen exactly when `ps_saw_pack` is 0, i.e. right after a mount). Landing
+  mid-PES on `00 00 01 B3` latched it for the rest of the title and handed PES headers,
+  audio, subpicture and NAV packs to the video decoder = the grey picture, no
+  self-recovery from any seek or watchdog. Now leaves on `00 00 01 BA`; a genuine bare ES
+  cannot contain one (`0xB9`-`0xFF` are system codes, illegal in a video ES, and MPEG-2
+  forbids emulation in the payload). ★ The 4 already-forwarded pack-code bytes LEAK ON
+  PURPOSE — the first three went out on earlier cycles, so suppressing only the `BA` emits
+  a headless `00 00 01` and the decoder eats the next real byte as its code. This also
+  subsumes arming the reader's `hunt_active` on the in-place `mode_switch`.
+  (3) **Two latches that did not do what their comments said.** `osd_btn` was a pure
+  decode of `osd_wait`, which advances only while `~status[0]` — so a reset inside the
+  `[FIRE, END)` window froze the count with the button HELD, and Main reads a ≥3 s hold as
+  "enter Bluetooth pairing"; now gated on `~status[0]`. And **`analog_want_l`'s "freeze
+  while a disc is mounted" NEVER FROZE**: `img_mounted` is a one-transaction PULSE, not a
+  level, so the latch tracked cfg forever, mid-title included — Main re-sends cfg on every
+  `video_mode_adjust`, INCLUDING the one the mount's own `VIDEO_ARX` flip provokes, so a
+  changed ini bit could fire a live `il_switch` under playing content (the issue #42
+  class). `media_seen` is the level that was meant.
+  **Gate: `bench/dvd/run_mgl.sh`.** `iso_reader_mount_tb` — RED 10 reads against an empty
+  slot and still `S_STREAM` (10 is only what fitted in the window; the walk has no end),
+  GREEN 0 reads and `S_DONE`. `ps_demux_esrecover_tb` — RED **48 video bytes and 0 AUDIO
+  bytes** after the next pack (the whole pack handed to the video decoder; 0 audio is the
+  sharp end, since raw-ES mode routes nothing to audio at all), GREEN 12 and 4. Both
+  measure what the hardware DOES (requests issued, bytes demuxed onto WHICH PORT), not a
+  signal the fix names, and each carries a control arm against over-reach (a real bare ES
+  must stay in ES mode; an empty mount must leave the reader able to start again).
+  ⚠ **`iso_reader_mount_tb` ships its OWN mock HPS because it POLLS.** The mock in
+  `iso_reader_tb.sv` and its clones latches the request on the first cycle `sd_rd` is high
+  and always serves it; the real `hps_io` picks requests up by polling cmd `'h16` at
+  Main's poll rate, so a request withdrawn in between is LOST. Without a polling mock the
+  "mount over an in-flight read" arm is a bench that cannot fail.
+  ⚠ **Residual (not fixed):** an MGL launch runs with the OSD DISABLED (`menu.cpp` calls
+  `OsdDisable()`), so a CSS-encrypted `.iso` mounted by an MGL cracks its keys with the
+  `ProgressMessage` bar invisible. Keys cache, so it is once per disc.
+  Detail: **`docs/mgl_launch.md`**.
 - ✅ **SEEK-PREVIEW CLOCK + A GENTLER SCRUB RAMP (2026-09-03, branch
   `feature/flat-file-time-seek`) — ✅ HW-CONFIRMED 2026-09-04** (build
   `DVD_timeline_20260904_0059.rbf`, SEED 5 first roll, clk_dec 94.06/93.11).

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -835,4 +835,16 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # button wire, edge detector and the D-pad seek path already existed and simply re-source
 # from joy_eff. That is the fit evidence for the design claim that OR-ing into one vector
 # costs nothing over parallel pulse plumbing.
+# 2026-09-04 (fix/mgl-launch, issue #48 -- three small emu.sv edits: start_streaming split
+# into img_evt/start_streaming/img_ejected on img_size, an img_ejected arm in the media_seen
+# block, analog_want_l's hold moved from the img_mounted pulse to the media_seen level, and
+# osd_btn ANDed with ~status[0]; plus dvd_iso_reader's zero-block S_INIT exit and a `==` ->
+# `>=` terminator, and one new arm in ps_demux's S_ES_PASS): SEED 5 held FIRST roll --
+# clk_dec 92.42 @100C / 88.35 @-40C (gate 86.0, PASS both corners) at 90% ALM (37,927),
+# RAM 498/553 and DSP 92/112 both UNCHANGED. TWENTIETH consecutive first-roll fit.
+# Build DVD_mgl_20260904_0435.rbf (4361 KB).
+# ★ +274 ALMs against the keyboard netlist, which is more than the logic added and worth
+# knowing: the new terms sit on img_size (64 bits) and on media_seen, a signal declared
+# ~1700 lines later and already feeding VIDEO_ARX, logo_vis and mode_realign -- so the cost
+# is fan-out and routing on an existing high-fan-out net, not the comparators.
 set_global_assignment -name SEED 5

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -847,4 +847,15 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # knowing: the new terms sit on img_size (64 bits) and on media_seen, a signal declared
 # ~1700 lines later and already feeding VIDEO_ARX, logo_vis and mode_realign -- so the cost
 # is fan-out and routing on an existing high-fan-out net, not the comparators.
+# 2026-09-04 (fix/mgl-launch round 4 -- emu.sv only: a `slot_empty` latch replacing the
+# combinational `img_ejected && !img_streaming && !video_live_s2` clear, so an emptied slot
+# returns to the idle screen once the picture runs out rather than at the one-cycle eject
+# pulse): SEED 5 held FIRST roll -- clk_dec 96.90 @100C / 91.89 @-40C (gate 86.0, PASS both
+# corners, and the best margin the ledger records) at 90% ALM (37,917), RAM 498/553 and DSP
+# 92/112 both UNCHANGED. TWENTY-FIRST consecutive first-roll fit.
+# Build DVD_mgl2_20260904_1653.rbf (4343 KB).
+# ★ TEN ALMs SMALLER than the previous entry despite adding a register, and that direction
+# is the point: the old form ANDed a one-cycle pulse with two live status signals, so those
+# nets had to reach the mount-watchdog block combinationally. Latching the event first cuts
+# that path -- which is also why clk_dec picked up ~4.5 MHz.
 set_global_assignment -name SEED 5

--- a/bench/dvd/iso_reader_mount_tb.sv
+++ b/bench/dvd/iso_reader_mount_tb.sv
@@ -1,0 +1,184 @@
+// iso_reader_mount_tb.sv — issue #48: the reader must survive a mount that carries
+// no media, and a mount that arrives on top of a read already in flight.
+//
+// Why these two:
+//
+// [1] EMPTY IMAGE. Main sends UIO_SET_SDSTAT even when the file never opened, with
+//     sd_image[].size zeroed, and hps_io raises img_mounted for an all-zero status
+//     word too (that is how an eject arrives). total_blocks is then 0, S_INIT took
+//     the "< 17 sectors" branch and wrote a ZERO-LENGTH extent, and S_STREAM's
+//     terminator was `strm_blk + 1 == ext_blocks_q` -- which 0 can never satisfy.
+//     The reader walked LBA 0,1,2,... of an empty slot for ever, and because no
+//     sector data ever arrives, emu.sv's "unsupported image" watchdog holds instead
+//     of firing: a blank screen with no logo and no message. emu.sv now also
+//     declines to start on a zero size; this is the second of the two locks.
+//
+// [2] MOUNT OVER AN IN-FLIGHT READ. `start` pre-empts every state and clears sd_rd
+//     and blk_inflight, but an HPS transaction is not cancellable. ⚠ The mock HPS
+//     used by the other iso_reader benches cannot see this class at all: it latches
+//     the request on the FIRST cycle sd_rd is high and always serves it. The real
+//     hps_io picks the request up by POLLING command 'h16 at Main's poll rate, so a
+//     request withdrawn before the next poll is simply lost. The mock here polls,
+//     which is what makes [2] able to fail.
+//
+// MEASURED against the pre-fix RTL (S_INIT's zero check removed and the S_STREAM
+// terminator back to `==`):
+//   [1] sd_rd requests after an empty mount   10  (expect 0)                FAIL
+//   [1] reader state                          10 = S_STREAM (expect DONE)   FAIL
+// 10 is only "how many fitted in the bench window" -- the walk has no end, which
+// is the defect. [2] and [3] pass either way and are there to catch the fix
+// over-reaching: an empty mount must not leave the reader unable to start again.
+`timescale 1ns/1ps
+
+module iso_reader_mount_tb;
+
+    // dvd_iso_reader's own state encoding; debug_state's low 6 bits are `state`.
+    localparam [5:0] S_IDLE   = 6'd0;
+    localparam [5:0] S_STREAM = 6'd10;
+    localparam [5:0] S_DONE   = 6'd11;
+
+    reg         clk = 0, rst_n = 0;
+    reg         start = 0;
+    reg  [63:0] file_size = 0;
+    wire [31:0] sd_lba;
+    wire        sd_rd;
+    reg         sd_ack = 0;
+    reg  [13:0] sd_buff_addr = 0;
+    reg  [7:0]  sd_buff_dout = 0;
+    reg         sd_buff_wr = 0;
+    wire [7:0]  stream_data;
+    wire        stream_valid;
+    reg         busy = 0;
+    wire [15:0] debug_state;
+    wire [5:0]  rd_state = debug_state[5:0];
+
+    always #5 clk = ~clk;
+
+    dvd_iso_reader dut (
+        .clk(clk), .rst_n(rst_n), .start(start), .file_size(file_size),
+        .title_sel(7'd0), .vbuf_empty(1'b0), .menu_snap(1'b0),
+        .jump_ttn(7'd0), .jump_pgn(8'd0),
+        .vm_mode(1'b0), .vm_adv(1'b0), .vm_replay(1'b0),
+        .vm_cell_cmd(), .vm_pgc_end(), .nav_ready_o(), .auto_vts(), .cell_count_o(),
+        .pm_we(), .pm_waddr(), .pm_wdata(), .cmd_nr_pgm(),
+        .sd_lba(sd_lba), .sd_rd(sd_rd), .sd_ack(sd_ack),
+        .sd_buff_addr(sd_buff_addr), .sd_buff_dout(sd_buff_dout), .sd_buff_wr(sd_buff_wr),
+        .stream_data(stream_data), .stream_valid(stream_valid), .busy(busy),
+        .debug_active(), .debug_sd_rd(), .debug_sd_ack(), .debug_cache_has_data(),
+        .debug_file_size(), .debug_total_sectors(), .debug_next_lba(),
+        .debug_state(debug_state), .debug_iso_mode(), .debug_iso_error()
+    );
+
+    // ---- a small flat image: no CD sync at byte 0, no CD001 at LBA 16, so the
+    // reader takes the linear fallback -- the .mpg path from the bug report.
+    localparam integer NSEC = 24;
+    reg [7:0] img [0:NSEC*2048-1];
+
+    // ---- mock HPS ----------------------------------------------------------
+    // POLLED, unlike the mock in iso_reader_tb.sv: the request is only picked up
+    // when the poll tick comes round, so a request the reader withdraws in the
+    // meantime is lost, exactly as it is on hardware.
+    localparam integer POLL_PERIOD = 40;   // clocks between "user_io_poll" visits
+    integer m = 0, bc = 0, poll = 0;
+    reg [31:0] rlba = 0;
+    integer reqs = 0;                      // requests the HPS actually accepted
+
+    always @(posedge clk) begin
+        sd_buff_wr <= 1'b0;
+        case (m)
+        0: begin
+            sd_ack <= 1'b0;
+            poll   <= (poll == POLL_PERIOD-1) ? 0 : poll + 1;
+            if (poll == 0 && sd_rd) begin
+                rlba <= sd_lba; reqs <= reqs + 1; bc <= 0; m <= 1;
+            end
+        end
+        1: begin
+            sd_ack       <= 1'b1;
+            sd_buff_wr   <= 1'b1;
+            sd_buff_addr <= bc[13:0];
+            sd_buff_dout <= (rlba < NSEC) ? img[rlba*2048 + bc] : 8'h00;
+            bc           <= bc + 1;
+            if (bc == 2047) m <= 2;
+        end
+        2: begin sd_ack <= 1'b0; m <= 0; end   // falling edge = block done
+        endcase
+    end
+
+    integer i, errs = 0;
+    integer reqs_mark;
+    reg [5:0] st;
+
+    initial begin
+        for (i = 0; i < NSEC*2048; i = i + 1) img[i] = 8'hB0;
+        // a pack start code at byte 0 so the linear path has something plausible
+        img[0] = 8'h00; img[1] = 8'h00; img[2] = 8'h01; img[3] = 8'hBA;
+
+        repeat (4) @(posedge clk);
+        rst_n = 1; repeat (2) @(posedge clk);
+
+        // ================================================================== [1]
+        $display("=== [1] an empty image must stop, not stream for ever ===");
+        file_size = 64'd0;
+        start = 1; @(posedge clk); start = 0;
+        reqs_mark = reqs;
+        repeat (20000) @(posedge clk);
+        st = rd_state;
+        $display("    sd_rd requests served: %0d (expect 0)", reqs - reqs_mark);
+        $display("    reader state: %0d (expect %0d = S_DONE)", st, S_DONE);
+        if (st !== S_DONE) begin
+            $display("FAIL [1]: state %0d, expected S_DONE (%0d)", st, S_DONE);
+            errs = errs + 1;
+        end
+        if (reqs != reqs_mark) begin
+            $display("FAIL [1]: the reader issued %0d reads against an empty slot",
+                     reqs - reqs_mark);
+            errs = errs + 1;
+        end
+        if (stream_valid) begin
+            $display("FAIL [1]: the reader is delivering bytes from an empty image");
+            errs = errs + 1;
+        end
+
+        // ================================================================== [2]
+        $display("=== [2] a real mount after the empty one must still work ===");
+        file_size = NSEC * 2048;
+        start = 1; @(posedge clk); start = 0;
+        reqs_mark = reqs;
+        repeat (30000) @(posedge clk);
+        $display("    sd_rd requests served: %0d (expect > 0)", reqs - reqs_mark);
+        if (reqs == reqs_mark) begin
+            $display("FAIL [2]: an empty mount left the reader unable to start again");
+            errs = errs + 1;
+        end
+
+        // ================================================================== [3]
+        $display("=== [3] a mount landing on an in-flight read must not wedge ===");
+        // Wait until a block is genuinely in flight (sd_ack high mid-transfer),
+        // then re-mount on top of it.
+        @(posedge clk);
+        while (!(sd_ack && bc > 100)) @(posedge clk);
+        start = 1; @(posedge clk); start = 0;
+        reqs_mark = reqs;
+        repeat (40000) @(posedge clk);
+        $display("    sd_rd requests served after the collision: %0d (expect > 0)",
+                 reqs - reqs_mark);
+        if (reqs == reqs_mark) begin
+            $display("FAIL [3]: the reader stopped requesting after a mount collision");
+            errs = errs + 1;
+        end
+
+        $display("=== iso_reader mount testbench: %0d error(s) ===", errs);
+        if (errs) begin
+            $display("iso_reader_mount_tb FAILED");
+            $fatal(1, "iso_reader_mount_tb FAILED");
+        end
+        $display("PASS");
+        $finish;
+    end
+
+    initial begin
+        #20_000_000;
+        $fatal(1, "iso_reader_mount_tb: timeout");
+    end
+endmodule

--- a/bench/dvd/ps_demux_esrecover_tb.sv
+++ b/bench/dvd/ps_demux_esrecover_tb.sv
@@ -1,0 +1,207 @@
+// ps_demux_esrecover_tb.sv — issue #48: the raw-elementary-stream verdict must not
+// be a one-way door.
+//
+// ps_demux decides "this is a bare .m2v, not a program stream" from the FIRST start
+// code it sees after a pipe reset (S_HUNT, code <= 0xB8 with ever_seen_pack == 0).
+// ever_seen_pack is cleared by pipe_rst_n, so that decision is retaken after EVERY
+// load_flush -- and a flush does not always land on a pack boundary. The in-place
+// mode_switch fallback (dvd/mode_realign.sv) flushes without moving the reader at
+// all, so the next byte can easily be mid-PES video payload beginning 00 00 01 B3.
+// The demux then latched S_ES_PASS, which used to have no exit, and spent the rest
+// of the title shoving PES headers, audio, subpicture and NAV packs at the video
+// decoder: a permanently mis-framed picture that no seek and no watchdog recovers.
+//
+// This bench measures a property of the BYTE STREAM, not a restatement of an RTL
+// expression: after a mid-PES reset, does correctly-demuxed video come out again,
+// and does the audio path come back at all?
+//
+// MEASURED against the pre-fix RTL (the S_ES_PASS arm reverted to a bare `;`):
+//   [1] video bytes after the next pack   48  (expect 12)   FAIL
+//   [1] audio bytes after the next pack    0  (expect  4)   FAIL
+// 48 is the whole following pack -- pack header, both PES headers, the audio
+// payload and the video payload, all of it handed to the video decoder. 0 audio
+// bytes is the sharp end of it: in raw-ES mode nothing is routed to audio at all,
+// which is the silent, permanently mis-framed picture users saw.
+// [2] is the control and passes either way -- a genuine bare ES must stay in ES mode.
+`timescale 1ns/1ps
+`default_nettype none
+
+module ps_demux_esrecover_tb;
+    logic        clk = 0, rst_n = 0;
+    logic  [7:0] in_byte;
+    logic        in_valid;
+    logic        in_ready;
+    logic  [7:0] vid_byte;
+    logic        vid_valid;
+    logic  [7:0] aud_byte;
+    logic        aud_valid;
+    logic        vid_ready = 1'b1;
+
+    always #5 clk = ~clk;
+
+    ps_demux dut (
+        .clk(clk), .rst_n(rst_n),
+        .in_byte(in_byte), .in_valid(in_valid), .in_ready(in_ready),
+        .aud_track(3'd0),
+        .vid_byte(vid_byte), .vid_valid(vid_valid), .vid_ready(vid_ready),
+        .aud_byte(aud_byte), .aud_valid(aud_valid), .aud_type(), .aud_frame_start(),
+        .aud_ready(1'b1),
+        .vid_pts(), .vid_pts_valid(), .aud_pts(), .aud_pts_valid()
+    );
+
+    // ---------------------------------------------------------------- capture
+    logic [7:0] vgot [0:1023];
+    logic [7:0] agot [0:1023];
+    int vi = 0, ai = 0;
+    always_ff @(posedge clk) begin
+        if (rst_n && vid_valid && vid_ready) begin vgot[vi] <= vid_byte; vi <= vi + 1; end
+        if (rst_n && aud_valid)              begin agot[ai] <= aud_byte; ai <= ai + 1; end
+    end
+
+    task automatic feed(input logic [7:0] b);
+        begin
+            in_byte <= b; in_valid <= 1'b1;
+            @(posedge clk);
+            while (!in_ready) @(posedge clk);
+        end
+    endtask
+
+    // Drop in_valid before idling. ⚠ Without this the last byte stays presented
+    // with in_valid high and is consumed once per idle cycle -- the bench then
+    // counts phantom bytes and every expectation is off by the idle length.
+    task automatic idle(input int n);
+        begin
+            in_valid <= 1'b0;
+            repeat (n) @(posedge clk);
+        end
+    endtask
+
+    // A complete pack: pack header (14 B) + video PES (8 B payload) + audio PES
+    // (AC-3 substream 0x80, 4 B frame payload after the 4-byte sub-header).
+    task automatic feed_pack;
+        int k;
+        begin
+            // 00 00 01 BA + 9 fixed + stuffing length 0
+            feed(8'h00); feed(8'h00); feed(8'h01); feed(8'hBA);
+            feed(8'h44); feed(8'h00); feed(8'h04); feed(8'h00); feed(8'h04);
+            feed(8'h01); feed(8'h00); feed(8'h1B); feed(8'hA3); feed(8'hF8);
+            // video PES: len = 3 flags + 0 hdr + 8 payload = 11
+            feed(8'h00); feed(8'h00); feed(8'h01); feed(8'hE0);
+            feed(8'h00); feed(8'h0B); feed(8'h80); feed(8'h00); feed(8'h00);
+            feed(8'h00); feed(8'h00); feed(8'h01); feed(8'hB3);
+            feed(8'hDE); feed(8'hAD); feed(8'hBE); feed(8'hEF);
+            // audio PES (private_stream_1): len = 3 flags + 0 hdr + 4 sub-hdr + 4 data = 11
+            feed(8'h00); feed(8'h00); feed(8'h01); feed(8'hBD);
+            feed(8'h00); feed(8'h0B); feed(8'h80); feed(8'h00); feed(8'h00);
+            feed(8'h80); feed(8'h01); feed(8'h00); feed(8'h00);       // substream 0x80 + 3
+            feed(8'h0B); feed(8'h77); feed(8'hAA); feed(8'hBB);       // AC-3 frame bytes
+            k = 0;
+        end
+    endtask
+
+    int errs = 0;
+    int vi_mark, ai_mark;
+    int i;
+
+    initial begin
+        in_valid = 0; in_byte = 0;
+        repeat (4) @(posedge clk);
+        rst_n = 1; @(posedge clk);
+
+        // ================================================================= [1]
+        // A pipe flush lands MID-PES, on video payload that starts 00 00 01 B3.
+        // The demux takes the raw-ES verdict; it must give it back at the next
+        // pack instead of keeping it for ever.
+        $display("=== [1] mid-PES flush must not latch raw-ES mode for ever ===");
+        feed_pack();
+        idle(4);
+
+        // the flush: pipe_rst_n drops, ever_seen_pack is cleared
+        rst_n = 0; repeat (3) @(posedge clk);
+        rst_n = 1; @(posedge clk);
+
+        // resume mid-PES: bare video-layer bytes, no pack in front of them
+        feed(8'h00); feed(8'h00); feed(8'h01); feed(8'hB3);   // -> S_ES_EMIT/S_ES_PASS
+        feed(8'h11); feed(8'h22); feed(8'h33); feed(8'h44);
+        idle(4);
+
+        vi_mark = vi; ai_mark = ai;
+
+        // the reader delivers the next pack; the demux must re-sync on it
+        feed_pack();
+        idle(20);
+
+        // 12 = the 4 bytes of the pack start code itself, which raw-ES mode had
+        // already forwarded by the cycle the escape fires, then the 8 payload
+        // bytes of the re-framed video PES. Leaking 00 00 01 BA is DELIBERATE and
+        // is the cheaper of the two options: the first three were sent on earlier
+        // cycles, so suppressing only the BA would emit a headless 00 00 01 and
+        // the decoder would swallow the next real byte as its code. A complete
+        // 0xBA is a system start code the VLD's start-code walk skips.
+        $display("    video bytes demuxed after the next pack: %0d (expect 12)", vi - vi_mark);
+        $display("    audio bytes demuxed after the next pack: %0d (expect 4)", ai - ai_mark);
+
+        if ((vi - vi_mark) != 12) begin
+            $display("FAIL [1]: video did not re-frame -- %0d bytes, not 12", vi - vi_mark);
+            errs++;
+        end else begin
+            if (vgot[vi_mark+0] !== 8'h00 || vgot[vi_mark+1] !== 8'h00 ||
+                vgot[vi_mark+2] !== 8'h01 || vgot[vi_mark+3] !== 8'hBA) begin
+                $display("FAIL [1]: the leaked prefix is not a whole pack start code");
+                errs++;
+            end
+            if (vgot[vi_mark+4] !== 8'h00 || vgot[vi_mark+5] !== 8'h00 ||
+                vgot[vi_mark+6] !== 8'h01 || vgot[vi_mark+7] !== 8'hB3 ||
+                vgot[vi_mark+8] !== 8'hDE || vgot[vi_mark+9] !== 8'hAD ||
+                vgot[vi_mark+10] !== 8'hBE || vgot[vi_mark+11] !== 8'hEF) begin
+                $display("FAIL [1]: video payload wrong after recovery"); errs++;
+            end
+        end
+
+        // The audio path is the sharper test: in raw-ES mode NOTHING is routed to
+        // audio, so a non-zero count can only mean the demuxer really came back.
+        if ((ai - ai_mark) != 4) begin
+            $display("FAIL [1]: audio did not resume -- %0d bytes, not 4", ai - ai_mark);
+            errs++;
+        end else if (agot[ai_mark] !== 8'h0B || agot[ai_mark+1] !== 8'h77) begin
+            $display("FAIL [1]: audio frame not at its sync word"); errs++;
+        end
+
+        // ================================================================= [2]
+        // Control: a genuine bare elementary stream must STAY in raw-ES mode.
+        // Video start codes are 0x00-0xB8, so 00 00 01 BA cannot occur in one --
+        // this is the case the escape must not steal.
+        $display("=== [2] control: a real bare ES stays in raw-ES mode ===");
+        idle(1);
+        rst_n = 0; repeat (3) @(posedge clk);
+        rst_n = 1; @(posedge clk);
+        vi_mark = vi; ai_mark = ai;
+
+        feed(8'h00); feed(8'h00); feed(8'h01); feed(8'hB3);
+        for (i = 0; i < 32; i++) feed(8'h5A);
+        feed(8'h00); feed(8'h00); feed(8'h01); feed(8'hB8);   // GOP
+        for (i = 0; i < 16; i++) feed(8'hA5);
+        idle(20);
+
+        $display("    video bytes forwarded: %0d (expect 56 = every byte)", vi - vi_mark);
+        $display("    audio bytes forwarded: %0d (expect 0)", ai - ai_mark);
+        if ((vi - vi_mark) != 56) begin
+            $display("FAIL [2]: raw ES must pass through byte for byte"); errs++;
+        end
+        if ((ai - ai_mark) != 0) begin
+            $display("FAIL [2]: raw ES must route nothing to audio"); errs++;
+        end
+
+        $display("=== ps_demux ES-recovery testbench: %0d error(s) ===", errs);
+        if (errs) $fatal(1, "ps_demux_esrecover_tb FAILED");
+        $display("PASS");
+        $finish;
+    end
+
+    initial begin
+        #4_000_000;
+        $fatal(1, "ps_demux_esrecover_tb: timeout");
+    end
+endmodule
+
+`default_nettype wire

--- a/bench/dvd/run_mgl.sh
+++ b/bench/dvd/run_mgl.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# run_mgl.sh — the issue #48 gate ("MGL loading not working").
+#
+# Two core-side defects that an MGL launch exposes, both of which end in a picture
+# that never recovers:
+#
+#   iso_reader_mount_tb   an empty/failed mount must stop the reader, not send it
+#                         walking LBA 0,1,2,... of an empty slot for ever
+#   ps_demux_esrecover_tb the raw-elementary-stream verdict must not be a one-way
+#                         door: a flush that lands mid-PES must re-sync on the next
+#                         pack instead of shoving PES/audio/nav at the video decoder
+#
+# The Main-side half of the fix (the InfoMessage-during-MGL freeze) is not
+# simulatable here -- it lives in main/support/dvd/dvd_launch.cpp and is gated on
+# hardware. Design: docs/mgl_launch.md.
+#
+# Default: the GREEN suite; everything must pass.
+#
+# --red: there is no plusarg model for these -- the pre-fix behaviour is three
+# reverted RTL lines, and modelling it in the bench would just restate the RTL. The
+# measured RED numbers are recorded in each bench's header, and reproducing them
+# means reverting those lines by hand. Both benches measure a property of what the
+# hardware DOES (requests issued, bytes demuxed onto which port), not a signal the
+# fix names, so neither can become a golden model that agrees with its own RTL.
+#
+set -e
+cd "$(dirname "$0")/../.."
+
+echo "### build"
+iverilog -g2012 -o bench/dvd/iso_reader_mount_sim \
+  dvd/dvd_iso_reader.sv dvd/bcd_time_add.sv bench/dvd/iso_reader_mount_tb.sv
+iverilog -g2012 -o bench/dvd/ps_demux_esrecover_sim \
+  dvd/ps_demux.sv bench/dvd/ps_demux_esrecover_tb.sv
+
+echo
+echo "### 1. mount: empty image, re-mount, mount-over-in-flight-read"
+vvp bench/dvd/iso_reader_mount_sim
+
+echo
+echo "### 2. ps_demux: raw-ES verdict must be escapable"
+vvp bench/dvd/ps_demux_esrecover_sim
+
+echo
+echo "### run_mgl.sh: ALL GREEN"

--- a/docs/idle_screen.md
+++ b/docs/idle_screen.md
@@ -99,8 +99,15 @@ Delivery is the framework's zero-CONF_STR **boot.rom convention**: Main
 sends `/media/fat/games/DVD/boot.rom` (fallbacks `<rbf_dir>/DVD.ROM`,
 `DVD.ROM`, `bootrom/DVD.ROM`) over `ioctl_download` with `ioctl_index==0`
 at every core load. Caveat: Main skips boot.rom when the core is launched
-with a direct file path (file association / MGL with a file element) — the
-default logo shows in that session's brief idle moments instead.
+with a **direct file path** (a file association) — the default logo shows in
+that session's brief idle moments instead.
+
+⚠ That caveat does **not** cover MGL, which was recorded here wrongly and read
+as fact for months. An MGL launch leaves `path` empty in `user_io_init()`, so
+`user_io_file_tx(path, …)` is never attempted and boot.rom **is** downloaded
+normally; the MGL's own `<file>` mount arrives seconds later through
+`user_io_file_mount()`, a different path entirely. See `docs/mgl_launch.md`
+for the full launch timeline.
 
 Format (max 528 bytes) — `tools/idle_logo.py` is the reference
 implementation:

--- a/docs/mgl_launch.md
+++ b/docs/mgl_launch.md
@@ -375,6 +375,50 @@ the install prompt over the idle screen, which is arguably kinder; it is a
 behaviour change to an HW-confirmed path, so it should be decided rather than
 drifted into.
 
+### The `delay` was being consumed before it was set
+
+Reported: the clip plays immediately, with `delay="5"`. The log settled it in three
+lines:
+
+```
+DVD_LAUNCH: MGL pending -- delay=5s, 5000 ms remaining
+DVD_REPORT: mount result: slot 0 OK size=83605900 path=...
+DVD_LAUNCH: MGL finished after ~0s
+```
+
+The timer was armed correctly — a full 5000 ms still to run at the first
+`user_io_poll()` — and the mount happened inside the same second anyway. So
+`CheckTimer` was never the gate; the state machine had already been advanced past
+`case 0` before the main loop ever started.
+
+```c
+unsigned long CheckTimer(unsigned long time)
+{
+    return (!time) || (GetTimer(0) >= time);   // ← an unarmed timer reads as expired
+}
+```
+
+`mgl_parse()` memsets the struct, so `mgl->timer` is **0** from the parse
+(`user_io_init` ~1516) until the arming at that function's very end (~1760).
+Anything that re-enters `HandleUI()` in that window runs `case 0` with
+`CheckTimer(0) == true` and sets `state = 1`. `user_io_file_tx()` ends with
+`ProgressMessage(0, 0, 0, 0)` → `MenuHide()` → `HandleUI()`, so a **`boot.rom`
+transfer does exactly that** — and this fork ships a `boot.rom` for the idle logo.
+
+Fixed at the invariant (integration step 32, the first edit outside `user_io.cpp`):
+
+```c
+if (mgl->timer && CheckTimer(mgl->timer))
+```
+
+`delay="0"` still works — that yields `GetTimer(0)`, a live millisecond count, never
+literally zero.
+
+★ **This is the third time in this note that a stock mechanism was fine and the
+overlay's own presence is what tipped it over** — the notice pumps, the drive scan,
+and now the idle logo's `boot.rom`. Worth carrying into the next one: ask what *this
+core* does that a stock core does not, before reading the stock code for a defect.
+
 ## 5. Gates
 
 - `bench/dvd/run_mgl.sh` — `iso_reader_mount_tb` (RED: 10 reads against an empty slot,

--- a/docs/mgl_launch.md
+++ b/docs/mgl_launch.md
@@ -249,6 +249,41 @@ that window would be cancelled by it. Much harder to reach now that the teardown
 only runs for a disc the drive still owns, but it is not *impossible* and it is a
 candidate if "Reset does nothing" is ever reported.
 
+### The drive probe runs on the thread that feeds the decoder
+
+Reported after 4.4 landed: the MGL launch was clean (no key crack), but **ejecting
+an unrelated disc still froze the `.mpg` — while the OSD kept working**.
+
+The OSD working is the whole diagnosis. Main is alive and HandleUI is running, so
+nothing unmounted the file and the core is not in reset: it is being **starved**.
+And with 4.4 in place `dvd_phys_tick()` does nothing at all on that eject — the
+drive does not own the slot. So the only thing left touching the drive is the scan
+itself:
+
+```c
+open("/dev/sr0", O_RDONLY|O_NONBLOCK);   // once a second, forever
+ioctl(fd, CDROM_DRIVE_STATUS, CDSL_CURRENT);
+```
+
+That is **blocking I/O on the same thread as `user_io_poll()`'s SD block service**,
+so however long it takes is time the core gets no data. On a settled drive it is
+microseconds. With the **tray open** it is not: the kernel's `sr` driver answers
+TEST UNIT READY with a media-change unit attention and retries, which can run to
+hundreds of milliseconds — every second, for as long as the tray stays open,
+because the state never settles.
+
+Fix: the scan is self-limiting. A probe over 50 ms doubles the period (capped at
+10 s); a fast one restores 1 s. And while a foreign image owns the slot the scan
+exists only to notice an *insertion*, so its floor is 5 s rather than 1 s. Measured
+in `dvd_phys_test.cpp` [8]: with a 400 ms probe, **60 blocking calls a minute → 7**.
+
+⚠ **This one is a hypothesis with instrumentation attached, not a confirmed
+root-cause.** It fits every observation — frozen picture, live OSD, starts at the
+eject, never recovers, unaffected by the slot-ownership fix — but it has not been
+measured on the reporter's drive. `dvd_phys` therefore logs any probe over 50 ms to
+`/tmp/dvd_report.log` with its duration. If that line is absent when the freeze
+happens, the drive scan is exonerated and the search moves to the core side.
+
 ## 5. Gates
 
 - `bench/dvd/run_mgl.sh` — `iso_reader_mount_tb` (RED: 10 reads against an empty slot,

--- a/docs/mgl_launch.md
+++ b/docs/mgl_launch.md
@@ -202,6 +202,53 @@ reader, and the garbage between flush and pack is bounded by one pack.
 
 ---
 
+## 4.4 The optical drive fights for the same slot
+
+Reported after the first fix landed: an MGL for a `.mpg` *worked*, but with a disc
+in the drive it waited for key extraction first — and removing that disc froze the
+`.mpg` and left the core unable to reach the idle screen.
+
+Both come from `dvd_phys.cpp` treating slot 0 as its own. It is not: the drive
+shares it with every image the user can load.
+
+- **`dvd_phys_tick()` auto-mounted on the very first poll.** An MGL's `<file>`
+  lands `delay` seconds later, so the drive won that race every time. On an
+  encrypted disc that is minutes of `crack_title_keys()` — synchronous, blocking
+  `user_io_poll()` — for a disc the MGL then replaces anyway.
+- **`mounted` meant "we mounted a disc at some point", not "we still own the
+  slot".** After any later mount took slot 0, an eject still ran the teardown:
+  `user_io_file_mount("", 0)` closed the file that *was* playing (so the reader
+  starved — the freeze) and pulsed `status[0]`.
+
+New `dvd_phys_note_mount(path, index)`, called from `user_io_file_mount()`
+(integration step 30), supplies the missing fact. The rules now:
+
+| condition | auto-mount? | eject tears down? |
+|---|---|---|
+| nothing in the slot, disc ready | ✅ | ✅ |
+| an MGL launch is pending (`dvd_launch_ui_busy()`) | ❌ deferred | — |
+| a file the user asked for is in the slot (`foreign`) | ❌ | ❌ |
+| the disc was already sitting there when the file loaded | ❌ | ❌ |
+| a disc is **inserted** while a file plays | ✅ (insertion edge clears `foreign`) | ✅ |
+
+★ **Every reason not to mount is checked before `dvd_video_probe()`**, which is the
+first thing that actually reads the disc. "Do no disc operations when we were
+launched to play a file" has to mean no *reads*, not just no mount — otherwise a
+spinning drive is probed once a second for the whole session. A non-DVD-Video disc
+(an audio CD) is likewise probed once per insertion, not once per scan.
+
+★ **The insertion EDGE, not the level, clears `foreign`.** Putting a disc in is a
+deliberate act and the auto-mount is the only way to play one, so an insertion
+still wins; a disc merely *sitting* in the drive never takes the slot back from an
+image the user chose. Readiness is the edge, so it costs one ioctl and reads
+nothing.
+
+⚠ The eject path also pulses `status[0]` and releases it ~1 s later from
+`reset_release_at`. That release is unconditional, so an OSD Reset pressed inside
+that window would be cancelled by it. Much harder to reach now that the teardown
+only runs for a disc the drive still owns, but it is not *impossible* and it is a
+candidate if "Reset does nothing" is ever reported.
+
 ## 5. Gates
 
 - `bench/dvd/run_mgl.sh` — `iso_reader_mount_tb` (RED: 10 reads against an empty slot,
@@ -215,7 +262,16 @@ reader, and the garbage between flush and pack is bounded by one pack.
   high and always serves it; the real `hps_io` picks requests up by polling command
   `'h16` at Main's poll rate, so a request withdrawn in between is simply lost. Without a
   polling mock, the "mount over an in-flight read" arm is a bench that cannot fail.
-- The Main-side half is not simulatable. It is gated on hardware, and
+- `main/tests/run_tests.sh` — host-side (plain `g++`, no MiSTer, no ARM toolchain,
+  no Docker). `dvd_phys_test.cpp` includes the module and stubs the rest of Main at
+  link time, so it exercises the real logic. Seven scenarios; RED against the
+  pre-fix module reproduces **both** field symptoms (disc read and mounted during
+  the MGL delay; eject unmounting and resetting over a playing file). [4]–[6] are
+  controls: every one of these bugs is trivially "fixed" by never mounting a disc.
+  ⚠ The module carries exactly one `#ifdef DVD_PHYS_TEST`, around `open_ready_drive`
+  — a real `/dev/srN` cannot be faked (a regular file opens fine and then fails
+  `CDROM_DRIVE_STATUS`). Everything else is an ordinary extern.
+- The rest of the Main-side half is not simulatable. It is gated on hardware, and
   `/tmp/dvd_report.log` now records what each mount achieved
   (`dvd_report_note_mount_result`) precisely so the next round is not another guess.
 

--- a/docs/mgl_launch.md
+++ b/docs/mgl_launch.md
@@ -232,10 +232,44 @@ reader, and the garbage between flush and pack is bounded by one pack.
    failed mount returns to the bouncing idle logo with the file picker, never a silent
    grey field.
 
-## 7. Known residual
+## 7. The CSS progress bar, and which mounts keep it
 
-An MGL launch runs with the OSD **disabled** (`menu.cpp` calls `OsdDisable()` rather than
-`OsdEnable()` when it opens the menu for the MGL). So a CSS-encrypted `.iso` mounted by
-an MGL runs its key crack with the `ProgressMessage` bar invisible — several seconds to
-minutes of apparent silence on a first play. The keys cache, so it happens once per disc.
-Not fixed; it needs Main-side OSD state we do not currently touch.
+`crack_title_keys()` reports through `ProgressMessage()` → `InfoMessage()`. Two properties
+of `InfoMessage` decide whether that bar is seen, and only one of them is about the OSD:
+
+```c
+void InfoMessage(const char *message, int timeout, const char *title)
+{
+    if (menustate <= MENU_INFO)                       //  ← the gate that matters
+    {
+        if (menustate != MENU_INFO) { OsdSetTitle(title, 0); OsdEnable(OSD_MSG); }
+        …
+```
+
+It **re-enables the OSD itself**, so the `OsdDisable()` an MGL performs when it opens the
+menu invisibly does *not* hide the bar. What hides it is the `menustate <= MENU_INFO`
+guard (`MENU_NONE1 = 0, MENU_NONE2 = 1, MENU_INFO = 2`).
+
+| mount | `menustate` while cracking | bar |
+|---|---|---|
+| **physical disc** (`dvd_phys_tick` → `dvd_css_open`) | `MENU_NONE1` — it mounts on the **very first** `user_io_poll()`, before HandleUI has run at all and long before an MGL's `delay` expires | ✅ visible |
+| `.iso` picked by hand (`dvd_css_open_image`) | `MENU_NONE1`, via the file browser's `MenuHide()` | ✅ visible |
+| **`.iso` mounted by an MGL** | `MENU_GENERIC_IMAGE_SELECTED` — the mount happens *inside* that case | ❌ `InfoMessage` no-ops |
+
+So a **physical disc keeps its progress bar on an MGL launch**; only an encrypted `.iso`
+that the MGL itself mounts loses it. Keys cache, so that is once per disc. Not fixed:
+making it visible means driving `menustate` from a support module mid-dispatch, which is
+more Main-internal surgery than a cosmetic bar is worth.
+
+⚠ An earlier version of this note blamed `OsdDisable()`. That was wrong — the conclusion
+happened to be right for the `.iso` case, which is exactly how a wrong mechanism survives.
+
+### ⚠ Why the watchdog measures ticks, not wall clock
+
+The same crack is why `dvd_launch_tick()` discounts gaps between its own invocations.
+`crack_title_keys()` is **synchronous inside `user_io_file_mount()`** and blocks
+`user_io_poll()` for minutes on an uncached disc. A physical disc mounts on the first poll,
+so with plain wall-clock timing the next tick would see minutes elapsed, call a
+still-pending MGL stalled, and destroy the user's auto-load — a watchdog killing the thing
+it was added to protect. A gap between ticks means the loop was not running, so it cannot
+be time the MGL spent stuck.

--- a/docs/mgl_launch.md
+++ b/docs/mgl_launch.md
@@ -277,12 +277,16 @@ Fix: the scan is self-limiting. A probe over 50 ms doubles the period (capped at
 exists only to notice an *insertion*, so its floor is 5 s rather than 1 s. Measured
 in `dvd_phys_test.cpp` [8]: with a 400 ms probe, **60 blocking calls a minute → 7**.
 
-⚠ **This one is a hypothesis with instrumentation attached, not a confirmed
-root-cause.** It fits every observation — frozen picture, live OSD, starts at the
-eject, never recovers, unaffected by the slot-ownership fix — but it has not been
-measured on the reporter's drive. `dvd_phys` therefore logs any probe over 50 ms to
-`/tmp/dvd_report.log` with its duration. If that line is absent when the freeze
-happens, the drive scan is exonerated and the search moves to the core side.
+✅ **HW-CONFIRMED** (2026-09-04, reporter: *"ejecting during .mpg playback works
+now"*). It shipped as a hypothesis with instrumentation — `dvd_phys` still logs any
+probe over 50 ms to `/tmp/dvd_report.log` with its duration, which is worth keeping:
+it is the fastest way to tell a slow drive from a core-side stall next time.
+
+★ The diagnosis came from **one clause in the report** — "the OSD still works".
+Main alive and HandleUI running ruled out every unmount and reset hypothesis at a
+stroke and left starvation as the only shape that fits. Worth asking for
+explicitly: "is the picture frozen or is the machine frozen" separates the HPS side
+from the core side before any code is read.
 
 ## 5. Gates
 

--- a/docs/mgl_launch.md
+++ b/docs/mgl_launch.md
@@ -1,0 +1,241 @@
+# MGL launch — how it works, and how it broke (issue #48)
+
+Engineering note, not user documentation. The user-facing page is
+`site/content/getting-started/loading.md`.
+
+An **MGL** is MiSTer's shortcut format: a small XML file in the SD root or a `_menu`
+folder that loads a core and then mounts a file into it. Users make one per movie so
+the DVD core appears in their menu next to everything else.
+
+```xml
+<mistergamedescription>
+  <rbf>_Other/DVD</rbf>
+  <file delay="5" type="s" index="0" path="/media/fat/cifs/games/DVD/Movies/Terminator.mpg"/>
+</mistergamedescription>
+```
+
+Issue #48 reported that this produced "a grey or green screen" and a MiSTer that was
+"completely unresponsive" and had to be restarted, while the same file played when
+picked by hand from **Load Video**.
+
+---
+
+## 1. The launch timeline
+
+`user_io_init()` is identical for both flows. The only thing it does differently for an
+MGL is parse it and arm a timer at the very end, *after* the core's reset is released:
+
+| t | what happens |
+|---|---|
+| — | `user_io_status_set("[0]", 1)` — core held in reset |
+| — | `cfg_parse()`, `video_init()`, first cfg word (`UIO_BUT_SW`) |
+| — | `mgl_parse(xml)` |
+| — | saved `DVD_v2.CFG` pushed as the status word |
+| — | `boot.rom` download (the idle logo — **this happens for an MGL too**) |
+| **0** | `user_io_status_set("[0]", 0)` — reset released; `mgl->timer = delay × 1000` |
+| 0.9–1.0 s | the core pulses its virtual OSD button (`BUTTONS[0]`, `dvd/emu.sv`) |
+| **delay** | `mgl->state 0 → 1` |
+| delay | `MENU_NONE2` sees `state == 1`, opens the main menu **invisibly** (`OsdDisable`), `state → 2` |
+| delay | the menu render matches `S0,…,Load Video` and records `submenu = 0` |
+| delay | `MENU_GENERIC_MAIN2` forces `menusub = 0` and `select = 1`, dispatches |
+| delay | `MENU_GENERIC_IMAGE_SELECTED`: `user_io_set_index(0x01)`, `user_io_file_mount(path, 0)` |
+| delay | `mgl->state = 3` → `mgl->done = 1` |
+
+**The dispatch itself is sound for this core.** `type="s" index="0"` matches the S0 row
+at `selentry 0`, `user_io_ext_idx` resolves `.mpg` to extension 0, the index byte is
+`0x01` in both flows, and `make_fullpath()` passes an absolute path through unchanged.
+Nothing about the MGL format needed to change.
+
+---
+
+## 2. The rule that matters: a running MGL owns the whole UI
+
+```c
+// menu.cpp, HandleUI()
+if (!mgl->done) { switch (mgl->state) { … } }
+else            { c = menu_key_get(); }
+```
+
+`menu_key_get()` is the **sole source of every input event** — the keyboard menu key,
+the gamepad menu key, the physical OSD button, and the core's own virtual one (the
+`KEY_F12|UPSTROKE` synthesis lives inside it). So while `mgl->done == 0`, the MiSTer
+accepts no input at all.
+
+And the MGL cannot finish on its own. States 1 and 2 have **no handler in the MGL
+switch**; they are advanced only by the `menustate` FSM, and there is no timeout and no
+watchdog. The single forward edge out of state 1 is:
+
+```c
+else if (menu || (is_menu() && !video_fb_state())
+              || (menustate == MENU_NONE2 && !mgl->done && mgl->state == 1))
+```
+
+It requires `menustate` to be **literally `MENU_NONE2`**. `menu` is permanently false,
+because producing it needs `menu_key_get()`.
+
+> ### ⚠ Never raise `Info()` / `InfoMessage()` / `ProgressMessage()` from a `user_io_poll()` tick while `mgl_get()->done == 0`.
+> Check `dvd_launch_ui_busy()` first and defer.
+
+`InfoMessage()` pins `menustate = MENU_INFO` whenever `menustate <= MENU_INFO`
+(`MENU_NONE1=0, MENU_NONE2=1, MENU_INFO=2`) and calls `HandleUI()` re-entrantly. Two of
+our own overlay pumps called it once a second from `user_io_poll()`, *before* `HandleUI`
+runs:
+
+- `dvd_css.cpp` `dvd_css_tick()` — 8 s window, armed when an encrypted disc is opened
+  without libdvdcss.
+- `dvd_hdmi_audio.cpp` `report_pump()` — 6 s per arm, **re-armed on every stage
+  transition**, and the stage is recomputed against `hdmi_config_init()`'s generation and
+  the scaler re-init a mount itself provokes.
+
+A `delay="5"` MGL fires its state-1 transition squarely inside those windows. Nothing
+mounted, nothing responded, and the only way out was the power switch.
+
+**This is why MGL misbehaved on this core and not on stock ones.** The pumps are ours.
+
+Both now hold their window open rather than spending it, so the notice still appears
+once the launch settles — which is what those pumps were written to do in the first
+place. `dvd_launch_tick()` adds a 20 s watchdog on top: not the fix, a floor under it,
+so a stall we have not thought of costs a failed load instead of a reboot.
+
+⚠ Two comments in those files described `InfoMessage` as "no-oping" or being "dropped"
+when the menu FSM is busy. For the *idle* case that is exactly backwards, and believing
+it is what let this ship. Both are corrected in place.
+
+---
+
+## 3. Reading the screen: grey vs green vs black
+
+Traced through `rtl/mpeg2/mixer.v` → `rtl/mpeg2/yuv2rgb.v` (SMPTE-170M coefficients,
+`cy = 38155`). This is a genuinely reusable diagnostic — it splits three different bugs
+apart before any instrumentation is added.
+
+| colour | RGB | what it means |
+|---|---|---|
+| **black** | (0,0,0) | nothing is scanning at all — the reader is wedged or the decoder is held in reset. `mixer` emits Y=16, U=V=128 when not displaying. |
+| **green** | (0,136,0) | a framestore slot is being scanned that was **never written** (Y=Cb=Cr=0). References were never established, or a flush left a slot flagged valid. |
+| **grey** | (130,130,130) | an **intra picture was decoded out of mis-framed bytes**. MPEG-2 resets the intra DC predictor to 128 at every slice, so an I-picture whose coefficients never decoded reconstructs flat mid-grey. Strongly indicates `ps_demux` framing. |
+
+The `mode_realign` switch blank is **not** a candidate for any of these: it has a hard
+~1.5 s ceiling (`BLANK_MAX`), is cleared on `start_streaming`, is gated off before the
+first mount, and produces black.
+
+---
+
+## 4. The core-side defects the launch exposed
+
+Neither is MGL-specific in mechanism; an MGL just makes them far more likely, because it
+mounts a cold path seconds after boot instead of after the user has walked the file
+browser over that same directory (`ScanDirectory` warms the CIFS dentry cache; the MGL
+flow's `FileOpenEx` is the first access).
+
+### 4.1 A mount with no media was treated as a mount
+
+`user_io_file_mount()` sends `UIO_SET_SDSTAT` even when the open failed, with
+`sd_image[].size` zeroed, and `hps_io.sv` raises `img_mounted` for an all-zero status
+word — which is also how an **eject** arrives. So the pulse means "the slot changed",
+not "there is media".
+
+`disc_ever` in `dvd/emu.sv` always guarded on `img_size != 0`. `start_streaming` and
+`media_seen` did not, so a failed mount killed the idle logo (and its file picker with
+it), flipped `VIDEO_ARX/ARY`, and started the reader on a zero-length image. In the
+reader, `total_blocks == 0` took the "< 17 sectors" branch and wrote a zero-length
+extent, which `S_STREAM`'s `strm_blk + 1 == ext_blocks_q` terminator can never satisfy —
+so it walked LBA 0,1,2,… of an empty slot indefinitely.
+
+And it could not be reported: `img_unplayable`'s window only advances while
+`img_streaming`, which needs sector data to be arriving. A reader that requests and
+receives nothing silences the one notice that would have named the problem. **A blank
+screen with no message means delivery stopped, not that decode failed.**
+
+Fixed in three places, deliberately: `start_streaming` gated on `img_size` and a new
+`img_ejected` clearing `media_seen` (guarded on the delivery/picture signals `logo_vis`
+already uses, so a failed mount cannot flip `VIDEO_ARX` out from under live content);
+`S_INIT` sending a zero-block image to `S_DONE`; and the terminator relaxed to `>=`.
+
+### 4.2 `S_ES_PASS` was terminal
+
+`ps_demux` decides "this is a bare `.m2v`, not a program stream" from the first start
+code after a pipe reset — and `ever_seen_pack` is cleared by **every** `load_flush`, so
+that verdict is retaken after each one. A flush does not always land on a pack boundary:
+the in-place `mode_switch` fallback (`dvd/mode_realign.sv`) flushes without moving the
+reader at all, which is *more* likely right after a mount because it is chosen when
+`lin_seek_ok_w` is 0, and that depends on `ps_saw_pack`, which the mount's own flush just
+cleared.
+
+Landing mid-PES on `00 00 01 B3` latched raw-ES mode for the rest of the title and handed
+PES headers, audio, subpicture and NAV packs to the video decoder — the grey picture,
+with no self-recovery from any seek or watchdog.
+
+The state now leaves on `00 00 01 BA`. A genuine bare elementary stream cannot contain
+one: start codes `0xB9`–`0xFF` are system codes, illegal inside a video ES, and MPEG-2
+forbids start-code emulation in the payload. The four bytes of the pack code that raw-ES
+mode had already forwarded are left to leak on purpose — the first three went out on
+earlier cycles, so suppressing only the `BA` would emit a headless `00 00 01` and the
+decoder would swallow the next real byte as its code. A complete `0xBA` is a system start
+code the VLD's start-code walk skips.
+
+This also subsumes the alternative of arming the reader's `hunt_active` on the in-place
+`mode_switch`: the demux now re-syncs on the next pack either way, without touching the
+reader, and the garbage between flush and pack is bounded by one pack.
+
+### 4.3 Two latches that did not do what their comments said
+
+- **The virtual OSD button could stick high.** `osd_wait` advances only while `status[0]`
+  is low, but `osd_btn` was a pure decode of the counter — so a reset inside the
+  `[FIRE, END)` window froze the count with the button *held*, and Main reads a ≥3 s hold
+  as "enter Bluetooth pairing". Now gated on `~status[0]`, so the button is high exactly
+  while it is counting.
+
+  Related, and worth knowing: `disc_ever` can only suppress a mount that lands *before*
+  the window, so the pulse **always** goes out on an MGL launch. Main swallows it —
+  during an MGL `menu_key_get()` never runs, which is where the press becomes `KEY_F12` —
+  so it is benign, but benign by someone else's accident rather than by design. The old
+  comment's "any mount cancels it" was too strong.
+
+- **`analog_want_l`'s "freeze while a disc is mounted" never froze.** It gated on
+  `img_mounted[0]`, which is a one-transaction *pulse* (cleared on `~io_enable`), not a
+  level — so the latch tracked the cfg word for ever, mid-title included, and the freeze
+  its comment described was never implemented. Main re-sends cfg on every
+  `video_mode_adjust`, including the one the mount's own `VIDEO_ARX` flip provokes, so a
+  changed ini bit could fire a live `il_switch` under playing content: the failure class
+  of issue #42. `media_seen` is the level that was meant.
+
+---
+
+## 5. Gates
+
+- `bench/dvd/run_mgl.sh` — `iso_reader_mount_tb` (RED: 10 reads against an empty slot,
+  still in `S_STREAM`; GREEN: 0 reads, `S_DONE`) and `ps_demux_esrecover_tb` (RED: 48
+  video bytes and **0 audio bytes** after the next pack; GREEN: 12 and 4). Both measure
+  what the hardware *does* — requests issued, bytes demuxed onto which port — not a
+  signal the fix names, so neither can agree with its own RTL by construction. Each
+  carries a control arm against over-reach.
+- ⚠ `iso_reader_mount_tb` ships its **own mock HPS, which polls**. The mock in
+  `iso_reader_tb.sv` and its clones latches the request on the first cycle `sd_rd` is
+  high and always serves it; the real `hps_io` picks requests up by polling command
+  `'h16` at Main's poll rate, so a request withdrawn in between is simply lost. Without a
+  polling mock, the "mount over an in-flight read" arm is a bench that cannot fail.
+- The Main-side half is not simulatable. It is gated on hardware, and
+  `/tmp/dvd_report.log` now records what each mount achieved
+  (`dvd_report_note_mount_result`) precisely so the next round is not another guess.
+
+## 6. Reproducing
+
+1. Put an MGL like the one above in `/media/fat/_Other/`, pointing first at a local
+   `.mpg`, then at a CIFS path.
+2. Launch it and collect `/tmp/dvd_report.log`, `/tmp/dvd_css.log`, and Main's console
+   (`F9`). The console prints `MGL <path>` with the parsed item, `Image selected: …`, and
+   either `Mount … on 0 slot` or `Failed to open file …`.
+3. Note the **colour** (§3) — it splits a wedged reader from a mis-framed demux before
+   anything else is measured.
+4. Expected after the fix: the OSD comes back within 20 s even if the load fails, and a
+   failed mount returns to the bouncing idle logo with the file picker, never a silent
+   grey field.
+
+## 7. Known residual
+
+An MGL launch runs with the OSD **disabled** (`menu.cpp` calls `OsdDisable()` rather than
+`OsdEnable()` when it opens the menu for the MGL). So a CSS-encrypted `.iso` mounted by
+an MGL runs its key crack with the `ProgressMessage` bar invisible — several seconds to
+minutes of apparent silence on a first play. The keys cache, so it happens once per disc.
+Not fixed; it needs Main-side OSD state we do not currently touch.

--- a/docs/mgl_launch.md
+++ b/docs/mgl_launch.md
@@ -327,6 +327,54 @@ The latch keeps the original guard honest, too: a *failed mount over live conten
 leaves the old image playing, `video_live` high and `media_seen` undisturbed, so
 `VIDEO_ARX/ARY` does not flip mid-title and Main does not re-init the scaler.
 
+## 4.5 Retrospect: what the original report probably was
+
+Asked late in the investigation — *could the core have been loading something other
+than a DVD from the physical drive?* The answer is instructive, because the near
+miss is not the one the question expects.
+
+**Non-DVD discs are guarded, and the guard is sound.** `dvd_video_probe()`
+(`dvd_detect.cpp`) requires an ISO9660 primary volume descriptor — `CD001` at sector
+16 — **and** a `VIDEO_TS` directory entry in the root, read over READ(10). An audio
+CD, a data disc, a Blu-ray (BDMV, and UDF-only anyway) are all rejected, and nothing
+is mounted that does not look like DVD-Video. A UDF-only DVD-Video is rejected too,
+which is conservative and correct — the core cannot navigate one either.
+
+**The gap is not "not a DVD", it is "a DVD we cannot decrypt".** `dvd_css_open()`
+detects a CSS-encrypted disc, finds no libdvdcss, arms an 8-second "Run
+install_dvdcss" warning — **and mounts it anyway**, over `raw_fd`, serving scrambled
+sectors. The core's own detector then fires `CSS ENCRYPTED` and mutes the audio, and
+the picture is the documented green field.
+
+That composes into a complete account of the original report, and it needs all three
+of this note's fixes to explain:
+
+1. An encrypted disc sits in the drive; libdvdcss is not installed.
+2. `dvd_phys_tick()` auto-mounts it on the **first poll** — seconds before the MGL's
+   `delay` expires (§4.4).
+3. Served raw, the core shows a **green screen**.
+4. The warning pump calls `InfoMessage` once a second, pinning
+   `menustate = MENU_INFO` (§2) — so the MGL freezes at state 1, `menu_key_get()`
+   never runs, **nothing responds**, and the `.mpg` is never mounted at all.
+5. Selecting the same file by hand works, because none of the MGL state machine is
+   involved.
+
+Grey or green, completely unresponsive, needs a restart, fine when loaded manually —
+all of it.
+
+It is closed three times over now: the pump defers while a launch is pending, the
+auto-mount defers with it, and once the MGL's file owns the slot the drive stands
+down for good.
+
+⚠ **One judgement call is left, deliberately unchanged.** On a *plain* launch, an
+encrypted disc with no libdvdcss still mounts raw and green-screens. That is the
+documented behaviour and it is a choice, not an oversight — video keeps playing so
+the disc is identifiable, the same reasoning as the `CSS ENCRYPTED` notice for
+images (`docs/fabric_audio.md` "CSS mute"). Refusing the mount instead would show
+the install prompt over the idle screen, which is arguably kinder; it is a
+behaviour change to an HW-confirmed path, so it should be decided rather than
+drifted into.
+
 ## 5. Gates
 
 - `bench/dvd/run_mgl.sh` — `iso_reader_mount_tb` (RED: 10 reads against an empty slot,

--- a/docs/mgl_launch.md
+++ b/docs/mgl_launch.md
@@ -288,6 +288,45 @@ stroke and left starvation as the only shape that fits. Worth asking for
 explicitly: "is the picture frozen or is the machine frozen" separates the HPS side
 from the core side before any code is read.
 
+### Returning to the idle screen must not depend on the HPS reset
+
+Reported: after an MGL launch the **OSD Reset row does nothing**, so neither the
+button nor an eject gets back to the idle screen.
+
+The core side cannot be launch-dependent — `status[0]` goes through one flip-flop:
+
+```verilog
+reg user_rst_q; always @(posedge clk_sys) user_rst_q <= status[0];
+wire reset_n = locked & ~RESET & ~user_rst_q;
+```
+
+and `user_io_status_set()` sends unconditionally, with `hps_io` latching
+`status[15:0]` on the *first* word of the transaction — so the OSD row's
+back-to-back `set(1); set(0)` still leaves the bit high for the rest of a
+transaction, hundreds of `clk_sys` cycles. Neither end has an MGL dependency, which
+is why this is instrumented (integration step 31) rather than guessed at: every
+`status[0]` write now logs to `/tmp/dvd_report.log` with the MGL state, so "Main
+never dispatched" and "the core ignored it" stop looking the same.
+
+**Independently of that**, the eject path had a defect of its own, and it was mine:
+
+```verilog
+// before
+end else if (img_ejected && !img_streaming && !video_live_s2) begin
+```
+
+`img_ejected` is a **one-cycle pulse**, and an eject arrives while the last frames
+are still on screen — so `video_live_s2` was still high at exactly the instant the
+condition was evaluated, and the clear was thrown away every time. The test was
+right; sampling it at the pulse was wrong. `slot_empty` now latches the emptied
+slot and the clear fires once the picture actually runs out, so **the return to the
+idle screen depends on nothing but the core** — notably not on the HPS reset, which
+is how the eject path used to get there.
+
+The latch keeps the original guard honest, too: a *failed mount over live content*
+leaves the old image playing, `video_live` high and `media_seen` undisturbed, so
+`VIDEO_ARX/ARY` does not flip mid-title and Main does not re-init the scaler.
+
 ## 5. Gates
 
 - `bench/dvd/run_mgl.sh` — `iso_reader_mount_tb` (RED: 10 reads against an empty slot,

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -116,6 +116,33 @@ still reads `bitstream=1` and cracks + plays, and a decrypted/unencrypted ISO re
 the mount but still shows `CSS ENCRYPTED`, that is the separate `DVDCSS_METHOD`-on-a-file
 question — per-title cracking on a file may need `DVDCSS_METHOD=title`.)
 
+**Why the probe tests two things, not one.** `dvd_video_probe()` requires an
+ISO9660 primary volume descriptor (`CD001` at sector 16) **and** a `VIDEO_TS`
+directory entry in the root. The second half is what makes it safe: `CD001` alone
+matches most of the optical-console library, including several systems MiSTer runs.
+
+| disc | ISO9660? | root `VIDEO_TS`? | mounted |
+|---|---|---|---|
+| PlayStation, Saturn, Sega CD, Neo Geo CD, CD32/CDTV, ao486 | yes | no (`SYSTEM.CNF`, `IP.BIN`, …) | no |
+| PC Engine CD / TurboGrafx-CD | no (custom, CD-DA + data) | — | no |
+| 3DO | no (Opera FS) | — | no |
+| CD-i | yes (XA) | no | no |
+| Video CD / SVCD | yes | no (`VCD/`, `MPEGAV/`) | no |
+| GameCube, Wii, Xbox | no (proprietary; XDVDFS starts at sector 32) | — | no |
+| audio CD | READ(10) fails outright | — | no |
+| DVD-Video, incl. DVD games and home-burned `VIDEO_TS` | yes | yes | **yes** |
+| DVD-Audio | yes | usually yes (the Video zone) | yes — and correctly: a real player plays that zone too |
+
+So no console disc can be mistaken for a movie, and that is worth keeping in mind
+before relaxing either half of the test.
+
+⚠ The probe scans at most the **first 8 sectors** of the root directory (16 KB,
+several hundred entries). A `VIDEO_TS` sorting past that would be missed — but that
+is a false *negative*: the disc is simply not auto-mounted, which is the safe
+direction. A rejection is now logged to `/tmp/dvd_report.log` once per insertion, so
+"I put a disc in and nothing happened" has a record; without it, "we rejected it"
+and "we never saw it" look identical from outside.
+
 **⚠ The cache directory must be created two levels deep, and the result checked.**
 `mkdir()` creates one level, and `/media/fat/dvdcss` only exists if libdvdcss was
 installed by our own `Scripts/install_dvdcss.sh` — `css_lib_names` also finds the

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -116,6 +116,21 @@ still reads `bitstream=1` and cracks + plays, and a decrypted/unencrypted ISO re
 the mount but still shows `CSS ENCRYPTED`, that is the separate `DVDCSS_METHOD`-on-a-file
 question — per-title cracking on a file may need `DVDCSS_METHOD=title`.)
 
+**⚠ The cache directory must be created two levels deep, and the result checked.**
+`mkdir()` creates one level, and `/media/fat/dvdcss` only exists if libdvdcss was
+installed by our own `Scripts/install_dvdcss.sh` — `css_lib_names` also finds the
+library in `/media/fat/linux/` or on the system path, and then the parent is
+missing, `mkdir("/media/fat/dvdcss/cache")` fails `ENOENT`, and the return was not
+checked. libdvdcss then does its own single-level `mkdir` on the same path, fails
+identically, and **disables caching silently** — so every play re-extracts the
+keys, which on a no-region drive or an image file means the full crack every time.
+`setup_cache()` now creates both levels, proves the directory is writable (a
+removable card can be mounted read-only after an unclean shutdown, which looks
+identical from `mkdir` alone), unsets `DVDCSS_CACHE` rather than leaving it
+pointing somewhere unusable, and logs which of those happened. It also logs the
+entry count either side of key extraction, so `/tmp/dvd_css.log` distinguishes
+"the cache is not being written" from "it is being written but not read back".
+
 **CSS key cache — legal guardrail.** Recovered keys are cached at
 `/media/fat/dvdcss/cache` (device-local, runtime-generated). Caching adds no legal
 exposure beyond the decryption itself — it is the standard `DVDCSS_CACHE` behaviour VLC

--- a/dvd/dvd_iso_reader.sv
+++ b/dvd/dvd_iso_reader.sv
@@ -2465,7 +2465,17 @@ always @(posedge clk or negedge rst_n) begin
 
             // ------------------------------------------------------------
             S_INIT: begin
-                if (total_blocks < 32'd17) begin
+                // DVD-FORK FIX (issue #48): an empty image is not playable, and
+                // it must not be treated as a tiny one. Main notifies the core of
+                // a mount even when the file never opened (size 0), and with
+                // total_blocks == 0 the extent below is zero-length -- which the
+                // S_STREAM terminator (strm_blk + 1 == ext_blocks_q) can never
+                // satisfy, so the reader walked LBA 0,1,2,... of an empty slot
+                // for ever. Stop here instead; emu.sv now also declines to start
+                // on a zero size, so this is the second of two locks.
+                if (total_blocks == 32'd0) begin
+                    state <= S_DONE;
+                end else if (total_blocks < 32'd17) begin
                     ext_mem[0] <= {32'd0, total_blocks};
                     best_base <= 7'd0; best_cnt <= 7'd1;
                     strm_idx  <= 7'd0; strm_left <= 7'd1;
@@ -4073,7 +4083,10 @@ always @(posedge clk or negedge rst_n) begin
                                 end
                             end
                         end else begin
-                            if (strm_blk + 32'd1 == ext_blocks_q) begin
+                            // >= not ==: a zero-length extent would otherwise
+                            // stream for ever (issue #48). Equality is the normal
+                            // case; the inequality is the floor under it.
+                            if (strm_blk + 32'd1 >= ext_blocks_q) begin
                                 strm_blk <= 32'd0;
                                 if (strm_left == 7'd1) strm_done <= 1'b1;
                                 else begin

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -986,19 +986,40 @@ wire [32:0] av_stc;
 wire signed [31:0] av_drift;
 wire [15:0] av_reanchor_cnt;
 
-// Detect image mount event (start streaming)
-reg        img_mounted_prev;
-wire       start_streaming = img_mounted[0] && !img_mounted_prev;
+// Detect image mount event (start streaming).
+//
+// DVD-FORK FIX (issue #48): a mount notification with img_size == 0 is NOT a
+// mount. Main sends UIO_SET_SDSTAT unconditionally -- on a failed FileOpenEx it
+// zeroes sd_image[].size and still notifies -- and hps_io forces img_mounted[0]
+// high even for an all-zero status word, which is how an EJECT arrives too. So
+// the pulse alone says "the slot changed", not "there is media".
+//
+// Left ungated this cost the reported blank screen: media_seen latched, which
+// kills the idle logo and the file picker with it, and the reader started on a
+// zero-length image. disc_ever below has ALWAYS guarded on img_size (it is the
+// one consumer that got this right); the other two now agree with it, so the
+// three cannot disagree about whether a disc arrived.
+wire       img_evt        = img_mounted[0] && !img_mounted_prev;   // slot changed
+wire       start_streaming = img_evt &&  (img_size != 64'd0);      // ...with media
+wire       img_ejected     = img_evt && !(img_size != 64'd0);      // ...without
 // DVD-FORK FIX (single-raster analog): the analog_want latch (see its declaration
 // near the top). Follows the cfg-derived request while nothing is mounted and once
 // Main has actually written cfg (cfg_seen - before that the ini bits read 0), holds
 // while media is mounted. Level-based on purpose: an OSD Reset (status[0]) pulls
 // reset_n with cfg_seen already high and no new cfg write coming, so an edge-armed
 // latch would come back empty.
+//
+// ⚠ DVD-FORK FIX (issue #48): the hold gated on img_mounted[0], which is a PULSE
+// lasting one hps_io transaction (it is cleared on ~io_enable), not a level -- so
+// the latch tracked cfg forever, mid-title included, and the freeze this comment
+// describes was never actually implemented. Main re-sends cfg on every
+// video_mode_adjust, INCLUDING the one the mount's own VIDEO_ARX flip provokes, so
+// a changed ini bit could fire a live il_switch under playing content: the exact
+// failure class of issue #42. media_seen is the level that was meant here.
 reg        analog_want_l;
 always @(posedge clk_sys or negedge reset_n) begin
-    if (!reset_n)                          analog_want_l <= 1'b0;
-    else if (cfg_seen && !img_mounted[0])  analog_want_l <= analog_want_raw;
+    if (!reset_n)                       analog_want_l <= 1'b0;
+    else if (cfg_seen && !media_seen)   analog_want_l <= analog_want_raw;
 end
 assign analog_want = analog_want_l;
 reg [63:0] current_file_size;
@@ -1029,8 +1050,16 @@ end
 // So this is a WAIT-THEN-PULSE instead: arm on the falling edge of
 // status[0] (the framework's core-load reset, released at the END of
 // user_io_init -- after every init-time auto-load), wait ~0.9 s watching
-// for a mount, and only then emit a 100 ms pulse. Any mount cancels it.
+// for a mount, and only then emit a 100 ms pulse.
 // Must stay well under 3 s: a >=3 s hold means "enter Bluetooth pairing".
+//
+// ⚠ "Any mount cancels it" was too strong, and it mattered for issue #48:
+// only a mount BEFORE the window can, because disc_ever is sampled with
+// the counter. An MGL <file> mount arrives `delay` seconds after load, so
+// the pulse always goes out on an MGL launch. Main swallows it there --
+// during an MGL, HandleUI never calls menu_key_get(), which is where the
+// press is turned into KEY_F12 -- so this is benign, but it is benign by
+// someone else's accident, not by design. See docs/mgl_launch.md.
 //
 // One-shot per FPGA configuration (the counter saturates and nothing resets
 // it, so OSD-menu Reset can't re-fire it), and disc_ever has no reset term
@@ -1043,12 +1072,21 @@ reg        hps_rst_seen = 1'b0;   // status[0] observed high since power-up
 reg        disc_ever    = 1'b0;   // any nonzero-size mount since power-up
 reg [24:0] osd_wait     = 25'd0;
 
+//
+// ⚠ DVD-FORK FIX (issue #48): osd_btn must also be gated on ~status[0]. The
+// counter advances only while status[0] is low, but the button was a pure decode
+// of the counter -- so a reset asserted inside the [FIRE, END) window froze the
+// count with the button HELD, indefinitely. Main reads a >=3 s hold as "enter
+// Bluetooth pairing" (menu.cpp), which is an unresponsive state of its own. With
+// this term the button is high exactly while it is counting, so its high time is
+// the 100 ms window and nothing else; a reset merely splits the pulse.
 always @(posedge clk_sys) begin
     if (img_mounted[0] && img_size != 64'd0) disc_ever <= 1'b1;
     if (status[0])                           hps_rst_seen <= 1'b1;
     if (hps_rst_seen && !status[0] && osd_wait != OSD_T_END)
         osd_wait <= osd_wait + 25'd1;
-    osd_btn <= (osd_wait >= OSD_T_FIRE) && (osd_wait != OSD_T_END) && !disc_ever;
+    osd_btn <= (osd_wait >= OSD_T_FIRE) && (osd_wait != OSD_T_END)
+               && !disc_ever && !status[0];
 end
 
 assign BUTTONS = {1'b0, osd_btn};
@@ -2724,6 +2762,21 @@ always @(posedge clk_sys or negedge reset_n) begin
 
         if (start_streaming) begin                    // fresh mount: re-arm
             img_wd_cnt <= 30'd0; img_unplayable <= 1'b0; media_seen <= 1'b1;
+        end else if (img_ejected && !img_streaming && !video_live_s2) begin
+            // DVD-FORK FIX (issue #48): the slot changed and there is no media --
+            // an eject, or a mount whose file never opened (Main notifies either
+            // way, with size 0). Go back to "nothing is loaded" so the idle logo
+            // and its file picker return, instead of leaving media_seen latched
+            // and the screen showing an unwritten framestore with no message.
+            //
+            // Guarded on the delivery/picture signals logo_vis already uses,
+            // because a FAILED mount does not stop whatever was already playing:
+            // clearing media_seen under live content would flip VIDEO_ARX/ARY
+            // mid-title, and Main answers that with a scaler re-init and a cfg
+            // re-send. "The new file did not load, the old one plays on" is the
+            // least surprising outcome there; the idle screen is for a slot that
+            // really is empty.
+            img_wd_cnt <= 30'd0; img_unplayable <= 1'b0; media_seen <= 1'b0;
         end else if (!media_seen || video_live_s2 || iso_mode_w) begin
             img_wd_cnt <= 30'd0;                      // idle, playing, or a real ISO
             if (video_live_s2) img_unplayable <= 1'b0;   // a picture disproves the verdict

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -999,6 +999,7 @@ wire [15:0] av_reanchor_cnt;
 // zero-length image. disc_ever below has ALWAYS guarded on img_size (it is the
 // one consumer that got this right); the other two now agree with it, so the
 // three cannot disagree about whether a disc arrived.
+reg        img_mounted_prev;
 wire       img_evt        = img_mounted[0] && !img_mounted_prev;   // slot changed
 wire       start_streaming = img_evt &&  (img_size != 64'd0);      // ...with media
 wire       img_ejected     = img_evt && !(img_size != 64'd0);      // ...without
@@ -1072,7 +1073,6 @@ reg        hps_rst_seen = 1'b0;   // status[0] observed high since power-up
 reg        disc_ever    = 1'b0;   // any nonzero-size mount since power-up
 reg [24:0] osd_wait     = 25'd0;
 
-//
 // ⚠ DVD-FORK FIX (issue #48): osd_btn must also be gated on ~status[0]. The
 // counter advances only while status[0] is low, but the button was a pure decode
 // of the counter -- so a reset asserted inside the [FIRE, END) window froze the

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -2748,11 +2748,19 @@ reg [29:0] img_wd_cnt;
 reg [24:0] img_idle_cnt;                           // saturating "time since last sector byte"
 reg        img_unplayable;
 reg        media_seen;
+// The slot has been emptied and no new media has arrived. LATCHED, not acted on
+// at the instant it happens: an eject arrives while the last frames are still on
+// screen, so the "is anything still playing" test below would say yes and the
+// clear would be lost for ever (img_ejected is a one-cycle pulse). Held until the
+// picture actually runs out, which is what makes the return to the idle screen
+// depend on nothing but the core itself -- notably not on the HPS reset, which is
+// how the eject path used to get there.
+reg        slot_empty;
 wire       img_streaming = (img_idle_cnt != IMG_IDLE);
 always @(posedge clk_sys or negedge reset_n) begin
     if (!reset_n) begin
         img_wd_cnt <= 30'd0; img_idle_cnt <= IMG_IDLE;
-        img_unplayable <= 1'b0; media_seen <= 1'b0;
+        img_unplayable <= 1'b0; media_seen <= 1'b0; slot_empty <= 1'b0;
     end else begin
         // Delivery-activity detector (free-running, mount-independent): every
         // sector-buffer write re-arms it; it saturates at IMG_IDLE = "nothing has
@@ -2760,23 +2768,31 @@ always @(posedge clk_sys or negedge reset_n) begin
         if (sd_buff_wr)                     img_idle_cnt <= 25'd0;
         else if (img_idle_cnt != IMG_IDLE)  img_idle_cnt <= img_idle_cnt + 25'd1;
 
+        if (img_ejected) slot_empty <= 1'b1;        // remembered until it can act
+
         if (start_streaming) begin                    // fresh mount: re-arm
             img_wd_cnt <= 30'd0; img_unplayable <= 1'b0; media_seen <= 1'b1;
-        end else if (img_ejected && !img_streaming && !video_live_s2) begin
-            // DVD-FORK FIX (issue #48): the slot changed and there is no media --
-            // an eject, or a mount whose file never opened (Main notifies either
-            // way, with size 0). Go back to "nothing is loaded" so the idle logo
-            // and its file picker return, instead of leaving media_seen latched
-            // and the screen showing an unwritten framestore with no message.
+            slot_empty <= 1'b0;
+        end else if (slot_empty && !img_streaming && !video_live_s2) begin
+            // DVD-FORK FIX (issue #48): the slot has been emptied -- a disc
+            // ejected, or a mount whose file never opened, which Main reports the
+            // same way (SDSTAT with size 0). Once the picture has actually run
+            // out, go back to "nothing is loaded" so the idle logo and its file
+            // picker return, instead of leaving media_seen latched and a dead
+            // framestore on screen with no message.
             //
-            // Guarded on the delivery/picture signals logo_vis already uses,
-            // because a FAILED mount does not stop whatever was already playing:
-            // clearing media_seen under live content would flip VIDEO_ARX/ARY
-            // mid-title, and Main answers that with a scaler re-init and a cfg
-            // re-send. "The new file did not load, the old one plays on" is the
-            // least surprising outcome there; the idle screen is for a slot that
-            // really is empty.
+            // ⚠ Waiting for the picture to stop is the point, not politeness.
+            // img_ejected is a one-cycle pulse and an eject lands while frames are
+            // still being displayed, so testing these signals AT the pulse threw
+            // the clear away every time -- which is how "eject leaves the core
+            // stuck" survived the first fix. Latching it also keeps the guard
+            // honest for a FAILED mount over live content: the old image keeps
+            // playing, video_live stays high, and media_seen is not disturbed
+            // (clearing it would flip VIDEO_ARX/ARY mid-title and make Main
+            // re-init the scaler). "The new file did not load, the old one plays
+            // on" is still the outcome there.
             img_wd_cnt <= 30'd0; img_unplayable <= 1'b0; media_seen <= 1'b0;
+            slot_empty <= 1'b0;
         end else if (!media_seen || video_live_s2 || iso_mode_w) begin
             img_wd_cnt <= 30'd0;                      // idle, playing, or a real ISO
             if (video_live_s2) img_unplayable <= 1'b0;   // a picture disproves the verdict

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -566,7 +566,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "dev-keyboard"
+`define CORE_VERSION "dev-mgl"
 
 parameter CONF_STR = {
     "DVD;;",

--- a/dvd/ps_demux.sv
+++ b/dvd/ps_demux.sv
@@ -195,7 +195,8 @@ typedef enum logic [4:0] {
     S_M1_HDR,         // MPEG-1 PES optional header: stuffing/STD/timestamp dispatch
     S_M1_STD,         // MPEG-1 STD buffer field second byte
     S_ES_EMIT,        // raw ES: emit reconstructed 00 00 01 <code> preamble
-    S_ES_PASS,        // raw ES: forward every input byte to video (no demux)
+    S_ES_PASS,        // raw ES: forward every input byte to video (no demux);
+                      //   leaves on a 00 00 01 BA pack (issue #48)
     S_VID_FLUSH       // after a sequence_end_code: emit trailing filler so the
                       //   VLD can flush the still's last slice (see below)
 } state_t;
@@ -769,8 +770,33 @@ always_ff @(posedge clk or negedge rst_n) begin
                 if (pes_length == 16'd1) state <= S_HUNT;
             end
 
-            // ---- Raw elementary stream: forward every byte, never leave ----
-            S_ES_PASS: ;  // forwarding handled in the output comb block; stay here
+            // ---- Raw elementary stream: forward every byte ----
+            // Forwarding is handled in the output comb block. Keep watching for
+            // a PS pack anyway.
+            //
+            // DVD-FORK FIX (issue #48): this used to be a TERMINAL state -- once
+            // entered there was no way out for the life of the pipe reset. The
+            // verdict is taken on the FIRST start code after every load_flush
+            // (ever_seen_pack is cleared by pipe_rst_n), so any flush that lands
+            // mid-PES on a byte <= 0xB8 latched "this is a raw ES" and from then
+            // on shoved PES headers, audio, subpicture and NAV packs at the video
+            // decoder: a permanently mis-framed picture with no self-recovery.
+            // The in-place mode_switch fallback is exactly such a flush.
+            //
+            // A genuine bare .m2v cannot contain 00 00 01 BA -- start codes
+            // 0xB9-0xFF are system codes and are illegal inside a video
+            // elementary stream, and MPEG-2 forbids start-code emulation in the
+            // payload -- so this cannot mis-fire on the case the state exists
+            // for. The four bytes of the pack code already forwarded are an
+            // unknown start code to the decoder, which skips them.
+            S_ES_PASS: begin
+                if (start_code_detected && (in_byte == 8'hBA)) begin
+                    ever_seen_pack  <= 1'b1;      // and lock the ES verdict out
+                    stream_id_r     <= in_byte;
+                    bytes_remaining <= 16'd9;
+                    state           <= S_PACK_SKIP;
+                end
+            end
 
             default: state <= S_HUNT;
             endcase

--- a/main/integration/INTEGRATION.md
+++ b/main/integration/INTEGRATION.md
@@ -231,6 +231,7 @@ Notes that matter on a `MAIN_MISTER_REF` bump:
 | 27 | `user_io.cpp` | include `support/dvd/dvd_launch.h` |
 | 28 | `user_io.cpp` | `dvd_launch_tick()` **first** of the DVD ticks in `user_io_poll()` |
 | 29 | `user_io.cpp` | `dvd_report_note_mount_result(...)` immediately before `UIO_SET_SDSTAT` |
+| 30 | `user_io.cpp` | `dvd_phys_note_mount(name, index)` beside step 26, so the drive can see slot 0 being taken |
 
 The rule these steps exist to enforce, and it applies to **any** future overlay
 code that runs from a `user_io_poll()` tick:
@@ -257,3 +258,24 @@ the MiSTer must be restarted".
   even when the open FAILED (with size 0), so from the core's side a failed mount
   and a real one are the same pulse. `/tmp/dvd_report.log` then says which
   happened, which is the difference between a Main-side and a core-side bug.
+
+### Step 30 — slot 0 has more than one claimant
+
+The optical drive shares slot 0 with every image the user can load, and
+`dvd_phys.cpp` used to track only *"we mounted a disc at some point"*. Two field
+bugs came out of that on an MGL launch with a disc in the drive:
+
+- the drive auto-mounted on the first poll, so a `.mpg` named by the MGL waited
+  minutes for CSS key extraction nobody asked for — on a disc that was then
+  replaced by the file anyway;
+- ejecting that disc unmounted the file that *was* playing (freezing it) and reset
+  the core.
+
+`dvd_phys_note_mount()` gives the module the one fact it was missing. The rules it
+now follows are pinned by `main/tests/run_tests.sh` (host-side, no MiSTer needed),
+which reproduces both symptoms against the pre-fix module.
+
+⚠ It takes the **index** as well as the path. Main mounts `boot*.vhd` across slots
+0–3 during init, and the drive only ever binds slot 0 — without the index a
+`boot.vhd` in `games/DVD/` would read as a claim on the drive's slot and silently
+disable physical-disc playback.

--- a/main/integration/INTEGRATION.md
+++ b/main/integration/INTEGRATION.md
@@ -220,3 +220,40 @@ Notes that matter on a `MAIN_MISTER_REF` bump:
   `$(wildcard ./support/*/*.cpp)`.
 - The work forks; it must never run inline in the poll loop, which also services
   SD blocks for the core.
+
+## Steps 27-29 — MGL launch (issue #48)
+
+`main/support/dvd/dvd_launch.{h,cpp}`. Design and the full launch timeline:
+`MiSTer_DVD/docs/mgl_launch.md`.
+
+| # | File | Edit |
+|---|---|---|
+| 27 | `user_io.cpp` | include `support/dvd/dvd_launch.h` |
+| 28 | `user_io.cpp` | `dvd_launch_tick()` **first** of the DVD ticks in `user_io_poll()` |
+| 29 | `user_io.cpp` | `dvd_report_note_mount_result(...)` immediately before `UIO_SET_SDSTAT` |
+
+The rule these steps exist to enforce, and it applies to **any** future overlay
+code that runs from a `user_io_poll()` tick:
+
+> **Never raise `Info()` / `InfoMessage()` / `ProgressMessage()` while
+> `mgl_get()->done == 0`.** Check `dvd_launch_ui_busy()` first and defer.
+
+Why it is not merely cosmetic: during an MGL launch `HandleUI()` takes the MGL
+branch and **never calls `menu_key_get()`**, which is the sole source of every
+input event — keyboard menu key, gamepad menu key, the physical OSD button and
+the core's own virtual one. The MGL's only forward edge out of `state == 1`
+requires `menustate == MENU_NONE2`, and `InfoMessage()` pins
+`menustate = MENU_INFO`. So a notice raised from a poll tick stalls the load
+**and** every input path on the machine — the reported "completely unresponsive,
+the MiSTer must be restarted".
+
+- **Step 28 is placed first** so that when the watchdog releases a stalled MGL,
+  the notice pumps see `done == 1` in the same poll iteration.
+- **The watchdog is a floor, not the fix.** It bounds a stall at ~20 s and hands
+  the UI back; the fix is the `dvd_launch_ui_busy()` gate in the pumps
+  (`dvd_css_tick`, `report_pump`). Keep both: the gate covers the causes we know
+  about, the watchdog covers the ones we do not.
+- **Step 29 is a log line only.** It matters because `UIO_SET_SDSTAT` is sent
+  even when the open FAILED (with size 0), so from the core's side a failed mount
+  and a real one are the same pulse. `/tmp/dvd_report.log` then says which
+  happened, which is the difference between a Main-side and a core-side bug.

--- a/main/integration/INTEGRATION.md
+++ b/main/integration/INTEGRATION.md
@@ -297,3 +297,32 @@ so a `signature\n{` anchor lands the call between the signature and its brace (t
 same trap as step 24). One consequence, and it is acceptable: a write whose option
 string fails to parse logs nothing, but that is still on Main's side of the line
 this exists to draw.
+
+## Step 32 — an unarmed MGL timer is not an expired one
+
+**The first edit outside `user_io.cpp`.** `menu.cpp`, one condition:
+
+```c
+-  if (CheckTimer(mgl->timer))
++  if (mgl->timer && CheckTimer(mgl->timer))
+```
+
+`mgl_parse()` memsets the struct, so `mgl->timer` is **0** from the moment the MGL
+is parsed (`user_io_init` line ~1516) until it is armed at that function's very end
+(~line 1760). And `CheckTimer(0)` returns **true** — its `(!time) ||` clause reads an
+unarmed timer as an expired one.
+
+So anything that re-enters `HandleUI()` inside that window advances the MGL state
+machine past its `case 0` and **consumes the delay before it is ever set**. The file
+then mounts as soon as the menu opens, with no wait at all. `user_io_file_tx()`
+finishes with `ProgressMessage(0, 0, 0, 0)`, whose zero-argument form calls
+`MenuHide()`, which calls `HandleUI()` — so a `boot.rom` transfer does exactly this,
+and this fork ships a `boot.rom` (the idle logo).
+
+This is stock behaviour, not something the overlay introduced; it just costs *this*
+core its MGL delay more readily than most, because of the idle logo. The fix states
+the invariant where the bug is rather than working around it elsewhere, and the
+`replace_once()` helper fails loudly if the three-line anchor ever moves.
+
+⚠ `mgl->timer` is only ever 0 while unarmed: `delay="0"` still yields
+`GetTimer(0)`, a live millisecond count, so a zero delay keeps working.

--- a/main/integration/INTEGRATION.md
+++ b/main/integration/INTEGRATION.md
@@ -232,6 +232,7 @@ Notes that matter on a `MAIN_MISTER_REF` bump:
 | 28 | `user_io.cpp` | `dvd_launch_tick()` **first** of the DVD ticks in `user_io_poll()` |
 | 29 | `user_io.cpp` | `dvd_report_note_mount_result(...)` immediately before `UIO_SET_SDSTAT` |
 | 30 | `user_io.cpp` | `dvd_phys_note_mount(name, index)` beside step 26, so the drive can see slot 0 being taken |
+| 31 | `user_io.cpp` | `dvd_launch_note_status(opt, value)` in `user_io_status_set()` — logs writes to the core's reset bit |
 
 The rule these steps exist to enforce, and it applies to **any** future overlay
 code that runs from a `user_io_poll()` tick:
@@ -279,3 +280,20 @@ which reproduces both symptoms against the pre-fix module.
 0–3 during init, and the drive only ever binds slot 0 — without the index a
 `boot.vhd` in `games/DVD/` would read as a claim on the drive's slot and silently
 disable physical-disc playback.
+
+### Step 31 — who asked for the reset
+
+`status[0]` is the core's reset, and both the OSD **Reset** row and the disc-eject
+teardown reach it through `user_io_status_set()`. When neither appears to work
+there are exactly two possibilities — Main never dispatched, or it dispatched and
+the core ignored it — and they are fixed in completely different places. This logs
+the write to `/tmp/dvd_report.log` so the next test says which.
+
+⚠ **The anchor is `if (!size) return;`**, which is the only line in
+`user_io_status_set()` that is unique in the file: `user_io_status_get()` opens with
+the same two body lines and first differs at its `return 0;`. It cannot be the
+signature either — `insert_after()` splits on the first newline *after* the anchor,
+so a `signature\n{` anchor lands the call between the signature and its brace (the
+same trap as step 24). One consequence, and it is acceptable: a write whose option
+string fails to parse logs nothing, but that is still on Main's side of the line
+this exists to draw.

--- a/main/integration/apply_integration.py
+++ b/main/integration/apply_integration.py
@@ -41,6 +41,15 @@ def insert_after(text, anchor, block, step, marker):
         fail(step, "anchor at EOF")
     return text[:eol + 1] + block + text[eol + 1:]
 
+def replace_once(text, old, new, step, marker):
+    if marker in text:
+        print(f"[integration] step {step}: already applied, skipping")
+        return text
+    n = text.count(old)
+    if n != 1:
+        fail(step, f"anchor matched {n} times, expected exactly 1: {old!r}")
+    return text.replace(old, new, 1)
+
 def insert_before(text, anchor, block, step, marker):
     if marker in text:
         print(f"[integration] step {step}: already applied, skipping")
@@ -466,5 +475,32 @@ h = insert_after(h, 'char is_dvd();',
     25, 'user_io_last_lba')
 write(h_path, h)
 print("[integration] user_io.h patched (support bundle)")
+
+# ------------------------------------------------------------------ menu.cpp
+# 32. An UNARMED MGL timer is not an expired one.
+m_path = os.path.join(ROOT, "menu.cpp")
+if not os.path.exists(m_path):
+    fail(32, f"{m_path} not found")
+m = read(m_path)
+
+m = replace_once(m,
+    "\t\t\tif (CheckTimer(mgl->timer))\n"
+    "\t\t\t{\n"
+    "\t\t\t\tmgl->state = (mgl->item[mgl->current].action == MGL_ACTION_LOAD) ? 1 : 4;\n",
+
+    "\t\t\t// dvd:mgl \u2014 an UNARMED timer is not an EXPIRED one. mgl_parse()\n"
+    "\t\t\t// memsets the struct, so mgl->timer is 0 until user_io_init() arms it\n"
+    "\t\t\t// at its very end -- and CheckTimer(0) returns TRUE. Anything that\n"
+    "\t\t\t// re-enters HandleUI() in between consumes the delay before it is\n"
+    "\t\t\t// ever set, and the file mounts immediately: ProgressMessage()/\n"
+    "\t\t\t// MenuHide() at the end of a boot.rom transfer does exactly that.\n"
+    "\t\t\t// See MiSTer_DVD/docs/mgl_launch.md.\n"
+    "\t\t\tif (mgl->timer && CheckTimer(mgl->timer))\n"
+    "\t\t\t{\n"
+    "\t\t\t\tmgl->state = (mgl->item[mgl->current].action == MGL_ACTION_LOAD) ? 1 : 4;\n",
+    32, "mgl->timer && CheckTimer")
+
+write(m_path, m)
+print("[integration] menu.cpp patched (MGL delay)")
 
 print("[integration] done")

--- a/main/integration/apply_integration.py
+++ b/main/integration/apply_integration.py
@@ -436,6 +436,20 @@ u = insert_after(u, '\tdvd_report_note_mount(name);   // dvd:report — observe 
     '\tdvd_phys_note_mount(name, index);   // dvd:phys — observe only\n',
     30, 'dvd_phys_note_mount(name)')
 
+# 31. observe status[0] (the core reset) writes. Both the OSD Reset row and the
+# disc-eject teardown go through user_io_status_set(); when neither appears to work,
+# this line separates "Main never dispatched" from "the core ignored it".
+# ⚠ The anchor is 'if (!size) return;' because it is the only line in this
+# function that is UNIQUE in the file: user_io_status_get() opens with the same two
+# body lines and differs first at its 'return 0;'. And it cannot be the signature --
+# insert_after() splits on the first newline AFTER the anchor, so a 'signature\n{'
+# anchor lands the call between the signature and its brace (the step-24 note).
+# Consequence: a write whose option string does not parse logs nothing. That is
+# still on Main's side of the line this exists to draw, so it does not blunt it.
+u = insert_after(u, '\tif (!size) return;',
+    '\tdvd_launch_note_status(opt, value);   // dvd:launch — observe only\n',
+    31, 'dvd_launch_note_status')
+
 # 29. say what the mount actually did. UIO_SET_SDSTAT is sent even when the open
 # FAILED, so without this line a blank screen is ambiguous between "never opened"
 # and "opened and produced nothing".

--- a/main/integration/apply_integration.py
+++ b/main/integration/apply_integration.py
@@ -411,6 +411,31 @@ u = insert_after(u, '\tint len = strlen(name);',
     '\tdvd_report_note_mount(name);   // dvd:report — observe only\n',
     26, 'dvd_report_note_mount(name)')
 
+# ---------------------------------------------------------- launch / MGL (#48)
+# An MGL launch puts HandleUI() into a branch that never calls menu_key_get(),
+# the sole source of every input event, and the MGL's only forward edge needs
+# menustate == MENU_NONE2. Anything that pins menustate elsewhere -- an
+# InfoMessage from one of our own poll ticks -- therefore stalls the load AND
+# the whole UI. See docs/mgl_launch.md.
+
+# 27. include
+u = insert_after(u, '#include "support/dvd/dvd_report.h"',
+    '#include "support/dvd/dvd_launch.h"\n',
+    27, 'support/dvd/dvd_launch.h')
+
+# 28. poll tick, FIRST of the DVD ticks so a released MGL is visible to the
+# notice pumps in the same iteration.
+u = insert_before(u, 'dvd_css_tick();    // deferred "install libdvdcss" popup once launch settles',
+    'dvd_launch_tick();      // MGL watchdog: a stalled launch must not cost a reboot\n',
+    28, 'dvd_launch_tick();')
+
+# 29. say what the mount actually did. UIO_SET_SDSTAT is sent even when the open
+# FAILED, so without this line a blank screen is ambiguous between "never opened"
+# and "opened and produced nothing".
+u = insert_before(u, '\tspi_uio_cmd8(UIO_SET_SDSTAT, (1 << index) | (writable ? 0 : 0x80));',
+    'dvd_report_note_mount_result(name, index, ret ? 1 : 0, (uint64_t)size);   // dvd:report\n',
+    29, 'dvd_report_note_mount_result')
+
 write(uio_path, u)
 print("[integration] user_io.cpp patched (support bundle)")
 

--- a/main/integration/apply_integration.py
+++ b/main/integration/apply_integration.py
@@ -429,6 +429,13 @@ u = insert_before(u, 'dvd_css_tick();    // deferred "install libdvdcss" popup o
     'dvd_launch_tick();      // MGL watchdog: a stalled launch must not cost a reboot\n',
     28, 'dvd_launch_tick();')
 
+# 30. let dvd_phys see slot 0 being taken by something that is not the drive, so
+# an eject only tears down what the drive still owns and the auto-mount does not
+# fire over an image the user asked for (an MGL <file>, say). Observes only.
+u = insert_after(u, '\tdvd_report_note_mount(name);   // dvd:report — observe only',
+    '\tdvd_phys_note_mount(name, index);   // dvd:phys — observe only\n',
+    30, 'dvd_phys_note_mount(name)')
+
 # 29. say what the mount actually did. UIO_SET_SDSTAT is sent even when the open
 # FAILED, so without this line a blank screen is ambiguous between "never opened"
 # and "opened and produced nothing".

--- a/main/support/dvd/dvd_css.cpp
+++ b/main/support/dvd/dvd_css.cpp
@@ -16,6 +16,7 @@
 #include <dlfcn.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <dirent.h>
 #include <scsi/sg.h>
 #include <linux/cdrom.h>
 #include <linux/fs.h>
@@ -368,6 +369,75 @@ static int enumerate_vobs(void)
 	return g_nvobs > 0;
 }
 
+// ---------------------------------------------------------------------------
+// libdvdcss title-key cache
+// ---------------------------------------------------------------------------
+// A key that had to be CRACKED costs minutes; read back from the cache it costs
+// nothing, so this is the difference between "a first play is slow" and "every
+// play is slow". libdvdcss does the caching itself -- all we owe it is a writable
+// directory in DVDCSS_CACHE before dvdcss_open().
+//
+// ⚠ We owed it more than the old two lines gave. mkdir() creates ONE level, and
+// /media/fat/dvdcss only exists if libdvdcss was installed by our own Scripts
+// entry -- css_lib_names also finds it in /media/fat/linux or on the system path,
+// and then the parent is missing, mkdir fails ENOENT, and the return was not
+// checked. libdvdcss then does its own single-level mkdir on the same path, fails
+// the same way, and disables the cache SILENTLY. Every play re-cracked.
+//
+// So: create both levels, prove the directory is writable, and say so in the log
+// either way. `DVDCSS_CACHE` is unset rather than left pointing at somewhere
+// unusable, so the behaviour is at least defined.
+#define CSS_CACHE_ROOT "/media/fat/dvdcss"
+#define CSS_CACHE_DIR  CSS_CACHE_ROOT "/cache"
+
+// How many per-disc entries libdvdcss has stored. Logged either side of key
+// extraction: growing means the cache took, and a non-zero count at open time on a
+// disc that is still slow means it is being written but not read back.
+static int cache_entries(void)
+{
+	DIR *d = opendir(CSS_CACHE_DIR);
+	if (!d) return -1;
+	int n = 0;
+	struct dirent *e;
+	while ((e = readdir(d)) != NULL)
+		if (strcmp(e->d_name, ".") && strcmp(e->d_name, "..")) n++;
+	closedir(d);
+	return n;
+}
+
+static void setup_cache(void)
+{
+	if (mkdir(CSS_CACHE_ROOT, 0755) && errno != EEXIST)
+		css_log("cache: cannot create %s (%s)", CSS_CACHE_ROOT, strerror(errno));
+
+	if (mkdir(CSS_CACHE_DIR, 0755) && errno != EEXIST)
+	{
+		css_log("cache: cannot create %s (%s) -- keys will be re-extracted every play",
+		        CSS_CACHE_DIR, strerror(errno));
+		unsetenv("DVDCSS_CACHE");
+		return;
+	}
+
+	// Writable, not merely present: /media/fat is removable and can be mounted
+	// read-only after an unclean shutdown, which looks identical from mkdir alone.
+	char probe[sizeof(CSS_CACHE_DIR) + 16];
+	snprintf(probe, sizeof(probe), "%s/.wtest", CSS_CACHE_DIR);
+	int fd = open(probe, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+	if (fd < 0)
+	{
+		css_log("cache: %s is not writable (%s) -- keys will be re-extracted every play",
+		        CSS_CACHE_DIR, strerror(errno));
+		unsetenv("DVDCSS_CACHE");
+		return;
+	}
+	close(fd);
+	unlink(probe);
+
+	setenv("DVDCSS_CACHE", CSS_CACHE_DIR, 1);
+	css_log("cache: %s ready, %d entr%s", CSS_CACHE_DIR,
+	        cache_entries(), cache_entries() == 1 ? "y" : "ies");
+}
+
 // Pre-crack each VOB's title key at its start sector (fast cached lookups thereafter).
 // With a drive region set this is instant (ioctl); with none — or an image file with no
 // drive at all — it is a slow crack, so show a bar (it blocks the main loop) with the
@@ -383,7 +453,9 @@ static void crack_title_keys(const char *text)
 		if (p_seek(css, (int)g_vobs[i].start, DVDCSS_SEEK_KEY) >= 0) keyed++;
 	}
 	ProgressMessage();   // clear
-	css_log("%d VOBs, %d title keys (region %s)", g_nvobs, keyed, region_set ? "set" : "NOT set");
+	css_log("%d VOBs, %d title keys (region %s), cache now %d entr%s",
+	        g_nvobs, keyed, region_set ? "set" : "NOT set",
+	        cache_entries(), cache_entries() == 1 ? "y" : "ies");
 	css_pos = -1;
 }
 
@@ -464,8 +536,7 @@ int dvd_css_open(void)
 
 		// Persist keys per disc: a slow crack becomes a one-time cost, and
 		// re-inserting the same disc reads the keys back instantly.
-		mkdir("/media/fat/dvdcss/cache", 0755);
-		setenv("DVDCSS_CACHE", "/media/fat/dvdcss/cache", 1);
+		setup_cache();
 
 		// Default method: fetch each title key from the drive via the CSS ioctls
 		// (instant) when a region is set, falling back to cracking otherwise.
@@ -552,8 +623,7 @@ int dvd_css_open_image(const char *path)
 	if (stat(full, &st) != 0 || st.st_size <= 0) { css_log("image %s: stat(%s) failed", path, full); return 0; }
 
 	// Persist cracked keys per disc (shared with the drive path).
-	mkdir("/media/fat/dvdcss/cache", 0755);
-	setenv("DVDCSS_CACHE", "/media/fat/dvdcss/cache", 1);
+	setup_cache();
 
 	dvdcss_t h = p_open(full);
 	if (!h) { css_log("dvdcss_open(image) FAILED: %s", full); return 0; }

--- a/main/support/dvd/dvd_css.cpp
+++ b/main/support/dvd/dvd_css.cpp
@@ -21,6 +21,7 @@
 #include <linux/fs.h>
 
 #include "dvd_css.h"
+#include "dvd_launch.h"
 #include "../../menu.h"      // ProgressMessage() — on-screen feedback during key crack
 #include "../../file_io.h"   // getFullPath() — resolve MiSTer's storage-relative mount path
 
@@ -488,6 +489,10 @@ int dvd_css_open(void)
 			// the mount runs mid-launch when the menu FSM is in a high state, so a
 			// call here is dropped. Defer it: dvd_css_tick() (from user_io_poll)
 			// re-asserts it until the launch settles to MENU_NONE1 and it shows.
+			// ⚠ And that tick must NOT re-assert while an MGL launch is still
+			// running -- pinning menustate there stalls the load and every input
+			// path on the machine (issue #48). dvd_css_tick() gates on
+			// dvd_launch_ui_busy(); this 8 s window is pushed along, not spent.
 			warn_until = time(NULL) + 8;
 		}
 		raw_fd = open(dev, O_RDONLY | O_CLOEXEC);
@@ -597,13 +602,24 @@ int dvd_css_active(void)
 }
 
 // Called every user_io_poll. Re-asserts the "encrypted disc, install libdvdcss"
-// popup ~once/second until its window closes — InfoMessage no-ops while the
-// launch FSM is busy and renders once menustate settles to idle (core running).
+// popup ~once/second until its window closes, and renders once menustate settles
+// to idle (core running).
+//
+// ⚠ The original comment here claimed "InfoMessage no-ops while the launch FSM is
+// busy". It does not — it PINS menustate = MENU_INFO whenever menustate is idle,
+// which is exactly the state an MGL launch needs to advance out of. That belief
+// cost issue #48: a notice raised from this tick froze the MGL and, with it,
+// every input path on the machine. Hence the dvd_launch_ui_busy() gate, which
+// holds the window open rather than consuming it. See docs/mgl_launch.md.
 void dvd_css_tick(void)
 {
 	if (!warn_until) return;
 	time_t now = time(NULL);
 	if (now >= warn_until) { warn_until = 0; return; }
+
+	// Defer, don't spend: push the window along so the notice still appears
+	// once the launch settles.
+	if (dvd_launch_ui_busy()) { warn_until = now + 2; return; }
 
 	static time_t last = 0;
 	if (now != last)   // at most once per second — the 2 s InfoMessage timeout bridges the gap

--- a/main/support/dvd/dvd_hdmi_audio.cpp
+++ b/main/support/dvd/dvd_hdmi_audio.cpp
@@ -12,6 +12,7 @@
 #include "../../hardware.h"
 #include "../../menu.h"
 #include "dvd_hdmi_audio.h"
+#include "dvd_launch.h"
 
 // ---------------------------------------------------------------------------
 // EDID: does the sink actually accept a compressed bitstream?
@@ -102,11 +103,15 @@ static int sink_supports_bitstream(void)
 static const char *stage_msg = 0;
 static time_t      show_until = 0;
 
-// ⚠ InfoMessage no-ops unless the menu FSM is idle, and the user changes Audio
-// Out from INSIDE the OSD - so a single call at the transition is dropped every
-// time. dvd_css hit this exact trap with its libdvdcss popup and solved it by
-// re-asserting once a second until the launch settles; do the same. The log file
-// is the reliable channel regardless of menu state.
+// ⚠ InfoMessage renders nothing unless the menu FSM is idle, and the user changes
+// Audio Out from INSIDE the OSD - so a single call at the transition is dropped
+// every time. dvd_css hit this exact trap with its libdvdcss popup and solved it
+// by re-asserting once a second until the launch settles; do the same. The log
+// file is the reliable channel regardless of menu state.
+//
+// ⚠ "Dropped" is the WRONG word for the idle case and that mistake cost issue #48:
+// when menustate IS idle, InfoMessage does not no-op, it PINS menustate = MENU_INFO.
+// See report_pump() below.
 static void report(const char *msg)
 {
 	if (stage_msg == msg) return;      // only on transition
@@ -117,11 +122,17 @@ static void report(const char *msg)
 	if (f) { fprintf(f, "%s\n", msg); fclose(f); }
 }
 
+// ⚠ InfoMessage() PINS menustate = MENU_INFO. An MGL launch advances only out of
+// MENU_NONE2, and while it has not finished HandleUI() never calls menu_key_get()
+// — the sole source of every input event. So a notice raised from this tick froze
+// both the load and the whole UI: issue #48. Defer while the launch is running,
+// pushing the window along rather than spending it. See docs/mgl_launch.md.
 static void report_pump(void)
 {
 	if (!show_until || !stage_msg) return;
 	time_t now = time(NULL);
 	if (now >= show_until) { show_until = 0; return; }
+	if (dvd_launch_ui_busy()) { show_until = now + 2; return; }
 
 	static time_t last = 0;
 	if (now != last)                   // 2 s timeout bridges the 1 s cadence

--- a/main/support/dvd/dvd_launch.cpp
+++ b/main/support/dvd/dvd_launch.cpp
@@ -105,9 +105,13 @@ void dvd_launch_tick(void)
 		// (Info() does not re-enter HandleUI; InfoMessage() does, but none of our
 		// ticks are running yet) -- which is precisely why this is logged rather
 		// than assumed. A "TIMER NOT ARMED" line here is that hazard, live.
-		launch_log("DVD_LAUNCH: MGL pending -- delay=%ds, %ld ms remaining%s",
+		// state is the tell. 0 means the timer has not been consulted yet and the
+		// wait is genuinely ahead; anything higher means the FSM was already
+		// advanced during user_io_init(), before the timer existed -- which is a
+		// completely different bug from a timer that expired early.
+		launch_log("DVD_LAUNCH: MGL pending -- delay=%ds, %ld ms remaining, state=%d%s",
 		           mgl->item[mgl->current].delay,
-		           (long)(mgl->timer - GetTimer(0)),
+		           (long)(mgl->timer - GetTimer(0)), mgl->state,
 		           mgl->timer ? "" : "  (TIMER NOT ARMED -- fires immediately)");
 		return;
 	}

--- a/main/support/dvd/dvd_launch.cpp
+++ b/main/support/dvd/dvd_launch.cpp
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #include "../../user_io.h"
+#include "../../hardware.h"   // GetTimer() — the same clock the MGL timer is set from
 #include "../../menu.h"
 #include "../arcade/mra_loader.h"
 #include "dvd_launch.h"
@@ -76,6 +77,12 @@ void dvd_launch_tick(void)
 
 	if (mgl->done)
 	{
+		// Say how long it actually took, once. The delay is the whole reason an
+		// MGL can name a file on a share that is not awake yet, so "did it wait"
+		// should be answerable from a log rather than a stopwatch.
+		if (pending_since)
+			launch_log("DVD_LAUNCH: MGL finished after ~%ds", (int)(now - pending_since));
+
 		// Re-arm for a hypothetical second MGL in the same process. `fired`
 		// deliberately does NOT reset: once the watchdog has spoken, saying it
 		// again adds nothing and the log stays readable.
@@ -83,7 +90,27 @@ void dvd_launch_tick(void)
 		return;
 	}
 
-	if (!pending_since) { pending_since = now; return; }
+	if (!pending_since)
+	{
+		pending_since = now;
+
+		// What the MGL asked for, against what is left to wait. `timer` is an
+		// absolute deadline on the same millisecond clock GetTimer(0) reads, so
+		// this says whether the delay was armed at all.
+		//
+		// ⚠ mgl_parse() memsets the struct, so an UNARMED timer is 0 -- and
+		// CheckTimer(0) returns TRUE. Anything that runs HandleUI() between
+		// mgl_parse() and the arming at the end of user_io_init() therefore fires
+		// the MGL with no delay whatsoever. Nothing on the normal path does today
+		// (Info() does not re-enter HandleUI; InfoMessage() does, but none of our
+		// ticks are running yet) -- which is precisely why this is logged rather
+		// than assumed. A "TIMER NOT ARMED" line here is that hazard, live.
+		launch_log("DVD_LAUNCH: MGL pending -- delay=%ds, %ld ms remaining%s",
+		           mgl->item[mgl->current].delay,
+		           (long)(mgl->timer - GetTimer(0)),
+		           mgl->timer ? "" : "  (TIMER NOT ARMED -- fires immediately)");
+		return;
+	}
 	if (gap > 1) pending_since += gap;              // discount the blocked span
 	if (now - pending_since < DVD_MGL_WD_S) return;
 

--- a/main/support/dvd/dvd_launch.cpp
+++ b/main/support/dvd/dvd_launch.cpp
@@ -5,6 +5,7 @@
 #include <time.h>
 
 #include "../../user_io.h"
+#include "../../menu.h"
 #include "../arcade/mra_loader.h"
 #include "dvd_launch.h"
 
@@ -67,4 +68,12 @@ void dvd_launch_tick(void)
 	}
 	mgl->done = 1;
 	pending_since = 0;
+
+	// Leave the menu FSM somewhere sane. Without this the stall is usually
+	// abandoned in MENU_GENERIC_MAIN2 with the OSD disabled (an MGL opens the
+	// menu invisibly), so the user's first Menu press is spent closing a menu
+	// they cannot see. MenuHide() re-enters HandleUI once -- the same thing
+	// InfoMessage does, and by now mgl->done is 1, so it takes the ordinary
+	// branch.
+	MenuHide();
 }

--- a/main/support/dvd/dvd_launch.cpp
+++ b/main/support/dvd/dvd_launch.cpp
@@ -1,0 +1,70 @@
+// dvd_launch.cpp — see dvd_launch.h.
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <time.h>
+
+#include "../../user_io.h"
+#include "../arcade/mra_loader.h"
+#include "dvd_launch.h"
+
+#define DVD_LAUNCH_LOG "/tmp/dvd_report.log"
+
+// The MGL state machine has no timeout of its own: states 1 and 2 are advanced
+// only by the menustate FSM, so every way that FSM can fail to reach the right
+// case is an unbounded stall with all input dead. 20 s is far longer than any
+// legitimate MGL (the delay= attribute is seconds and the dispatch itself takes
+// a handful of HandleUI iterations), and short enough that a user reaches for
+// the OSD rather than the power switch.
+#define DVD_MGL_WD_S 20
+
+static void launch_log(const char *fmt, ...)
+{
+	va_list ap;
+	FILE *f = fopen(DVD_LAUNCH_LOG, "a");
+	if (!f) return;
+	va_start(ap, fmt);
+	vfprintf(f, fmt, ap);
+	va_end(ap);
+	fprintf(f, "\n");
+	fclose(f);
+}
+
+int dvd_launch_ui_busy(void)
+{
+	return !mgl_get()->done;
+}
+
+void dvd_launch_tick(void)
+{
+	static time_t pending_since = 0;
+	static int    fired         = 0;
+
+	mgl_struct *mgl = mgl_get();
+
+	if (mgl->done)
+	{
+		// Re-arm for a hypothetical second MGL in the same process. `fired`
+		// deliberately does NOT reset: once the watchdog has spoken, saying it
+		// again adds nothing and the log stays readable.
+		pending_since = 0;
+		return;
+	}
+
+	time_t now = time(NULL);
+	if (!pending_since) { pending_since = now; return; }
+	if (now - pending_since < DVD_MGL_WD_S) return;
+
+	// Stalled. Give the user their input back. The load is lost either way;
+	// what this buys is that the OSD, the gamepad and the menu key come alive
+	// so the file can be picked by hand instead of power-cycling the board.
+	if (!fired)
+	{
+		fired = 1;
+		launch_log("DVD_LAUNCH: MGL stalled %ds in state=%d current=%d/%d -- releasing the UI",
+		           (int)(now - pending_since), mgl->state, mgl->current, mgl->count);
+		printf("DVD_LAUNCH: MGL stalled in state %d, releasing the UI\n", mgl->state);
+	}
+	mgl->done = 1;
+	pending_since = 0;
+}

--- a/main/support/dvd/dvd_launch.cpp
+++ b/main/support/dvd/dvd_launch.cpp
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <time.h>
+#include <string.h>
 
 #include "../../user_io.h"
 #include "../../menu.h"
@@ -29,6 +30,23 @@ static void launch_log(const char *fmt, ...)
 	va_end(ap);
 	fprintf(f, "\n");
 	fclose(f);
+}
+
+void dvd_launch_note_status(const char *opt, unsigned value)
+{
+	if (!opt) return;
+
+	// Only the reset bit, and only for our core. Every other status write is an
+	// ordinary OSD option change and would bury the one line that matters.
+	// "[0]" is what dvd_phys and the framework pass; the generic menu hands the
+	// option string past its type letter, so an "R0,Reset" row arrives as
+	// "0,Reset".
+	int is_bit0 = !strncmp(opt, "[0]", 3) ||
+	              (opt[0] == '0' && (opt[1] == 0 || opt[1] == ','));
+	if (!is_bit0 || !is_dvd()) return;
+
+	launch_log("DVD_LAUNCH: status[0] <= %u (opt \"%s\", mgl done=%d)",
+	           value, opt, mgl_get()->done);
 }
 
 int dvd_launch_ui_busy(void)

--- a/main/support/dvd/dvd_launch.cpp
+++ b/main/support/dvd/dvd_launch.cpp
@@ -39,9 +39,22 @@ int dvd_launch_ui_busy(void)
 void dvd_launch_tick(void)
 {
 	static time_t pending_since = 0;
+	static time_t last_tick     = 0;
 	static int    fired         = 0;
 
 	mgl_struct *mgl = mgl_get();
+	time_t now = time(NULL);
+
+	// ⚠ Measure only time the poll loop was actually TURNING. Several things
+	// legitimately block user_io_poll() for minutes -- a CSS title-key crack is
+	// the one that bites here: dvd_phys_tick() mounts an optical disc on the very
+	// first poll, long before a delay=N MGL fires, and crack_title_keys() then
+	// runs synchronously for minutes on an uncached disc. Wall-clock timing would
+	// read that as a stall and kill a perfectly healthy pending MGL, losing the
+	// user's auto-load to a fix meant to protect it. A gap between ticks means we
+	// were not running, so it cannot be time the MGL spent stuck.
+	time_t gap = (last_tick && now > last_tick) ? (now - last_tick) : 0;
+	last_tick = now;
 
 	if (mgl->done)
 	{
@@ -52,8 +65,8 @@ void dvd_launch_tick(void)
 		return;
 	}
 
-	time_t now = time(NULL);
 	if (!pending_since) { pending_since = now; return; }
+	if (gap > 1) pending_since += gap;              // discount the blocked span
 	if (now - pending_since < DVD_MGL_WD_S) return;
 
 	// Stalled. Give the user their input back. The load is lost either way;

--- a/main/support/dvd/dvd_launch.h
+++ b/main/support/dvd/dvd_launch.h
@@ -1,0 +1,33 @@
+// dvd_launch.h — what the MiSTer launch sequence is doing, for the DVD overlay.
+//
+// Exists because of issue #48 ("MGL loading not working"): an MGL launch puts
+// HandleUI() into a branch that never calls menu_key_get(), which is the SOLE
+// source of every input event -- keyboard menu key, gamepad menu key, the
+// physical OSD button and the core's own virtual one. So for as long as the MGL
+// state machine has not finished, the MiSTer accepts NO input at all, and the
+// MGL's only forward edge (menu.cpp, "menustate == MENU_NONE2 && mgl->state==1")
+// is blocked by anything that moves menustate elsewhere.
+//
+// InfoMessage() moves it: it pins menustate = MENU_INFO. Two DVD overlay pumps
+// call InfoMessage once a second from user_io_poll(), BEFORE HandleUI runs, so
+// an MGL firing inside one of those windows stalls -- nothing mounts and nothing
+// responds. See docs/mgl_launch.md.
+//
+// Two services here:
+//   dvd_launch_ui_busy()  - "do not raise an on-screen notice right now".
+//   dvd_launch_tick()     - a watchdog so a stalled MGL costs a failed load,
+//                           never a reboot.
+
+#ifndef DVD_LAUNCH_H
+#define DVD_LAUNCH_H
+
+// 1 while an MGL launch is still running. Any overlay code that would call
+// Info()/InfoMessage()/ProgressMessage() from a user_io_poll() tick MUST check
+// this first and defer -- see the pumps in dvd_css.cpp and dvd_hdmi_audio.cpp
+// for the pattern (hold the window open, do not consume it).
+int dvd_launch_ui_busy(void);
+
+// Called once per user_io_poll(). Bounds how long an MGL may sit unfinished.
+void dvd_launch_tick(void);
+
+#endif

--- a/main/support/dvd/dvd_launch.h
+++ b/main/support/dvd/dvd_launch.h
@@ -30,4 +30,13 @@ int dvd_launch_ui_busy(void);
 // Called once per user_io_poll(). Bounds how long an MGL may sit unfinished.
 void dvd_launch_tick(void);
 
+// Call from user_io_status_set() with what it was asked to write. Observes only.
+//
+// status[0] is the core's reset. Both the OSD "Reset" row and the disc-eject
+// teardown go through it, and when neither appears to work there are exactly two
+// possibilities -- Main never dispatched, or it dispatched and the core ignored it
+// -- which are fixed in completely different places. The console cannot be
+// captured on most setups, so this lands in /tmp/dvd_report.log instead.
+void dvd_launch_note_status(const char *opt, unsigned value);
+
 #endif

--- a/main/support/dvd/dvd_phys.cpp
+++ b/main/support/dvd/dvd_phys.cpp
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
+#include <sys/time.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <time.h>
@@ -41,6 +42,36 @@ static time_t reset_release_at = 0; // >0 while an eject reset pulse is being he
 static int    foreign = 0;
 static int    prev_ready = 0;      // the drive reported a disc ready on the last scan
 static int    probed_not_video = 0; // this disc was probed and is not DVD-Video
+
+// ---------------------------------------------------------------------------
+// Scan backoff — the drive probe runs on the thread that feeds the decoder
+// ---------------------------------------------------------------------------
+// open_ready_drive() is BLOCKING I/O on the same thread as user_io_poll()'s SD
+// block service, so however long it takes is time the core gets no data. With a
+// settled drive that is microseconds and nobody notices. With an OPEN TRAY it is
+// not: the kernel's sr driver answers TEST UNIT READY with a media-change unit
+// attention and retries, which can run to hundreds of milliseconds -- every
+// second, for as long as the tray stays open, because the state never settles.
+//
+// Field report that produced this: an MGL-loaded .mpg played fine, and ejecting an
+// unrelated disc froze the picture for good while the OSD kept working. Main was
+// alive; the core was being starved a large fraction of every second.
+//
+// So the probe is now self-limiting. A slow scan backs the period off (doubling,
+// capped), a fast one restores it. Worst case is one hiccup per DVD_PHYS_SCAN_MAX_S
+// instead of one per second, and a disc insertion is still noticed within that.
+#define DVD_PHYS_SLOW_MS      50   // above this, the probe is disturbing playback
+#define DVD_PHYS_SCAN_MAX_S   10   // hard cap on the backoff
+
+static int    scan_period = DVD_PHYS_SCAN_PERIOD_S;
+static int    slow_logged = 0;
+
+static unsigned now_ms(void)
+{
+	struct timeval tv;
+	gettimeofday(&tv, 0);
+	return (unsigned)(tv.tv_sec * 1000u + tv.tv_usec / 1000u);
+}
 
 // Shares /tmp/dvd_report.log with dvd_report.cpp -- one file to ask a reporter for.
 // Only decisions get a line, never the 1 Hz scan, so the log stays readable across
@@ -127,11 +158,38 @@ void dvd_phys_tick(void)
 		reset_release_at = 0;
 	}
 
-	if (now - last_scan < DVD_PHYS_SCAN_PERIOD_S) return;
+	// Only watching for an INSERTION while somebody else owns the slot, so there
+	// is nothing to be quick about; a disc going in is noticed a few seconds later
+	// and nothing else changes.
+	int period = foreign ? 5 : scan_period;
+	if (period < scan_period) period = scan_period;
+	if (now - last_scan < period) return;
 	last_scan = now;
 
+	unsigned t0 = now_ms();
 	char dev[16] = {0};
 	int fd = open_ready_drive(dev, sizeof(dev));
+	unsigned took = now_ms() - t0;
+
+	if (took >= DVD_PHYS_SLOW_MS)
+	{
+		int was = scan_period;
+		scan_period *= 2;
+		if (scan_period > DVD_PHYS_SCAN_MAX_S) scan_period = DVD_PHYS_SCAN_MAX_S;
+		if (!slow_logged || scan_period != was)
+		{
+			slow_logged = 1;
+			phys_log("DVD_PHYS: drive probe took %u ms (blocking the poll loop) -- "
+			         "backing the scan off to %ds", took, scan_period);
+		}
+	}
+	else if (scan_period != DVD_PHYS_SCAN_PERIOD_S)
+	{
+		scan_period = DVD_PHYS_SCAN_PERIOD_S;
+		slow_logged = 0;
+		phys_log("DVD_PHYS: drive probe is fast again (%u ms) -- back to %ds",
+		         took, scan_period);
+	}
 
 	if (fd < 0)
 	{

--- a/main/support/dvd/dvd_phys.cpp
+++ b/main/support/dvd/dvd_phys.cpp
@@ -17,6 +17,7 @@
 #include "dvd_phys.h"
 #include "dvd_detect.h"
 #include "dvd_css.h"
+#include "dvd_launch.h"
 #include "../../user_io.h"   // user_io_file_mount(), is_dvd()
 
 // Poll cadence: a full SCSI probe every tick would hammer the drive, so gate the
@@ -24,14 +25,31 @@
 // spins up, so a freshly inserted disc is simply picked up on a later tick.
 #define DVD_PHYS_SCAN_PERIOD_S 1
 
-static int    mounted = 0;         // 1 while a DVD-Video disc is mounted into the core
+static int    mounted = 0;         // 1 while WE own slot 0 with the optical drive
 static char   mounted_dev[16] = {0};  // its /dev/srN, exported by dvd_phys_device()
 static time_t last_scan = 0;
 static time_t reset_release_at = 0; // >0 while an eject reset pulse is being held
 
+// Slot 0 is shared with every image the user can load, and the drive is only one
+// claimant. `foreign` means somebody else holds it: do not auto-mount over them,
+// and do not treat their image as ours to tear down when a disc is removed.
+//
+// Cleared on a disc INSERTION edge, not on a timer -- putting a disc in is a
+// deliberate act and the auto-mount is the only way to play one, so an insertion
+// still wins. A disc merely SITTING in the drive never does.
+static int    foreign = 0;
+static int    prev_ready = 0;      // the drive reported a disc ready on the last scan
+static int    probed_not_video = 0; // this disc was probed and is not DVD-Video
+
 // Find the first /dev/srN that currently holds a disc reported ready. Fills `out`
 // (size >= 16) and returns an fd opened O_RDONLY|O_NONBLOCK, or -1. Mirrors the
 // scan in dvd_css.cpp so the two agree on which drive is "the" drive.
+//
+// The one seam for main/tests/dvd_phys_test.cpp, which #includes this file and
+// supplies its own: everything else the tick touches is an ordinary extern the
+// test can stub at link time, but a real /dev/srN cannot be faked (a regular file
+// opens fine and then fails CDROM_DRIVE_STATUS). Nothing else is conditional.
+#ifndef DVD_PHYS_TEST
 static int open_ready_drive(char *out, int out_sz)
 {
 	for (int i = 0; i < 8; i++)
@@ -49,6 +67,32 @@ static int open_ready_drive(char *out, int out_sz)
 		close(fd);
 	}
 	return -1;
+}
+#endif
+
+void dvd_phys_note_mount(const char *path, unsigned char index)
+{
+	if (!path || index != 0) return;   // the drive only ever binds slot 0
+
+	if (!path[0])
+	{
+		// An unmount. If it is ours, dvd_phys_tick() is the one doing it and has
+		// already cleared `mounted`; if it is somebody else's, the slot is simply
+		// free again and the next insertion may claim it.
+		foreign = 0;
+		return;
+	}
+
+	if (!strcmp(path, DVD_PHYS_SENTINEL)) { foreign = 0; return; }   // that is us
+
+	// A real file went into the slot. Whatever we thought we owned, we do not own
+	// it any more -- user_io_file_mount() has already called dvd_css_close() on
+	// our source. Forgetting `mounted` here is what stops a later eject from
+	// unmounting the user's file and resetting the core out from under it.
+	if (mounted) printf("DVD_PHYS: slot taken by %s, releasing the drive\n", path);
+	mounted = 0;
+	mounted_dev[0] = 0;
+	foreign = 1;
 }
 
 void dvd_phys_tick(void)
@@ -73,9 +117,17 @@ void dvd_phys_tick(void)
 
 	if (fd < 0)
 	{
-		// No ready disc. If we had one mounted, the disc was ejected/removed:
-		// tear the slot down and soft-reset the core back to the idle logo so a
-		// gone disc doesn't leave a frozen last frame.
+		prev_ready = 0;
+
+		// No ready disc. If WE still own the slot, the disc was ejected/removed:
+		// tear it down and soft-reset the core back to the idle logo so a gone
+		// disc doesn't leave a frozen last frame.
+		//
+		// ⚠ Only if we still own it. `mounted` used to mean "we mounted a disc at
+		// some point", so ejecting a disc nobody was watching unmounted whatever
+		// the user had loaded since -- freezing playback (the file handle is gone)
+		// and resetting the core. dvd_phys_note_mount() now clears `mounted` the
+		// moment another image takes the slot.
 		if (mounted)
 		{
 			printf("DVD_PHYS: disc removed, unmounting + reset to idle\n");
@@ -89,13 +141,40 @@ void dvd_phys_tick(void)
 		return;
 	}
 
-	if (mounted) { close(fd); return; }   // already playing this disc
+	// An insertion edge clears the "somebody else has the slot" latch: putting a
+	// disc in is a deliberate act, and the auto-mount is the only way to play one.
+	// A disc that was ALREADY sitting in the drive does not get to take the slot
+	// back from an image the user asked for. Drive READINESS is the edge, not the
+	// DVD-Video verdict, so this costs one ioctl and reads nothing off the disc.
+	if (!prev_ready) { foreign = 0; probed_not_video = 0; }
+	prev_ready = 1;
 
-	// A disc is ready and nothing is mounted yet. Only mount DVD-Video discs —
-	// leave audio CDs / data discs alone (they are not ours to play).
+	// ⚠ Every reason not to mount is checked BEFORE dvd_video_probe(), which is
+	// the first thing here that actually reads the disc. "Do no disc operations
+	// when we were launched to play a file" has to mean no reads, not just no
+	// mount -- otherwise a spinning drive is probed once a second for the whole
+	// session, and on an encrypted disc the mount that follows costs minutes of
+	// key extraction the user never asked for.
+	//   mounted  - already playing this disc
+	//   ui_busy  - an MGL launch is pending; its own <file> lands `delay` seconds
+	//              from now and would replace whatever we mounted anyway.
+	//              Deferring costs nothing: if no file arrives, the launch settles
+	//              and the next scan mounts the disc a second later.
+	//   foreign  - an image the user chose is in the slot
+	//   probed_not_video - an audio CD or data disc; the verdict cannot change
+	//              without an eject, so probe it once per insertion, not once a
+	//              second for as long as it sits there
+	if (mounted || dvd_launch_ui_busy() || foreign || probed_not_video)
+	{
+		close(fd);
+		return;
+	}
+
+	// Only mount DVD-Video discs — leave audio CDs / data discs alone (they are
+	// not ours to play).
 	int is_dvd_video = dvd_video_probe(fd);
 	close(fd);
-	if (!is_dvd_video) return;
+	if (!is_dvd_video) { probed_not_video = 1; return; }
 
 	printf("DVD_PHYS: DVD-Video on %s, mounting\n", dev);
 	// The sentinel routes user_io_file_mount() to the CSS-decrypted drive path

--- a/main/support/dvd/dvd_phys.cpp
+++ b/main/support/dvd/dvd_phys.cpp
@@ -6,6 +6,7 @@
 // dvd_detect.*. This file adds only "when to mount / unmount".
 
 #include <stdio.h>
+#include <stdarg.h>
 #include <string.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -40,6 +41,23 @@ static time_t reset_release_at = 0; // >0 while an eject reset pulse is being he
 static int    foreign = 0;
 static int    prev_ready = 0;      // the drive reported a disc ready on the last scan
 static int    probed_not_video = 0; // this disc was probed and is not DVD-Video
+
+// Shares /tmp/dvd_report.log with dvd_report.cpp -- one file to ask a reporter for.
+// Only decisions get a line, never the 1 Hz scan, so the log stays readable across
+// a whole session. This exists because "eject froze playback" has two completely
+// different causes depending on WHICH image was playing, and the console is not
+// something most users can capture.
+static void phys_log(const char *fmt, ...)
+{
+	va_list ap;
+	FILE *f = fopen("/tmp/dvd_report.log", "a");
+	if (!f) return;
+	va_start(ap, fmt);
+	vfprintf(f, fmt, ap);
+	va_end(ap);
+	fprintf(f, "\n");
+	fclose(f);
+}
 
 // Find the first /dev/srN that currently holds a disc reported ready. Fills `out`
 // (size >= 16) and returns an fd opened O_RDONLY|O_NONBLOCK, or -1. Mirrors the
@@ -89,7 +107,7 @@ void dvd_phys_note_mount(const char *path, unsigned char index)
 	// it any more -- user_io_file_mount() has already called dvd_css_close() on
 	// our source. Forgetting `mounted` here is what stops a later eject from
 	// unmounting the user's file and resetting the core out from under it.
-	if (mounted) printf("DVD_PHYS: slot taken by %s, releasing the drive\n", path);
+	if (mounted) phys_log("DVD_PHYS: slot taken by %s -- releasing the drive", path);
 	mounted = 0;
 	mounted_dev[0] = 0;
 	foreign = 1;
@@ -117,6 +135,7 @@ void dvd_phys_tick(void)
 
 	if (fd < 0)
 	{
+		int was_ready = prev_ready;
 		prev_ready = 0;
 
 		// No ready disc. If WE still own the slot, the disc was ejected/removed:
@@ -128,16 +147,23 @@ void dvd_phys_tick(void)
 		// the user had loaded since -- freezing playback (the file handle is gone)
 		// and resetting the core. dvd_phys_note_mount() now clears `mounted` the
 		// moment another image takes the slot.
-		if (mounted)
+		if (!mounted)
 		{
-			printf("DVD_PHYS: disc removed, unmounting + reset to idle\n");
-			user_io_file_mount("", 0);
-			dvd_css_close();
-			mounted_dev[0] = 0;
-			user_io_status_set("[0]", 1);   // OSD-reset: unload + VM reset -> idle logo
-			reset_release_at = now + 1;      // release after ~1 s (see the tick top)
-			mounted = 0;
+			// Nothing of ours to tear down. Say so once per removal: if playback
+			// froze at this moment anyway, this line proves it was not us.
+			if (was_ready)
+				phys_log("DVD_PHYS: disc removed, but the drive does not own slot 0 "
+				         "(foreign=%d) -- leaving playback alone", foreign);
+			return;
 		}
+
+		phys_log("DVD_PHYS: disc removed while playing it -- unmount + reset to idle");
+		user_io_file_mount("", 0);
+		dvd_css_close();
+		mounted_dev[0] = 0;
+		user_io_status_set("[0]", 1);   // OSD-reset: unload + VM reset -> idle logo
+		reset_release_at = now + 1;      // release after ~1 s (see the tick top)
+		mounted = 0;
 		return;
 	}
 
@@ -176,7 +202,7 @@ void dvd_phys_tick(void)
 	close(fd);
 	if (!is_dvd_video) { probed_not_video = 1; return; }
 
-	printf("DVD_PHYS: DVD-Video on %s, mounting\n", dev);
+	phys_log("DVD_PHYS: DVD-Video on %s -- mounting", dev);
 	// The sentinel routes user_io_file_mount() to the CSS-decrypted drive path
 	// (see the SD_TYPE_DVDCSS handling in user_io.cpp). dvd_css_open() inside it
 	// re-scans for the drive and runs the CSS handshake; a failure there (no

--- a/main/support/dvd/dvd_phys.cpp
+++ b/main/support/dvd/dvd_phys.cpp
@@ -258,7 +258,16 @@ void dvd_phys_tick(void)
 	// not ours to play).
 	int is_dvd_video = dvd_video_probe(fd);
 	close(fd);
-	if (!is_dvd_video) { probed_not_video = 1; return; }
+	if (!is_dvd_video)
+	{
+		// Say so once per insertion. Without this, "I put a disc in and nothing
+		// happened" has no record at all, and the two explanations -- we rejected
+		// it, or we never saw it -- look identical from the outside.
+		probed_not_video = 1;
+		phys_log("DVD_PHYS: disc on %s is not DVD-Video (no ISO9660 VIDEO_TS) "
+		         "-- not mounting", dev);
+		return;
+	}
 
 	phys_log("DVD_PHYS: DVD-Video on %s -- mounting", dev);
 	// The sentinel routes user_io_file_mount() to the CSS-decrypted drive path

--- a/main/support/dvd/dvd_phys.h
+++ b/main/support/dvd/dvd_phys.h
@@ -22,9 +22,30 @@
 // Call every user_io_poll (only meaningful while the DVD core is loaded — it
 // self-gates on is_dvd()). Debounced drive scan:
 //   - DVD-Video disc appears  -> user_io_file_mount(DVD_PHYS_SENTINEL, 0)
-//   - disc removed while mounted -> user_io_file_mount("", 0) + dvd_css_close()
+//   - disc removed while WE own the slot -> user_io_file_mount("", 0) + dvd_css_close()
 // No-op on non-DVD cores and while nothing changes.
+//
+// ⚠ "while WE own the slot" is load-bearing and was not always true. The drive
+// shares slot 0 with every image the user can load, so an auto-mounted disc that
+// is later replaced by a file must be FORGOTTEN, not remembered: otherwise
+// ejecting a disc nobody is watching tears down the file that IS playing and
+// resets the core. See dvd_phys_note_mount().
 void dvd_phys_tick(void);
+
+// Call from user_io_file_mount() with the path and slot it was handed, so this
+// module can see slot 0 being taken by something that is not the drive. Slots
+// other than 0 are ignored -- the drive only ever binds slot 0, and the core
+// declares no other file entry, but Main mounts boot*.vhd across slots 0-3 at
+// init and this module must not read one of those as a claim on its slot.
+//
+// Two things depend on it:
+//   - an eject only tears down and resets when the drive still owns the slot;
+//   - the auto-mount does not fire over an image the user asked for, which is
+//     what an MGL launch does (its <file> mount lands `delay` seconds after the
+//     core comes up, so without this the drive would win the race, crack keys
+//     for minutes, and then be replaced by the file anyway).
+// Observes only.
+void dvd_phys_note_mount(const char *path, unsigned char index);
 
 // The /dev/srN node of the disc currently mounted by this module, or NULL when
 // nothing is mounted. Exported for dvd_report.cpp, which hands it to

--- a/main/support/dvd/dvd_report.cpp
+++ b/main/support/dvd/dvd_report.cpp
@@ -159,6 +159,16 @@ void dvd_report_note_mount(const char *path)
 	rep_log("DVD_REPORT: mount hook: %s -> %s", path, mounted_path);
 }
 
+void dvd_report_note_mount_result(const char *path, int index, int ok, uint64_t size)
+{
+	rep_log("DVD_REPORT: mount result: slot %d %s size=%llu path=%s",
+	        index, ok ? "OK" : "FAILED", (unsigned long long)size,
+	        (path && path[0]) ? path : "(eject)");
+	if (!ok || !size)
+		rep_log("DVD_REPORT:   ^ the core is still told a disc arrived (UIO_SET_SDSTAT "
+		        "is sent regardless) -- expect no picture");
+}
+
 static const char *find_source(void)
 {
 	// A physical disc first: dvd_phys owns the drive and its node is what the

--- a/main/support/dvd/dvd_report.h
+++ b/main/support/dvd/dvd_report.h
@@ -44,4 +44,13 @@ void dvd_report_tick(void);
 // Observes only; the empty string (an unmount) clears it.
 void dvd_report_note_mount(const char *path);
 
+// Call from user_io_file_mount() just before it notifies the core, with what the
+// mount actually achieved. Purely a log line, and it earns its keep: Main sends
+// UIO_SET_SDSTAT even when the open FAILED (with size 0), and the core cannot
+// tell that apart from a real mount by looking at the pulse. When a load produces
+// a blank screen, this line is the difference between "the file never opened" and
+// "the file opened and the core did nothing with it" -- which are fixed in
+// completely different places. Issue #48; see docs/mgl_launch.md.
+void dvd_report_note_mount_result(const char *path, int index, int ok, uint64_t size);
+
 #endif

--- a/main/tests/dvd_phys_test.cpp
+++ b/main/tests/dvd_phys_test.cpp
@@ -1,0 +1,169 @@
+// dvd_phys_test.cpp — the slot-ownership rules for the optical drive.
+//
+// dvd_phys shares slot 0 with every image the user can load, and it got that
+// wrong twice in one field report (an MGL launch with a disc in the drive):
+//
+//   - it auto-mounted the disc on the first poll, so a .mpg named by an MGL
+//     waited minutes for CSS key extraction nobody asked for, on a disc that was
+//     then replaced by the file anyway;
+//   - `mounted` meant "we mounted a disc at some point", not "we still own the
+//     slot", so ejecting a disc nobody was watching unmounted the file that WAS
+//     playing -- freezing it -- and reset the core.
+//
+// Those are five interacting flags (mounted / foreign / prev_ready /
+// probed_not_video / the launch gate) over a handful of discrete events, which is
+// precisely the shape that regresses without anyone noticing. This runs on the
+// host: build with main/tests/run_tests.sh.
+//
+// MEASURED against the pre-fix module (no foreign/ui_busy/probe gating, `mounted`
+// sticky) -- both field symptoms reproduce:
+//   [1] disc reads while the MGL is pending   1  (expect 0)   FAIL  } "waits for key
+//   [1] mounts while the MGL is pending       1  (expect 0)   FAIL  }  extraction first"
+//   [3] unmounts on eject                     1  (expect 0)   FAIL  } "playback freezes
+//   [3] core resets on eject                  1  (expect 0)   FAIL  }  when the disc is out"
+//   [7] disc reads over six scans             6  (expect 1)   FAIL
+// [4]-[6] pass either way: they are the controls that stop the fix over-reaching,
+// because every one of these bugs is trivially "fixed" by never mounting a disc.
+//
+// The module is #included rather than linked so the drive scan can be replaced;
+// everything else is stubbed at link time. See the DVD_PHYS_TEST seam in
+// dvd_phys.cpp -- it is the only conditional line in the module.
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "dvd_phys.h"      // staged on the include path by run_tests.sh
+
+// ---------------------------------------------------------------- fake world
+static int  fake_disc_ready   = 0;   // the drive reports a disc ready
+static int  fake_disc_is_dvd  = 1;   // ...and it is DVD-Video
+static int  fake_launch_busy  = 0;   // an MGL launch is pending
+static int  probe_calls       = 0;   // how often we READ the disc
+static int  mount_calls       = 0;
+static int  reset_asserts     = 0;
+static char last_mount[256]   = {0};
+
+#define DVD_PHYS_TEST 1
+static int open_ready_drive(char *out, int out_sz)
+{
+    if (!fake_disc_ready) return -1;
+    if (out && out_sz > 0) { strncpy(out, "/dev/sr0", out_sz - 1); out[out_sz-1] = 0; }
+    return 99;                        // a token fd; close(99) is a harmless EBADF
+}
+
+// ------------------------------------------------------------------- stubs
+// Defined BEFORE the module is included, so they are in scope by the time its own
+// "../../user_io.h" (staged empty on purpose) would have declared them. That is
+// why there is no second copy of Main's API here to drift out of date.
+char is_dvd() { return 1; }
+int  dvd_video_probe(int) { probe_calls++; return fake_disc_is_dvd; }
+void dvd_css_close(void) {}
+int  dvd_launch_ui_busy(void) { return fake_launch_busy; }
+
+int user_io_file_mount(const char *name, unsigned char index = 0, char = 0, int = 0)
+{
+    mount_calls++;
+    snprintf(last_mount, sizeof(last_mount), "%s", name ? name : "");
+    dvd_phys_note_mount(name, index);   // Main calls this at the top of the real one
+    return 1;
+}
+void user_io_status_set(const char *name, uint32_t value, int = 0)
+{
+    if (!strcmp(name, "[0]") && value) reset_asserts++;
+}
+
+// The module reads the wall clock; the harness owns it so every tick is a real
+// scan rather than one the 1 Hz gate throws away. Defined after <time.h> so the
+// macro cannot mangle the real declaration.
+static time_t fake_now = 1000;
+#define time(p) (fake_now)
+
+#include "dvd_phys.cpp"
+
+// ------------------------------------------------------------------ harness
+static int errs = 0;
+static void check(const char *what, long got, long want)
+{
+    if (got != want) { printf("  FAIL %-46s got %ld, want %ld\n", what, got, want); errs++; }
+    else             { printf("  ok   %-46s %ld\n", what, got); }
+}
+
+// The tick is rate-limited to one scan a second; step() walks the clock so each
+// call is a real scan rather than a no-op.
+static void step(int n = 1)
+{
+    for (int i = 0; i < n; i++) { fake_now += 2; dvd_phys_tick(); }
+}
+
+static void reset_counters(void)
+{
+    probe_calls = mount_calls = reset_asserts = 0; last_mount[0] = 0;
+}
+
+int main(void)
+{
+    printf("=== [1] MGL launch with a disc in the drive: no disc reads, no mount ===\n");
+    fake_disc_ready = 1; fake_launch_busy = 1;
+    reset_counters();
+    step(5);                                   // five seconds of MGL delay
+    check("[1] disc reads while the MGL is pending", probe_calls, 0);
+    check("[1] mounts while the MGL is pending",     mount_calls, 0);
+
+    printf("=== [2] the MGL mounts its file: the drive stands down for good ===\n");
+    dvd_phys_note_mount("/media/fat/cifs/Movies/Terminator.mpg", 0);
+    fake_launch_busy = 0;
+    reset_counters();
+    step(10);                                  // ten more seconds, disc still sitting there
+    check("[2] disc reads after the file is mounted", probe_calls, 0);
+    check("[2] mounts after the file is mounted",     mount_calls, 0);
+
+    printf("=== [3] ejecting that disc must not touch the playing file ===\n");
+    reset_counters();
+    fake_disc_ready = 0;
+    step(2);
+    check("[3] unmounts on eject",       mount_calls,   0);
+    check("[3] core resets on eject",    reset_asserts, 0);
+
+    printf("=== [4] inserting a disc afterwards still plays it ===\n");
+    reset_counters();
+    fake_disc_ready = 1;
+    step(2);
+    check("[4] disc reads (probed once)", probe_calls, 1);
+    check("[4] mounts",                   mount_calls, 1);
+    if (strcmp(last_mount, DVD_PHYS_SENTINEL)) {
+        printf("  FAIL [4] mounted %s, want the drive sentinel\n", last_mount); errs++;
+    } else printf("  ok   [4] mounted the drive sentinel\n");
+
+    printf("=== [5] ejecting the disc WE are playing does reset to idle ===\n");
+    reset_counters();
+    fake_disc_ready = 0;
+    step(2);
+    check("[5] unmounts", mount_calls, 1);
+    check("[5] resets",   reset_asserts, 1);
+    if (last_mount[0]) { printf("  FAIL [5] unmount path passed %s, want \"\"\n", last_mount); errs++; }
+    else printf("  ok   [5] unmounted with an empty path\n");
+
+    printf("=== [6] plain launch, disc in the drive: mounts, probing once ===\n");
+    reset_counters();
+    fake_disc_ready = 1;
+    step(4);
+    check("[6] disc reads over four scans", probe_calls, 1);
+    check("[6] mounts",                     mount_calls, 1);
+
+    printf("=== [7] an audio CD is probed once per insertion, not once a second ===\n");
+    // eject the DVD, then present a non-DVD-Video disc
+    fake_disc_ready = 0; step(2);
+    reset_counters();
+    fake_disc_is_dvd = 0; fake_disc_ready = 1;
+    step(6);
+    check("[7] disc reads over six scans", probe_calls, 1);
+    check("[7] mounts",                    mount_calls, 0);
+
+    printf("\n=== dvd_phys tests: %d error(s) ===\n", errs);
+    if (errs) { printf("FAILED\n"); return 1; }
+    printf("PASS\n");
+    return 0;
+}

--- a/main/tests/dvd_phys_test.cpp
+++ b/main/tests/dvd_phys_test.cpp
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <time.h>
+#include <sys/time.h>
 #include <unistd.h>
 
 #include "dvd_phys.h"      // staged on the include path by run_tests.sh
@@ -45,10 +46,15 @@ static int  probe_calls       = 0;   // how often we READ the disc
 static int  mount_calls       = 0;
 static int  reset_asserts     = 0;
 static char last_mount[256]   = {0};
+static int  scan_calls        = 0;   // how often the drive was probed for readiness
+static unsigned fake_probe_ms = 0;   // how long that probe takes (a stalled drive)
+static unsigned fake_ms       = 0;   // the millisecond clock the module measures with
 
 #define DVD_PHYS_TEST 1
 static int open_ready_drive(char *out, int out_sz)
 {
+    scan_calls++;
+    fake_ms += fake_probe_ms;         // blocking I/O: the clock moves inside the call
     if (!fake_disc_ready) return -1;
     if (out && out_sz > 0) { strncpy(out, "/dev/sr0", out_sz - 1); out[out_sz-1] = 0; }
     return 99;                        // a token fd; close(99) is a harmless EBADF
@@ -80,6 +86,8 @@ void user_io_status_set(const char *name, uint32_t value, int = 0)
 // macro cannot mangle the real declaration.
 static time_t fake_now = 1000;
 #define time(p) (fake_now)
+#define gettimeofday(tv, tz) (((tv)->tv_sec = fake_ms / 1000), \
+                              ((tv)->tv_usec = (fake_ms % 1000) * 1000), 0)
 
 #include "dvd_phys.cpp"
 
@@ -91,12 +99,18 @@ static void check(const char *what, long got, long want)
     else             { printf("  ok   %-46s %ld\n", what, got); }
 }
 
-// The tick is rate-limited to one scan a second; step() walks the clock so each
-// call is a real scan rather than a no-op.
-static void step(int n = 1)
+// The tick rate-limits itself, and the period varies (1 s normally, 5 s while
+// somebody else owns the slot, backing off further if the drive probe turns out to
+// be slow). So the harness walks the clock in seconds and lets the module decide
+// when to scan, rather than assuming one tick == one scan.
+static void run_for(int seconds)
 {
-    for (int i = 0; i < n; i++) { fake_now += 2; dvd_phys_tick(); }
+    for (int i = 0; i < seconds; i++) { fake_now += 1; dvd_phys_tick(); }
 }
+
+// How long a disc may sit in the drive before we notice it. The scan backs off to
+// at most this, so nothing may take longer.
+#define NOTICE_WINDOW_S 10
 
 static void reset_counters(void)
 {
@@ -108,7 +122,7 @@ int main(void)
     printf("=== [1] MGL launch with a disc in the drive: no disc reads, no mount ===\n");
     fake_disc_ready = 1; fake_launch_busy = 1;
     reset_counters();
-    step(5);                                   // five seconds of MGL delay
+    run_for(5);                                // five seconds of MGL delay
     check("[1] disc reads while the MGL is pending", probe_calls, 0);
     check("[1] mounts while the MGL is pending",     mount_calls, 0);
 
@@ -116,21 +130,21 @@ int main(void)
     dvd_phys_note_mount("/media/fat/cifs/Movies/Terminator.mpg", 0);
     fake_launch_busy = 0;
     reset_counters();
-    step(10);                                  // ten more seconds, disc still sitting there
+    run_for(30);                               // half a minute, disc still sitting there
     check("[2] disc reads after the file is mounted", probe_calls, 0);
     check("[2] mounts after the file is mounted",     mount_calls, 0);
 
     printf("=== [3] ejecting that disc must not touch the playing file ===\n");
     reset_counters();
     fake_disc_ready = 0;
-    step(2);
+    run_for(NOTICE_WINDOW_S);
     check("[3] unmounts on eject",       mount_calls,   0);
     check("[3] core resets on eject",    reset_asserts, 0);
 
     printf("=== [4] inserting a disc afterwards still plays it ===\n");
     reset_counters();
     fake_disc_ready = 1;
-    step(2);
+    run_for(NOTICE_WINDOW_S);
     check("[4] disc reads (probed once)", probe_calls, 1);
     check("[4] mounts",                   mount_calls, 1);
     if (strcmp(last_mount, DVD_PHYS_SENTINEL)) {
@@ -140,7 +154,7 @@ int main(void)
     printf("=== [5] ejecting the disc WE are playing does reset to idle ===\n");
     reset_counters();
     fake_disc_ready = 0;
-    step(2);
+    run_for(NOTICE_WINDOW_S);
     check("[5] unmounts", mount_calls, 1);
     check("[5] resets",   reset_asserts, 1);
     if (last_mount[0]) { printf("  FAIL [5] unmount path passed %s, want \"\"\n", last_mount); errs++; }
@@ -149,18 +163,42 @@ int main(void)
     printf("=== [6] plain launch, disc in the drive: mounts, probing once ===\n");
     reset_counters();
     fake_disc_ready = 1;
-    step(4);
-    check("[6] disc reads over four scans", probe_calls, 1);
-    check("[6] mounts",                     mount_calls, 1);
+    run_for(NOTICE_WINDOW_S);
+    check("[6] disc reads over ten seconds", probe_calls, 1);
+    check("[6] mounts",                      mount_calls, 1);
 
     printf("=== [7] an audio CD is probed once per insertion, not once a second ===\n");
     // eject the DVD, then present a non-DVD-Video disc
-    fake_disc_ready = 0; step(2);
+    fake_disc_ready = 0; run_for(NOTICE_WINDOW_S);
     reset_counters();
     fake_disc_is_dvd = 0; fake_disc_ready = 1;
-    step(6);
-    check("[7] disc reads over six scans", probe_calls, 1);
-    check("[7] mounts",                    mount_calls, 0);
+    run_for(30);
+    check("[7] disc reads over half a minute", probe_calls, 1);
+    check("[7] mounts",                        mount_calls, 0);
+
+    printf("=== [8] a slow drive probe must back off ===\n");
+    // The field case: a .mpg is playing, the tray is OPEN, and every probe costs
+    // hundreds of ms on the same thread that feeds the decoder. Un-backed-off that
+    // is ~60 blocking calls a minute, which is what froze the picture.
+    fake_disc_ready = 0; run_for(NOTICE_WINDOW_S);
+    dvd_phys_note_mount("/media/fat/cifs/Movies/Terminator.mpg", 0);
+    fake_disc_is_dvd = 1;
+    fake_probe_ms = 400;                       // an open tray, retrying
+    reset_counters(); scan_calls = 0;
+    run_for(60);
+    if (scan_calls > 12) { printf("  FAIL [8] %d probes in 60 s, want <= 12\n", scan_calls); errs++; }
+    else printf("  ok   [8] probes in 60 s of a stalled drive       %d (was 60)\n", scan_calls);
+
+    printf("=== [9] ...and recovers once the drive settles ===\n");
+    fake_probe_ms = 0;
+    run_for(NOTICE_WINDOW_S);                  // let one fast probe reset the backoff
+    scan_calls = 0;
+    run_for(20);
+    // foreign is still set (the .mpg is playing), so the floor is the 5 s
+    // insertion-watch period, not 1 s. Four scans is the whole point: fast enough
+    // to notice a disc, rare enough to be invisible.
+    if (scan_calls < 4) { printf("  FAIL [9] %d probes in 20 s, want >= 4\n", scan_calls); errs++; }
+    else printf("  ok   [9] probes in 20 s of a healthy drive       %d\n", scan_calls);
 
     printf("\n=== dvd_phys tests: %d error(s) ===\n", errs);
     if (errs) { printf("FAILED\n"); return 1; }

--- a/main/tests/run_tests.sh
+++ b/main/tests/run_tests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# run_tests.sh — host-side tests for the MiSTer_DVDcss overlay modules.
+#
+# These are ordinary native builds: no ARM toolchain, no MiSTer, no Docker. Each
+# test #includes the module under test and stubs the rest of Main at link time,
+# so it exercises the real logic rather than a paraphrase of it.
+#
+set -e
+cd "$(dirname "$0")"
+
+CXX="${CXX:-g++}"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+# Stage the overlay where its own relative includes resolve. dvd_phys.cpp reaches
+# for "../../user_io.h"; an EMPTY file there is deliberate -- the test defines the
+# handful of Main functions it needs before including the module, so they are
+# already in scope and there is no second copy of Main's API to drift out of date.
+TREE="$OUT/tree"
+mkdir -p "$TREE/support/dvd"
+cp ../support/dvd/*.cpp ../support/dvd/*.h "$TREE/support/dvd/"
+: > "$TREE/user_io.h"
+: > "$TREE/menu.h"
+: > "$TREE/video.h"
+: > "$TREE/cfg.h"
+: > "$TREE/hardware.h"
+
+fail=0
+for t in *_test.cpp; do
+    n="${t%.cpp}"
+    echo "### $n"
+    "$CXX" -std=c++11 -Wall -Wno-unused-function -O0 -g \
+        -I "$TREE/support/dvd" -o "$OUT/$n" "$t"
+    "$OUT/$n" || fail=1
+    echo
+done
+
+if [ "$fail" != 0 ]; then echo "main/tests: FAILURES"; exit 1; fi
+echo "main/tests: ALL GREEN"

--- a/site/content/getting-started/loading.md
+++ b/site/content/getting-started/loading.md
@@ -49,6 +49,34 @@ disc whose menus misbehave.
     main menu, before the disc has shown you one. Some discs — DVD games especially — use this boot chain to perform set up steps and may behave incorrectly if skipped. See
     [Menu during the opening chain](../playback/controls.md#menu-during-the-discs-opening-chain).
 
+## Launching from an MGL shortcut
+
+An **MGL** is MiSTer's shortcut file: put one in the SD root or in a `_` menu folder and
+it appears in the MiSTer menu, loads the core and starts a movie in one step. The DVD core
+supports them.
+
+```xml title="The Terminator (1984).mgl"
+<mistergamedescription>
+  <rbf>_Other/DVD</rbf>
+  <file delay="5" type="s" index="0" path="Movies/The Terminator (1984).mpg"/>
+</mistergamedescription>
+```
+
+- `rbf` — where the core lives on the SD card, without the date and `.rbf`.
+- `type="s"` and `index="0"` — the core's one file slot, **Load Video**. These do not
+  change; any file type from the table above goes in the same slot.
+- `path` — relative to `/media/fat/games/DVD/`, or an absolute path starting with `/` if
+  the file lives somewhere else (a network share, for example).
+- `delay` — seconds to wait after the core loads before mounting. 1 is usually enough;
+  raise it if the file lives on a slow share.
+
+The name of the `.mgl` file is what shows in the menu, so it can differ from the movie's
+filename.
+
+!!! info "Unreleased"
+    MGL launching did not work before this build: the core could come up blank and stop
+    responding to the gamepad, needing a restart. If that is what you saw, update.
+
 ## Loading something else
 
 **`Reset`** in the OSD stops playback, unloads the current image, resets the navigation

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -21,6 +21,28 @@ which makes it look like a size or filesystem problem.
     all, the core never got the file; if you get `UNSUPPORTED IMAGE`, it read the file and
     could not play it. Those are different problems.
 
+### Launched from an MGL: blank screen, nothing responds
+
+!!! info "Unreleased"
+    Fixed in this build. If you are on v0.4.0 or earlier, this is what you are seeing.
+
+Older builds could freeze during an MGL launch. Two separate faults, and both are fixed:
+
+- The core's own on-screen notices could stall MiSTer's shortcut handling. While a
+  shortcut is still running, MiSTer reads no input at all — so the gamepad, the keyboard
+  and the OSD button were all dead and only a restart cleared it. There is now a 20-second
+  backstop: even if a shortcut fails, the OSD always comes back so you can load the file
+  by hand.
+- If the file did not open — a wrong path, or a share that was not ready yet — the core
+  was still told a disc had arrived, hid the idle screen and showed a flat grey or green
+  field with no message. A load that fails now returns to the idle screen and the file
+  picker.
+
+If a shortcut still does not load the movie, check the `path` in the `.mgl`: it is
+relative to `/media/fat/games/DVD/` unless it starts with `/`. Raising `delay` to 5 helps
+when the file is on a network share that takes a moment to wake. See
+[Launching from an MGL shortcut](../getting-started/loading.md#launching-from-an-mgl-shortcut).
+
 ### `UNSUPPORTED IMAGE`
 
 Either the image is not ISO9660 — a **UDF-only** image will not load — or the file is not a


### PR DESCRIPTION
Launching the core from an MGL shortcut was unreliable in several independent
ways. This is the accumulated set of fixes, all HW-tested on the maintainer's rig.

## What was wrong

**A running MGL owns the whole UI.** While `mgl->done == 0`, `HandleUI()` takes the
MGL branch and never calls `menu_key_get()` — the sole source of every input event,
including the OSD button. The MGL's only forward edge needs `menustate ==
MENU_NONE2`, and `InfoMessage()` pins `menustate = MENU_INFO`. Two of our own poll
ticks called it once a second, so a launch could stall with nothing mounted and no
input at all. Both now defer while a launch is running, and a 20 s watchdog puts a
floor under any stall we have not thought of.

**A mount with no media was treated as a mount.** Main notifies the core even when
the file never opened (size 0), and `hps_io` raises `img_mounted` for an all-zero
word too — that is also how an eject arrives. The core now agrees with `disc_ever`,
which always read it correctly, and the reader stops on a zero-block image instead
of walking LBA 0,1,2,… of an empty slot forever.

**`ps_demux`'s raw-elementary-stream verdict was a one-way door.** A flush landing
mid-PES latched it for the rest of the title and handed PES headers, audio and NAV
packs to the video decoder. It now leaves on the next pack.

**The optical drive does not own slot 0, it shares it.** It auto-mounted on the
first poll, so a file named by an MGL waited minutes for CSS key extraction on a
disc that was then replaced anyway; and `mounted` meant "we mounted a disc at some
point", so ejecting a disc nobody was watching tore down the file that *was*
playing. Both fixed, with every "don't mount" check moved ahead of the first read.

**The drive probe ran on the thread that feeds the decoder.** `open()` +
`ioctl(CDROM_DRIVE_STATUS)` once a second is blocking I/O in `user_io_poll()`; with
an open tray the `sr` driver retries for hundreds of milliseconds, every second,
and the picture froze while the OSD kept working. The scan is now self-limiting.

**Returning to the idle screen depended on the HPS reset.** `img_ejected` is a
one-cycle pulse and an eject arrives while frames are still on screen, so the clear
was discarded every time. A latch defers it until the picture runs out.

**The MGL `delay` was consumed before it was set.** `CheckTimer(0)` reads an unarmed
timer as an expired one, and `user_io_file_tx()` ends with a `MenuHide()` that
re-enters `HandleUI()` — so a `boot.rom` transfer (this fork ships one for the idle
logo) fired the MGL with no delay at all.

Also fixed: the CSS key cache directory was created one level deep with the return
unchecked, so if `/media/fat/dvdcss` did not exist the cache was silently disabled
and every play re-extracted keys.

## Gates

- `bench/dvd/run_mgl.sh` — new. `iso_reader_mount_tb` (RED: 10 reads against an
  empty slot, still `S_STREAM`) and `ps_demux_esrecover_tb` (RED: 48 video bytes and
  0 audio bytes after the next pack). Both measure what the hardware does, not a
  signal the fix names, and each carries a control arm.
- `main/tests/run_tests.sh` — the overlay's first host-side test (plain `g++`, no
  MiSTer, no ARM toolchain). Nine scenarios over the drive's slot-ownership rules;
  RED against the pre-fix module reproduces both field symptoms.
- Regressions green: `run_mode_realign`, `run_vcd`, `run_mp2`, `run_subpic`,
  `run_dpad_seek`, `run_modeline_boot`, `run_seek_realign`, `run_prefetch_chain`,
  and 13/15 `ps_demux_*` (2 need fixtures absent from this machine).
- `tools/docs_check.py` OK; `mkdocs build --strict` clean.
- Build `DVD_mgl2_20260904_1653.rbf`: SEED 5 first roll, clk_dec 96.90 @100C /
  91.89 @-40C against the 86.0 gate, 90% ALM, RAM and DSP unchanged.

## Notes

Integration steps 27–32; step 32 is the first edit outside `user_io.cpp`, so
`apply_integration.py` gains a `replace_once()` helper that fails loudly if the
anchor moves on a stock bump.

Design and the full launch timeline: `docs/mgl_launch.md`. It also records the
grey/green/black colour table traced through `yuv2rgb.v`, which tells a wedged
reader from a mis-framed demux from across the room.

The pattern worth carrying forward: the stock mechanism was sound every time, and
this core's own additions are what tipped it over — our notice pumps froze the MGL
FSM, our drive scan starved the decoder, our `boot.rom` ate the delay.

## Test plan

- [x] MGL launch of a `.mpg` with a disc in the drive — no key extraction, plays
- [x] Eject during `.mpg` playback — no freeze
- [x] Eject during disc playback — returns to the idle screen
- [x] MGL `delay` honoured
- [x] Manual `Load Video` unregressed
- [ ] Confirmation from the original reporter's setup, which was never reproducible
      here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
