### PR TITLE
set_dvd_region: report a successful change correctly, and handle stricter drives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2089,9 +2089,11 @@ MALFORMED. `pdrc` is a region MASK with one bit CLEAR (region 1 = `0xfe`), NOT t
 number**, which as a mask claims seven playable regions. MEASURED with `sg_raw` sending the
 byte-identical command: sense **05/26/00, "invalid field in PARAMETER LIST"** — ★ *parameter
 list*, not *CDB*, which localised it to one byte of the payload in a single shot. `regionset`
-has always sent the mask (`regionset.c` `~(1 << (n-1))` → `dvd_udf.c:UDFRPCSet`). ⚠ Issue
-#52's LG GS40N errored AND ended up regioned, which the encoding bug does not explain; do
-not build on either reading of that.** ★ **The write now goes out over SG_IO with `DVD_AUTH`
+has always sent the mask (`regionset.c` `~(1 << (n-1))` → `dvd_udf.c:UDFRPCSet`). ★ **Drives DIFFER on this
+byte, which is why it survived so long:** issue #52's LG GS40N *took* the plain number (that
+user's region change succeeded — only the read-back afterwards failed), while the TSSTcorp
+rejects it. The number worked by luck on tolerant firmware; the mask is what a strict drive
+demands.** ★ **The write now goes out over SG_IO with `DVD_AUTH`
 as the fallback** — byte-identical commands, but `sr_do_ioctl` collapses every refusal into a
 bare `EIO` (Illegal Request and most Not Ready alike), so the ioctl route CANNOT say why a
 one-way operation failed. ★★ **And it earned its keep on the first run: the second reason was THE DISC IN THE TRAY.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2083,18 +2083,34 @@ T13. Detail: `docs/fabric_audio.md` "CSS mute", `docs/transport_hud.md`.
 
 **DVD drive region tool (`main/Scripts/set_dvd_region.sh`, 2026-08-30) — ✅ READ +
 gamepad menu HW-CONFIRMED 2026-08-31 (Scripts menu, gamepad-driven, 1 and 2 drives);
-⏳ the SET ioctl is the one remaining gate.**
+✅ the SET ioctl FIELD-CONFIRMED 2026-09-04 (issue #52: a user's LG GS40N took the region
+and a PC confirmed it).**
 A drive with no region set refuses the CSS title-key ioctl, so every physical disc pays a
 multi-second crack (`No drive region: cracking`); the Scripts-menu tool reads the region
 (and the remaining-change count) and can set it, via `DVD_AUTH` — no compiled helper, since
-python3 is stock on MiSTer. Two durable facts it is built around, worth knowing before
+python3 is stock on MiSTer. **Three** durable facts it is built around, worth knowing before
 writing ANY MiSTer Scripts tool: a Scripts-menu script is run by handing its bare path to
-`agetty`, so it can **never take arguments** (SSH only); and MiSTer injects uinput KEYBOARD
+`agetty`, so it can **never take arguments** (SSH only); MiSTer injects uinput KEYBOARD
 events from the gamepad while a script runs (D-pad→arrows, B1→Enter, B2→Esc) but **no digits
-or letters** — so interactive means a cursor menu, never a typed prompt. A region set is
+or letters** — so interactive means a cursor menu, never a typed prompt; and ★ **a script
+that returns quickly LOSES ITS LAST SCREEN** — `menu.cpp`'s `MENU_SCRIPTS_FB2` ignores keys
+while the script's process lives, then closes the framebuffer terminal on the first key
+**RELEASE** after it is reaped, so the press that confirms a menu erases the result of that
+press. Every exit must wait for a FRESH keypress. A region set is
 **irreversible** (no un-set, ~5 changes ever), hence cursor-starts-on-Cancel/No throughout.
-Tested by `tools/test_set_dvd_region.py` (fakes the drive, drives the menus through a pty);
-the ioctl itself is the HW gate. Design + ioctl details: `docs/physical_disc.md`.
+★★ **And the reporting rule issue #52 earned, which generalises past this tool: a failure to
+READ BACK a change is not a failure to MAKE it.** The set succeeded on that drive; the
+script's unguarded re-read hit the drive's post-SEND-KEY unit attention, threw an uncaught
+traceback, and the user reasonably reported it as a failed region set. Verification now
+re-opens the device and retries 6 × 0.5 s, an unconfirmed read reports "accepted, not yet
+reported" (exit 3) instead of failure, and only the change command itself refusing is an
+error. ★ The same round found `dvd_css.cpp:drive_region_set()` reading `region_mask` alone,
+which labels an **RPC-1 (region-free) drive** — empty mask, `rpc_scheme == 0`, no region
+enforced at all — as having no region, i.e. the best case reported as the worst; it now
+also passes on `rpc_scheme == 0`.
+Tested by `tools/test_set_dvd_region.py` (fakes the drive incl. post-change faults, drives
+the menus through a pty, **mutation-checked** 5/5, `SET_DVD_REGION_SH=` points it at another
+copy to prove RED). Design + ioctl details: `docs/physical_disc.md`.
 
 ### User bug reports arrive as sparse-sector nav bundles, not ISOs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2082,9 +2082,15 @@ identifiable. Sim: `ps_demux_scram_tb`, `iec61937_wrap_tb` T8, `transport_hud_tb
 T13. Detail: `docs/fabric_audio.md` "CSS mute", `docs/transport_hud.md`.
 
 **DVD drive region tool (`main/Scripts/set_dvd_region.sh`, 2026-08-30) — ✅ READ +
-gamepad menu HW-CONFIRMED 2026-08-31 (Scripts menu, gamepad-driven, 1 and 2 drives);
-✅ the SET ioctl FIELD-CONFIRMED 2026-09-04 (issue #52: a user's LG GS40N took the region
-and a PC confirmed it).**
+gamepad menu HW-CONFIRMED (2026-08-31, re-confirmed 2026-09-04 on the rewritten script);
+⏳ the SET ioctl STILL UNGATED — and issue #52 found out why: ★★ **the command was
+MALFORMED. `pdrc` is a region MASK with one bit CLEAR (region 1 = `0xfe`), NOT the region
+number**, which as a mask claims seven playable regions. MEASURED with `sg_raw` sending the
+byte-identical command: sense **05/26/00, "invalid field in PARAMETER LIST"** — ★ *parameter
+list*, not *CDB*, which localised it to one byte of the payload in a single shot. `regionset`
+has always sent the mask (`regionset.c` `~(1 << (n-1))` → `dvd_udf.c:UDFRPCSet`). ⚠ Issue
+#52's LG GS40N errored AND ended up regioned, which the encoding bug does not explain; do
+not build on either reading of that.**
 A drive with no region set refuses the CSS title-key ioctl, so every physical disc pays a
 multi-second crack (`No drive region: cracking`); the Scripts-menu tool reads the region
 (and the remaining-change count) and can set it, via `DVD_AUTH` — no compiled helper, since
@@ -2099,9 +2105,9 @@ while the script's process lives, then closes the framebuffer terminal on the fi
 press. Every exit must wait for a FRESH keypress. A region set is
 **irreversible** (no un-set, ~5 changes ever), hence cursor-starts-on-Cancel/No throughout.
 ★★ **And the reporting rule issue #52 earned, which generalises past this tool: a failure to
-READ BACK a change is not a failure to MAKE it.** The set succeeded on that drive; the
-script's unguarded re-read hit the drive's post-SEND-KEY unit attention, threw an uncaught
-traceback, and the user reasonably reported it as a failed region set. Verification now
+READ BACK a change is not a failure to MAKE it.** The script's unguarded re-read would hit
+the drive's post-SEND-KEY unit attention and throw an uncaught traceback over a change that
+had worked. Verification now
 re-opens the device and retries 6 × 0.5 s, an unconfirmed read reports "accepted, not yet
 reported" (exit 3) instead of failure, and only the change command itself refusing is an
 error. ★ The same round found `dvd_css.cpp:drive_region_set()` reading `region_mask` alone,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2107,7 +2107,11 @@ reported" (exit 3) instead of failure, and only the change command itself refusi
 error. ★ The same round found `dvd_css.cpp:drive_region_set()` reading `region_mask` alone,
 which labels an **RPC-1 (region-free) drive** — empty mask, `rpc_scheme == 0`, no region
 enforced at all — as having no region, i.e. the best case reported as the worst; it now
-also passes on `rpc_scheme == 0`.
+also passes on `rpc_scheme == 0`. ⏳ **That arm is UNGATED — every local drive is RPC-2, so
+it cannot run here**; what was re-checked on HW (2026-09-04) is that an RPC-2 no-region drive
+still cracks and still says so. It moves a MESSAGE only (`region_set` never picks a code
+path), and a zeroed REPORT KEY reply already read as "set" before, so it adds no new way to
+be wrong.
 Tested by `tools/test_set_dvd_region.py` (fakes the drive incl. post-change faults, drives
 the menus through a pty, **mutation-checked** 5/5, `SET_DVD_REGION_SH=` points it at another
 copy to prove RED). Design + ioctl details: `docs/physical_disc.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2090,7 +2090,12 @@ byte-identical command: sense **05/26/00, "invalid field in PARAMETER LIST"** �
 list*, not *CDB*, which localised it to one byte of the payload in a single shot. `regionset`
 has always sent the mask (`regionset.c` `~(1 << (n-1))` → `dvd_udf.c:UDFRPCSet`). ⚠ Issue
 #52's LG GS40N errored AND ended up regioned, which the encoding bug does not explain; do
-not build on either reading of that.**
+not build on either reading of that.** ★ **The write now goes out over SG_IO with `DVD_AUTH`
+as the fallback** — byte-identical commands, but `sr_do_ioctl` collapses every refusal into a
+bare `EIO` (Illegal Request and most Not Ready alike), so the ioctl route CANNOT say why a
+one-way operation failed. ⏳ It is also the open suspect: the corrected `pdrc` was accepted
+over SG_IO on a PC and refused with `EIO` over the ioctl on the board — ⚠ two variables at
+once (route AND machine), which the SG_IO path exists to separate.
 A drive with no region set refuses the CSS title-key ioctl, so every physical disc pays a
 multi-second crack (`No drive region: cracking`); the Scripts-menu tool reads the region
 (and the remaining-change count) and can set it, via `DVD_AUTH` — no compiled helper, since

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2083,7 +2083,8 @@ T13. Detail: `docs/fabric_audio.md` "CSS mute", `docs/transport_hud.md`.
 
 **DVD drive region tool (`main/Scripts/set_dvd_region.sh`, 2026-08-30) — ✅ READ +
 gamepad menu HW-CONFIRMED (2026-08-31, re-confirmed 2026-09-04 on the rewritten script);
-⏳ the SET ioctl STILL UNGATED — and issue #52 found out why: ★★ **the command was
+✅ **the SET path is HW-CONFIRMED 2026-09-04 too** (region 1 → 2, read back first try,
+counter 3 → 2) — after issue #52 found TWO reasons it never had been: ★★ **the command was
 MALFORMED. `pdrc` is a region MASK with one bit CLEAR (region 1 = `0xfe`), NOT the region
 number**, which as a mask claims seven playable regions. MEASURED with `sg_raw` sending the
 byte-identical command: sense **05/26/00, "invalid field in PARAMETER LIST"** — ★ *parameter
@@ -2093,9 +2094,16 @@ has always sent the mask (`regionset.c` `~(1 << (n-1))` → `dvd_udf.c:UDFRPCSet
 not build on either reading of that.** ★ **The write now goes out over SG_IO with `DVD_AUTH`
 as the fallback** — byte-identical commands, but `sr_do_ioctl` collapses every refusal into a
 bare `EIO` (Illegal Request and most Not Ready alike), so the ioctl route CANNOT say why a
-one-way operation failed. ⏳ It is also the open suspect: the corrected `pdrc` was accepted
-over SG_IO on a PC and refused with `EIO` over the ioctl on the board — ⚠ two variables at
-once (route AND machine), which the SG_IO path exists to separate.
+one-way operation failed. ★★ **And it earned its keep on the first run: the second reason was THE DISC IN THE TRAY.**
+Sense `05/6f/04` — a drive takes its new region from the loaded disc, which must **ALLOW**
+the region being set (measured: a disc with `RMI 40`, everything but region 7, satisfied a
+switch to region 2; an empty tray gives `02/3a/01`). ⚠⚠ **The diagnostic lesson cost two HW
+rounds and is the durable part:** the evidence read "accepted on a PC over SG_IO, refused on
+the MiSTer over the ioctl", and BOTH variables that framing offers — route and machine — were
+wrong; the cause was a third nobody had written down. Then the first correction ("take the
+disc out") was wrong TOO, because one refuting measurement was read as establishing its
+opposite. A drive that can *explain itself* outranks any amount of A/B reasoning, and `EIO`
+is all the ioctl route can ever say.
 A drive with no region set refuses the CSS title-key ioctl, so every physical disc pays a
 multi-second crack (`No drive region: cracking`); the Scripts-menu tool reads the region
 (and the remaining-change count) and can set it, via `DVD_AUTH` — no compiled helper, since

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -285,6 +285,30 @@ for the `No drive region: cracking` path, and a set destroys it forever.
 ended up regioned, so either it tolerates the malformed number (firmware varies) or it
 rejected the change and the region came from somewhere else. Do not build on either reading.
 
+**The write goes out over SG_IO, with `DVD_AUTH` as the fallback (2026-09-04).** Both
+routes carry byte-identical commands — the kernel builds this exact one from the ioctl
+(`cdrom.c`: `setup_send_key`, then `buf[1] = 6`, `buf[4] = pdrc`) — so this is not a
+correctness change but an **observability** one: `sr_do_ioctl` funnels every drive refusal
+into a bare **`EIO`** (Illegal Request *and* most Not Ready conditions alike), which is
+useless when the operation is one-way and the user needs to know why. SG_IO hands the sense
+data back, so a refusal now reads `sense 05/26/00 (invalid field in parameter list)` instead
+of `Input/output error`. The ioctl remains the fallback for a python without `ctypes` or a
+device that refuses SG_IO, so this can only add outcomes, never remove the one that worked.
+A `SenseError` is never retried on the other route — the drive explained itself, and a
+second send could spend a change.
+
+⏳ **It is also the current suspect.** On the maintainer's TSSTcorp TS-L633C behind an Initio
+`13fd:0840` USB bridge (`ANSI: 0`), the corrected `pdrc` was accepted over **SG_IO on a PC**
+and refused with `EIO` over the **ioctl on the MiSTer**, twice, with the change counter
+unmoved and *nothing* logged by `sr` in dmesg. ⚠ **That is two variables at once — route and
+machine — so it does not yet convict the ioctl.** The SG_IO path is what isolates it: same
+board, same drive, one variable.
+
+`sg_io_hdr` is built with `ctypes`, so it lays itself out for whatever ABI it runs on (88
+bytes on x86-64, 64 on the MiSTer's armv7). Both were checked against the C ABI rather than
+assumed — the field list reproduces `sizeof`/`offsetof` exactly on x86-64, and the armv7
+sizes come from a `_Static_assert` compiled with the MiSTer toolchain's own headers.
+
 **Reporting a change.** Two further defects, real regardless of the encoding, sharing one
 durable rule — **a failure to read the region back is not a failure to set it**: the SEND KEY
 either succeeded or it did not, and everything after it is reporting.

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -304,6 +304,15 @@ unmoved and *nothing* logged by `sr` in dmesg. ⚠ **That is two variables at on
 machine — so it does not yet convict the ioctl.** The SG_IO path is what isolates it: same
 board, same drive, one variable.
 
+⚠⚠ **`DRIVER_SENSE` (0x08) is in the LOW nibble of `driver_status` and means the drive
+ANSWERED — sense attached — not that the transport failed.** Reading it as a transport error
+cost a hardware round: the board logged `SG_IO status 02 host 00 driver 08 sb_len 18`, i.e.
+a Check Condition with 18 bytes of sense sitting right there, and the guard threw it away
+and fell back to the ioctl, which could then only say `EIO` — the exact information the
+SG_IO route existed to recover. Classification now lives in a pure `sg_check()` precisely so
+it can be tested: a synthetic `(status 02, host 00, driver 08, sense 05/26/00)` must decode,
+and the mutation that reinstates the bug is caught by it.
+
 `sg_io_hdr` is built with `ctypes`, so it lays itself out for whatever ABI it runs on (88
 bytes on x86-64, 64 on the MiSTer's armv7). Both were checked against the C ABI rather than
 assumed — the field list reproduces `sizeof`/`offsetof` exactly on x86-64, and the armv7

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -62,6 +62,15 @@ while the core is open plays it (`dvd_phys` polls for media change).
   read only the mask until 2026-09-04, so a region-free drive (the best case there is) was
   labelled `No drive region: cracking` and logged as having no region set. The verdict now
   also passes on `rpc_scheme == 0` (REPORT KEY byte 6).
+  ⏳ **The RPC-1 arm is UNGATED and cannot be gated here — every local drive reports RPC-2**
+  (the new arm is unreachable on them by construction). What WAS re-checked on hardware
+  2026-09-04 is the arm that could regress: an RPC-2 drive with no region set still cracks
+  and still says `No drive region: cracking`. The blast radius is one message: `region_set`
+  feeds the progress text and the log, never a code path, and a degenerate REPORT KEY reply
+  (status 0, buffer left zeroed) already read as "set" under the mask-only test, so the new
+  term adds no new way to be wrong. To gate it, a region-free drive is needed — the updated
+  `set_dvd_region.sh` names one on sight (`RPC state` third byte `00`), so a user can say so
+  without owning any of this.
 - **CSS-without-libdvdcss:** READ DVD STRUCTURE copyright byte detects CSS upfront; a
   deferred popup asks the user to run `install_dvdcss.sh` (immediate reads would black-screen
   on many drives). The fabric core's own `pes_scrambled` → `CSS ENCRYPTED` + mute is the
@@ -328,10 +337,18 @@ Remaining:
    path testable, which a set would destroy forever), one matching the local library, one
    deliberately mismatched. `DVDCSS_METHOD=title` forces the crack path on any drive if the
    physical unset state is not available.
-3. **Eject → idle reset (just added):** confirm the `status[0]` pulse returns to the idle
+3. **RPC-1 message arm ungated (2026-09-04):** `drive_region_set()` now treats
+   `rpc_scheme == 0` as "no region needed", but no local drive is RPC-1, so the arm has never
+   run. Needs a region-free drive — or a user's report, since `set_dvd_region.sh` now prints
+   the scheme byte. Expected on such a drive: `Preparing disc` instead of
+   `No drive region: cracking`, no "RPC-II with NO region set" line in `/tmp/dvdcss.log`, and
+   — the falsifiable part — keys actually arriving fast with the cache cleared. If it still
+   crawls VOB by VOB, key the message on measured key-fetch behaviour rather than the RPC
+   bits.
+4. **Eject → idle reset (just added):** confirm the `status[0]` pulse returns to the idle
    logo cleanly and a subsequent insert plays.
-4. **Drive lifecycle across re-exec:** confirm `/dev/srN` is free for our Main to re-open.
-5. **libdvdcss-absent fallback:** confirm `CSS ENCRYPTED` still triggers (disc **and** ISO)
+5. **Drive lifecycle across re-exec:** confirm `/dev/srN` is free for our Main to re-open.
+6. **libdvdcss-absent fallback:** confirm `CSS ENCRYPTED` still triggers (disc **and** ISO)
    when libdvdcss is missing.
-6. **Then** fold physical-disc + encrypted-ISO + libdvdcss into the top-level `README.md`
+7. **Then** fold physical-disc + encrypted-ISO + libdvdcss into the top-level `README.md`
    "What works" and drop the "CSS is not handled in-core" limitation — only once HW-confirmed.

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -305,10 +305,13 @@ THE TRAY.** Measured on a TSSTcorp TS-L633C, drive at region 1:
 | region-1 disc | region 1 | **Good** (this was the PC success) |
 | region-1 disc | region 2 | `05/6f/04` media region code is mismatched to logical unit region |
 | empty | region 2 | `02/3a/01` medium not present, tray closed |
+| disc with RMI `40` (allows 1-6, 8) | region 2 | **Good** — ✅ and this is the end-to-end gate |
 
 That is the Windows model — insert a foreign disc and the OS offers to switch the drive to
-match — and it means **the region a drive will accept is the region of the disc you put in
-it**. Neither "with a disc" nor "without a disc" is the rule; *matching* is.
+match. ★ **The exact rule is that the loaded disc must ALLOW the target region, not that it
+name exactly that region**: the fourth row is a multi-region disc (`RMI 40` = every region
+but 7) and it satisfied a switch to region 2. Neither "with a disc" nor "without a disc" is
+the rule, and neither is "a disc of that region" — *allows* is.
 
 ★ **The diagnostic lesson is bigger than the bug, and it bit twice.** The evidence was
 "accepted on a PC over SG_IO, refused on the MiSTer over the ioctl", and both variables that
@@ -380,15 +383,13 @@ called a failure, raw bytes dropped, RPC-1 treated as unset) are each caught by 
 scenario — these are string assertions on console output, exactly the shape that passes
 without proving anything.
 
-The **read** ioctl and the gamepad-driven console are ✅ **HW-CONFIRMED** (2026-08-31, and
-again 2026-09-04 on the rewritten script). The **command** is ✅ HW-proven too: correct
-`pdrc`, matching disc, accepted with Good status over SG_IO. ⏳ What remains ungated is
-narrow and exact — **the script itself issuing a successful set**. Every refusal it has
-produced was the drive declining for a reason it named; it has not yet been the thing that
-sends a change a drive accepts. Closing that needs a drive whose owner wants a region it can
-actually reach, which on a disc-follows-the-disc drive means owning a disc from that region.
-⚠ Do not spend the unset drive on it (the cracking-path rig) — the next user with a genuinely
-unset drive gates it for free, since any disc they own matches a region they would pick.
+✅ **THE WHOLE TOOL IS NOW HW-CONFIRMED (2026-09-04), READ AND WRITE.** The read ioctl and
+the gamepad-driven console were confirmed 2026-08-31 and again on the rewritten script; the
+**write** closed the same day on a TSSTcorp TS-L633C — `route: SG_IO, accepted`,
+`verify 0: 51 fd 01`, `Done. The drive is now region 2, with 2 changes left`, `ucca` 3 → 2.
+★ Two details worth keeping from that log: the drive answered the read-back **on the first
+attempt** (`verify 0`), so the 6 × 0.5 s retry is insurance rather than a routine need; and
+`disc_regions()` ran on real iron for the first time, reading `RMI 40` correctly.
 
 ## HW status / open items
 
@@ -415,12 +416,10 @@ Remaining:
    the multi-drive warning listed both, and (2026-09-04) the rewritten script reads and
    pauses correctly on the board. That confirms the `DVD_AUTH` read, drive enumeration, and
    the uinput key injection on tty2, which was the design's riskiest assumption.
-   **Write: the command is proven, the script issuing one successfully is not.** The
-   corrected `pdrc` with a matching disc loaded is accepted (Good status, SG_IO, 2026-09-04);
-   the script's own runs have all been refusals the drive explained (`05/6f/04`, `02/3a/01`),
-   because the local drive is region 1 and no region-2 disc exists here to switch it with.
-   The gate is one run on a drive that can reach the region asked of it. Issue #52's LG
-   errored and ended up regioned anyway, which remains unexplained.
+   **Write: ✅ HW-CONFIRMED 2026-09-04** — the script set a TSSTcorp TS-L633C from region 1
+   to region 2 with a disc loaded that allowed region 2, read the new region back on the
+   first attempt, and the change counter went 3 → 2. Issue #52's LG errored and ended up
+   regioned anyway, which remains unexplained and is the only loose end left here.
    A **set is one-way and spends one of the drive's ~5 permanent changes**. Bench plan for
    the Q2 rig is still three drives — one left unset (keeps the `No drive region: cracking`
    path testable, which a set would destroy forever), one matching the local library, one

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -297,12 +297,22 @@ device that refuses SG_IO, so this can only add outcomes, never remove the one t
 A `SenseError` is never retried on the other route — the drive explained itself, and a
 second send could spend a change.
 
-⏳ **It is also the current suspect.** On the maintainer's TSSTcorp TS-L633C behind an Initio
-`13fd:0840` USB bridge (`ANSI: 0`), the corrected `pdrc` was accepted over **SG_IO on a PC**
-and refused with `EIO` over the **ioctl on the MiSTer**, twice, with the change counter
-unmoved and *nothing* logged by `sr` in dmesg. ⚠ **That is two variables at once — route and
-machine — so it does not yet convict the ioctl.** The SG_IO path is what isolates it: same
-board, same drive, one variable.
+★★ **AND IT PAID FOR ITSELF ON THE FIRST RUN. The blocker was a DISC IN THE TRAY:
+sense `05/6f/04`, "media region code is mismatched to logical unit region".** A drive set to
+region 1, asked for region 2 with a region-1 disc loaded, refuses — the change would orphan
+the disc in its own tray. The same drive took the same change with an empty tray.
+
+★ **The diagnostic lesson is bigger than the bug.** The evidence was "accepted on a PC over
+SG_IO, refused on the MiSTer over the ioctl", and both of the variables that framing offers —
+route and machine — were **wrong**. The real one was a third that nobody had written down:
+the PC attempt had an empty tray. Two hardware rounds went into route-vs-machine before one
+sense byte settled it. ⚠ When a comparison has two obvious differences, the cause can still
+be a third; a drive that can *explain* itself outranks any amount of A/B reasoning. Everything
+before this point was inference from `EIO`, and `EIO` is what the ioctl gives you.
+
+The script now checks `CDROM_DRIVE_STATUS` and says "take the disc out first" **before** the
+menu, and `05/6f/04` is a named sense so the refusal explains itself if a drive reports it
+anyway.
 
 ⚠⚠ **`DRIVER_SENSE` (0x08) is in the LOW nibble of `driver_status` and means the drive
 ANSWERED — sense attached — not that the transport failed.** Reading it as a transport error

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -297,22 +297,35 @@ device that refuses SG_IO, so this can only add outcomes, never remove the one t
 A `SenseError` is never retried on the other route — the drive explained itself, and a
 second send could spend a change.
 
-★★ **AND IT PAID FOR ITSELF ON THE FIRST RUN. The blocker was a DISC IN THE TRAY:
-sense `05/6f/04`, "media region code is mismatched to logical unit region".** A drive set to
-region 1, asked for region 2 with a region-1 disc loaded, refuses — the change would orphan
-the disc in its own tray. The same drive took the same change with an empty tray.
+★★ **AND IT PAID FOR ITSELF IN TWO RUNS. THE DRIVE TAKES ITS NEW REGION FROM THE DISC IN
+THE TRAY.** Measured on a TSSTcorp TS-L633C, drive at region 1:
 
-★ **The diagnostic lesson is bigger than the bug.** The evidence was "accepted on a PC over
-SG_IO, refused on the MiSTer over the ioctl", and both of the variables that framing offers —
-route and machine — were **wrong**. The real one was a third that nobody had written down:
-the PC attempt had an empty tray. Two hardware rounds went into route-vs-machine before one
-sense byte settled it. ⚠ When a comparison has two obvious differences, the cause can still
-be a third; a drive that can *explain* itself outranks any amount of A/B reasoning. Everything
-before this point was inference from `EIO`, and `EIO` is what the ioctl gives you.
+| tray | asked for | answer |
+|---|---|---|
+| region-1 disc | region 1 | **Good** (this was the PC success) |
+| region-1 disc | region 2 | `05/6f/04` media region code is mismatched to logical unit region |
+| empty | region 2 | `02/3a/01` medium not present, tray closed |
 
-The script now checks `CDROM_DRIVE_STATUS` and says "take the disc out first" **before** the
-menu, and `05/6f/04` is a named sense so the refusal explains itself if a drive reports it
-anyway.
+That is the Windows model — insert a foreign disc and the OS offers to switch the drive to
+match — and it means **the region a drive will accept is the region of the disc you put in
+it**. Neither "with a disc" nor "without a disc" is the rule; *matching* is.
+
+★ **The diagnostic lesson is bigger than the bug, and it bit twice.** The evidence was
+"accepted on a PC over SG_IO, refused on the MiSTer over the ioctl", and both variables that
+framing offers — route and machine — were **wrong**; the real one was a third nobody had
+written down, the disc in the tray. Then the first correction was wrong TOO ("take the disc
+out"), because a single new data point (`6f/04`) was read as the whole rule when it was one
+row of a table that needed three. ⚠ When a comparison has two obvious differences, the cause
+can still be a third — and one measurement that refutes a hypothesis does not establish its
+opposite. Everything before the sense data was inference from `EIO`, which is all the ioctl
+route can ever give you.
+
+The script now reads the loaded disc's own region (`READ DVD STRUCTURE` format 1, byte 5 =
+Region Management Information, a clear bit per allowed region), shows it beside the drive's
+(`Disc in drive  : region 2`), says on the menu that the drive follows the disc, and warns on
+the confirm screen when the chosen region is one the loaded disc cannot support — a warning,
+not a block, since other drives may not care. `6f/04`, `3a/00`, `3a/01` and `3a/02` are all
+named sense codes, so a refusal names which of the two mistakes it was.
 
 ⚠⚠ **`DRIVER_SENSE` (0x08) is in the LOW nibble of `driver_status` and means the drive
 ANSWERED — sense attached — not that the transport failed.** Reading it as a transport error

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -57,6 +57,11 @@ while the core is open plays it (`dvd_phys` polls for media change).
 
 - **No drive region (RPC-II):** SG_IO REPORT KEY reports `region_mask == 0xff`; libdvdcss
   falls back to statistical cracking. Shown on screen as `No drive region: cracking`.
+  ⚠ **An RPC-1 drive reports the same empty mask and means the opposite** — it enforces no
+  region at all and answers the key exchange whatever the disc's region. `drive_region_set()`
+  read only the mask until 2026-09-04, so a region-free drive (the best case there is) was
+  labelled `No drive region: cracking` and logged as having no region set. The verdict now
+  also passes on `rpc_scheme == 0` (REPORT KEY byte 6).
 - **CSS-without-libdvdcss:** READ DVD STRUCTURE copyright byte detects CSS upfront; a
   deferred popup asks the user to run `install_dvdcss.sh` (immediate reads would black-screen
   on many drives). The fabric core's own `pes_scrambled` → `CSS ENCRYPTED` + mute is the
@@ -211,6 +216,15 @@ which rules out any typed prompt; hence menus only. Consequences baked into the 
   (`popen(..., "r")`) — output only, **no stdin at all**. The script detects a non-tty stdin
   and degrades to printing status rather than blocking on input nobody can give.
 - Esc needs a ~50 ms timeout to be told apart from the start of an arrow's CSI sequence.
+- ★ **Every exit waits for a keypress, and it has to.** `MENU_SCRIPTS_FB2` ignores key
+  events while the script's process lives, then tears the framebuffer terminal down on the
+  first key **RELEASE** after it is reaped. A script that finishes inside the duration of
+  the press that confirmed it therefore has its last screen erased *by that press* — which
+  is issue #52's "spit out an error and exited faster than I could read it". Staying alive
+  until a **fresh** press spends that release on the pause instead. The pause drains
+  buffered input (auto-repeat included) for up to 2 s before waiting, or it dismisses
+  itself. This applies to any Scripts tool that prints a verdict and returns, not just
+  this one.
 
 **Safety, because a region change is irreversible.** There is no un-set: MMC has no "clear
 region" command, the code field is 1–8 with no none value, each set spends one of ~5 user
@@ -233,13 +247,51 @@ built: the drives are told apart by device node, which says nothing about which 
 unit it is, so connecting only the target drive is the reliable habit and the warning
 nudges toward it.
 
+**Reporting a change, after issue #52 (2026-09-04).** The reporter's LG GS40N *took* the
+region — Windows confirmed it afterwards — and the script called it an error. Two causes,
+and the durable rule they share is that **a failure to read the region back is not a failure
+to set it**: the SEND KEY either succeeded or it did not, and everything after it is
+reporting.
+
+- `apply_region()` re-read the drive with no `try` at all. A drive answers the command after
+  SEND KEY with a unit attention (its RPC state just changed), so that read raising is
+  *normal*, and it produced an uncaught Python traceback.
+- Even when it answered, `region_mask` can lag the change, so the old code's
+  `region == want` test printed "the drive did not take the change" about a drive that had.
+
+Now: the change is issued once and only once; verification re-opens the device (cheapest way
+to clear the unit attention) and retries 6 × 0.5 s, swallowing `OSError` between tries; a
+confirmed read says "Done"; an unconfirmed one says the change was **accepted but not yet
+reported**, tells the user not to repeat it, and exits **3** (distinct from the usage code 2
+and the genuine rejection code 1). Only `set_region()` itself raising is reported as a
+failure. A top-level handler turns any other exception into one line plus a logged
+traceback, because a traceback on a television scrolls the useful part off the screen.
+
+Also added for the next second-hand report: the status screen shows the **raw 3 RPC bytes**
+and decodes `rpc_scheme`/`type` (`RPC state : b0 ff 01   (RPC-2, region not set)`), and every
+printed line is appended to `/media/fat/DVD_reports/set_dvd_region.log` (or `/tmp` if that
+directory does not exist). `type` is a second, independent "is a region set" signal that does
+not depend on the mask having refreshed.
+
 **Testing.** The ioctl itself cannot be tested without a drive; everything guarding it can,
 and that is where the damage would be. `tools/test_set_dvd_region.py` fakes the drive
-(`DVD_REGION_FAKE=<region>:<changes>:<resets>:<scheme>`, honoured by the script) and drives
-the menus through a pty using the exact key sequences MiSTer sends for a gamepad — 13
-scenarios, including "a stray B1 on entry changes nothing" and "the confirm defaults to No".
-The **read** ioctl and the gamepad-driven console are ✅ **HW-CONFIRMED 2026-08-31**; the
-**set** ioctl is the one part still ungated (see open items).
+(`DVD_REGION_FAKE=<region>:<changes>:<resets>:<scheme>[:<fault>]`, honoured by the script)
+and drives the menus through a pty using the exact key sequences MiSTer sends for a gamepad —
+21 scenarios, including "a stray B1 on entry changes nothing" and "the confirm defaults to
+No". The `<fault>` field reproduces what a real drive does around a change: `rbfail` (every
+read after the change raises), `stale` (the mask keeps reporting the old region) and
+`setfail` (the change itself refuses) — of which **only the last may be reported as a
+failure**. `SET_DVD_REGION_SH=<path>` points the suite at another copy of the script, which
+is how the issue-52 checks were proven RED against the pre-fix version. The suite is
+**mutation-checked**: five targeted mutations (unguarded read-back, no pause, unconfirmed
+called a failure, raw bytes dropped, RPC-1 treated as unset) are each caught by their own
+scenario — these are string assertions on console output, exactly the shape that passes
+without proving anything.
+
+The **read** ioctl and the gamepad-driven console were ✅ **HW-CONFIRMED 2026-08-31**; the
+**set** ioctl is ✅ **FIELD-CONFIRMED 2026-09-04** by issue #52 — the change reached the drive
+and stuck, which is the one part of this tool nobody could gate locally without spending a
+permanent change.
 
 ## HW status / open items
 
@@ -260,19 +312,22 @@ Remaining:
    against the drive's set region (`REPORT KEY` RPC state) and show the cracking text on a
    mismatch. Needs a region-mismatched disc to verify — a second drive set to a region the
    local library does **not** match is the practical rig (see item 2).
-2. **`set_dvd_region.sh` on hardware — ✅ READ HW-CONFIRMED 2026-08-31, ⏳ SET still gated.**
-   Run from the Scripts menu and driven with a **gamepad**, with one drive connected and
-   with two: regions read correctly (an unset drive and a region-1 drive each identified),
-   and the multi-drive warning listed both. That confirms everything except the write — the
-   `DVD_AUTH` read, drive enumeration, and the uinput key injection on tty2, which was the
-   design's riskiest assumption (nothing else in the repo depends on it).
-   **Remaining: the SET ioctl** (`DVD_HOST_SEND_RPC_STATE` accepted by the drive and reading
-   back). The read path is safe to re-test freely; a **set is one-way and spends one of the
-   drive's ~5 permanent changes**, so it wants a drive you have decided to commit. Bench plan
-   is three drives — one left unset (keeps the `No drive region: cracking` path testable,
-   which a set would destroy forever), one matching the local library, one deliberately
-   mismatched as the permanent Q2 rig. `DVDCSS_METHOD=title` forces the crack path on any
-   drive if the physical unset state is not available.
+2. **`set_dvd_region.sh` on hardware — ✅ READ HW-CONFIRMED 2026-08-31, ✅ SET
+   FIELD-CONFIRMED 2026-09-04 (issue #52).** Read: run from the Scripts menu and driven with
+   a **gamepad**, with one drive connected and with two — regions read correctly (an unset
+   drive and a region-1 drive each identified), and the multi-drive warning listed both.
+   That confirmed the `DVD_AUTH` read, drive enumeration, and the uinput key injection on
+   tty2, which was the design's riskiest assumption. Write: a user set region on an LG GS40N
+   from the Scripts menu and a PC confirmed the drive was locked to it — so
+   `DVD_HOST_SEND_RPC_STATE` reaches the drive and sticks. The *reporting* around it was
+   wrong and is fixed above; what remains ungated is only the **happy read-back path** (a
+   drive that answers immediately with the new region), which cannot be gated without
+   spending another permanent change and is not worth one.
+   A **set is one-way and spends one of the drive's ~5 permanent changes**. Bench plan for
+   the Q2 rig is still three drives — one left unset (keeps the `No drive region: cracking`
+   path testable, which a set would destroy forever), one matching the local library, one
+   deliberately mismatched. `DVDCSS_METHOD=title` forces the crack path on any drive if the
+   physical unset state is not available.
 3. **Eject → idle reset (just added):** confirm the `status[0]` pulse returns to the idle
    logo cleanly and a subsequent insert plays.
 4. **Drive lifecycle across re-exec:** confirm `/dev/srN` is free for our Main to re-open.

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -381,10 +381,14 @@ scenario — these are string assertions on console output, exactly the shape th
 without proving anything.
 
 The **read** ioctl and the gamepad-driven console are ✅ **HW-CONFIRMED** (2026-08-31, and
-again 2026-09-04 on the rewritten script). The **set** ioctl is ⏳ **still ungated**: every
-attempt so far carried the malformed `pdrc`, so nothing yet proves the corrected command is
-accepted. The next attempt on a real drive is the gate — and it costs one of that drive's
-permanent changes, which is why it has not been spent casually.
+again 2026-09-04 on the rewritten script). The **command** is ✅ HW-proven too: correct
+`pdrc`, matching disc, accepted with Good status over SG_IO. ⏳ What remains ungated is
+narrow and exact — **the script itself issuing a successful set**. Every refusal it has
+produced was the drive declining for a reason it named; it has not yet been the thing that
+sends a change a drive accepts. Closing that needs a drive whose owner wants a region it can
+actually reach, which on a disc-follows-the-disc drive means owning a disc from that region.
+⚠ Do not spend the unset drive on it (the cracking-path rig) — the next user with a genuinely
+unset drive gates it for free, since any disc they own matches a region they would pick.
 
 ## HW status / open items
 
@@ -411,11 +415,12 @@ Remaining:
    the multi-drive warning listed both, and (2026-09-04) the rewritten script reads and
    pauses correctly on the board. That confirms the `DVD_AUTH` read, drive enumeration, and
    the uinput key injection on tty2, which was the design's riskiest assumption.
-   **Write: not yet proven with a correct command.** Every attempt before 2026-09-04 sent
-   the malformed `pdrc` (the region number instead of the mask) and was rejected on the
-   maintainer's drive with sense 05/26/00; issue #52's drive errored too, and why it ended
-   up regioned anyway is unexplained. The gate is one run of the corrected script on a drive
-   whose owner has decided to commit a change.
+   **Write: the command is proven, the script issuing one successfully is not.** The
+   corrected `pdrc` with a matching disc loaded is accepted (Good status, SG_IO, 2026-09-04);
+   the script's own runs have all been refusals the drive explained (`05/6f/04`, `02/3a/01`),
+   because the local drive is region 1 and no region-2 disc exists here to switch it with.
+   The gate is one run on a drive that can reach the region asked of it. Issue #52's LG
+   errored and ended up regioned anyway, which remains unexplained.
    A **set is one-way and spends one of the drive's ~5 permanent changes**. Bench plan for
    the Q2 rig is still three drives — one left unset (keeps the `No drive region: cracking`
    path testable, which a set would destroy forever), one matching the local library, one

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -272,6 +272,15 @@ command reached the drive and parsed — only byte 4 of the 8-byte payload was w
 `regionset.c` computes `~(1 << (n-1))` and `dvd_udf.c:UDFRPCSet()` assigns it straight to
 `ai.hrpcs.pdrc`. `region_pdrc()` now does the same.
 
+✅ **The corrected encoding is HW-PROVEN (2026-09-04):** the same `sg_raw` command with byte
+4 = `0xfe` returned **Good status** on the drive that had just rejected `0x01`, and set it to
+region 1 — one permanent change spent to learn it. ⏳ What that does NOT gate is the
+script's own path: it reaches the drive through the `DVD_AUTH` ioctl rather than raw SG_IO,
+and the kernel building the identical CDB from it is read from `cdrom.c` (`setup_send_key`
+→ `cmd[10] = type | agid<<6`, `cmd[8:9] = buflen = 8`, `buf[1] = 6`, `buf[4] = pdrc`), not
+measured. ⚠ **Do not spend the unset drive to close that gap** — it is the only local rig
+for the `No drive region: cracking` path, and a set destroys it forever.
+
 ⚠ **The reporter's LG GS40N behaved differently and that is not explained.** It errored AND
 ended up regioned, so either it tolerates the malformed number (firmware varies) or it
 rejected the change and the region came from somewhere else. Do not build on either reading.

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -281,9 +281,12 @@ and the kernel building the identical CDB from it is read from `cdrom.c` (`setup
 measured. ⚠ **Do not spend the unset drive to close that gap** — it is the only local rig
 for the `No drive region: cracking` path, and a set destroys it forever.
 
-⚠ **The reporter's LG GS40N behaved differently and that is not explained.** It errored AND
-ended up regioned, so either it tolerates the malformed number (firmware varies) or it
-rejected the change and the region came from somewhere else. Do not build on either reading.
+★ **Drives differ in what they accept here, which is why this survived so long.** Issue
+#52's LG GS40N **took** the plain number — the reporter's change succeeded and a PC confirmed
+the drive was regioned; what failed on that drive was only the read-back afterwards (below).
+The TSSTcorp rejects the same byte outright. So the number worked by luck on tolerant
+firmware, and the mask is the encoding that is actually correct — it is what `regionset` has
+always sent, and what a strict drive demands.
 
 **The write goes out over SG_IO, with `DVD_AUTH` as the fallback (2026-09-04).** Both
 routes carry byte-identical commands — the kernel builds this exact one from the ioctl
@@ -344,8 +347,9 @@ bytes on x86-64, 64 on the MiSTer's armv7). Both were checked against the C ABI 
 assumed — the field list reproduces `sizeof`/`offsetof` exactly on x86-64, and the armv7
 sizes come from a `_Static_assert` compiled with the MiSTer toolchain's own headers.
 
-**Reporting a change.** Two further defects, real regardless of the encoding, sharing one
-durable rule — **a failure to read the region back is not a failure to set it**: the SEND KEY
+**Reporting a change — the defect issue #52 actually hit.** On a drive that accepts the
+change, these two are what turn a success into an apparent failure. Both share one durable
+rule — **a failure to read the region back is not a failure to set it**: the SEND KEY
 either succeeded or it did not, and everything after it is reporting.
 
 - `apply_region()` re-read the drive with no `try` at all. A drive answers the command after
@@ -418,8 +422,9 @@ Remaining:
    the uinput key injection on tty2, which was the design's riskiest assumption.
    **Write: ✅ HW-CONFIRMED 2026-09-04** — the script set a TSSTcorp TS-L633C from region 1
    to region 2 with a disc loaded that allowed region 2, read the new region back on the
-   first attempt, and the change counter went 3 → 2. Issue #52's LG errored and ended up
-   regioned anyway, which remains unexplained and is the only loose end left here.
+   first attempt, and the change counter went 3 → 2. Issue #52's LG GS40N had already set its
+   region successfully on the pre-fix script (tolerant firmware, plain number accepted); the
+   corrected encoding is what makes strict drives work too.
    A **set is one-way and spends one of the drive's ~5 permanent changes**. Bench plan for
    the Q2 rig is still three drives — one left unset (keeps the `No drive region: cracking`
    path testable, which a set would destroy forever), one matching the local library, one

--- a/docs/physical_disc.md
+++ b/docs/physical_disc.md
@@ -200,7 +200,7 @@ into the SCSI REPORT KEY / SEND KEY commands for RPC state:
 | | value | struct |
 |---|---|---|
 | read  | `DVD_LU_SEND_RPC_STATE` = **10** | `{type:2, vra:3, ucca:3, region_mask, rpc_scheme}` — 3 bytes, bitfields packed from the low end |
-| write | `DVD_HOST_SEND_RPC_STATE` = **11** | `{type, pdrc}` — `pdrc` is the region, 1–8 |
+| write | `DVD_HOST_SEND_RPC_STATE` = **11** | `{type, pdrc}` — ⚠ `pdrc` is a region **MASK with one bit CLEAR**, not the region number: region 1 is `0xfe`, region 2 `0xfd`. Same polarity as the `region_mask` the read returns |
 
 `sizeof(dvd_authinfo)` is 16. `region_mask` has a **clear** bit per playable region, so
 `0xff` = no region set (the same test `dvd_css.cpp:drive_region_set()` already makes over
@@ -256,11 +256,29 @@ built: the drives are told apart by device node, which says nothing about which 
 unit it is, so connecting only the target drive is the reliable habit and the warning
 nudges toward it.
 
-**Reporting a change, after issue #52 (2026-09-04).** The reporter's LG GS40N *took* the
-region — Windows confirmed it afterwards — and the script called it an error. Two causes,
-and the durable rule they share is that **a failure to read the region back is not a failure
-to set it**: the SEND KEY either succeeded or it did not, and everything after it is
-reporting.
+**Issue #52 (2026-09-04): the change command itself was malformed.** ★★ **`pdrc` is a
+region MASK with one bit CLEAR, not the region number.** We sent the number, and as a mask
+`0x01` claims *seven* playable regions — so a conforming drive rejects it. MEASURED on the
+maintainer's RPC-2 drive with `sg_raw` sending the byte-identical command the kernel builds:
+
+```
+sudo sg_raw -v -s 8 -i /tmp/rpc.bin /dev/sr0 a3 00 00 00 00 00 00 00 00 08 06 00
+  Sense key: Illegal Request / Additional sense: Invalid field in PARAMETER LIST  (05/26/00)
+```
+
+★ **The sense code is what localised it in one shot**: *parameter list*, not *CDB*, so the
+command reached the drive and parsed — only byte 4 of the 8-byte payload was wrong. And
+`regionset`, which has worked on Linux for twenty years, has always sent the mask:
+`regionset.c` computes `~(1 << (n-1))` and `dvd_udf.c:UDFRPCSet()` assigns it straight to
+`ai.hrpcs.pdrc`. `region_pdrc()` now does the same.
+
+⚠ **The reporter's LG GS40N behaved differently and that is not explained.** It errored AND
+ended up regioned, so either it tolerates the malformed number (firmware varies) or it
+rejected the change and the region came from somewhere else. Do not build on either reading.
+
+**Reporting a change.** Two further defects, real regardless of the encoding, sharing one
+durable rule — **a failure to read the region back is not a failure to set it**: the SEND KEY
+either succeeded or it did not, and everything after it is reporting.
 
 - `apply_region()` re-read the drive with no `try` at all. A drive answers the command after
   SEND KEY with a unit attention (its RPC state just changed), so that read raising is
@@ -297,10 +315,11 @@ called a failure, raw bytes dropped, RPC-1 treated as unset) are each caught by 
 scenario — these are string assertions on console output, exactly the shape that passes
 without proving anything.
 
-The **read** ioctl and the gamepad-driven console were ✅ **HW-CONFIRMED 2026-08-31**; the
-**set** ioctl is ✅ **FIELD-CONFIRMED 2026-09-04** by issue #52 — the change reached the drive
-and stuck, which is the one part of this tool nobody could gate locally without spending a
-permanent change.
+The **read** ioctl and the gamepad-driven console are ✅ **HW-CONFIRMED** (2026-08-31, and
+again 2026-09-04 on the rewritten script). The **set** ioctl is ⏳ **still ungated**: every
+attempt so far carried the malformed `pdrc`, so nothing yet proves the corrected command is
+accepted. The next attempt on a real drive is the gate — and it costs one of that drive's
+permanent changes, which is why it has not been spent casually.
 
 ## HW status / open items
 
@@ -321,17 +340,17 @@ Remaining:
    against the drive's set region (`REPORT KEY` RPC state) and show the cracking text on a
    mismatch. Needs a region-mismatched disc to verify — a second drive set to a region the
    local library does **not** match is the practical rig (see item 2).
-2. **`set_dvd_region.sh` on hardware — ✅ READ HW-CONFIRMED 2026-08-31, ✅ SET
-   FIELD-CONFIRMED 2026-09-04 (issue #52).** Read: run from the Scripts menu and driven with
-   a **gamepad**, with one drive connected and with two — regions read correctly (an unset
-   drive and a region-1 drive each identified), and the multi-drive warning listed both.
-   That confirmed the `DVD_AUTH` read, drive enumeration, and the uinput key injection on
-   tty2, which was the design's riskiest assumption. Write: a user set region on an LG GS40N
-   from the Scripts menu and a PC confirmed the drive was locked to it — so
-   `DVD_HOST_SEND_RPC_STATE` reaches the drive and sticks. The *reporting* around it was
-   wrong and is fixed above; what remains ungated is only the **happy read-back path** (a
-   drive that answers immediately with the new region), which cannot be gated without
-   spending another permanent change and is not worth one.
+2. **`set_dvd_region.sh` on hardware — ✅ READ HW-CONFIRMED, ⏳ SET STILL UNGATED.** Read:
+   run from the Scripts menu and driven with a **gamepad**, with one drive connected and
+   with two — regions read correctly (an unset drive and a region-1 drive each identified),
+   the multi-drive warning listed both, and (2026-09-04) the rewritten script reads and
+   pauses correctly on the board. That confirms the `DVD_AUTH` read, drive enumeration, and
+   the uinput key injection on tty2, which was the design's riskiest assumption.
+   **Write: not yet proven with a correct command.** Every attempt before 2026-09-04 sent
+   the malformed `pdrc` (the region number instead of the mask) and was rejected on the
+   maintainer's drive with sense 05/26/00; issue #52's drive errored too, and why it ended
+   up regioned anyway is unexplained. The gate is one run of the corrected script on a drive
+   whose owner has decided to commit a change.
    A **set is one-way and spends one of the drive's ~5 permanent changes**. Bench plan for
    the Q2 rig is still three drives — one left unset (keeps the `No drive region: cracking`
    path testable, which a set would destroy forever), one matching the local library, one

--- a/main/Scripts/set_dvd_region.sh
+++ b/main/Scripts/set_dvd_region.sh
@@ -84,9 +84,15 @@ KF_RPC_STATE    = 6            # ... key format 6 = Send RPC State
 CHECK_CONDITION = 0x02         # SCSI status: the drive has something to say
 DRIVER_SENSE    = 0x08         # driver_status: ... and the sense data is attached
 
+CDROM_DRIVE_STATUS = 0x5326    # linux/cdrom.h: is there a disc in the drive?
+CDS_DISC_OK        = 4
+
 # Sense codes worth naming. Everything else is printed as its raw triple, which is
 # what a bug report needs anyway.
 SENSE_TEXT = {
+    (5, 0x6f, 0x04): "a disc in the drive has a different region - EJECT IT and retry",
+    (5, 0x6f, 0x05): "the drive will not accept another region change",
+    (5, 0x6f, 0x00): "copy protection key exchange failure",
     (5, 0x26, 0x00): "invalid field in parameter list",
     (5, 0x24, 0x00): "invalid field in CDB",
     (5, 0x20, 0x00): "the drive does not support this command",
@@ -312,6 +318,20 @@ class Drive:
             pass
         self.fd = os.open(self.path, os.O_RDONLY | os.O_NONBLOCK)
 
+    def media_present(self):
+        """A loaded disc blocks a region change on at least some drives.
+
+        MEASURED: a TSSTcorp TS-L633C set to region 1, asked for region 2 with a
+        region-1 disc loaded, answers sense 05/6f/04 — "media region code is
+        mismatched to logical unit region". The change it is being asked to make
+        would orphan the disc in its own tray, so it refuses. The same drive took
+        the same change with an empty tray.
+        """
+        try:
+            return fcntl.ioctl(self.fd, CDROM_DRIVE_STATUS, 0) == CDS_DISC_OK
+        except OSError:
+            return False    # can't tell -> say nothing rather than nag wrongly
+
     def read_state(self):
         buf = bytearray(AUTHINFO_SIZE)
         buf[0] = LU_SEND_RPC_STATE
@@ -377,6 +397,9 @@ class FakeDrive:
 
     def reopen(self):
         pass
+
+    def media_present(self):
+        return self.fault == "disc"
 
     def read_state(self):
         if self.fault == "rbfail" and self.changed:
@@ -631,6 +654,11 @@ def interactive(drive, state, extra=()):
         pause()
         return 0
 
+    if drive.media_present():
+        header += ["",
+                   "  !! There is a disc in the drive. Take it out first - a drive",
+                   "  !! refuses to change region while a disc of a different region",
+                   "  !! is loaded, because the change would orphan that disc."]
     header += ["", "  Pick the region your discs come from:"]
     items = ["%d  %s" % (num, name) for num, name in CHOOSABLE] + ["Cancel - change nothing"]
     footer = ["  D-pad = move    B1 = select    B2 = cancel",

--- a/main/Scripts/set_dvd_region.sh
+++ b/main/Scripts/set_dvd_region.sh
@@ -169,6 +169,20 @@ def raw_hex(state):
     return " ".join("%02x" % b for b in state.raw)
 
 
+def region_pdrc(region):
+    """Region 1-8 -> the Preferred Drive Region Code byte SEND KEY wants.
+
+    ⚠ pdrc is a MASK with one bit CLEAR — the same polarity as the region_mask
+    REPORT KEY returns — and NOT the region number. Region 1 is 0xfe, region 2
+    is 0xfd. Sending the plain number is what a drive answers with sense
+    05/26/00, "invalid field in parameter list": as a mask, 0x01 claims seven
+    playable regions. Measured on a real drive via sg_raw, and it is what
+    regionset has always sent (regionset.c `~(1 << (n-1))` -> dvd_udf.c
+    UDFRPCSet -> `ai.hrpcs.pdrc`).
+    """
+    return ~(1 << (region - 1)) & 0xff
+
+
 class Drive:
     def __init__(self, path, fd):
         self.path = path
@@ -193,10 +207,11 @@ class Drive:
         return decode_state(bytes(buf[:3]))
 
     def set_region(self, region):
-        """struct dvd_host_send_rpcstate is {type, pdrc}; pdrc is the region 1-8."""
+        """struct dvd_host_send_rpcstate is {type, pdrc} — see region_pdrc()."""
         buf = bytearray(AUTHINFO_SIZE)
         buf[0] = HOST_SEND_RPC_STATE
-        buf[1] = region
+        buf[1] = region_pdrc(region)
+        note("  send pdrc %02x for region %d" % (buf[1], region))
         fcntl.ioctl(self.fd, DVD_AUTH, buf, True)
 
 
@@ -236,6 +251,13 @@ class FakeDrive:
         return decode_state(self.encode())
 
     def set_region(self, region):
+        # Encode exactly what the ioctl would carry and decode it back, so a
+        # wrong pdrc fails here the way a real drive fails: strictly.
+        pdrc = region_pdrc(region)
+        note("  send pdrc %02x for region %d" % (pdrc, region))
+        clear = [n + 1 for n in range(8) if not (pdrc >> n) & 1]
+        if clear != [region]:
+            raise OSError(22, "Invalid argument")   # sense 05/26/00 on real iron
         if self.fault == "setfail" or self.changes <= 0:
             raise OSError(5, "Input/output error")
         self.changes -= 1

--- a/main/Scripts/set_dvd_region.sh
+++ b/main/Scripts/set_dvd_region.sh
@@ -79,8 +79,11 @@ AUTHINFO_SIZE       = 16       # sizeof(dvd_authinfo) — 16 on x86-64 AND armv7
 
 SG_IO           = 0x2285       # scsi/sg.h: send one SCSI command
 SG_DXFER_TO_DEV = -2
+SG_DXFER_FROM_DEV = -3
 SEND_KEY        = 0xa3         # MMC: SEND KEY
 KF_RPC_STATE    = 6            # ... key format 6 = Send RPC State
+READ_DVD_STRUCT = 0xad         # MMC: READ DVD STRUCTURE
+DVDS_COPYRIGHT  = 0x01         # ... format 1 = copyright info, incl. the disc region
 CHECK_CONDITION = 0x02         # SCSI status: the drive has something to say
 DRIVER_SENSE    = 0x08         # driver_status: ... and the sense data is attached
 
@@ -90,14 +93,16 @@ CDS_DISC_OK        = 4
 # Sense codes worth naming. Everything else is printed as its raw triple, which is
 # what a bug report needs anyway.
 SENSE_TEXT = {
-    (5, 0x6f, 0x04): "a disc in the drive has a different region - EJECT IT and retry",
+    (5, 0x6f, 0x04): "the disc in the drive is from a different region",
+    (2, 0x3a, 0x00): "no disc in the drive",
+    (2, 0x3a, 0x01): "no disc in the drive (tray closed)",
+    (2, 0x3a, 0x02): "the tray is open",
     (5, 0x6f, 0x05): "the drive will not accept another region change",
     (5, 0x6f, 0x00): "copy protection key exchange failure",
     (5, 0x26, 0x00): "invalid field in parameter list",
     (5, 0x24, 0x00): "invalid field in CDB",
     (5, 0x20, 0x00): "the drive does not support this command",
     (5, 0x6f, 0x05): "the drive's region-change counter is exhausted",
-    (2, 0x3a, 0x00): "no disc in the drive",
     (2, 0x04, 0x01): "the drive is still becoming ready - try again in a moment",
 }
 
@@ -240,8 +245,8 @@ def sg_check(status, host_status, driver_status, sense):
     raise OSError(5, "the drive refused it (SCSI status %02x, no sense)" % status)
 
 
-def sg_send_key(fd, payload, key_format=KF_RPC_STATE, timeout_ms=15000):
-    """SEND KEY over SG_IO, the way sg_raw does it.
+def sg_do(fd, cdb, to_dev, data, timeout_ms=15000):
+    """Run one SCSI command over SG_IO. `data` is bytes to send, or a read length.
 
     WHY THIS EXISTS: the `DVD_AUTH` ioctl builds the identical command, but the
     kernel funnels every drive refusal through `sr_do_ioctl`, which collapses
@@ -251,8 +256,9 @@ def sg_send_key(fd, payload, key_format=KF_RPC_STATE, timeout_ms=15000):
     refusing the ioctl is what sent us looking; either way this is the route that
     can explain itself.)
 
-    Returns None on success, raises SenseError on a refusal the drive explained,
-    and lets OSError through if SG_IO is unusable — the caller falls back then.
+    Returns the bytes read (empty for a send), raises SenseError on a refusal the
+    drive explained, and lets OSError through if SG_IO is unusable — the caller
+    falls back then.
     """
     import ctypes
 
@@ -271,26 +277,26 @@ def sg_send_key(fd, payload, key_format=KF_RPC_STATE, timeout_ms=15000):
                     ("driver_status", ctypes.c_ushort), ("resid", ctypes.c_int),
                     ("duration", ctypes.c_uint), ("info", ctypes.c_uint)]
 
-    n = len(payload)
-    cdb = bytes((SEND_KEY, 0, 0, 0, 0, 0, 0, 0, (n >> 8) & 0xff, n & 0xff, key_format, 0))
-    cdb_buf = ctypes.create_string_buffer(cdb, len(cdb))
-    data    = ctypes.create_string_buffer(bytes(payload), n)
+    n = len(data) if to_dev else int(data)
+    cdb_buf = ctypes.create_string_buffer(bytes(cdb), len(cdb))
+    buf     = ctypes.create_string_buffer(bytes(data) if to_dev else n, n)
     sense   = ctypes.create_string_buffer(32)
 
     hdr = sg_io_hdr()
     ctypes.memset(ctypes.byref(hdr), 0, ctypes.sizeof(hdr))
     hdr.interface_id = ord("S")
-    hdr.dxfer_direction = SG_DXFER_TO_DEV
+    hdr.dxfer_direction = SG_DXFER_TO_DEV if to_dev else SG_DXFER_FROM_DEV
     hdr.cmd_len = len(cdb)
     hdr.mx_sb_len = ctypes.sizeof(sense)
     hdr.dxfer_len = n
-    hdr.dxferp = ctypes.cast(data, ctypes.c_void_p)
+    hdr.dxferp = ctypes.cast(buf, ctypes.c_void_p)
     hdr.cmdp = ctypes.cast(cdb_buf, ctypes.c_void_p)
     hdr.sbp = ctypes.cast(sense, ctypes.c_void_p)
     hdr.timeout = timeout_ms
 
-    note("  SG_IO cdb %s payload %s"
-         % (" ".join("%02x" % b for b in cdb), " ".join("%02x" % b for b in payload)))
+    note("  SG_IO cdb %s%s"
+         % (" ".join("%02x" % b for b in cdb),
+            "" if not to_dev else " payload " + " ".join("%02x" % b for b in data)))
     fcntl.ioctl(fd, SG_IO, hdr)   # OSError here = SG_IO unusable, not a refusal
     note("  SG_IO status %02x host %02x driver %02x sb_len %d"
          % (hdr.status, hdr.host_status, hdr.driver_status, hdr.sb_len_wr))
@@ -298,7 +304,33 @@ def sg_send_key(fd, payload, key_format=KF_RPC_STATE, timeout_ms=15000):
     sb = sense.raw[:hdr.sb_len_wr] if hdr.sb_len_wr else b""
     if sb:
         note("  SG_IO sense %s" % " ".join("%02x" % b for b in sb))
-    return sg_check(hdr.status, hdr.host_status, hdr.driver_status, sb)
+    sg_check(hdr.status, hdr.host_status, hdr.driver_status, sb)
+    return b"" if to_dev else buf.raw[:n]
+
+
+def sg_send_key(fd, payload, key_format=KF_RPC_STATE):
+    n = len(payload)
+    cdb = (SEND_KEY, 0, 0, 0, 0, 0, 0, 0, (n >> 8) & 0xff, n & 0xff, key_format, 0)
+    return sg_do(fd, cdb, True, payload)
+
+
+def disc_regions(fd):
+    """Which regions the loaded disc allows, or None if it cannot be read.
+
+    READ DVD STRUCTURE format 1 (copyright info): byte 4 is the protection type,
+    byte 5 the Region Management Information — a CLEAR bit per allowed region,
+    the same polarity as everything else here. An RMI of 0 is an all-region disc.
+    """
+    cdb = (READ_DVD_STRUCT, 0, 0, 0, 0, 0, 0, DVDS_COPYRIGHT, 0, 8, 0, 0)
+    try:
+        buf = sg_do(fd, cdb, False, 8)
+    except (OSError, ImportError, AttributeError):
+        return None
+    if len(buf) < 6:
+        return None
+    rmi = buf[5]
+    note("  disc RMI %02x" % rmi)
+    return [n + 1 for n in range(8) if not (rmi >> n) & 1]
 
 
 class Drive:
@@ -319,18 +351,13 @@ class Drive:
         self.fd = os.open(self.path, os.O_RDONLY | os.O_NONBLOCK)
 
     def media_present(self):
-        """A loaded disc blocks a region change on at least some drives.
-
-        MEASURED: a TSSTcorp TS-L633C set to region 1, asked for region 2 with a
-        region-1 disc loaded, answers sense 05/6f/04 — "media region code is
-        mismatched to logical unit region". The change it is being asked to make
-        would orphan the disc in its own tray, so it refuses. The same drive took
-        the same change with an empty tray.
-        """
         try:
             return fcntl.ioctl(self.fd, CDROM_DRIVE_STATUS, 0) == CDS_DISC_OK
         except OSError:
             return False    # can't tell -> say nothing rather than nag wrongly
+
+    def disc_regions(self):
+        return disc_regions(self.fd) if self.media_present() else None
 
     def read_state(self):
         buf = bytearray(AUTHINFO_SIZE)
@@ -383,6 +410,8 @@ class FakeDrive:
     def __init__(self, spec, index=0):
         parts = spec.split(":")
         self.fault = parts[4] if len(parts) > 4 else ""
+        # "discN" loads a region-N disc in the tray; the drive follows the disc.
+        self.disc = int(self.fault[4:]) if self.fault.startswith("disc") else None
         region, changes, resets, scheme = (int(p) for p in (parts + ["0", "5", "4", "1"])[:4])
         self.path = "(simulated sr%d)" % index
         self.region, self.changes, self.resets, self.scheme = region, changes, resets, scheme
@@ -399,7 +428,10 @@ class FakeDrive:
         pass
 
     def media_present(self):
-        return self.fault == "disc"
+        return self.disc is not None
+
+    def disc_regions(self):
+        return [self.disc] if self.disc else None
 
     def read_state(self):
         if self.fault == "rbfail" and self.changed:
@@ -414,6 +446,13 @@ class FakeDrive:
         clear = [n + 1 for n in range(8) if not (pdrc >> n) & 1]
         if clear != [region]:
             raise OSError(22, "Invalid argument")   # sense 05/26/00 on real iron
+        # MEASURED on a TSSTcorp TS-L633C: the drive takes its new region from
+        # the disc in the tray. No disc -> 02/3a/01, wrong disc -> 05/6f/04.
+        if self.fault.startswith("disc") or self.fault == "nodisc":
+            if self.disc is None:
+                raise SenseError(2, 0x3a, 0x01)
+            if self.disc != region:
+                raise SenseError(5, 0x6f, 0x04)
         if self.fault == "setfail" or self.changes <= 0:
             raise OSError(5, "Input/output error")
         self.changes -= 1
@@ -591,6 +630,16 @@ def status_lines(drive, state):
         lines.append("                   CSS keys must be cracked - slow first play")
     lines.append("  Changes left   : %d       (vendor resets: %d)" % (state.changes, state.resets))
     lines.append("  RPC state      : %s   (%s)" % (raw_hex(state), describe_rpc(state)))
+    regions = drive.disc_regions()
+    if regions is None:
+        lines.append("  Disc in drive  : %s"
+                     % ("yes (region unreadable)" if drive.media_present() else "none"))
+    elif len(regions) == 8:
+        lines.append("  Disc in drive  : all regions")
+    else:
+        lines.append("  Disc in drive  : region %s"
+                     % ",".join(str(r) for r in regions) if regions else
+                     "  Disc in drive  : no region allowed")
     return lines
 
 
@@ -654,11 +703,10 @@ def interactive(drive, state, extra=()):
         pause()
         return 0
 
-    if drive.media_present():
-        header += ["",
-                   "  !! There is a disc in the drive. Take it out first - a drive",
-                   "  !! refuses to change region while a disc of a different region",
-                   "  !! is loaded, because the change would orphan that disc."]
+    header += ["",
+               "  Many drives take the new region FROM THE DISC in the tray: put a",
+               "  disc from the region you want in the drive before changing it.",
+               "  An empty tray or a disc from another region is refused."]
     header += ["", "  Pick the region your discs come from:"]
     items = ["%d  %s" % (num, name) for num, name in CHOOSABLE] + ["Cancel - change nothing"]
     footer = ["  D-pad = move    B1 = select    B2 = cancel",
@@ -685,6 +733,18 @@ def interactive(drive, state, extra=()):
     confirm_header += ["",
                        "  This uses one of the %d changes the drive has left" % state.changes,
                        "  and CANNOT be undone."]
+    regions = drive.disc_regions()
+    if regions is not None and want not in regions:
+        confirm_header += ["",
+                           "  !! The disc in the drive is region %s. A drive that takes its"
+                           % ",".join(str(r) for r in regions),
+                           "  !! region from the disc will REFUSE this - swap in a region",
+                           "  !! %d disc first if it does." % want]
+    elif regions is None and drive.media_present() is False:
+        confirm_header += ["",
+                           "  !! The drive is empty. A drive that takes its region from the",
+                           "  !! disc will REFUSE this - put a region %d disc in if it does."
+                           % want]
     if state.changes == 1:
         confirm_header += ["",
                            "  *** This is the LAST change this drive allows.",

--- a/main/Scripts/set_dvd_region.sh
+++ b/main/Scripts/set_dvd_region.sh
@@ -9,7 +9,7 @@
 # HOW TO USE IT: run "set_dvd_region" from the MiSTer Scripts menu. It shows the
 # drive's current region and how many changes it has left; picking a new region is a
 # menu, driven with the D-pad and B1 (or arrow keys and Enter). Nothing is changed
-# until you confirm.
+# until you confirm, and every screen waits for a keypress before it closes.
 #
 # !! A region change is close to permanent. Drives allow only a handful of user
 # !! changes — typically five — and when the counter reaches zero the region is
@@ -20,6 +20,9 @@
 # the DVD core holds the drive open while a disc is mounted. If several drives are
 # connected it only ever touches the first, and says so; connect just the one you
 # mean to change.
+#
+# Everything printed is also appended to a log (/media/fat/DVD_reports if that
+# exists, else /tmp), so a result that scrolls past can still be read afterwards.
 #
 # Over SSH you can skip the menu:
 #   ./set_dvd_region.sh          show the current region and changes remaining
@@ -46,6 +49,16 @@ Gamepad support is not our doing: while a Scripts-menu script runs, MiSTer's Mai
 injects real keyboard events from the gamepad (D-pad -> arrows, B1 -> Enter,
 B2 -> Esc, B3 -> Space, B4 -> Tab). There are no digits or letters in that mapping,
 which is why every choice here is a cursor menu and never a typed value.
+
+Two rules this tool exists to obey, both learned from issue #52 (a region change
+that WORKED and reported itself as an error):
+
+  * A failure to read the region back is NOT a failure to set it. The SEND KEY
+    either succeeded or it didn't; everything after it is reporting.
+  * Nothing may exit without waiting for a keypress. MiSTer's framebuffer script
+    runner ignores keys while the script runs, then closes the terminal on the
+    first key RELEASE once it exits — so the press that confirms the last menu
+    wipes the result screen of any script that finishes quickly.
 """
 
 import fcntl
@@ -54,12 +67,18 @@ import os
 import select
 import sys
 import termios
+import time
+import traceback
 import tty
+from collections import namedtuple
 
 DVD_AUTH            = 0x5392   # linux/cdrom.h: DVD authentication ioctl
 LU_SEND_RPC_STATE   = 10       # drive -> host: report the current RPC state
 HOST_SEND_RPC_STATE = 11       # host -> drive: set the region
 AUTHINFO_SIZE       = 16       # sizeof(dvd_authinfo)
+
+VERIFY_TRIES = 6               # read-backs after a change ...
+VERIFY_WAIT  = 0.5             # ... spaced this far apart
 
 REGIONS = [
     (1, "US, Canada"),
@@ -78,31 +97,100 @@ REGIONS = [
 # handful of permanent changes on one would be a mistake with no way back.
 CHOOSABLE = [entry for entry in REGIONS if entry[0] <= 6]
 
+# The transcript. First writable location wins; /tmp always is, so there is always
+# somewhere to point a bug report at.
+LOG_PATHS = ("/media/fat/DVD_reports/set_dvd_region.log", "/tmp/set_dvd_region.log")
+
+
+# --------------------------------------------------------------------- the log
+
+log_file = None
+log_path = None
+
+
+def log_open():
+    """Best effort: no logging is a nuisance, a crash trying to log is a bug."""
+    global log_file, log_path
+    for path in LOG_PATHS:
+        folder = os.path.dirname(path)
+        if not os.path.isdir(folder):
+            # Create it only where it belongs — under an existing /media/fat.
+            if not os.path.isdir(os.path.dirname(folder)):
+                continue
+            try:
+                os.mkdir(folder)
+            except OSError:
+                continue
+        try:
+            log_file = open(path, "a")
+            log_path = path
+            return
+        except OSError:
+            continue
+
+
+def note(text):
+    """Log without printing — diagnostics nobody needs on a television."""
+    if log_file is None:
+        return
+    try:
+        log_file.write(text.rstrip("\n") + "\n")
+        log_file.flush()
+    except OSError:
+        pass
+
 
 # ---------------------------------------------------------------- drive access
+
+State = namedtuple("State", "region changes resets scheme rpc_type raw")
+
+
+def decode_state(raw):
+    """Three bytes of struct dvd_lu_send_rpcstate -> State.
+
+    {type:2, vra:3, ucca:3, region_mask, rpc_scheme}, the bitfields packed from
+    the low end. Two independent answers to "is a region set?" come back and both
+    are kept, because a drive that has just been changed can update one before the
+    other: `type` is the drive's own verdict (0 = none set, 1 = set), while
+    region_mask has a CLEAR bit per PLAYABLE region, so 0xff means none is set and
+    exactly one clear bit names the drive's region. rpc_scheme 0 is an RPC-1 drive,
+    which enforces no region at all.
+    """
+    rpc_type      = raw[0] & 3
+    vendor_resets = (raw[0] >> 2) & 7
+    changes_left  = (raw[0] >> 5) & 7
+    mask, scheme  = raw[1], raw[2]
+    playable = [n + 1 for n in range(8) if not (mask >> n) & 1]
+    region = playable[0] if len(playable) == 1 else None
+    return State(region, changes_left, vendor_resets, scheme, rpc_type, raw)
+
+
+def raw_hex(state):
+    return " ".join("%02x" % b for b in state.raw)
+
 
 class Drive:
     def __init__(self, path, fd):
         self.path = path
         self.fd = fd
 
-    def read_state(self):
-        """-> (region or None, changes_left, vendor_resets, rpc_scheme).
+    def reopen(self):
+        """Fresh handle, used before reading back a change.
 
-        struct dvd_lu_send_rpcstate is {type:2, vra:3, ucca:3, region_mask,
-        rpc_scheme} — three bytes, the bitfields packed from the low end.
-        region_mask has a CLEAR bit per PLAYABLE region, so 0xff means no region
-        is set and exactly one clear bit means that region is the drive's.
+        A drive answers the command after SEND KEY with a unit attention — its RPC
+        state just changed — and re-opening is the cheapest way to start clean.
         """
+        try:
+            os.close(self.fd)
+        except OSError:
+            pass
+        self.fd = os.open(self.path, os.O_RDONLY | os.O_NONBLOCK)
+
+    def read_state(self):
         buf = bytearray(AUTHINFO_SIZE)
         buf[0] = LU_SEND_RPC_STATE
         fcntl.ioctl(self.fd, DVD_AUTH, buf, True)
-        vendor_resets = (buf[0] >> 2) & 7
-        changes_left  = (buf[0] >> 5) & 7
-        mask, scheme  = buf[1], buf[2]
-        playable = [n + 1 for n in range(8) if not (mask >> n) & 1]
-        region = playable[0] if len(playable) == 1 else None
-        return region, changes_left, vendor_resets, scheme
+        return decode_state(bytes(buf[:3]))
 
     def set_region(self, region):
         """struct dvd_host_send_rpcstate is {type, pdrc}; pdrc is the region 1-8."""
@@ -115,24 +203,45 @@ class Drive:
 class FakeDrive:
     """Test stand-in so the menus can be exercised without an optical drive.
 
-    Enable with DVD_REGION_FAKE=<region>:<changes>:<resets>:<scheme>, region 0
-    meaning none set, e.g. DVD_REGION_FAKE=0:5:4:1. Several drives can be
+    Enable with DVD_REGION_FAKE=<region>:<changes>:<resets>:<scheme>[:<fault>],
+    region 0 meaning none set, e.g. DVD_REGION_FAKE=0:5:4:1. Several drives can be
     simulated by separating them with commas. Touches no hardware.
+
+    <fault> reproduces what a real drive does around a change, which is where the
+    reporting has to be right: "rbfail" makes every read AFTER a change raise (the
+    unit attention), "stale" makes the drive keep reporting the old region for a
+    while, "setfail" makes the change itself fail.
     """
     def __init__(self, spec, index=0):
-        parts = (spec.split(":") + ["0", "5", "4", "1"])[:4]
-        region, changes, resets, scheme = (int(p) for p in parts)
+        parts = spec.split(":")
+        self.fault = parts[4] if len(parts) > 4 else ""
+        region, changes, resets, scheme = (int(p) for p in (parts + ["0", "5", "4", "1"])[:4])
         self.path = "(simulated sr%d)" % index
-        self.state = [region or None, changes, resets, scheme]
+        self.region, self.changes, self.resets, self.scheme = region, changes, resets, scheme
+        self.changed = False
+
+    def encode(self):
+        mask = 0xff
+        if self.region:
+            mask &= ~(1 << (self.region - 1)) & 0xff
+        head = (1 if self.region else 0) | (self.resets << 2) | (self.changes << 5)
+        return bytes((head, mask, self.scheme))
+
+    def reopen(self):
+        pass
 
     def read_state(self):
-        return tuple(self.state)
+        if self.fault == "rbfail" and self.changed:
+            raise OSError(5, "Input/output error")
+        return decode_state(self.encode())
 
     def set_region(self, region):
-        if self.state[1] <= 0:
+        if self.fault == "setfail" or self.changes <= 0:
             raise OSError(5, "Input/output error")
-        self.state[0] = region
-        self.state[1] -= 1
+        self.changes -= 1
+        self.changed = True
+        if self.fault != "stale":
+            self.region = region
 
 
 def find_drives():
@@ -152,10 +261,16 @@ def find_drives():
 
 # ------------------------------------------------------------------ console UI
 
-def out(text=""):
+def draw(text=""):
+    """Screen only. Menu redraws must not fill the log with themselves."""
     # Raw mode turns off the newline translation, so line ends must be explicit.
     sys.stdout.write(text + "\r\n")
     sys.stdout.flush()
+
+
+def out(text=""):
+    draw(text)
+    note(text)
 
 
 def clear():
@@ -182,6 +297,42 @@ def read_key(fd):
     return ""
 
 
+def pause():
+    """Hold the screen until a key is pressed. Every interactive exit goes here.
+
+    MiSTer's framebuffer script runner (menu.cpp, MENU_SCRIPTS_FB2) ignores key
+    events while the script's process lives, then tears the terminal down on the
+    first key RELEASE after it is reaped. A script that finishes inside the
+    duration of the press that confirmed it therefore has its last screen erased
+    by that very press — which is how a successful region change came back as
+    "an error that vanished before I could read it". Staying alive until a FRESH
+    press spends that release on us instead.
+    """
+    if not sys.stdin.isatty():
+        return
+    out()
+    out("  Press B1 / Enter to close%s"
+        % ("      (log: %s)" % log_path if log_path else ""))
+    fd = sys.stdin.fileno()
+    try:
+        saved = termios.tcgetattr(fd)
+    except termios.error:
+        return
+    try:
+        tty.setcbreak(fd)
+        # Drain what the confirming press left behind — auto-repeat included —
+        # before waiting, or the pause dismisses itself. Bounded, so a key stuck
+        # down cannot hold the drain open forever.
+        deadline = time.time() + 2.0
+        while time.time() < deadline and select.select([fd], [], [], 0.25)[0]:
+            os.read(fd, 256)
+        os.read(fd, 1)
+    except OSError:
+        pass
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, saved)
+
+
 def menu(header, items, footer, selected=0):
     """Cursor menu. Returns the chosen index, or None if cancelled."""
     fd = sys.stdin.fileno()
@@ -191,21 +342,23 @@ def menu(header, items, footer, selected=0):
         while True:
             clear()
             for row in header:
-                out(row)
-            out()
+                draw(row)
+            draw()
             for n, item in enumerate(items):
-                out(("  > " if n == selected else "    ") + item)
-            out()
+                draw(("  > " if n == selected else "    ") + item)
+            draw()
             for row in footer:
-                out(row)
+                draw(row)
             key = read_key(fd)
             if key == "up":
                 selected = (selected - 1) % len(items)
             elif key == "down":
                 selected = (selected + 1) % len(items)
             elif key == "enter":
+                note("[menu] %s -> %s" % (header[0].strip(), items[selected]))
                 return selected
             elif key == "esc":
+                note("[menu] %s -> cancelled" % header[0].strip())
                 return None
             elif key.isdigit() and 1 <= int(key) <= len(items):
                 selected = int(key) - 1
@@ -220,6 +373,12 @@ def describe(region):
         if num == region:
             return "%d  (%s)" % (num, name)
     return str(region)
+
+
+def describe_rpc(state):
+    if state.scheme == 0:
+        return "RPC-1, region-free"
+    return "RPC-2, region %s" % ("set" if state.rpc_type else "not set")
 
 
 def sibling_lines(drives):
@@ -237,8 +396,8 @@ def sibling_lines(drives):
              "  !! %s, the first one:" % drives[0].path]
     for drive in drives:
         try:
-            region, _changes, _resets, scheme = drive.read_state()
-            what = "region-free (RPC-1)" if scheme == 0 else describe(region)
+            state = drive.read_state()
+            what = "region-free (RPC-1)" if state.scheme == 0 else describe(state.region)
         except OSError:
             what = "(could not be read)"
         lines.append("       %-16s %s%s"
@@ -247,12 +406,13 @@ def sibling_lines(drives):
     return lines
 
 
-def status_lines(drive, region, changes, resets, rpc1=False):
+def status_lines(drive, state):
     lines = ["  DVD drive region                    %s" % drive.path, ""]
-    lines.append("  Current region : %s" % describe(region))
-    if region is None and not rpc1:
+    lines.append("  Current region : %s" % describe(state.region))
+    if state.region is None and state.scheme != 0:
         lines.append("                   CSS keys must be cracked - slow first play")
-    lines.append("  Changes left   : %d       (vendor resets: %d)" % (changes, resets))
+    lines.append("  Changes left   : %d       (vendor resets: %d)" % (state.changes, state.resets))
+    lines.append("  RPC state      : %s   (%s)" % (raw_hex(state), describe_rpc(state)))
     return lines
 
 
@@ -264,51 +424,85 @@ def apply_region(drive, want):
     try:
         drive.set_region(want)
     except OSError as err:
-        out("  FAILED: %s" % err)
-        out("  The drive rejected the change; nothing was altered.")
+        out("  The drive REJECTED the change: %s" % err)
+        out("  The region was not changed. Run this script again to check")
+        out("  whether the change counter moved.")
         return 1
-    region, changes, _resets, _scheme = drive.read_state()
-    if region == want:
+
+    # The command succeeded, so the region IS set. Everything from here is only an
+    # attempt to READ IT BACK, and a drive that will not answer yet — or answers
+    # with a mask it has not refreshed — has still taken the change. Reporting that
+    # as a failure is what issue #52 was.
+    state, err = None, None
+    for attempt in range(VERIFY_TRIES):
+        if attempt:
+            time.sleep(VERIFY_WAIT)
+        try:
+            drive.reopen()
+            state = drive.read_state()
+        except OSError as exc:
+            err, state = exc, None
+            continue
+        note("  verify %d: %s" % (attempt, raw_hex(state)))
+        if state.region == want:
+            break
+
+    if state is not None and state.region == want:
         out("  Done. The drive is now region %d, with %d changes left."
-            % (region, changes))
+            % (want, state.changes))
         return 0
-    out("  The drive did not take the change (it now reports %s)." % describe(region))
-    return 1
+
+    out("  The change was sent and the drive accepted it, but it has not")
+    if state is None:
+        out("  reported the new region back yet (%s)." % err)
+    else:
+        out("  reported the new region back yet - it still says %s." % describe(state.region))
+    out("  This is normal on some drives. The change was sent ONCE; do not")
+    out("  repeat it. Run this script again to see the region it settles on.")
+    return 3
 
 
-def interactive(drive, region, changes, resets, extra=()):
-    header = status_lines(drive, region, changes, resets) + list(extra)
-    if changes == 0:
+def interactive(drive, state, extra=()):
+    header = status_lines(drive, state) + list(extra)
+    if state.changes == 0:
         header += ["", "  This drive has NO changes left - its region is locked",
                    "  permanently and cannot be altered."]
         menu(header, ["Exit"], ["  B1 / Enter = exit"])
+        clear()
+        for row in status_lines(drive, state):
+            out(row)
+        out()
+        out("  No changes left - the region is locked permanently.")
+        pause()
         return 0
 
     header += ["", "  Pick the region your discs come from:"]
     items = ["%d  %s" % (num, name) for num, name in CHOOSABLE] + ["Cancel - change nothing"]
     footer = ["  D-pad = move    B1 = select    B2 = cancel",
               "",
-              "  A change costs one of the drive's %d remaining changes" % changes,
+              "  A change costs one of the drive's %d remaining changes" % state.changes,
               "  and cannot be undone."]
     # Default the cursor to Cancel so an accidental B1 changes nothing.
     choice = menu(header, items, footer, selected=len(items) - 1)
     if choice is None or choice == len(items) - 1:
         clear()
         out("  Cancelled. Nothing was changed.")
+        pause()
         return 0
 
     want = CHOOSABLE[choice][0]
-    if want == region:
+    if want == state.region:
         clear()
         out("  The drive is already set to region %d. Nothing was changed." % want)
+        pause()
         return 0
 
     confirm_header = ["  Set %s to region %d?" % (drive.path, want), ""]
     confirm_header.append("  %s" % describe(want))
     confirm_header += ["",
-                       "  This uses one of the %d changes the drive has left" % changes,
+                       "  This uses one of the %d changes the drive has left" % state.changes,
                        "  and CANNOT be undone."]
-    if changes == 1:
+    if state.changes == 1:
         confirm_header += ["",
                            "  *** This is the LAST change this drive allows.",
                            "  *** It will be locked to region %d forever." % want]
@@ -319,14 +513,18 @@ def interactive(drive, region, changes, resets, extra=()):
     clear()
     if verdict != 1:
         out("  Cancelled. Nothing was changed.")
+        pause()
         return 0
-    for row in status_lines(drive, region, changes, resets):
+    for row in status_lines(drive, state):
         out(row)
-    return apply_region(drive, want)
+    rc = apply_region(drive, want)
+    pause()
+    return rc
 
 
 def main():
     argv = sys.argv[1:]
+    note("--- %s  argv=%s" % (time.strftime("%Y-%m-%d %H:%M:%S"), " ".join(argv)))
     assume_yes = "--yes" in argv
     args = [a for a in argv if a != "--yes"]
     want = None
@@ -345,25 +543,29 @@ def main():
         out("  No optical drive found at /dev/sr0.")
         out("  Check that the drive is plugged in and has power (some USB drives")
         out("  need a powered hub or a second USB lead).")
+        pause()
         return 1
     drive = drives[0]
 
     try:
-        region, changes, resets, scheme = drive.read_state()
+        state = drive.read_state()
     except OSError as err:
         out("  Could not read the drive's region state: %s" % err)
         out("  The drive may not report RPC state, or the disc may be in use -")
         out("  stop playback and try again.")
+        pause()
         return 1
 
     extra = sibling_lines(drives)
 
-    if scheme == 0:
-        for row in status_lines(drive, region, changes, resets, rpc1=True) + extra:
+    if state.scheme == 0:
+        for row in status_lines(drive, state) + extra:
             out(row)
         out()
-        out("  This drive is RPC-1 (region-free): it ignores disc regions and")
-        out("  needs no region set. Nothing to do.")
+        out("  This drive is RPC-1: it enforces no region at all. That is the best")
+        out("  case - it answers the CSS key exchange whatever region a disc comes")
+        out("  from, so there is nothing to set here and nothing to gain.")
+        pause()
         return 0
 
     if want is None:
@@ -371,22 +573,22 @@ def main():
         # no stdin at all, and a pipe has none either): report and stop rather than
         # block on input nobody can give.
         if not sys.stdin.isatty():
-            for row in status_lines(drive, region, changes, resets) + extra:
+            for row in status_lines(drive, state) + extra:
                 out(row)
             out()
             out("  Run this from the MiSTer Scripts menu (with fb_terminal=1) to")
             out("  change the region, or pass the region number as an argument.")
             return 0
-        return interactive(drive, region, changes, resets, extra)
+        return interactive(drive, state, extra)
 
     # Argument form (SSH): same safety rules, minus the cursor menu.
-    for row in status_lines(drive, region, changes, resets) + extra:
+    for row in status_lines(drive, state) + extra:
         out(row)
-    if want == region:
+    if want == state.region:
         out()
         out("  Already region %d. Nothing was changed." % want)
         return 0
-    if changes == 0:
+    if state.changes == 0:
         out()
         out("  No changes left - the region is locked permanently.")
         return 1
@@ -398,7 +600,7 @@ def main():
             return 1
         verdict = menu(["  Set %s to region %d?" % (drive.path, want),
                         "",
-                        "  Uses one of %d remaining changes; cannot be undone." % changes],
+                        "  Uses one of %d remaining changes; cannot be undone." % state.changes],
                        ["No  - leave the drive alone", "Yes - set region %d" % want],
                        ["  arrows = move    Enter = select    Esc = cancel"],
                        selected=0)
@@ -409,7 +611,23 @@ def main():
     return apply_region(drive, want)
 
 
-sys.exit(main())
+log_open()
+try:
+    code = main()
+except KeyboardInterrupt:
+    code = 1
+except Exception as exc:
+    # A traceback on a television tells the user nothing and scrolls the useful
+    # part off the screen. One line here, the whole thing in the log.
+    out()
+    out("  Something went wrong: %s: %s" % (type(exc).__name__, exc))
+    if log_path:
+        out("  The details are in %s" % log_path)
+    note(traceback.format_exc())
+    pause()
+    code = 1
+note("exit %s" % code)
+sys.exit(code)
 PYEOF
 
 python3 "$PY" "$@"

--- a/main/Scripts/set_dvd_region.sh
+++ b/main/Scripts/set_dvd_region.sh
@@ -198,6 +198,32 @@ def raw_hex(state):
     return " ".join("%02x" % b for b in state.raw)
 
 
+def region_span(regions):
+    """[1,2,3,4,5,6,8] -> "1-6,8". A multi-region disc should not print as a list."""
+    if not regions:
+        return "none"
+    parts, start, prev = [], regions[0], regions[0]
+    for r in list(regions[1:]) + [None]:
+        if r != prev + 1:
+            parts.append(str(start) if start == prev else
+                         "%d,%d" % (start, prev) if prev == start + 1 else
+                         "%d-%d" % (start, prev))
+            start = r
+        prev = r
+    return ",".join(parts)
+
+
+def region_words(regions):
+    """How a loaded disc's regions are named in prose, singular or plural."""
+    if regions is None:
+        return "unknown"
+    if len(regions) == 8:
+        return "all regions"
+    if len(regions) == 1:
+        return "region %d" % regions[0]
+    return "regions %s" % region_span(regions)
+
+
 def region_pdrc(region):
     """Region 1-8 -> the Preferred Drive Region Code byte SEND KEY wants.
 
@@ -337,6 +363,7 @@ class Drive:
     def __init__(self, path, fd):
         self.path = path
         self.fd = fd
+        self._discs = ()        # () = not looked at yet, distinct from None
 
     def reopen(self):
         """Fresh handle, used before reading back a change.
@@ -349,6 +376,7 @@ class Drive:
         except OSError:
             pass
         self.fd = os.open(self.path, os.O_RDONLY | os.O_NONBLOCK)
+        self._discs = ()
 
     def media_present(self):
         try:
@@ -357,7 +385,10 @@ class Drive:
             return False    # can't tell -> say nothing rather than nag wrongly
 
     def disc_regions(self):
-        return disc_regions(self.fd) if self.media_present() else None
+        # Cached: every screen asks, and each miss is a real SCSI command.
+        if self._discs == ():
+            self._discs = disc_regions(self.fd) if self.media_present() else None
+        return self._discs
 
     def read_state(self):
         buf = bytearray(AUTHINFO_SIZE)
@@ -410,8 +441,10 @@ class FakeDrive:
     def __init__(self, spec, index=0):
         parts = spec.split(":")
         self.fault = parts[4] if len(parts) > 4 else ""
-        # "discN" loads a region-N disc in the tray; the drive follows the disc.
-        self.disc = int(self.fault[4:]) if self.fault.startswith("disc") else None
+        # "disc25" loads a disc allowing regions 2 and 5 — a real disc often
+        # allows several (a measured one read RMI 40: everything but region 7).
+        self.disc = ([int(c) for c in self.fault[4:]]
+                     if self.fault.startswith("disc") and self.fault[4:].isdigit() else None)
         region, changes, resets, scheme = (int(p) for p in (parts + ["0", "5", "4", "1"])[:4])
         self.path = "(simulated sr%d)" % index
         self.region, self.changes, self.resets, self.scheme = region, changes, resets, scheme
@@ -431,7 +464,7 @@ class FakeDrive:
         return self.disc is not None
 
     def disc_regions(self):
-        return [self.disc] if self.disc else None
+        return list(self.disc) if self.disc else None
 
     def read_state(self):
         if self.fault == "rbfail" and self.changed:
@@ -451,7 +484,7 @@ class FakeDrive:
         if self.fault.startswith("disc") or self.fault == "nodisc":
             if self.disc is None:
                 raise SenseError(2, 0x3a, 0x01)
-            if self.disc != region:
+            if region not in self.disc:
                 raise SenseError(5, 0x6f, 0x04)
         if self.fault == "setfail" or self.changes <= 0:
             raise OSError(5, "Input/output error")
@@ -632,14 +665,10 @@ def status_lines(drive, state):
     lines.append("  RPC state      : %s   (%s)" % (raw_hex(state), describe_rpc(state)))
     regions = drive.disc_regions()
     if regions is None:
-        lines.append("  Disc in drive  : %s"
-                     % ("yes (region unreadable)" if drive.media_present() else "none"))
-    elif len(regions) == 8:
-        lines.append("  Disc in drive  : all regions")
+        what = "yes (region unreadable)" if drive.media_present() else "none"
     else:
-        lines.append("  Disc in drive  : region %s"
-                     % ",".join(str(r) for r in regions) if regions else
-                     "  Disc in drive  : no region allowed")
+        what = region_words(regions)
+    lines.append("  Disc in drive  : %s" % what)
     return lines
 
 
@@ -704,9 +733,9 @@ def interactive(drive, state, extra=()):
         return 0
 
     header += ["",
-               "  Many drives take the new region FROM THE DISC in the tray: put a",
-               "  disc from the region you want in the drive before changing it.",
-               "  An empty tray or a disc from another region is refused."]
+               "  Many drives take the new region FROM THE DISC in the tray: the",
+               "  disc must ALLOW the region you are setting. An empty tray, or a",
+               "  disc that bars that region, is refused. Many discs allow several."]
     header += ["", "  Pick the region your discs come from:"]
     items = ["%d  %s" % (num, name) for num, name in CHOOSABLE] + ["Cancel - change nothing"]
     footer = ["  D-pad = move    B1 = select    B2 = cancel",
@@ -736,10 +765,10 @@ def interactive(drive, state, extra=()):
     regions = drive.disc_regions()
     if regions is not None and want not in regions:
         confirm_header += ["",
-                           "  !! The disc in the drive is region %s. A drive that takes its"
-                           % ",".join(str(r) for r in regions),
-                           "  !! region from the disc will REFUSE this - swap in a region",
-                           "  !! %d disc first if it does." % want]
+                           "  !! The disc in the drive is for %s and does not"
+                           % region_words(regions),
+                           "  !! allow region %d. A drive that takes its region from the" % want,
+                           "  !! disc REFUSES that - put in a disc that allows region %d." % want]
     elif regions is None and drive.media_present() is False:
         confirm_header += ["",
                            "  !! The drive is empty. A drive that takes its region from the",

--- a/main/Scripts/set_dvd_region.sh
+++ b/main/Scripts/set_dvd_region.sh
@@ -81,6 +81,8 @@ SG_IO           = 0x2285       # scsi/sg.h: send one SCSI command
 SG_DXFER_TO_DEV = -2
 SEND_KEY        = 0xa3         # MMC: SEND KEY
 KF_RPC_STATE    = 6            # ... key format 6 = Send RPC State
+CHECK_CONDITION = 0x02         # SCSI status: the drive has something to say
+DRIVER_SENSE    = 0x08         # driver_status: ... and the sense data is attached
 
 # Sense codes worth naming. Everything else is printed as its raw triple, which is
 # what a bug report needs anyway.
@@ -208,6 +210,30 @@ class SenseError(OSError):
                          % (key, asc, ascq, " (%s)" % text if text else ""))
 
 
+def sg_check(status, host_status, driver_status, sense):
+    """Classify one completed SG_IO command. Returns None if it succeeded.
+
+    Kept pure and separate because getting this wrong is silent and expensive:
+    ⚠ **`DRIVER_SENSE` (0x08) lives in the LOW nibble of driver_status and means
+    "sense data is attached", i.e. the drive answered — NOT a transport error.**
+    Reading it as one threw away the drive's own explanation and fell back to the
+    ioctl, which could then only say EIO. That is the whole reason this function
+    is testable.
+    """
+    if host_status:
+        raise OSError(5, "SG_IO transport error (host %02x)" % host_status)
+    driver = driver_status & 0x0f
+    if driver not in (0, DRIVER_SENSE):
+        raise OSError(5, "SG_IO driver error (driver %02x)" % driver_status)
+    if status == 0:
+        return None
+    if len(sense) >= 14 and (sense[0] & 0x7e) == 0x70:        # fixed format
+        raise SenseError(sense[2] & 0x0f, sense[12], sense[13])
+    if len(sense) >= 4 and (sense[0] & 0x7e) == 0x72:         # descriptor format
+        raise SenseError(sense[1] & 0x0f, sense[2], sense[3])
+    raise OSError(5, "the drive refused it (SCSI status %02x, no sense)" % status)
+
+
 def sg_send_key(fd, payload, key_format=KF_RPC_STATE, timeout_ms=15000):
     """SEND KEY over SG_IO, the way sg_raw does it.
 
@@ -263,19 +289,10 @@ def sg_send_key(fd, payload, key_format=KF_RPC_STATE, timeout_ms=15000):
     note("  SG_IO status %02x host %02x driver %02x sb_len %d"
          % (hdr.status, hdr.host_status, hdr.driver_status, hdr.sb_len_wr))
 
-    if hdr.host_status or hdr.driver_status & 0x0f:
-        raise OSError(5, "SG_IO transport error (host %02x driver %02x)"
-                      % (hdr.host_status, hdr.driver_status))
-    if hdr.status == 0:
-        return None
-
-    sb = sense.raw[:hdr.sb_len_wr or 18]
-    note("  SG_IO sense %s" % " ".join("%02x" % b for b in sb))
-    if len(sb) >= 14 and (sb[0] & 0x7e) == 0x70:        # fixed format
-        raise SenseError(sb[2] & 0x0f, sb[12], sb[13])
-    if len(sb) >= 4 and (sb[0] & 0x7e) == 0x72:         # descriptor format
-        raise SenseError(sb[1] & 0x0f, sb[2], sb[3])
-    raise OSError(5, "the drive refused it (SCSI status %02x)" % hdr.status)
+    sb = sense.raw[:hdr.sb_len_wr] if hdr.sb_len_wr else b""
+    if sb:
+        note("  SG_IO sense %s" % " ".join("%02x" % b for b in sb))
+    return sg_check(hdr.status, hdr.host_status, hdr.driver_status, sb)
 
 
 class Drive:

--- a/main/Scripts/set_dvd_region.sh
+++ b/main/Scripts/set_dvd_region.sh
@@ -75,7 +75,23 @@ from collections import namedtuple
 DVD_AUTH            = 0x5392   # linux/cdrom.h: DVD authentication ioctl
 LU_SEND_RPC_STATE   = 10       # drive -> host: report the current RPC state
 HOST_SEND_RPC_STATE = 11       # host -> drive: set the region
-AUTHINFO_SIZE       = 16       # sizeof(dvd_authinfo)
+AUTHINFO_SIZE       = 16       # sizeof(dvd_authinfo) — 16 on x86-64 AND armv7 EABI
+
+SG_IO           = 0x2285       # scsi/sg.h: send one SCSI command
+SG_DXFER_TO_DEV = -2
+SEND_KEY        = 0xa3         # MMC: SEND KEY
+KF_RPC_STATE    = 6            # ... key format 6 = Send RPC State
+
+# Sense codes worth naming. Everything else is printed as its raw triple, which is
+# what a bug report needs anyway.
+SENSE_TEXT = {
+    (5, 0x26, 0x00): "invalid field in parameter list",
+    (5, 0x24, 0x00): "invalid field in CDB",
+    (5, 0x20, 0x00): "the drive does not support this command",
+    (5, 0x6f, 0x05): "the drive's region-change counter is exhausted",
+    (2, 0x3a, 0x00): "no disc in the drive",
+    (2, 0x04, 0x01): "the drive is still becoming ready - try again in a moment",
+}
 
 VERIFY_TRIES = 6               # read-backs after a change ...
 VERIFY_WAIT  = 0.5             # ... spaced this far apart
@@ -183,6 +199,85 @@ def region_pdrc(region):
     return ~(1 << (region - 1)) & 0xff
 
 
+class SenseError(OSError):
+    """A drive refusal we can actually explain, unlike the ioctl's bare EIO."""
+    def __init__(self, key, asc, ascq):
+        self.key, self.asc, self.ascq = key, asc, ascq
+        text = SENSE_TEXT.get((key, asc, ascq))
+        OSError.__init__(self, "sense %02x/%02x/%02x%s"
+                         % (key, asc, ascq, " (%s)" % text if text else ""))
+
+
+def sg_send_key(fd, payload, key_format=KF_RPC_STATE, timeout_ms=15000):
+    """SEND KEY over SG_IO, the way sg_raw does it.
+
+    WHY THIS EXISTS: the `DVD_AUTH` ioctl builds the identical command, but the
+    kernel funnels every drive refusal through `sr_do_ioctl`, which collapses
+    Illegal Request and most Not Ready conditions alike into a bare **EIO** — no
+    use at all when the operation is one-way and the user needs to know WHY. Here
+    the sense data comes straight back. (A drive that answered this route while
+    refusing the ioctl is what sent us looking; either way this is the route that
+    can explain itself.)
+
+    Returns None on success, raises SenseError on a refusal the drive explained,
+    and lets OSError through if SG_IO is unusable — the caller falls back then.
+    """
+    import ctypes
+
+    class sg_io_hdr(ctypes.Structure):
+        # ctypes lays this out for whatever ABI it is running on, which is the
+        # point: 64 bytes on the MiSTer's armv7, 88 on an x86-64 desktop.
+        _fields_ = [("interface_id", ctypes.c_int), ("dxfer_direction", ctypes.c_int),
+                    ("cmd_len", ctypes.c_ubyte), ("mx_sb_len", ctypes.c_ubyte),
+                    ("iovec_count", ctypes.c_ushort), ("dxfer_len", ctypes.c_uint),
+                    ("dxferp", ctypes.c_void_p), ("cmdp", ctypes.c_void_p),
+                    ("sbp", ctypes.c_void_p), ("timeout", ctypes.c_uint),
+                    ("flags", ctypes.c_uint), ("pack_id", ctypes.c_int),
+                    ("usr_ptr", ctypes.c_void_p), ("status", ctypes.c_ubyte),
+                    ("masked_status", ctypes.c_ubyte), ("msg_status", ctypes.c_ubyte),
+                    ("sb_len_wr", ctypes.c_ubyte), ("host_status", ctypes.c_ushort),
+                    ("driver_status", ctypes.c_ushort), ("resid", ctypes.c_int),
+                    ("duration", ctypes.c_uint), ("info", ctypes.c_uint)]
+
+    n = len(payload)
+    cdb = bytes((SEND_KEY, 0, 0, 0, 0, 0, 0, 0, (n >> 8) & 0xff, n & 0xff, key_format, 0))
+    cdb_buf = ctypes.create_string_buffer(cdb, len(cdb))
+    data    = ctypes.create_string_buffer(bytes(payload), n)
+    sense   = ctypes.create_string_buffer(32)
+
+    hdr = sg_io_hdr()
+    ctypes.memset(ctypes.byref(hdr), 0, ctypes.sizeof(hdr))
+    hdr.interface_id = ord("S")
+    hdr.dxfer_direction = SG_DXFER_TO_DEV
+    hdr.cmd_len = len(cdb)
+    hdr.mx_sb_len = ctypes.sizeof(sense)
+    hdr.dxfer_len = n
+    hdr.dxferp = ctypes.cast(data, ctypes.c_void_p)
+    hdr.cmdp = ctypes.cast(cdb_buf, ctypes.c_void_p)
+    hdr.sbp = ctypes.cast(sense, ctypes.c_void_p)
+    hdr.timeout = timeout_ms
+
+    note("  SG_IO cdb %s payload %s"
+         % (" ".join("%02x" % b for b in cdb), " ".join("%02x" % b for b in payload)))
+    fcntl.ioctl(fd, SG_IO, hdr)   # OSError here = SG_IO unusable, not a refusal
+    note("  SG_IO status %02x host %02x driver %02x sb_len %d"
+         % (hdr.status, hdr.host_status, hdr.driver_status, hdr.sb_len_wr))
+
+    if hdr.host_status or hdr.driver_status & 0x0f:
+        raise OSError(5, "SG_IO transport error (host %02x driver %02x)"
+                      % (hdr.host_status, hdr.driver_status))
+    if hdr.status == 0:
+        return None
+
+    sb = sense.raw[:hdr.sb_len_wr or 18]
+    note("  SG_IO sense %s" % " ".join("%02x" % b for b in sb))
+    if len(sb) >= 14 and (sb[0] & 0x7e) == 0x70:        # fixed format
+        raise SenseError(sb[2] & 0x0f, sb[12], sb[13])
+    if len(sb) >= 4 and (sb[0] & 0x7e) == 0x72:         # descriptor format
+        raise SenseError(sb[1] & 0x0f, sb[2], sb[3])
+    raise OSError(5, "the drive refused it (SCSI status %02x)" % hdr.status)
+
+
 class Drive:
     def __init__(self, path, fd):
         self.path = path
@@ -207,12 +302,33 @@ class Drive:
         return decode_state(bytes(buf[:3]))
 
     def set_region(self, region):
-        """struct dvd_host_send_rpcstate is {type, pdrc} — see region_pdrc()."""
+        """Set the region, over SG_IO if we can and DVD_AUTH if we cannot.
+
+        Both routes carry the SAME bytes — the kernel builds this exact command
+        from the ioctl (cdrom.c: setup_send_key, then buf[1] = 6, buf[4] = pdrc).
+        SG_IO is preferred only because it hands back the drive's sense data
+        instead of the ioctl's bare EIO. The ioctl remains the fallback for a
+        python without ctypes or a device that refuses SG_IO, so this can only
+        add outcomes, never remove the one that worked before.
+        """
+        pdrc = region_pdrc(region)
+        payload = bytes((0, 6, 0, 0, pdrc, 0, 0, 0))
+        note("  send pdrc %02x for region %d" % (pdrc, region))
+        try:
+            sg_send_key(self.fd, payload)
+            note("  route: SG_IO, accepted")
+            return
+        except SenseError:
+            note("  route: SG_IO, refused with sense")
+            raise                    # the drive explained itself; do not re-send
+        except (OSError, ImportError, AttributeError) as err:
+            note("  SG_IO unusable (%s) - falling back to DVD_AUTH" % err)
+
         buf = bytearray(AUTHINFO_SIZE)
         buf[0] = HOST_SEND_RPC_STATE
-        buf[1] = region_pdrc(region)
-        note("  send pdrc %02x for region %d" % (buf[1], region))
+        buf[1] = pdrc
         fcntl.ioctl(self.fd, DVD_AUTH, buf, True)
+        note("  route: DVD_AUTH, accepted")
 
 
 class FakeDrive:
@@ -633,23 +749,27 @@ def main():
     return apply_region(drive, want)
 
 
-log_open()
-try:
-    code = main()
-except KeyboardInterrupt:
-    code = 1
-except Exception as exc:
-    # A traceback on a television tells the user nothing and scrolls the useful
-    # part off the screen. One line here, the whole thing in the log.
-    out()
-    out("  Something went wrong: %s: %s" % (type(exc).__name__, exc))
-    if log_path:
-        out("  The details are in %s" % log_path)
-    note(traceback.format_exc())
-    pause()
-    code = 1
-note("exit %s" % code)
-sys.exit(code)
+# Guarded so the payload can be IMPORTED as a module and its pure functions
+# tested directly (tools/test_set_dvd_region.py extracts it) — running it the
+# normal way, `python3 <file>`, is unaffected.
+if __name__ == "__main__":
+    log_open()
+    try:
+        code = main()
+    except KeyboardInterrupt:
+        code = 1
+    except Exception as exc:
+        # A traceback on a television tells the user nothing and scrolls the
+        # useful part off the screen. One line here, the whole thing in the log.
+        out()
+        out("  Something went wrong: %s: %s" % (type(exc).__name__, exc))
+        if log_path:
+            out("  The details are in %s" % log_path)
+        note(traceback.format_exc())
+        pause()
+        code = 1
+    note("exit %s" % code)
+    sys.exit(code)
 PYEOF
 
 python3 "$PY" "$@"

--- a/main/support/dvd/dvd_css.cpp
+++ b/main/support/dvd/dvd_css.cpp
@@ -188,10 +188,14 @@ static int raw_read10(int fd, uint32_t lba, void *buf, int count)
 	return count;
 }
 
-// Does the drive have a CSS region set? RPC-II drives refuse the title-key ioctl
-// (ReadTitleKey) unless a region matching the disc is set, which forces libdvdcss
-// into the slow, sometimes-failing per-title crack. Read the RPC state via SG_IO
-// REPORT KEY (format 0x08): region_mask 0xff means no region is set.
+// Can the drive answer the CSS key exchange? RPC-II drives refuse the title-key
+// ioctl (ReadTitleKey) unless a region matching the disc is set, which forces
+// libdvdcss into the slow, sometimes-failing per-title crack. Read the RPC state
+// via SG_IO REPORT KEY (format 0x08): region_mask 0xff means no region is set,
+// and rpc_scheme (byte 6) 0 is an RPC-1 drive, which enforces no region AT ALL —
+// it hands keys over whatever the disc's region, so its empty mask is not the
+// problem an RPC-II drive's empty mask is. Treating the two alike labelled a
+// region-free drive "No drive region: cracking", which is the opposite of true.
 static int drive_region_set(const char *dev)
 {
 	int fd = open(dev, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
@@ -213,7 +217,8 @@ static int drive_region_set(const char *dev)
 
 	int set = 1;
 	if (ioctl(fd, SG_IO, &io) == 0 && io.status == 0)
-		set = (buf[5] != 0xff);   // region_mask == 0xff -> no region set
+		set = (buf[5] != 0xff)    // region_mask == 0xff -> no region set ...
+		   || (buf[6] == 0);      // ... but RPC-1 needs none: nothing to set
 	close(fd);
 	return set;
 }
@@ -522,7 +527,7 @@ int dvd_css_open(void)
 
 	region_set = drive_region_set(dev);
 	if (!region_set)
-		css_log("drive has NO CSS region set — title keys must be cracked (slow); see README");
+		css_log("drive is RPC-II with NO region set — title keys must be cracked (slow); see README");
 
 	if (load_library())
 	{

--- a/site/content/formats/physical-discs.md
+++ b/site/content/formats/physical-discs.md
@@ -151,17 +151,6 @@ into a bug report. The script names the file on its last line.
     own firmware, so it is not reset by a different PC, a reformat, or a different operating
     system. Pick the region matching the discs you own and set it once.
 
-!!! success "Reading and setting are both confirmed on real hardware"
-    Reading a drive's region has long been confirmed; **setting one now is too**. The first
-    user to try it had it work on theirs but saw an error afterwards and reported it — thank
-    you, because that report is what uncovered the rest.
-
-    The script used to treat a drive that was slow to answer as a failure, and it closed
-    before its last screen could be read. It now retries, says plainly whether it could
-    confirm the new region, tells you what the drive actually said when it refuses, and
-    **waits for a keypress before it closes**. It also sends the change in the form stricter
-    drives require — some drives accept either form, some reject one of them.
-
 **Region codes:** **1** US/Canada · **2** Europe/Japan/Middle East/South Africa ·
 **3** SE Asia · **4** Latin America/Australia/NZ · **5** Africa/Russia/South Asia ·
 **6** China.

--- a/site/content/formats/physical-discs.md
+++ b/site/content/formats/physical-discs.md
@@ -95,7 +95,10 @@ shows the drive's current region and how many changes it has left. Setting one i
 drive with the **D-pad and B1** — no keyboard needed. Nothing changes until you confirm, and
 the cursor starts on *Cancel*.
 
-Run it with no disc playing, since the core holds the drive open while one is mounted.
+**Take the disc out of the drive first.** A drive refuses to change its region while a disc
+of a different region is loaded — the change would leave that disc unplayable — so with one
+in the tray the change fails with `a disc in the drive has a different region`. An empty
+drive also avoids the core holding it open while a disc is mounted.
 
 Every screen waits for a button before it closes, and everything it prints is also written
 to `DVD_reports/set_dvd_region.log` on the SD card (or `/tmp` if the SD card is not

--- a/site/content/formats/physical-discs.md
+++ b/site/content/formats/physical-discs.md
@@ -89,22 +89,56 @@ best case. The script recognises one and tells you there is nothing to set.
 
 An encrypted *image* is always cracked from the data, so this only affects physical discs.
 
+!!! info "Unreleased"
+    The region tool was substantially fixed in the development build. **In v0.3.0 the change
+    is refused by some drives** — it sends the request in a form stricter drives reject — and
+    when it does work the script can still report it as an error and close before you can
+    read it. Everything below describes the fixed version; take the newer
+    `set_dvd_region.sh` if you intend to set a region.
+
+### Put a disc in the drive first
+
+!!! warning "The disc in the drive usually has to allow the region you are setting"
+    Many drives take their new region **from the disc in the tray**, the same way Windows
+    offers to switch a drive when you insert a disc from elsewhere. On such a drive the
+    change is refused outright unless a disc is loaded *and* that disc allows the region you
+    asked for. Plenty of discs allow several regions at once, so this is usually easier than
+    it sounds — but if nothing you own allows the region you want, that drive will not switch
+    to it.
+
+    Not every drive behaves this way. Some accept the change with an empty tray. The tool
+    cannot tell which kind yours is in advance, so it warns rather than refusing.
+
 **From the MiSTer:** run **set_dvd_region** from the **Scripts** menu (it is in the release
-zip; otherwise grab the `set_dvd_region.sh` asset and drop it in `/media/fat/Scripts/`). It
-shows the drive's current region and how many changes it has left. Setting one is a menu you
-drive with the **D-pad and B1** — no keyboard needed. Nothing changes until you confirm, and
-the cursor starts on *Cancel*.
+zip; otherwise grab the `set_dvd_region.sh` asset and drop it in `/media/fat/Scripts/`).
+Setting a region is a menu you drive with the **D-pad and B1** — no keyboard needed. Nothing
+changes until you confirm, and the cursor starts on *Cancel*.
 
-!!! tip "Put a disc from the region you want in the drive first"
-    Many drives take their new region **from the disc in the tray** — the same way Windows
-    offers to switch a drive when you insert a disc from elsewhere. The disc has to *allow*
-    the region you are setting, which plenty of discs do for several regions at once. An
-    empty tray is refused with `no disc in the drive`, and a disc that bars that region with
-    `the disc in the drive is from a different region`.
+The first screen tells you where you stand:
 
-    The tool shows the loaded disc's region next to the drive's, and warns before you commit
-    if the two do not agree. If nothing you own allows the region you want, such a drive
-    will not switch to it.
+```
+  DVD drive region                    /dev/sr0
+
+  Current region : 1  (US, Canada)
+  Changes left   : 3       (vendor resets: 4)
+  RPC state      : 71 fe 01   (RPC-2, region set)
+  Disc in drive  : regions 1-6,8
+```
+
+**`Disc in drive`** is the loaded disc's own region — `regions 1-6,8` above means that disc
+allows every region except 7, so it would satisfy a switch to any of them. If you pick a
+region the loaded disc bars, the confirm screen says so before you commit.
+
+#### If the drive refuses
+
+The tool prints what the drive actually said. The two common ones are about the disc, not
+about the drive being broken:
+
+| It says | What to do |
+|---|---|
+| `no disc in the drive` | Put in a disc that allows the region you want, and try again |
+| `the disc in the drive is from a different region` | Swap it for one that allows that region — `Disc in drive` on the first screen tells you what the current one allows |
+| `the drive will not accept another region change` | The drive is out of changes; nothing can be done |
 
 Every screen waits for a button before it closes, and everything it prints is also written
 to `DVD_reports/set_dvd_region.log` on the SD card (or `/tmp` if the SD card is not
@@ -118,15 +152,15 @@ into a bug report. The script names the file on its last line.
     system. Pick the region matching the discs you own and set it once.
 
 !!! success "Reading and setting are both confirmed on real hardware"
-    Reading a drive's region has long been confirmed; **setting one now is too**. The first
-    user to try it had it work on their drive but saw an error afterwards and reported it —
-    thank you, because that report uncovered several things.
+    Reading a drive's region has long been confirmed; **setting one now is too**, on two
+    different drives. The first user to try it had it work on theirs but saw an error
+    afterwards and reported it — thank you, because that report is what uncovered the rest.
 
     The script used to treat a drive that was slow to answer as a failure, and it closed
     before its last screen could be read. It now retries, says plainly whether it could
     confirm the new region, tells you what the drive actually said when it refuses, and
     **waits for a keypress before it closes**. It also sends the change in the form stricter
-    drives require — some accept either, some reject one of them.
+    drives require — some drives accept either form, some reject one of them.
 
 **Region codes:** **1** US/Canada · **2** Europe/Japan/Middle East/South Africa ·
 **3** SE Asia · **4** Latin America/Australia/NZ · **5** Africa/Russia/South Asia ·

--- a/site/content/formats/physical-discs.md
+++ b/site/content/formats/physical-discs.md
@@ -77,11 +77,15 @@ the process is seek-heavy and random reads from a file beat optical seek latency
 
 *Physical discs only — this makes them start faster.*
 
-A USB DVD drive ships with **no region set**. In that state the drive refuses the CSS key
+Most USB DVD drives ship with **no region set**. In that state the drive refuses the CSS key
 exchange, so libdvdcss has to crack every key out of the disc data — that is the
 several-second wait before a title starts, shown on screen as `No drive region: cracking`.
 Set the drive's region to match your discs and it hands the keys over directly, so playback
 starts almost immediately.
+
+Some drives are **region-free** (the "RPC-1" drives, usually sold that way or reflashed to
+be). Those need nothing: they answer for any disc whatever region it is from, which is the
+best case. The script recognises one and tells you there is nothing to set.
 
 An encrypted *image* is always cracked from the data, so this only affects physical discs.
 
@@ -93,21 +97,28 @@ the cursor starts on *Cancel*.
 
 Run it with no disc playing, since the core holds the drive open while one is mounted.
 
+Every screen waits for a button before it closes, and everything it prints is also written
+to `DVD_reports/set_dvd_region.log` on the SD card (or `/tmp` if the SD card is not
+writable) — so if something goes wrong you can read what happened afterwards, and paste it
+into a bug report. The script names the file on its last line.
+
 !!! danger "A region change is close to permanent"
     Drives allow only a handful of user changes — typically five — and when the counter runs
     out the region is **locked to whatever was set last**. The counter lives in the drive's
     own firmware, so it is not reset by a different PC, a reformat, or a different operating
     system. Pick the region matching the discs you own and set it once.
 
-!!! warning "Reading is proven; setting is not"
-    Identifying a drive's region and its remaining changes has been confirmed on real
-    hardware, with one drive connected and with two. **Nobody has yet used the script to
-    actually set a region** — it does the right thing in testing, but the write has never
-    touched a real drive, because proving it costs one of a drive's permanent changes.
+!!! success "Setting a region works"
+    Reading a drive's region has long been confirmed on real hardware; **setting one is now
+    confirmed too**, by the first user to try it — thank you. The change reached the drive
+    and stuck.
 
-    Reading is safe to try freely. Setting is a step into the unknown. If you take it,
-    please [open an issue](https://github.com/owenb321/MiSTer_DVD/issues) saying whether it
-    worked — you will be the first, and thank you for it.
+    That first attempt also showed an error afterwards and closed too quickly to read, even
+    though the region had been set correctly. That was the script mis-reporting a change
+    that had worked: some drives will not answer for a moment after a change, and it treated
+    the silence as a failure. Fixed — the script now retries, says plainly whether it could
+    confirm the new region, and **waits for a keypress before it closes**, so no result
+    disappears again.
 
 **Region codes:** **1** US/Canada · **2** Europe/Japan/Middle East/South Africa ·
 **3** SE Asia · **4** Latin America/Australia/NZ · **5** Africa/Russia/South Asia ·

--- a/site/content/formats/physical-discs.md
+++ b/site/content/formats/physical-discs.md
@@ -95,10 +95,15 @@ shows the drive's current region and how many changes it has left. Setting one i
 drive with the **D-pad and B1** — no keyboard needed. Nothing changes until you confirm, and
 the cursor starts on *Cancel*.
 
-**Take the disc out of the drive first.** A drive refuses to change its region while a disc
-of a different region is loaded — the change would leave that disc unplayable — so with one
-in the tray the change fails with `a disc in the drive has a different region`. An empty
-drive also avoids the core holding it open while a disc is mounted.
+!!! tip "Put a disc from the region you want in the drive first"
+    Many drives take their new region **from the disc in the tray** — the same way Windows
+    offers to switch a drive when you insert a disc from elsewhere. On such a drive, setting
+    region 2 needs a region 2 disc loaded: an empty tray is refused with `no disc in the
+    drive`, and a disc from another region with `the disc in the drive is from a different
+    region`.
+
+    The tool shows the loaded disc's region next to the drive's, and warns before you commit
+    if the two do not agree.
 
 Every screen waits for a button before it closes, and everything it prints is also written
 to `DVD_reports/set_dvd_region.log` on the SD card (or `/tmp` if the SD card is not

--- a/site/content/formats/physical-discs.md
+++ b/site/content/formats/physical-discs.md
@@ -97,14 +97,14 @@ the cursor starts on *Cancel*.
 
 !!! tip "Put a disc from the region you want in the drive first"
     Many drives take their new region **from the disc in the tray** — the same way Windows
-    offers to switch a drive when you insert a disc from elsewhere. On such a drive, setting
-    region 2 needs a region 2 disc loaded: an empty tray is refused with `no disc in the
-    drive`, and a disc from another region with `the disc in the drive is from a different
-    region`.
+    offers to switch a drive when you insert a disc from elsewhere. The disc has to *allow*
+    the region you are setting, which plenty of discs do for several regions at once. An
+    empty tray is refused with `no disc in the drive`, and a disc that bars that region with
+    `the disc in the drive is from a different region`.
 
     The tool shows the loaded disc's region next to the drive's, and warns before you commit
-    if the two do not agree. If you do not own a disc from the region you want yet, wait
-    until you do — such a drive will not switch without one.
+    if the two do not agree. If nothing you own allows the region you want, such a drive
+    will not switch to it.
 
 Every screen waits for a button before it closes, and everything it prints is also written
 to `DVD_reports/set_dvd_region.log` on the SD card (or `/tmp` if the SD card is not
@@ -117,21 +117,15 @@ into a bug report. The script names the file on its last line.
     own firmware, so it is not reset by a different PC, a reformat, or a different operating
     system. Pick the region matching the discs you own and set it once.
 
-!!! warning "Reading is proven; setting is not — but it is fixed"
-    Reading a drive's region is confirmed on real hardware. **Setting one is not yet**, and
-    the first user to try it found out why: the script sent the drive a malformed request,
-    which most drives reject outright. Thank you — that report is what found it.
+!!! success "Reading and setting are both confirmed on real hardware"
+    Reading a drive's region has long been confirmed; **setting one now is too**, and the
+    first user to try it is why. Their attempt failed, which uncovered a malformed request
+    the script had always sent — most drives reject it outright. Thank you for reporting it.
 
-    That is now fixed, along with the two things that made it hard to see: the script used
-    to treat a drive that was slow to answer as a failure, and it closed before its last
-    screen could be read. It now retries, says plainly whether it could confirm the new
-    region, and **waits for a keypress before it closes**.
-
-    So setting a region should work now, but nobody has confirmed it on a real drive yet —
-    each attempt spends one of a drive's permanent changes, which is not something to spend
-    on a test. Reading is safe to try freely. If you do set one, please
-    [open an issue](https://github.com/owenb321/MiSTer_DVD/issues) saying whether it
-    worked.
+    Fixed, along with the two things that hid it: the script used to treat a drive that was
+    slow to answer as a failure, and it closed before its last screen could be read. It now
+    retries, says plainly whether it could confirm the new region, tells you what the drive
+    actually said when it refuses, and **waits for a keypress before it closes**.
 
 **Region codes:** **1** US/Canada · **2** Europe/Japan/Middle East/South Africa ·
 **3** SE Asia · **4** Latin America/Australia/NZ · **5** Africa/Russia/South Asia ·

--- a/site/content/formats/physical-discs.md
+++ b/site/content/formats/physical-discs.md
@@ -108,17 +108,21 @@ into a bug report. The script names the file on its last line.
     own firmware, so it is not reset by a different PC, a reformat, or a different operating
     system. Pick the region matching the discs you own and set it once.
 
-!!! success "Setting a region works"
-    Reading a drive's region has long been confirmed on real hardware; **setting one is now
-    confirmed too**, by the first user to try it — thank you. The change reached the drive
-    and stuck.
+!!! warning "Reading is proven; setting is not — but it is fixed"
+    Reading a drive's region is confirmed on real hardware. **Setting one is not yet**, and
+    the first user to try it found out why: the script sent the drive a malformed request,
+    which most drives reject outright. Thank you — that report is what found it.
 
-    That first attempt also showed an error afterwards and closed too quickly to read, even
-    though the region had been set correctly. That was the script mis-reporting a change
-    that had worked: some drives will not answer for a moment after a change, and it treated
-    the silence as a failure. Fixed — the script now retries, says plainly whether it could
-    confirm the new region, and **waits for a keypress before it closes**, so no result
-    disappears again.
+    That is now fixed, along with the two things that made it hard to see: the script used
+    to treat a drive that was slow to answer as a failure, and it closed before its last
+    screen could be read. It now retries, says plainly whether it could confirm the new
+    region, and **waits for a keypress before it closes**.
+
+    So setting a region should work now, but nobody has confirmed it on a real drive yet —
+    each attempt spends one of a drive's permanent changes, which is not something to spend
+    on a test. Reading is safe to try freely. If you do set one, please
+    [open an issue](https://github.com/owenb321/MiSTer_DVD/issues) saying whether it
+    worked.
 
 **Region codes:** **1** US/Canada · **2** Europe/Japan/Middle East/South Africa ·
 **3** SE Asia · **4** Latin America/Australia/NZ · **5** Africa/Russia/South Asia ·

--- a/site/content/formats/physical-discs.md
+++ b/site/content/formats/physical-discs.md
@@ -152,9 +152,9 @@ into a bug report. The script names the file on its last line.
     system. Pick the region matching the discs you own and set it once.
 
 !!! success "Reading and setting are both confirmed on real hardware"
-    Reading a drive's region has long been confirmed; **setting one now is too**, on two
-    different drives. The first user to try it had it work on theirs but saw an error
-    afterwards and reported it — thank you, because that report is what uncovered the rest.
+    Reading a drive's region has long been confirmed; **setting one now is too**. The first
+    user to try it had it work on theirs but saw an error afterwards and reported it — thank
+    you, because that report is what uncovered the rest.
 
     The script used to treat a drive that was slow to answer as a failure, and it closed
     before its last screen could be read. It now retries, says plainly whether it could

--- a/site/content/formats/physical-discs.md
+++ b/site/content/formats/physical-discs.md
@@ -103,7 +103,8 @@ the cursor starts on *Cancel*.
     region`.
 
     The tool shows the loaded disc's region next to the drive's, and warns before you commit
-    if the two do not agree.
+    if the two do not agree. If you do not own a disc from the region you want yet, wait
+    until you do — such a drive will not switch without one.
 
 Every screen waits for a button before it closes, and everything it prints is also written
 to `DVD_reports/set_dvd_region.log` on the SD card (or `/tmp` if the SD card is not

--- a/site/content/formats/physical-discs.md
+++ b/site/content/formats/physical-discs.md
@@ -118,14 +118,15 @@ into a bug report. The script names the file on its last line.
     system. Pick the region matching the discs you own and set it once.
 
 !!! success "Reading and setting are both confirmed on real hardware"
-    Reading a drive's region has long been confirmed; **setting one now is too**, and the
-    first user to try it is why. Their attempt failed, which uncovered a malformed request
-    the script had always sent — most drives reject it outright. Thank you for reporting it.
+    Reading a drive's region has long been confirmed; **setting one now is too**. The first
+    user to try it had it work on their drive but saw an error afterwards and reported it —
+    thank you, because that report uncovered several things.
 
-    Fixed, along with the two things that hid it: the script used to treat a drive that was
-    slow to answer as a failure, and it closed before its last screen could be read. It now
-    retries, says plainly whether it could confirm the new region, tells you what the drive
-    actually said when it refuses, and **waits for a keypress before it closes**.
+    The script used to treat a drive that was slow to answer as a failure, and it closed
+    before its last screen could be read. It now retries, says plainly whether it could
+    confirm the new region, tells you what the drive actually said when it refuses, and
+    **waits for a keypress before it closes**. It also sends the change in the form stricter
+    drives require — some accept either, some reject one of them.
 
 **Region codes:** **1** US/Canada · **2** Europe/Japan/Middle East/South Africa ·
 **3** SE Asia · **4** Latin America/Australia/NZ · **5** Africa/Russia/South Asia ·

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -72,6 +72,16 @@ Check, in order:
 
 See [Physical discs](../formats/physical-discs.md).
 
+### `set_dvd_region` refuses to change the region
+
+Read what the drive said — the script prints it. `no disc in the drive` and `the disc in the
+drive is from a different region` both mean the same thing: **many drives take their new
+region from the disc in the tray**, and will only switch to a region the loaded disc allows.
+Put in a disc that allows the region you want and run it again. `the drive will not accept
+another region change` means its counter is spent, and nothing can be done.
+
+See [Set the drive region](../formats/physical-discs.md#set-the-drive-region).
+
 ## No sound
 
 ### Silent on every track

--- a/tools/test_set_dvd_region.py
+++ b/tools/test_set_dvd_region.py
@@ -135,6 +135,14 @@ except OSError as e:
     ok, why = False, "read DRIVER_SENSE as a transport error: %s" % e
 unit("a Check Condition with sense is decoded, not called a transport error", ok, why)
 
+SENSE_6F04 = bytes([0x70, 0, 0x05, 0, 0, 0, 0, 0x0a, 0, 0, 0, 0, 0x6f, 0x04, 0, 0, 0, 0])
+try:
+    M.sg_check(0x02, 0x00, 0x08, SENSE_6F04)
+    detail = "no error"
+except M.SenseError as e:
+    detail = str(e)
+unit("the loaded-disc refusal explains itself", "EJECT IT" in detail, detail)
+
 unit("the named sense text is used",
      "invalid field in parameter list" in why, why)
 
@@ -262,6 +270,13 @@ def check_pdrc(region, want_byte):
 
 check_pdrc(1, 0xfe)
 check_pdrc(4, 0xf7)
+
+# A loaded disc blocks the change on at least some drives (sense 05/6f/04,
+# measured), so say so before the user spends the trip rather than after.
+check("a loaded disc is called out before the menu", [ESC],
+      ["There is a disc in the drive. Take it out first"], fake="1:3:4:1:disc")
+check("an empty tray says nothing about discs", [ESC],
+      ["Pick the region"], ["There is a disc in the drive"], fake="1:3:4:1")
 
 # --- issue #52: the result screen must outlive the press that caused it -------
 # MiSTer closes the framebuffer terminal on the first key RELEASE after the

--- a/tools/test_set_dvd_region.py
+++ b/tools/test_set_dvd_region.py
@@ -17,7 +17,7 @@ error. The fake drive can now reproduce all three post-change behaviours — the
 read-back raising (rbfail), the region_mask lagging (stale), and the change itself
 failing (setfail) — and only the last of those may be reported as a failure.
 """
-import os, pty, subprocess, select, time, sys
+import os, pty, subprocess, select, time, sys, importlib.util
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 # SET_DVD_REGION_SH points the suite at another copy — used to prove the issue-52
@@ -83,6 +83,56 @@ def run(keys, fake="0:5:4:1", args=(), expect_pause=True, dismiss=True):
     return out.decode(errors="replace"), p.returncode
 
 FAIL = 0
+
+# --- unit checks on the payload's pure functions ------------------------------
+# The script is a python payload inside a shell heredoc; extract it and import
+# it (its entry point is under a __main__ guard) so the encoders and the SG_IO
+# structure can be checked directly rather than only through the menus.
+def load_payload():
+    src = open(SCRIPT).read()
+    body = src.split('cat > "$PY" <<\'PYEOF\'\n', 1)[1].split("\nPYEOF\n", 1)[0]
+    path = os.path.join(os.getenv("TMPDIR", "/tmp"), "set_dvd_region_payload.py")
+    open(path, "w").write(body)
+    spec = importlib.util.spec_from_file_location("set_dvd_region_payload", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+def unit(name, ok, detail=""):
+    global FAIL
+    print(("PASS  " if ok else "FAIL  ") + name)
+    if not ok:
+        if detail:
+            print("        " + detail)
+        FAIL += 1
+
+M = load_payload()
+
+unit("pdrc is a mask with one bit clear",
+     [M.region_pdrc(n) for n in range(1, 9)] == [0xfe, 0xfd, 0xfb, 0xf7,
+                                                 0xef, 0xdf, 0xbf, 0x7f],
+     repr([hex(M.region_pdrc(n)) for n in range(1, 9)]))
+
+st = M.decode_state(b"\x91\xfd\x01")
+unit("RPC state decodes as the kernel packs it",
+     (st.region, st.changes, st.resets, st.scheme, st.rpc_type) == (2, 4, 4, 1, 1),
+     repr(st))
+unit("an all-ones mask is no region set", M.decode_state(b"\xb0\xff\x01").region is None)
+unit("rpc_scheme 0 is carried through", M.decode_state(b"\xb0\xff\x00").scheme == 0)
+
+# SG_IO on something that is not a SCSI device must raise a plain OSError, not a
+# SenseError — that is what makes set_region() fall back to the ioctl rather than
+# reporting a refusal the drive never made.
+with open(os.devnull, "rb") as devnull:
+    try:
+        M.sg_send_key(devnull.fileno(), bytes(8))
+        ok, why = False, "no error at all"
+    except M.SenseError as e:
+        ok, why = False, "raised SenseError (%s) - would suppress the fallback" % e
+    except OSError as e:
+        ok, why = True, str(e)
+unit("SG_IO on a non-SCSI fd falls back rather than blaming the drive", ok, why)
+
 def check(name, keys, must_have, must_not=(), fake="0:5:4:1", rc=0, expect_pause=True):
     global FAIL
     text, code = run(keys, fake, expect_pause=expect_pause)
@@ -143,7 +193,7 @@ check("a lagging region_mask is not a failure", [DOWN, ENTER, DOWN, ENTER],
       ["Traceback", "FAILED", "did not take the change"],
       fake="0:5:4:1:stale", rc=3)
 # The one thing that IS a failure: the change command itself refused.
-check("a rejected change says so, and says nothing was spent",
+check("a rejected change says so, and does not claim the counter",
       [DOWN, ENTER, DOWN, ENTER],
       ["The drive REJECTED the change", "The region was not changed"],
       ["Traceback", "Done."], fake="0:5:4:1:setfail", rc=1)

--- a/tools/test_set_dvd_region.py
+++ b/tools/test_set_dvd_region.py
@@ -10,13 +10,23 @@ menu that selects the wrong entry or treats a stray keypress as consent does rea
 unrecoverable damage. So the drive is faked (DVD_REGION_FAKE, honoured by the script
 itself) and the menus are driven through a pty with the exact key sequences MiSTer
 sends for a gamepad: D-pad -> arrows, B1 -> Enter, B2 -> Esc.
+
+Issue #52 added the second thing worth testing: what the script SAYS about a change
+it cannot read back. The drive there took the region and the script called it an
+error. The fake drive can now reproduce all three post-change behaviours — the
+read-back raising (rbfail), the region_mask lagging (stale), and the change itself
+failing (setfail) — and only the last of those may be reported as a failure.
 """
 import os, pty, subprocess, select, time, sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-SCRIPT = os.path.join(HERE, os.pardir, "main", "Scripts", "set_dvd_region.sh")
+# SET_DVD_REGION_SH points the suite at another copy — used to prove the issue-52
+# checks RED against the pre-fix script (git show <rev>:main/Scripts/...).
+SCRIPT = os.environ.get("SET_DVD_REGION_SH",
+                        os.path.join(HERE, os.pardir, "main", "Scripts", "set_dvd_region.sh"))
 
 UP, DOWN, ENTER, ESC = b"\x1b[A", b"\x1b[B", b"\r", b"\x1b"
+PROMPT = "Press B1 / Enter to close"
 
 def drain(fd, wait=0.25):
     buf = b""
@@ -32,16 +42,38 @@ def drain(fd, wait=0.25):
             buf += chunk
     return buf
 
-def run(keys, fake="0:5:4:1", args=()):
+def poke(fd, key):
+    """The script may already have exited; a write to a dead pty is not a failure."""
+    try:
+        os.write(fd, key)
+    except OSError:
+        pass
+
+def run(keys, fake="0:5:4:1", args=(), expect_pause=True, dismiss=True):
     m, s = pty.openpty()
-    env = dict(os.environ, DVD_REGION_FAKE=fake, TERM="linux")
+    env = dict(os.environ, DVD_REGION_FAKE=fake, TERM="linux",
+               # Keep the transcript out of the developer's /tmp between runs.
+               HOME=os.environ.get("HOME", "/tmp"))
     p = subprocess.Popen([SCRIPT, *args],
                          stdin=s, stdout=s, stderr=s, env=env, close_fds=True)
     os.close(s)
     out = b""
     for k in keys:
         out += drain(m)
-        os.write(m, k)
+        poke(m, k)
+    # Every interactive path now ends by waiting for a keypress, so the result
+    # screen survives MiSTer closing the terminal on the confirming key's RELEASE.
+    # Wait for that prompt before answering it: a key sent while the script is
+    # still verifying would be eaten by the pause's own input drain.
+    if expect_pause:
+        end = time.time() + 8
+        while PROMPT not in out.decode(errors="replace") and time.time() < end:
+            if p.poll() is not None:
+                break
+            out += drain(m, 0.2)
+        time.sleep(0.4)   # let the pause finish draining before we press a key
+    if dismiss:
+        poke(m, ENTER)
     out += drain(m, 0.6)
     try:
         p.wait(timeout=5)
@@ -51,9 +83,9 @@ def run(keys, fake="0:5:4:1", args=()):
     return out.decode(errors="replace"), p.returncode
 
 FAIL = 0
-def check(name, keys, must_have, must_not=(), fake="0:5:4:1", rc=0):
+def check(name, keys, must_have, must_not=(), fake="0:5:4:1", rc=0, expect_pause=True):
     global FAIL
-    text, code = run(keys, fake)
+    text, code = run(keys, fake, expect_pause=expect_pause)
     bad = [n for n in must_have if n not in text]
     bad += ["(unexpected) " + n for n in must_not if n in text]
     if code != rc:
@@ -99,7 +131,78 @@ check("single drive gets no warning", [ESC],
 check("confirm screen names the drive", [DOWN, ENTER, ESC],
       ["Set (simulated sr0) to region 1?"], fake="0:5:4:1,1:3:4:1")
 
-text, code = run([], args=("8",))
+# --- issue #52: what the script says about a change it cannot read back -------
+# The drive took the region; only the verification failed. Reporting that as an
+# error (or as a traceback) is the bug, so none of these may look like failure.
+check("read-back that raises is not a failure", [DOWN, ENTER, DOWN, ENTER],
+      ["the drive accepted it", "do not", "Run this script again"],
+      ["Traceback", "FAILED", "did not take the change"],
+      fake="0:5:4:1:rbfail", rc=3)
+check("a lagging region_mask is not a failure", [DOWN, ENTER, DOWN, ENTER],
+      ["the drive accepted it", "it still says NONE set"],
+      ["Traceback", "FAILED", "did not take the change"],
+      fake="0:5:4:1:stale", rc=3)
+# The one thing that IS a failure: the change command itself refused.
+check("a rejected change says so, and says nothing was spent",
+      [DOWN, ENTER, DOWN, ENTER],
+      ["The drive REJECTED the change", "The region was not changed"],
+      ["Traceback", "Done."], fake="0:5:4:1:setfail", rc=1)
+
+# The raw RPC bytes make a second-hand bug report diagnosable: a photo of this
+# screen answers "what did the drive actually say?" without another round trip.
+check("raw RPC state is on screen", [ESC],
+      ["RPC state      : b0 ff 01   (RPC-2, region not set)"])
+check("a set region reads back in both fields", [ESC],
+      ["RPC state      : 91 fd 01   (RPC-2, region set)"], fake="2:4:4:1")
+# An RPC-1 drive enforces no region at all - there is nothing to set, and the
+# menu must not offer to spend a change on it.
+check("RPC-1 drive is described as region-free", [],
+      ["RPC-1: it enforces no region at all"], ["Pick the region"], fake="0:5:4:0")
+
+# --- issue #52: the result screen must outlive the press that caused it -------
+# MiSTer closes the framebuffer terminal on the first key RELEASE after the
+# script exits, so a script that returns immediately loses its last screen. The
+# script must still be alive, holding the prompt, until a FRESH key arrives.
+def check_pause_holds():
+    global FAIL
+    m, s = pty.openpty()
+    env = dict(os.environ, DVD_REGION_FAKE="0:5:4:1", TERM="linux")
+    p = subprocess.Popen([SCRIPT], stdin=s, stdout=s, stderr=s, env=env, close_fds=True)
+    os.close(s)
+    out = drain(m)
+    poke(m, ESC)                      # cancel: the fastest possible exit path
+    out += drain(m, 1.5)
+    text = out.decode(errors="replace")
+    bad = []
+    if PROMPT not in text:
+        bad.append("no pause prompt")
+    if p.poll() is not None:
+        bad.append("exited without waiting for a key")
+    poke(m, ENTER)
+    try:
+        p.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        p.kill(); bad.append("did not exit after the key")
+    os.close(m)
+    print(("PASS  " if not bad else "FAIL  ") + "result screen waits for a keypress")
+    for b in bad:
+        print("        missing/wrong: " + b)
+        FAIL += 1
+
+check_pause_holds()
+
+# Non-interactive callers (a pipe, or fb_terminal=0) must never block on a key:
+# there is nothing to press. run() hands the script a pty, so this one goes direct.
+p = subprocess.run([SCRIPT], env=dict(os.environ, DVD_REGION_FAKE="0:5:4:1"),
+                   stdin=subprocess.DEVNULL, capture_output=True, timeout=10)
+piped = p.stdout.decode(errors="replace")
+ok = p.returncode == 0 and PROMPT not in piped and "Run this from the MiSTer Scripts menu" in piped
+print(("PASS  " if ok else "FAIL  ") + "piped run reports and exits without blocking")
+if not ok:
+    print("        rc=%s out=%r" % (p.returncode, piped))
+    FAIL += 1
+
+text, code = run([], args=("8",), expect_pause=False)
 print(("PASS  " if code == 2 and "not consumer regions" in text else "FAIL  ")
       + "argument form refuses region 8")
 if code != 2 or "not consumer regions" not in text:

--- a/tools/test_set_dvd_region.py
+++ b/tools/test_set_dvd_region.py
@@ -141,7 +141,8 @@ try:
     detail = "no error"
 except M.SenseError as e:
     detail = str(e)
-unit("the loaded-disc refusal explains itself", "EJECT IT" in detail, detail)
+unit("the loaded-disc refusal explains itself",
+     "is from a different region" in detail, detail)
 
 unit("the named sense text is used",
      "invalid field in parameter list" in why, why)
@@ -271,12 +272,34 @@ def check_pdrc(region, want_byte):
 check_pdrc(1, 0xfe)
 check_pdrc(4, 0xf7)
 
-# A loaded disc blocks the change on at least some drives (sense 05/6f/04,
-# measured), so say so before the user spends the trip rather than after.
-check("a loaded disc is called out before the menu", [ESC],
-      ["There is a disc in the drive. Take it out first"], fake="1:3:4:1:disc")
-check("an empty tray says nothing about discs", [ESC],
-      ["Pick the region"], ["There is a disc in the drive"], fake="1:3:4:1")
+# MEASURED on a TSSTcorp TS-L633C: the drive takes its new region FROM THE DISC
+# in the tray — empty tray gives 02/3a/01, a disc from another region 05/6f/04,
+# and a matching disc succeeds. So the tool reports the disc beside the drive and
+# warns before the user spends the trip, not after.
+check("the loaded disc's region is on the status screen", [ESC],
+      ["Disc in drive  : region 2"], fake="1:3:4:1:disc2")
+check("an empty tray says so", [ESC],
+      ["Disc in drive  : none"], fake="1:3:4:1")
+check("the menu explains that the drive follows the disc", [ESC],
+      ["take the new region FROM THE DISC"], fake="1:3:4:1")
+check("confirming a region the loaded disc cannot support warns first",
+      [b"3", ENTER, ESC],
+      ["The disc in the drive is region 2", "swap in a region", "3 disc first"],
+      fake="1:3:4:1:disc2")
+check("confirming the region the loaded disc allows does not warn",
+      [b"2", ENTER, ESC], ["Set (simulated sr0) to region 2?"],
+      ["swap in a region"], fake="1:3:4:1:disc2")
+check("an empty tray warns on the confirm screen too", [b"2", ENTER, ESC],
+      ["The drive is empty", "put a region 2 disc in"], fake="1:3:4:1")
+# ... and when the drive refuses anyway, it says which of the two it was.
+check("a disc from the wrong region is named as the reason",
+      [b"3", ENTER, DOWN, ENTER],
+      ["the disc in the drive is from a different region"],
+      fake="1:3:4:1:disc2", rc=1)
+check("an empty tray is named as the reason", [b"2", ENTER, DOWN, ENTER],
+      ["no disc in the drive (tray closed)"], fake="1:3:4:1:nodisc", rc=1)
+check("a matching disc is accepted", [b"2", ENTER, DOWN, ENTER],
+      ["Done. The drive is now region 2"], fake="1:3:4:1:disc2")
 
 # --- issue #52: the result screen must outlive the press that caused it -------
 # MiSTer closes the framebuffer terminal on the first key RELEASE after the

--- a/tools/test_set_dvd_region.py
+++ b/tools/test_set_dvd_region.py
@@ -120,6 +120,37 @@ unit("RPC state decodes as the kernel packs it",
 unit("an all-ones mask is no region set", M.decode_state(b"\xb0\xff\x01").region is None)
 unit("rpc_scheme 0 is carried through", M.decode_state(b"\xb0\xff\x00").scheme == 0)
 
+# The regression that cost a hardware round: DRIVER_SENSE (0x08) sits in the LOW
+# nibble of driver_status and means "the drive answered, sense attached". Reading
+# it as a transport error discards the drive's own explanation and falls back to
+# the ioctl, which can then only say EIO. Exactly the log line from the board:
+#   SG_IO status 02 host 00 driver 08 sb_len 18
+SENSE_26 = bytes([0x70, 0, 0x05, 0, 0, 0, 0, 0x0a, 0, 0, 0, 0, 0x26, 0x00, 0, 0, 0, 0])
+try:
+    M.sg_check(0x02, 0x00, 0x08, SENSE_26)
+    ok, why = False, "accepted a Check Condition as success"
+except M.SenseError as e:
+    ok, why = (e.key, e.asc, e.ascq) == (5, 0x26, 0), str(e)
+except OSError as e:
+    ok, why = False, "read DRIVER_SENSE as a transport error: %s" % e
+unit("a Check Condition with sense is decoded, not called a transport error", ok, why)
+
+unit("the named sense text is used",
+     "invalid field in parameter list" in why, why)
+
+for name, args in (("a host error is a transport error", (0x02, 0x07, 0x00, b"")),
+                   ("a driver error is a transport error", (0x02, 0x00, 0x04, b""))):
+    try:
+        M.sg_check(*args)
+        ok, why = False, "no error"
+    except M.SenseError as e:
+        ok, why = False, "blamed the drive: %s" % e
+    except OSError as e:
+        ok, why = True, str(e)
+    unit(name, ok, why)
+
+unit("a Good status is success", M.sg_check(0x00, 0x00, 0x00, b"") is None)
+
 # SG_IO on something that is not a SCSI device must raise a plain OSError, not a
 # SenseError — that is what makes set_region() fall back to the ioctl rather than
 # reporting a refusal the drive never made.

--- a/tools/test_set_dvd_region.py
+++ b/tools/test_set_dvd_region.py
@@ -113,6 +113,16 @@ unit("pdrc is a mask with one bit clear",
                                                  0xef, 0xdf, 0xbf, 0x7f],
      repr([hex(M.region_pdrc(n)) for n in range(1, 9)]))
 
+unit("region spans read as spans, not lists",
+     [M.region_span(r) for r in ([1, 2, 3, 4, 5, 6, 8], [2], [1, 2], [1, 3, 5], [])]
+     == ["1-6,8", "2", "1,2", "1,3,5", "none"],
+     repr([M.region_span(r) for r in ([1, 2, 3, 4, 5, 6, 8], [2], [1, 2], [1, 3, 5], [])]))
+
+# MEASURED: a real disc read RMI 40 — every region except 7. So the rule is that
+# the loaded disc must ALLOW the region being set, not that it names exactly it.
+unit("an RMI of 40 allows everything but region 7",
+     [n + 1 for n in range(8) if not (0x40 >> n) & 1] == [1, 2, 3, 4, 5, 6, 8])
+
 st = M.decode_state(b"\x91\xfd\x01")
 unit("RPC state decodes as the kernel packs it",
      (st.region, st.changes, st.resets, st.scheme, st.rpc_type) == (2, 4, 4, 1, 1),
@@ -278,21 +288,27 @@ check_pdrc(4, 0xf7)
 # warns before the user spends the trip, not after.
 check("the loaded disc's region is on the status screen", [ESC],
       ["Disc in drive  : region 2"], fake="1:3:4:1:disc2")
+check("a multi-region disc reads as a span", [ESC],
+      ["Disc in drive  : regions 1-6"], fake="1:3:4:1:disc123456")
+check("a disc that allows the target region is accepted, not just an exact match",
+      [b"2", ENTER, DOWN, ENTER],
+      ["Done. The drive is now region 2"], ["does not allow region"],
+      fake="1:3:4:1:disc123456")
 check("an empty tray says so", [ESC],
       ["Disc in drive  : none"], fake="1:3:4:1")
 check("the menu explains that the drive follows the disc", [ESC],
       ["take the new region FROM THE DISC"], fake="1:3:4:1")
 check("confirming a region the loaded disc cannot support warns first",
       [b"3", ENTER, ESC],
-      ["The disc in the drive is region 2", "swap in a region", "3 disc first"],
+      ["The disc in the drive is for region 2", "does not", "allow region 3"],
       fake="1:3:4:1:disc2")
 check("confirming the region the loaded disc allows does not warn",
       [b"2", ENTER, ESC], ["Set (simulated sr0) to region 2?"],
-      ["swap in a region"], fake="1:3:4:1:disc2")
+      ["does not allow region"], fake="1:3:4:1:disc2")
 check("an empty tray warns on the confirm screen too", [b"2", ENTER, ESC],
       ["The drive is empty", "put a region 2 disc in"], fake="1:3:4:1")
 # ... and when the drive refuses anyway, it says which of the two it was.
-check("a disc from the wrong region is named as the reason",
+check("a disc that bars the target region is named as the reason",
       [b"3", ENTER, DOWN, ENTER],
       ["the disc in the drive is from a different region"],
       fake="1:3:4:1:disc2", rc=1)

--- a/tools/test_set_dvd_region.py
+++ b/tools/test_set_dvd_region.py
@@ -159,6 +159,29 @@ check("a set region reads back in both fields", [ESC],
 check("RPC-1 drive is described as region-free", [],
       ["RPC-1: it enforces no region at all"], ["Pick the region"], fake="0:5:4:0")
 
+# The byte on the wire. pdrc is a region MASK with one bit CLEAR, not the region
+# number — a real drive answers the number with sense 05/26/00, "invalid field in
+# parameter list". The fake drive decodes the mask strictly, so the scenarios above
+# already fail if this regresses; this pins the actual value so the next reader can
+# see what is meant to go out.
+def check_pdrc(region, want_byte):
+    global FAIL
+    logs = ["/media/fat/DVD_reports/set_dvd_region.log", "/tmp/set_dvd_region.log"]
+    logs = [f for f in logs if os.path.isdir(os.path.dirname(f))]
+    for f in logs:
+        if os.path.exists(f):
+            os.truncate(f, 0)
+    run([str(region).encode(), ENTER, DOWN, ENTER], fake="0:5:4:1")
+    want = "send pdrc %02x for region %d" % (want_byte, region)
+    seen = any(want in open(f).read() for f in logs if os.path.exists(f))
+    print(("PASS  " if seen else "FAIL  ") + "region %d goes out as pdrc %02x"
+          % (region, want_byte))
+    if not seen:
+        FAIL += 1
+
+check_pdrc(1, 0xfe)
+check_pdrc(4, 0xf7)
+
 # --- issue #52: the result screen must outlive the press that caused it -------
 # MiSTer closes the framebuffer terminal on the first key RELEASE after the
 # script exits, so a script that returns immediately loses its last screen. The


### PR DESCRIPTION
Fixes #52.

Huge thanks to @mikochu for testing the region change script and reporting an issue!

They set the region on their LG GS40N from the Scripts menu, the drive took it — a PC
confirmed it afterwards — and the script showed an error and vanished before they could read
it. The
manual had been asking for weeks for someone to try setting a region and say what happened,
and that one report led to a fix for the reporting, and then to three enhancements for drive
behaviours the script did not handle at all.

## The reported bug: a successful change reported as a failure

**A failure to read the region back is not a failure to set it.** `apply_region()` re-read
the drive with no `try` at all — and a drive answers the command after SEND KEY with a unit
attention, its RPC state having just changed, so that read raising is *normal*. It produced
an uncaught traceback over a change that had already worked. Even when the drive did answer,
`region_mask` can lag the change, so the old `region == want` test would announce "the drive
did not take the change" about a drive that had.

Verification now re-opens the device and retries 6 × 0.5 s, swallowing errors between tries.
A confirmed read says "Done"; an unconfirmed one says the change was **accepted but not yet
reported**, tells the user not to repeat it, and exits 3. Only the change command itself
refusing is treated as a failure.

**And nothing waited for a keypress.** `MENU_SCRIPTS_FB2` ignores key events while a script's
process lives, then tears the framebuffer terminal down on the first key **release** after it
is reaped — so the press that confirms a menu erases the result of that press, for any script
that finishes quickly. That is why the error was unreadable. Every interactive exit now holds
on a fresh keypress, draining buffered input first so the pause cannot dismiss itself. This
applies to any MiSTer Scripts tool that prints a verdict and returns, not just this one.

## Enhancements: drive conditions the script did not handle

Chasing the above on a second drive — a TSSTcorp TS-L633C behind a USB bridge — turned up
three things that never worked, because drives vary more than the tool assumed.

**1. Stricter drives need `pdrc` as a region mask.** MMC's Preferred Drive Region Code is a
byte with **one bit clear** — region 1 is `0xfe`, region 2 `0xfd` — the same polarity as the
`region_mask` REPORT KEY returns. We sent the plain region number, which *as a mask* claims
seven playable regions. The LG evidently tolerates that; the TSSTcorp rejects it outright,
measured with `sg_raw` issuing the byte-identical command the kernel builds:

```
Sense key: Illegal Request / Additional sense: Invalid field in PARAMETER LIST  (05/26/00)
```

*Parameter list*, not *CDB* — the command parsed and one payload byte was wrong. The mask is
what `regionset` has always sent (`regionset.c` `~(1 << (n-1))` → `dvd_udf.c:UDFRPCSet`), so
it is the correct encoding and the number worked by luck on tolerant firmware.

**2. The write goes over SG_IO, so a refusal can explain itself.** Byte-identical command
either way — the kernel builds this exact one from `DVD_AUTH` — but `sr_do_ioctl` collapses
every refusal into a bare `EIO` (Illegal Request and most Not Ready conditions alike), which
is useless when the operation is one-way. SG_IO returns the sense data, so a refusal now
reads `sense 05/6f/04 (the disc in the drive is from a different region)`. `DVD_AUTH` remains
the fallback for a python without `ctypes` or a device that refuses SG_IO, so this can only
add outcomes, never remove the one that worked.

**3. Many drives take their new region from the disc in the tray.** Measured on the TSSTcorp,
at region 1:

| tray | asked for | answer |
|---|---|---|
| region-1 disc | region 1 | **Good** |
| region-1 disc | region 2 | `05/6f/04` media region code is mismatched to logical unit region |
| empty | region 2 | `02/3a/01` medium not present, tray closed |
| disc with `RMI 40` (allows 1-6, 8) | region 2 | **Good** |

It is the Windows model — insert a foreign disc and the OS offers to switch the drive to
match. The rule is that the loaded disc must **allow** the target region, not name exactly
it: the fourth row is a multi-region disc and it satisfied a switch to region 2. The tool now
reads the loaded disc's region (`READ DVD STRUCTURE` format 1), shows it beside the drive's
(`Disc in drive  : regions 1-6,8`), says on the menu that the drive follows the disc, and
warns on the confirm screen when the chosen region is one the loaded disc bars — a warning,
not a block, since other drives clearly do not care.

## Also in here

- **A region-free drive is no longer reported as having no region.**
  `dvd_css.cpp:drive_region_set()` read `region_mask` alone, and an RPC-1 drive reports the
  same empty mask while meaning the opposite: it enforces no region at all and answers the
  key exchange for any disc. The best case was being labelled `No drive region: cracking`.
  Now also passes on `rpc_scheme == 0`. ⏳ Ungated — no local drive is RPC-1, so the arm
  cannot run here. It moves a message only (`region_set` never picks a code path), and a
  zeroed REPORT KEY reply already read as "set" before, so it adds no new way to be wrong.
  **Needs a `main/build_main.sh` rebuild.**
- **Diagnosis for the next second-hand report:** the status screen shows the raw RPC bytes
  decoded (`RPC state : 71 fe 01  (RPC-2, region set)`), and everything printed is appended
  to `DVD_reports/set_dvd_region.log` — which is how the rounds above were actually solved.

## Testing

`tools/test_set_dvd_region.py` grows from 13 scenarios to 40, and gains unit tests on the
pure functions (the payload moved under a `__main__` guard so the suite can import it).
`DVD_REGION_FAKE` gains fault injection reproducing what real drives do around a change — a
read-back that raises, a lagging `region_mask`, a refusal, an empty tray, a disc that bars
the target region — of which only two may be reported as failures.

**Mutation-checked, 7/7:** the pre-fix `pdrc` encoding, an unguarded read-back, no pause, an
unconfirmed change called a failure, raw bytes dropped, RPC-1 treated as unset, and
`DRIVER_SENSE` read as a transport error are each caught by their own scenario. These are
string assertions on console output — exactly the shape that passes without proving anything
— so `SET_DVD_REGION_SH=<path>` points the suite at another copy of the script, and the
issue-52 checks were proven RED against the pre-fix version.

- [x] `./tools/test_set_dvd_region.py` — 40/40
- [x] `python3 tools/docs_check.py`, `mkdocs build --strict`
- [x] `main/build_main.sh` builds with the `dvd_css.cpp` change
- [x] `sg_io_hdr` layout checked against the C ABI on both targets — `ctypes` reproduces
      `sizeof`/`offsetof` exactly on x86-64, and armv7's 64 bytes/`sbp@24` from a
      `_Static_assert` compiled with the MiSTer toolchain's own headers
- [x] **HW: reading** — Scripts menu, gamepad-driven, region and change count correct
- [x] **HW: writing** — region 1 → 2 on a TSSTcorp TS-L633C, read back on the first attempt,
      change counter 3 → 2
- [x] **HW: the result screen survives** — the verdict stays up until a button is pressed
- [x] **Field: writing** — @mikochu's LG GS40N, confirmed on a PC (on the pre-fix script)
- [ ] The RPC-1 arm in `dvd_css.cpp` — needs a region-free drive; no local drive is RPC-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
