### PR TITLE
field parity: correct the phase while the picture is held

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -568,8 +568,11 @@ worse maintenance burden than targeted in-place edits. So:
   Measured, not asserted: 4 starvation events cost **4** repeated fields with the shipped
   corrector, **0** with the gate and **0** with the corrector off. Detail:
   `docs/field_parity.md`.
-  🔧 **HOLD ARM — THE CORRECTOR COULD NOT ACT WHILE THE PICTURE WAS HELD (2026-09-04,
-  branch `fix/field-parity-hold`); sim-proven RED/GREEN, ⏳ HW-confirm pending.**
+  ✅ **HOLD ARM — THE CORRECTOR COULD NOT ACT WHILE THE PICTURE WAS HELD (2026-09-04,
+  branch `fix/field-parity-hold`); sim-proven RED/GREEN and ✅ HW-CONFIRMED 2026-09-04
+  (build `DVD_holdparity_20260904_1902.rbf`, SEED 5 first roll, clk_dec 91.72/87.62 —
+  the reported card on HDMI Weave AND the CRT, the cards behind it, pause, menu stills,
+  compute-heavy playback for the churn budget, and chapter skips: all good).**
   Field report: a disc (`RINGER_WS`) combed under Weave and jittered on a CRT **only on
   the FOX warning card it boots to**, clean once the movie started.
   ★★ **THE BLIND SPOT WAS WRITTEN DOWN AS A REASSURANCE.** `docs/field_parity.md`'s root

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -581,7 +581,7 @@ worse maintenance burden than targeted in-place edits. So:
   frame is held, and for a menu still `output_frame_valid` is 0 **by construction**
   (`mpeg2video.v`'s `freeze_wd`: a still is an end-of-stream hold) — so the mount's
   coin-flip landing displays uncorrected for as long as the still lasts. MEASURED
-  360/360 held fields misaligned vs 0/360 for a hold entered aligned.
+  360/360 held fields misaligned over a 6 s hold vs 0/360 for a hold entered aligned.
   ★ **A still is the worst case TWICE: frozen dense text is the content most sensitive to
   a one-line error, and it is the state in which the corrector is most disabled** — which
   is why a general defect read as disc-specific. The disc is ordinary: its boot cells are

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -568,6 +568,44 @@ worse maintenance burden than targeted in-place edits. So:
   Measured, not asserted: 4 starvation events cost **4** repeated fields with the shipped
   corrector, **0** with the gate and **0** with the corrector off. Detail:
   `docs/field_parity.md`.
+  🔧 **HOLD ARM — THE CORRECTOR COULD NOT ACT WHILE THE PICTURE WAS HELD (2026-09-04,
+  branch `fix/field-parity-hold`); sim-proven RED/GREEN, ⏳ HW-confirm pending.**
+  Field report: a disc (`RINGER_WS`) combed under Weave and jittered on a CRT **only on
+  the FOX warning card it boots to**, clean once the movie started.
+  ★★ **THE BLIND SPOT WAS WRITTEN DOWN AS A REASSURANCE.** `docs/field_parity.md`'s root
+  cause says the `STATE_REPEAT` persistence re-scan "preserves strict TOP/BOTTOM
+  alternation, so content parity and raster parity stay locked". True — and that is the
+  bug: preserving alternation **freezes a bad phase**, and the corrector's only cure
+  (defer a pickup) needs a pickup a hold does not have. `par_slip` requires
+  `STATE_INIT && ofv_pickup`; `STATE_REPEAT` returns straight to `STATE_NEXT_IMG` while a
+  frame is held, and for a menu still `output_frame_valid` is 0 **by construction**
+  (`mpeg2video.v`'s `freeze_wd`: a still is an end-of-stream hold) — so the mount's
+  coin-flip landing displays uncorrected for as long as the still lasts. MEASURED
+  360/360 held fields misaligned vs 0/360 for a hold entered aligned.
+  ★ **A still is the worst case TWICE: frozen dense text is the content most sensitive to
+  a one-line error, and it is the state in which the corrector is most disabled** — which
+  is why a general defect read as disc-specific. The disc is ordinary: its boot cells are
+  single clean I-frames (`progressive_frame=1`, ffprobe `interlaced_frame=0`).
+  FIX = `par_hold_ins` reuses `par_fb` UNCHANGED (so the hold arm adds opportunities to
+  act, not permissions — `PAR_CONFIRM`/`PAR_HOLD` still bound it) and the `STATE_REPEAT`
+  image build emits the held pair in the OTHER ORDER for one visit. The junction repeats
+  a field = an ODD slot shift = the re-alignment, and on a frozen picture a repeated
+  field is invisible.
+  ⛔ **NOT the obvious one-field form** (`image_0 <= last_image; image_1 <= NO_OUTPUT`):
+  identical emitted stream, but `late_pair`/`late_ext` stretch `frame_late` to two cycles
+  BECAUSE a repeat visit is a PAIR, so a one-field visit banks a refresh of phantom drop
+  debt per correction (an unearned B-drop); it also leaves the tail parity unchanged, so
+  a `tff=1` resume re-fires `alt_break` for a phase already fixed. ⚠ **Both counters must
+  clear on the insertion** — the verdict is 1–2 refreshes + CDC stale, so clearing only
+  `par_cnt` lets the first `STATE_INIT` after the hold re-break the phase it just fixed.
+  ⚠ **No `frame_late` from this arm**: the addrgen free-runs against the raster, so
+  re-ordering a held pair adds no raster field, no scan and no STC tick.
+  Gate: `field_phase_tb` **[8-hold-heal]** — ★ `force_misaligned()` MEASURES the phase
+  break and retries, because a stall eats one field or two and a scenario keyed on the
+  cold-start landing would be VACUOUS on whichever `+phase` arm started aligned (exactly
+  why `[7-post-stutter]` passes on both arms today). ⚠ **`[6-stutter]` did not guard the
+  new arm at all** — its `mem_stall` parks the FSM in `STATE_WAIT`, which never reaches
+  the persistence branch; it now drops `output_frame_valid` through each stall.
 - ✅ **VIDEO OUTPUT CONSOLIDATION + FIELD-PARITY RE-ENGAGE FIX (2026-09-02,
   PR #37) — ✅ HW-CONFIRMED (rounds 1-2 recorded further down this bullet; the
   field-parity half was then repaired and re-confirmed by PR #44).** Two CRT field reports

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -858,4 +858,19 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # is the point: the old form ANDed a one-cycle pulse with two live status signals, so those
 # nets had to reach the mount-watchdog block combinationally. Latching the event first cuts
 # that path -- which is also why clk_dec picked up ~4.5 MHz.
+# 2026-09-04 (fix/field-parity-hold -- resample_addrgen.v only: par_hold_ins lets the
+# field-parity feedback arm act from inside the STATE_REPEAT persistence re-scan, by
+# emitting the held field pair in the other order for one visit): SEED 5 held FIRST roll --
+# clk_dec 91.72 @100C / 87.62 @-40C (gate 86.0, PASS both corners) at 90% ALM (37,902),
+# RAM 498/553 and DSP 92/112 both UNCHANGED. TWENTY-SECOND consecutive first-roll fit.
+# Build DVD_holdparity_20260904_1902.rbf (4361 KB).
+# ★ 15 ALMs SMALLER than the previous entry despite adding a wire and two mux inputs -- fit
+# noise, not a real reduction; do not read it as the change being free. What IS worth
+# knowing is the other column: clk_dec fell 96.90 -> 91.72 @100C, the largest single-round
+# drop the recent ledger records, and the mechanism is visible in the diff. par_hold_ins is
+# qualified on `next`, so the next-state cone now sits combinationally in front of the
+# image_0/image_1 schedule registers and the par_cnt/par_age counters, which previously saw
+# only `state` and `last_image`. Still 5.7 MHz of margin over the gate, so it ships -- but if
+# a later round on this file lands under 86, this is the term to look at first, and the cheap
+# fix is to register par_hold_ins one cycle rather than to re-roll seeds.
 set_global_assignment -name SEED 5

--- a/bench/dvd/field_phase_tb.sv
+++ b/bench/dvd/field_phase_tb.sv
@@ -338,6 +338,14 @@ module field_phase_tb;
   function clean_head(input integer i);
     clean_head = (rec_code[i] == base_code) || (rec_code[i] == base_code + 8'd1);
   endfunction
+
+  /* Invariant C for ONE field, usable live on the last closed field rather than only
+   * over a window. Same external criterion tally() uses: the source line's parity
+   * (derived from the measured base_code, not from any RTL label) must match the raster
+   * field it landed in. */
+  function mis_now(input integer i);
+    mis_now = clean_head(i) && (((rec_code[i] - base_code) & 1) != rec_vpar[i]);
+  endfunction
   task tally(input integer a, input integer b, input reg verbose);
     integer i;
     begin
@@ -417,8 +425,15 @@ module field_phase_tb;
       for (i = 0; i < n; i = i + 1) begin
         wait_flds(5);
         mem_stall = 1'b1;
+        /* ...and no new frame is ready either. A framestore stall ALONE parks the FSM in
+         * STATE_WAIT, which never reaches the persistence branch, so it did not exercise
+         * the hold arm of the corrector at all; a compute-bound core starves the queue
+         * and misses the frame together. Dropping the frame here puts the churn where
+         * BOTH arms live, so this budget guards both. */
+        output_frame_valid = 1'b0;
         repeat (2) @(negedge v_sync);
         mem_stall = 1'b0;
+        output_frame_valid = 1'b1;
       end
       wait_flds(3);
       stamp_track = 1'b1;
@@ -430,6 +445,59 @@ module field_phase_tb;
         errors = errors + 1;
         $display("[6-stutter] FAIL: %0d starvation event(s) cost %0d repeated field(s) over %0d fields (budget %0d, %0d resumed mid-picture) - the corrector is chasing starvation at field rate",
                  n, v_same, fld_n - s0, STUTTER_MAX_SAME, v_part);
+      end
+    end
+  endtask
+
+  /* Break the raster phase ON PURPOSE, whatever +phase started it at: one starved raster
+   * field displays nothing and shifts every following content field one slot. A stall can
+   * eat one field or two, so the break is NOT guaranteed — measure it and retry, and
+   * $fatal rather than run a window that proves nothing. Without this, a hold scenario
+   * keyed on the cold-start landing would be vacuous on whichever arm happens to start
+   * aligned, which is exactly why [7-post-stutter] passes on both arms today. */
+  task force_misaligned;
+    integer k;
+    begin
+      k = 0;
+      while ((k < 4) && !mis_now(fld_n - 1)) begin
+        stamp_track = 1'b0;            // a resumed field's head line is arbitrary
+        mem_stall = 1'b1;
+        repeat (2) @(negedge v_sync);
+        mem_stall = 1'b0;
+        wait_flds(3);
+        stamp_track = 1'b1;
+        k = k + 1;
+      end
+      if (!mis_now(fld_n - 1))
+        $fatal(1, "[8] SCENARIO VACUOUS: the raster phase would not break in %0d starvation event(s)", k);
+      $display("[8-setup] raster phase broken after %0d starvation event(s) - the hold below starts MISALIGNED", k);
+    end
+  endtask
+
+  /* Hold-heal window: the frame is HELD (no pickups at all), so a correction here can
+   * only have come from the persistence branch. Settle until the phase has been right for
+   * four consecutive fields (bounded by `cap`), then require NCHK clean HELD fields.
+   * Adaptive so the normal cost is PAR_CONFIRM-sized; pre-fix it burns the cap, which is
+   * the RED. The settle may spend at most ONE repeated field — that is the churn budget
+   * for this arm, the same thing STUTTER_MAX_SAME does for the pickup arm. */
+  task hold_heal(input [8*40-1:0] name, input integer cap);
+    integer s0, c0, run, s_same;
+    begin
+      s0 = fld_n;  run = 0;
+      while (((fld_n - s0) < cap) && (run < 4)) begin
+        wait_flds(1);
+        if (clean_head(fld_n - 1) && !mis_now(fld_n - 1)) run = run + 1;
+        else                                              run = 0;
+      end
+      tally(s0, fld_n, 1'b0);  s_same = v_same;
+      c0 = fld_n;  wait_flds(NCHK);  tally(c0, c0 + NCHK, 1'b1);
+      if (v_same == 0 && v_alt == 0 && v_mis == 0 && s_same <= 1)
+        $display("[%0s] PASS: healed %0d held field(s) in, at a cost of %0d repeated field(s); %0d held fields clean after",
+                 name, c0 - s0, s_same, NCHK);
+      else begin
+        errors = errors + 1;
+        $display("[%0s] FAIL: %0d misaligned, %0d repeat(s), %0d period-2 break(s) over %0d HELD fields after a %0d-field settle (settle cost %0d repeat(s), budget 1)",
+                 name, v_mis, v_same, v_alt, NCHK, c0 - s0, s_same);
       end
     end
   endtask
@@ -479,6 +547,32 @@ module field_phase_tb;
     // cadence keeps strict alternation) — the corrector must stay silent
     progressive_frame = 1; repeat_first_field = 1; film_mode = 1;
     check_window("5-film-3:2");
+
+    // [8] PERSISTENCE HOLD entered MISALIGNED — a disc-menu STILL (one I-frame, then the
+    // reader parks), a pause, or a long decode stall. STATE_REPEAT never returns to
+    // STATE_INIT while a frame is held, so the pickup-time corrector is unreachable and a
+    // hold that STARTS misaligned stayed misaligned for every held field (measured
+    // 360/360 against 0/360 for a hold entered aligned). Real symptom: a disc whose first
+    // content after the mount is a 7 s FOX/FBI warning card displays the mount's
+    // coin-flip landing — combed under Weave, jittering a line on a CRT — for the whole
+    // card, then plays clean, which reads as a disc bug and is not one.
+    // ⚠ PLACEMENT IS LOAD-BEARING: the feedback arm needs par_age == PAR_HOLD (120
+    // refreshes) and [1] is the only earlier window that spends it, so [1]'s check region
+    // plus [2]-[5] (~90 fields) put us past the budget by here. Moved earlier, [8] would
+    // sit waiting the budget out instead of measuring, and its runtime would triple.
+    progressive_frame = 0; repeat_first_field = 0; film_mode = 0; top_field_first = 1;
+    force_misaligned();                   // non-vacuous on BOTH arms, by measurement
+    output_frame_valid = 0;               // the reader parks: persistence re-scan only
+    hold_heal("8-hold-heal", 170);
+
+    // [9] the hold ends and content resumes — the no-regression guard on the insertion:
+    // the schedule and last_image must survive it, and alt_break must not thrash on the
+    // resume (which is why the correction swaps the held PAIR rather than emitting one
+    // field: the tail parity flips, so a tff=1 head lands aligned by itself).
+    // ⚠ [9] PASSES PRE-FIX — the error has held all through the hold, so the pickup arm
+    // heals it at the first pickup. [8] is the RED; do not mistake this window for it.
+    output_frame_valid = 1;
+    check_window("9-post-hold");
 
     // self-check the measurement itself: a field can only ever head on source line 0
     // or 1, so exactly two stamps may appear and they must be adjacent. Anything else

--- a/docs/field_parity.md
+++ b/docs/field_parity.md
@@ -325,6 +325,14 @@ not hygiene: the verdict is 1–2 refreshes + a CDC stale, so clearing only `par
 the first `STATE_INIT` after the hold fire `par_fb` again on the same error and re-break
 the phase it just fixed.
 
+✅ **The arm is live in the shipped configuration** — worth checking, because it rides a
+path the benches tie on by hand. `persistence` is 1 both from `regfile.v`'s hard-reset
+default and from every `trick_w` write `emu.sv` makes (`[4] persistence = on`,
+`[9:5] repeat_frame = 0`), in both Interlaced and Progressive. So the persistence branch
+is the one a real hold takes, and the `repeat_cnt == 0` exclusion never disables the arm
+in practice — nothing in the fork drives a non-zero `repeat_frame` into `resample`
+(`mpeg2video.v` forces 31 only into the *watchdog*).
+
 **Exclusions.** `~hold_freeze`: a clip-load hold belongs to the *outgoing* clip, and
 spending the 120-refresh budget there could delay the incoming clip's correction by up to
 2 s — the exact latency `par_age`'s saturated reset exists to avoid. `repeat_cnt == 0`

--- a/docs/field_parity.md
+++ b/docs/field_parity.md
@@ -1,9 +1,15 @@
-# Field-parity re-engage corrector (2026-09-02, repaired 2026-09-03)
+# Field-parity re-engage corrector (2026-09-02, repaired 2026-09-03, hold arm 2026-09-04)
 
 **Status: ✅ RE-ENABLED and ✅ HW-CONFIRMED (2026-09-03, issue #41). Round 1 confirmed the
 analog CRT — "this one seems to always get the fields right on the TV", where PR #40 was a
 coin flip — and exposed an inverted `VGA_F1`; round 2 confirmed that fix
 (`DVD_parityf1_20260903_1253.rbf`). Sim gate: `bench/dvd/field_phase_tb.sv`, RED/GREEN.**
+
+🔧 **HOLD ARM (2026-09-04, branch `fix/field-parity-hold`): the corrector could not act
+while the picture was HELD — a menu still, a warning card, a pause — because its cure is
+to defer a pickup and a hold has none. Measured 360/360 held fields misaligned. Fixed by
+swapping the held pair's order for one visit; sim-proven RED/GREEN by the new
+`field_phase_tb` scenario [8], ⏳ HW-confirm pending. See "The hold gap" below.**
 
 ★ **HW ROUND 1 (2026-09-03) — the corrector is right, and it exposed an INVERTED
 `VGA_F1` (fixed; ✅ confirmed in round 2).** With the field phase now deterministic, HDMI Weave went from a coin flip to
@@ -246,6 +252,109 @@ lengthened to the feedback arm's new latency — an expectation change, not a st
 `pickup_hold_tb`, `menu_ff_tb`, `cadence_slip_tb`, `resample_persist_tb`,
 `resample_addr_realstride_tb`, `film_detect_tb`.
 
+## The hold gap (2026-09-04) — the corrector could not act while the picture was HELD
+
+★ **The blind spot was written down as a reassurance.** "Root cause" point 2 above says
+the `STATE_REPEAT` persistence re-scan "preserves strict TOP/BOTTOM alternation, so in
+steady state content parity and raster parity stay locked". That is TRUE, and it is
+exactly the problem: preserving alternation is what **freezes a bad phase**. A hold
+neither breaks a good phase nor heals a bad one, and the corrector's only cure — defer a
+pickup — needs a pickup that a hold does not have.
+
+**Reported symptom.** A disc (`RINGER_WS`) whose first content after the mount is a
+7-second FOX/FBI warning card: Weave combing on HDMI and field jitter on a CRT for the
+whole card, clean the moment the movie starts. It reads as a disc bug and is not one —
+the card is a single clean I-frame (720×480, `progressive_frame=1`, `tff=1`, `rff=0`,
+`interlaced_frame=0` per ffprobe). Its boot chain is FP → VMGM PGC 10 (1 cell,
+`still=7`) → PGC 13 (2 cells, `still=7`) → `JumpTT 22`; each cell is one I-frame and
+nothing else.
+
+**Why a still is the worst case, twice over.** It is the content most sensitive to a
+one-line error (frozen dense text — every stroke combs), and it is the state in which
+the corrector is most thoroughly disabled. `par_slip` requires `state == STATE_INIT &&
+ofv_pickup`, but `STATE_REPEAT` returns straight to `STATE_NEXT_IMG` while a frame is
+held, so `STATE_INIT` is never re-entered. For a menu still it is unreachable **by
+construction**: `mpeg2video.v`'s `freeze_wd` comment records that a still is an
+end-of-stream hold, so `output_frame_valid` is 0 — there is no frame to pick up, ever.
+So the mount's coin-flip landing is displayed, uncorrected, for as long as the still
+lasts.
+
+**Measured** (`field_phase_tb` scenario [8], cold start at the `+phase`-selected raster
+parity, ONE pickup, then a 6-second hold):
+
+| landing phase | misaligned fields during the hold | on resume |
+|---|---|---|
+| aligned | 0 / 360 | clean |
+| misaligned | **360 / 360** | heals in ~2 fields |
+
+### The fix — swap the held pair's order for one visit
+
+`par_hold_ins` in `dvd/resample_addrgen.v` reuses `par_fb` **unchanged**, so the hold arm
+inherits the whole stability contract (`PAR_CONFIRM` = 30 held-error refreshes,
+`PAR_HOLD` = 120-refresh budget) and adds *opportunities to act*, not *permissions*. The
+counters advance during a hold: `refresh_done` ticks on repeat re-scans, and the mixer
+re-latches its verdict at every held field's frame top.
+
+In the `STATE_REPEAT` image build, the pair is emitted in the other order for that one
+visit ({BOTTOM,TOP} → {TOP,BOTTOM}). The junction repeats a field — an **odd** shift of
+the content-to-slot mapping, i.e. the re-alignment — and on a frozen picture a repeated
+field is invisible, which is why this arm is cheap where the pickup-time one is not.
+
+⛔ **Not the obvious one-field form** (`image_0 <= last_image; image_1 <= NO_OUTPUT`).
+It emits an identical stream, but two things ride on the visit being a PAIR:
+
+1. `late_pair`/`late_ext` stretch `frame_late` to two cycles *because* a repeat visit is
+   two refreshes. A one-field visit on a plain decode-stall hold would bank one refresh
+   of phantom drop debt per correction — an unearned B-drop, a visible ~33 ms skip.
+2. It leaves the tail on the same parity, so a `tff=1` resume re-fires `alt_break` for a
+   phase already fixed. The pair swap flips the tail, so the resume is clean.
+
+**No `frame_late` from this arm.** The addrgen free-runs against the raster: re-ordering
+a held pair adds no raster field, no image scan and no STC tick (`av_refresh_tick` comes
+from `core_v_sync`, not from this schedule). Nothing was retarded, unlike a deferred
+pickup. Pulsing it would also land one clock after a `STATE_REPEAT` cycle — where
+`late_ext` asserts — and since `frame_late` is an OR of pulses the two would merge and
+*under*-bank a real late.
+
+**Both counters clear on the insertion.** This is the anti-double-correction mechanism,
+not hygiene: the verdict is 1–2 refreshes + a CDC stale, so clearing only `par_cnt` lets
+the first `STATE_INIT` after the hold fire `par_fb` again on the same error and re-break
+the phase it just fixed.
+
+**Exclusions.** `~hold_freeze`: a clip-load hold belongs to the *outgoing* clip, and
+spending the 120-refresh budget there could delay the incoming clip's correction by up to
+2 s — the exact latency `par_age`'s saturated reset exists to avoid. `repeat_cnt == 0`
+keeps the decoder's native freeze/slow-motion path bit-identical. `pause` is deliberately
+**allowed**: a paused still is precisely when someone is staring at the comb, and
+`av_sync` freezes the STC under pause anyway.
+
+⛔ Also rejected: routing the hold through `STATE_INIT` (no valid frame — it parks there,
+the pixel queue drains and the mixer goes BLACK, the failure `hold_freeze` was written to
+prevent); re-picking-up the held frame (re-latches `cur_show` and fires the pickup into
+`vid_content_refr` for a frame that never advanced, corrupting `vid_err` and the drop
+reclaim to fix a cosmetic phase); an emu-side "a still is starting" hint (the error is
+only observable *after* the first field displays, by which time the reader has parked).
+
+### Gate — scenario [8], and a coverage gap it exposed in [6]
+
+`[8-hold-heal]` breaks the phase deliberately, then holds. ★ **`force_misaligned()`
+MEASURES the break and retries rather than assuming it**: a stall can eat one field or
+two, so a hold scenario keyed on the cold-start landing would be vacuous on whichever
+`+phase` arm happened to start aligned — which is precisely why `[7-post-stutter]` passes
+on both arms today. It `$fatal`s rather than run a window that proves nothing. The settle
+may spend at most ONE repeated field (this arm's churn budget), then `NCHK` **held**
+fields must be clean. `[9-post-hold]` guards the resume — and **passes pre-fix**, so it
+must not be mistaken for the RED.
+
+⚠ **`[6-stutter]` did not guard the new arm at all.** Its `mem_stall` parks the FSM in
+`STATE_WAIT`, which never reaches the persistence branch. It now drops
+`output_frame_valid` for the duration of each stall — a compute-bound core starves the
+queue and misses the frame together — so the churn budget covers both arms.
+
+⚠ Scenario placement is load-bearing: the feedback arm needs `par_age == PAR_HOLD`, and
+`[1]` is the only earlier window that spends it, so `[8]` sits after `[5]` where ~120
+refreshes have elapsed. Moved earlier it would wait the budget out instead of measuring.
+
 ## Consequences for the HW symptom
 
 - Chapter skip / FF / seek: the feed-forward guard aligns the first field of the new
@@ -254,6 +363,10 @@ lengthened to the feedback arm's new latency — an expectation change, not a st
   (~33 ms) of the first misaligned frame-top.
 - The "toggle Analog Out 3–4 times" ritual is obsolete; a mode toggle still works but
   is never needed.
+- Menu stills, authored warning cards and pause (2026-09-04): a hold entered misaligned
+  now heals ~0.5 s in (`PAR_CONFIRM`) instead of staying wrong for the whole hold. A
+  mount whose first content is a several-second still — the case that made this look
+  disc-specific — is the one that needed it.
 
 ## Files
 
@@ -262,7 +375,8 @@ lengthened to the feedback arm's new latency — an expectation change, not a st
 - `rtl/mpeg2/mpeg2video.v` — gate + `sync_reg` CDC + routing
 - `rtl/mpeg2/resample.v` — pass-through
 - `dvd/resample_addrgen.v` — the corrector (`alt_break` / `par_fb` / `par_armed` /
-  `pickup_go` / the insertion branch)
+  `pickup_go` / the insertion branch), and the hold arm (`par_hold_ins` / the pair swap
+  in the `STATE_REPEAT` image build)
 - `bench/dvd/field_phase_tb.sv`, `bench/dvd/run_field_phase.sh` — **the gate**
 - `bench/dvd/field_parity_tb.sv`, `bench/dvd/run_field_parity.sh` — the alignment view
   (kept, but it agrees with the RTL by construction: see the caveat above)

--- a/docs/field_parity.md
+++ b/docs/field_parity.md
@@ -5,12 +5,19 @@ analog CRT — "this one seems to always get the fields right on the TV", where 
 coin flip — and exposed an inverted `VGA_F1`; round 2 confirmed that fix
 (`DVD_parityf1_20260903_1253.rbf`). Sim gate: `bench/dvd/field_phase_tb.sv`, RED/GREEN.**
 
-🔧 **HOLD ARM (2026-09-04, branch `fix/field-parity-hold`): the corrector could not act
-while the picture was HELD — a menu still, a warning card, a pause — because its cure is
-to defer a pickup and a hold has none. Measured 360/360 held fields misaligned over a
-6-second hold (the committed gate is the shorter form of that experiment). Fixed by
-swapping the held pair's order for one visit; sim-proven RED/GREEN by the new
-`field_phase_tb` scenario [8], ⏳ HW-confirm pending. See "The hold gap" below.**
+✅ **HOLD ARM (2026-09-04, branch `fix/field-parity-hold`) — sim-proven RED/GREEN and
+✅ HW-CONFIRMED 2026-09-04 (build `DVD_holdparity_20260904_1902.rbf`, SEED 5 first roll,
+clk_dec 91.72/87.62): the corrector could not act while the picture was HELD — a menu
+still, a warning card, a pause — because its cure is to defer a pickup and a hold has
+none. Measured 360/360 held fields misaligned over a 6-second hold (the committed gate is
+the shorter form of that experiment). Fixed by swapping the held pair's order for one
+visit. See "The hold gap" below.**
+
+The HW round covered all six checks the fix could plausibly have broken: the reported FOX
+warning card on both HDMI Weave and the CRT, the second and third cards behind it, a
+mid-movie pause, menu stills, sustained playback on compute-heavy content (the churn
+budget — the failure mode that forced PR #37's withdrawal), and chapter skips (the
+untouched feed-forward arm). All good.
 
 ★ **HW ROUND 1 (2026-09-03) — the corrector is right, and it exposed an INVERTED
 `VGA_F1` (fixed; ✅ confirmed in round 2).** With the field phase now deterministic, HDMI Weave went from a coin flip to

--- a/docs/field_parity.md
+++ b/docs/field_parity.md
@@ -7,7 +7,8 @@ coin flip — and exposed an inverted `VGA_F1`; round 2 confirmed that fix
 
 🔧 **HOLD ARM (2026-09-04, branch `fix/field-parity-hold`): the corrector could not act
 while the picture was HELD — a menu still, a warning card, a pause — because its cure is
-to defer a pickup and a hold has none. Measured 360/360 held fields misaligned. Fixed by
+to defer a pickup and a hold has none. Measured 360/360 held fields misaligned over a
+6-second hold (the committed gate is the shorter form of that experiment). Fixed by
 swapping the held pair's order for one visit; sim-proven RED/GREEN by the new
 `field_phase_tb` scenario [8], ⏳ HW-confirm pending. See "The hold gap" below.**
 
@@ -279,8 +280,11 @@ end-of-stream hold, so `output_frame_valid` is 0 — there is no frame to pick u
 So the mount's coin-flip landing is displayed, uncorrected, for as long as the still
 lasts.
 
-**Measured** (`field_phase_tb` scenario [8], cold start at the `+phase`-selected raster
-parity, ONE pickup, then a 6-second hold):
+**Measured** — the diagnostic form of the experiment: a `field_phase_tb` variant that
+cold-starts at the `+phase`-selected raster parity, takes ONE pickup, then holds for six
+seconds. (Scenario [8] below is the short, committed form of the same thing; it reports
+16/16 after burning its settle cap rather than 360/360, because it stops measuring
+sooner.)
 
 | landing phase | misaligned fields during the hold | on resume |
 |---|---|---|

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -566,7 +566,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "dev-mgl"
+`define CORE_VERSION "dev-holdparity"
 
 parameter CONF_STR = {
     "DVD;;",

--- a/dvd/resample_addrgen.v
+++ b/dvd/resample_addrgen.v
@@ -635,6 +635,50 @@ module resample_addrgen (
    * it must still advance to scan the inserted field. */
   wire       pickup_go = ofv_pickup && ~par_ins;
 
+  /* ★ THE FEEDBACK ARM, INSIDE A PERSISTENCE HOLD (2026-09-04).
+   * Everything above cures a phase error by DEFERRING A PICKUP. While a frame is being
+   * HELD there is no pickup to defer: STATE_REPEAT goes straight back to STATE_NEXT_IMG
+   * (the next-state arc below), so STATE_INIT — and with it par_slip — is unreachable
+   * for the whole hold, and the repeat branch re-scans an EVEN field pair, which
+   * PRESERVES whatever phase the hold started in. A hold entered misaligned therefore
+   * stayed misaligned for every held field: measured 360/360 in bench/dvd/field_phase_tb
+   * scenario [8], against 0/360 for a hold entered aligned.
+   * That is the whole of a DVD menu STILL — and a disc whose first content after a mount
+   * is a 7 s warning card (one I-frame, then the reader parks) shows the mount's
+   * coin-flip landing, combed under Weave and jittering a line on a CRT, for the whole
+   * card. A still is also the WORST case for it: frozen dense text is where a one-line
+   * error is most visible, which is why it reads as a disc-specific bug.
+   * ⚠ For a menu still this is not merely un-entered but unreachable BY CONSTRUCTION:
+   * mpeg2video.v's freeze_wd comment records that a still is an end-of-stream hold, so
+   * output_frame_valid is 0 — there is no frame to pick up, ever.
+   * Cure: emit the held pair in the OTHER order for one visit (see the STATE_REPEAT
+   * image-build branch). That repeats one field at the junction — an ODD shift of the
+   * content-to-slot mapping, i.e. the re-alignment — while keeping the visit two fields
+   * long. On a frozen picture a repeated field is invisible, which is why this arm can
+   * be cheap where the pickup-time one is not.
+   * Same par_fb budget as the pickup arm, and the counters are SHARED, so the two arms
+   * can never double-correct one verdict. */
+  wire       par_hold_ins = (state == STATE_REPEAT) && (next == STATE_NEXT_IMG) &&
+                            (repeat_cnt == 5'd0) && ~hold_freeze && par_fb;
+  /* No combinational loop: next's cone is {state, repeat_cnt, ofv_paced, persistence,
+   * last_image, image_0..5} and par_fb's is {interlaced, raster_par_err, par_cnt,
+   * par_age, last_image} — all registers and inputs, none of them fed by this wire.
+   * (It is also the same qualifier the repeat branch itself already uses.)
+   * ~hold_freeze: a clip-load hold belongs to the OUTGOING clip, and spending the
+   * PAR_HOLD budget on it could delay the incoming clip's correction by up to 2 s —
+   * exactly the latency par_age's saturated reset exists to avoid.
+   * repeat_cnt == 0 keeps the decoder's native freeze/slow-motion path bit-identical.
+   * `pause` is deliberately NOT excluded: a paused still is precisely when someone is
+   * staring at the comb, and av_sync freezes the STC under pause anyway.
+   * ⛔ Rejected, so they are not re-proposed: (1) routing the hold through STATE_INIT —
+   * there is no valid frame, so it parks there, the pixel queue drains and the mixer
+   * goes BLACK, which is the failure hold_freeze was written to prevent; (2) re-picking
+   * up the held frame to synthesise a STATE_INIT visit — it would re-latch cur_show and
+   * fire the pickup into vid_content_refr for a frame that never advanced, corrupting
+   * vid_err and the drop reclaim to fix a cosmetic phase; (3) an emu-side "a still is
+   * starting" hint — the error is only observable AFTER the first field displays, by
+   * which time the reader has already parked. */
+
   /* PAR_CONFIRM stability counter: one tick per completed image scan (the same refresh
    * event the governor counts), cleared whenever the mixer's verdict clears — so the
    * count only reaches PAR_CONFIRM for an error that held that whole time — and cleared
@@ -643,20 +687,33 @@ module resample_addrgen (
   always @(posedge clk)
     if (~rst) par_cnt <= 6'd0;
     else if (clk_en) begin
-      if (par_slip || ~raster_par_err)             par_cnt <= 6'd0;
+      if (par_slip || par_hold_ins || ~raster_par_err) par_cnt <= 6'd0;
       else if (refresh_done && ~par_stable)        par_cnt <= par_cnt + 6'd1;
     end
 
   /* par_age starts SATURATED so the first correction of a session (the cold-start
-   * landing, the one case the schedule cannot see at all) is not delayed by the budget. */
+   * landing, the one case the schedule cannot see at all) is not delayed by the budget.
+   * ★ BOTH counters must clear on par_hold_ins too, and that is the anti-double-
+   * correction mechanism rather than bookkeeping hygiene: the mixer's verdict is 1-2
+   * refreshes + a CDC stale, so if only par_cnt cleared, the first STATE_INIT after the
+   * hold would fire par_fb again on the SAME error and re-break the phase it just fixed.
+   * The three events cannot collide — refresh_done is STATE_NEXT_MB, par_hold_ins is
+   * STATE_REPEAT, par_slip is STATE_INIT — so the if/else ordering hides no priority. */
   always @(posedge clk)
     if (~rst) par_age <= PAR_HOLD;
     else if (clk_en) begin
-      if (par_slip && par_fb)                      par_age <= 8'd0;
+      if ((par_slip && par_fb) || par_hold_ins)    par_age <= 8'd0;
       else if (refresh_done && (par_age != PAR_HOLD)) par_age <= par_age + 8'd1;
     end
 
   reg par_late_r;                      // hand the inserted refresh to the frame-drop ledger (cad_late_r pattern)
+  /* ⚠ par_slip ONLY — a hold insertion must NOT pulse frame_late. The addrgen free-runs
+   * against the raster, so re-ordering a held pair adds no raster field, no STC tick
+   * (emu.sv derives av_refresh_tick from core_v_sync, not from this schedule) and no
+   * image scan: nothing was retarded, unlike a deferred pickup, which genuinely diverts
+   * one refresh away from a pending frame. Pulsing it here would also land one clk after
+   * a STATE_REPEAT cycle — exactly where late_ext asserts — and since frame_late is an OR
+   * of pulses the two would merge into one high cycle and UNDER-bank a real late. */
   always @(posedge clk)
     if (~rst) par_late_r <= 1'b0;
     else if (clk_en) par_late_r <= par_slip;
@@ -1134,24 +1191,37 @@ module resample_addrgen (
        * Repeat last shown image.
        * If last shown image was a frame, show frame.
        * If last shown image was a field image, show both fields.
+       *
+       * DVD-FORK (field-parity corrector, hold arm, 2026-09-04): on par_hold_ins the
+       * pair is emitted in the OTHER ORDER for this one visit. The junction then repeats
+       * a field (…T | T…), which is an ODD shift of the content-to-slot mapping = the
+       * re-alignment, and the tail parity flips so the stream stays strictly alternating
+       * from there. See the par_hold_ins comment above for why this arm exists.
+       * ⛔ NOT the obvious "image_0 <= last_image; image_1 <= NO_OUTPUT" one-field form.
+       * It emits the identical stream, but it makes the visit ONE field long, and
+       * late_pair/late_ext below stretch frame_late to two cycles precisely BECAUSE a
+       * repeat visit is a field PAIR — so a plain decode-stall hold would bank one
+       * refresh of phantom drop debt per correction (an unearned B-drop, ~33 ms). It
+       * also leaves the tail on the same parity, so a tff=1 resume re-fires alt_break
+       * for a phase already fixed. Swapping the pair costs nothing in either ledger.
        */
       begin
         image   <= NO_OUTPUT;
         case (last_image)
-          FRAME: 
+          FRAME:
             begin
               image_0 <= FRAME;
               image_1 <= NO_OUTPUT;
             end
           TOP:
             begin
-              image_0 <= BOTTOM;
-              image_1 <= TOP;
+              image_0 <= par_hold_ins ? TOP    : BOTTOM;
+              image_1 <= par_hold_ins ? BOTTOM : TOP;
             end
           BOTTOM:
             begin
-              image_0 <= TOP;
-              image_1 <= BOTTOM;
+              image_0 <= par_hold_ins ? BOTTOM : TOP;
+              image_1 <= par_hold_ins ? TOP    : BOTTOM;
             end
           NO_OUTPUT:
             begin

--- a/dvd/resample_addrgen.v
+++ b/dvd/resample_addrgen.v
@@ -641,8 +641,10 @@ module resample_addrgen (
    * (the next-state arc below), so STATE_INIT — and with it par_slip — is unreachable
    * for the whole hold, and the repeat branch re-scans an EVEN field pair, which
    * PRESERVES whatever phase the hold started in. A hold entered misaligned therefore
-   * stayed misaligned for every held field: measured 360/360 in bench/dvd/field_phase_tb
-   * scenario [8], against 0/360 for a hold entered aligned.
+   * stayed misaligned for every held field: 360/360 measured over a 6-second hold,
+   * against 0/360 for a hold entered aligned. (The committed gate,
+   * bench/dvd/field_phase_tb scenario [8], is the shorter form of the same experiment —
+   * pre-fix it burns its whole settle cap and then reports 16/16.)
    * That is the whole of a DVD menu STILL — and a disc whose first content after a mount
    * is a 7 s warning card (one I-frame, then the reader parks) shows the mount's
    * coin-flip landing, combed under Weave and jittering a line on a CRT, for the whole

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -201,8 +201,17 @@ never show this; it depends on the set.
     corrector was switched off again: it was making both fields carry the same picture
     lines, which combed still images on every output including HDMI.) The same fix run
     also corrected HDMI `480i Deint` = `Weave`, which used to comb on a still about half
-    the time. Televisions differ, so if either symptom survives on a current build,
-    please [report it](reporting-a-bug.md). See
+    the time.
+
+    A later fix extends the correction to **held pictures** — disc menus, authored
+    copyright and warning cards, and paused frames. Before it, a disc that boots straight
+    to a several-second warning screen could show that screen misaligned for its whole
+    duration and then play cleanly, because the correction only ran when a new frame
+    arrived; a held picture never delivers one. Held pictures now straighten themselves
+    within about half a second.
+
+    Televisions differ, so if either symptom survives on a current build, please
+    [report it](reporting-a-bug.md). See
     [Field alignment](../video/interlaced.md#field-alignment).
 
 ### The picture blocks up briefly right after a chapter skip or seek

--- a/site/content/video/interlaced.md
+++ b/site/content/video/interlaced.md
@@ -104,9 +104,17 @@ tolerant sync separator may never see it at all.
     repaired version only steps in for a misalignment that persists, so it cannot do
     that.) The same coin flip decided whether **HDMI with `480i Deint` = `Weave`** came up
     combed on a still; that is fixed too, by a separate correction to the field flag the
-    core hands the framework scaler. Both are confirmed on hardware. Televisions differ,
-    so if a skip still leaves the picture aliased, or a still combs under Weave,
-    [please report it](../reference/reporting-a-bug.md).
+    core hands the framework scaler. Both are confirmed on hardware.
+
+    The correction now also applies **while a picture is being held** — a disc menu, an
+    authored copyright or warning card, or a paused frame. Until it did, a disc that
+    booted straight to a several-second warning screen could show that screen misaligned
+    for its whole duration and then play perfectly, because the correction only ran when
+    a new frame arrived and a held picture never delivers one. A held picture now
+    straightens itself within about half a second.
+
+    Televisions differ, so if a skip still leaves the picture aliased, or a still combs
+    under Weave, [please report it](../reference/reporting-a-bug.md).
 
 ## What changed from the old settings
 


### PR DESCRIPTION
A user reported HDMI Weave combing and CRT field jitter on one disc, **only on the FOX
warning card it boots to**, clean once the movie started. The card is not at fault: it is a
single clean progressive I-frame (720x480, `progressive_frame=1`, `tff=1`, `rff=0`,
ffprobe `interlaced_frame=0`). What singles it out is that it is **held**.

## The gap

The field-parity corrector cures a content-field/raster-field phase error by deferring a
pickup and inserting one field. A held picture has no pickup to defer: `STATE_REPEAT`
returns straight to `STATE_NEXT_IMG`, so `STATE_INIT` — and with it `par_slip` — is
unreachable for the whole hold. For a menu still it is unreachable *by construction*
(`mpeg2video.v`'s `freeze_wd`: a still is an end-of-stream hold, so `output_frame_valid`
is 0 and no frame ever arrives). Meanwhile the persistence re-scan emits an **even** field
pair, which preserves whatever phase the hold began in.

The blind spot was already written down in `docs/field_parity.md` as a reassurance — "the
persistence re-scan preserves strict TOP/BOTTOM alternation" is true, and preserving
alternation is exactly what freezes a bad phase.

So a mount's coin-flip landing is displayed uncorrected for as long as the still lasts, and
a still is the worst case twice over: frozen dense text is the content most sensitive to a
one-line error, and it is the state in which the corrector is most thoroughly disabled.
Hence a general defect reading as a disc-specific one.

## The fix

`par_hold_ins` reuses `par_fb` **unchanged**, so the hold arm adds *opportunities to act*
rather than permissions — `PAR_CONFIRM` (30 held-error refreshes) and `PAR_HOLD`
(120-refresh budget) still bound it, and the counters are shared so the two arms cannot
double-correct one verdict. The `STATE_REPEAT` image build then emits the held pair in the
other order for one visit: the junction repeats a field, an odd shift of the
content-to-slot mapping, which is the re-alignment. On a frozen picture a repeated field is
invisible.

Not the obvious one-field form (`image_0 <= last_image; image_1 <= NO_OUTPUT`): it emits an
identical stream, but `late_pair`/`late_ext` stretch `frame_late` to two cycles precisely
*because* a repeat visit is a pair, so a one-field visit would bank a refresh of phantom
drop debt per correction — an unearned B-drop. It also leaves the tail parity unchanged, so
a `tff=1` resume re-fires `alt_break` for a phase already fixed; `[9-post-hold]` measures
that cost directly (1 repeat + 2 misaligned pre-fix, 0 and 0 after).

No `frame_late` from this arm: the addrgen free-runs against the raster, so re-ordering a
held pair adds no raster field, no image scan and no STC tick.

## Gate

New `field_phase_tb` scenario `[8-hold-heal]`. `force_misaligned()` **measures** the phase
break and retries rather than assuming it — a stall eats one field or two, so a scenario
keyed on the cold-start landing would be vacuous on whichever `+phase` arm started aligned,
which is why `[7-post-stutter]` passes on both arms today.

| | `[8-hold-heal]` |
|---|---|
| pre-fix, both arms | **FAIL** — 16/16 misaligned after burning the full 170-field cap; never heals |
| fixed, `+phase=0` | PASS — healed 32 held fields in, 1 repeated field |
| fixed, `+phase=1` | PASS — healed 33 held fields in, 1 repeated field |

`[6-stutter]` did not guard the new arm at all — its `mem_stall` parks the FSM in
`STATE_WAIT`, which never reaches the persistence branch. It now drops
`output_frame_valid` through each stall, and still costs 0 repeated fields over 4
starvation events on both arms.

## Test plan

- [x] `run_field_phase.sh` — both raster phases green, incl. the new `[8]`/`[9]`
- [x] RED proof — pre-fix RTL against the new bench fails `[8]` on both arms
- [x] `run_field_parity.sh` — both arms, unchanged
- [x] `run_film_evidence.sh`, `run_prefetch_chain.sh` — green
- [x] The nine TBs that instantiate `resample_addrgen` and tie `raster_par_err` low —
      unchanged, as they must be (`par_hold_ins` can never assert there)
- [x] `tools/docs_check.py`, `mkdocs build --strict`
- [x] Fit: SEED 5 first roll, clk_dec **91.72 MHz @100C / 87.62 @-40C** (gate 86.0),
      90% ALM, RAM and DSP unchanged
- [x] **HW-confirmed** (`DVD_holdparity_20260904_1902.rbf`): the reported card on HDMI
      Weave and the CRT, the cards behind it, mid-movie pause, menu stills, sustained
      compute-heavy playback (the churn budget that forced PR #37's withdrawal), and
      chapter skips (the untouched feed-forward arm)

## Note for the next round on this file

clk_dec fell 96.90 → 91.72 MHz @100C, the largest single-round drop the recent ledger
records, and the mechanism is in the diff: `par_hold_ins` is qualified on `next`, so the
next-state cone now sits combinationally ahead of the image-schedule registers and the two
counters. 5.7 MHz of margin remains so it ships, but if a later change on this file lands
under the gate, this is the term to look at first and the cheap fix is to register
`par_hold_ins` — not to re-roll seeds. Recorded in the `DVD.qsf` ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
