### PR TITLE
OSD: rename O[13] Audio Genlock -> A/V Sync, correct what it and Frame Drop claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1463,11 +1463,25 @@ worse maintenance burden than targeted in-place edits. So:
     FAILED (do NOT retry): entry-side dispatch scheduling, pre-anchor gate bypass,
     mid-play gate re-arm (full-FIFO deadlock), fractional vbuf thresholds, 16-bit
     offset constants.
-  - **`O[13],Audio Genlock,On,Off`** (2026-06-28, branch
-  `feature/vob-audio-freerun`): set Off to free-run the audio NCO (`nco_trim=0`)
-  while a VOB plays through the full pipeline — a diagnostic to tell av_sync/governor
-  PACING apart from `audio_ring` overflow / `ps_demux` filtering, now that AC-3 File
-  Test has HW-exonerated the decoder. See `docs/fabric_audio.md` §"Audio Genlock toggle".
+  - **`P1O[13],A/V Sync,On,Off`** — ⚠ **RENAMED from `Audio Genlock` 2026-09-07**
+  (bit span unchanged; `wire av_freerun = status[13]` keeps its name, which is still
+  accurate). Its original job — free-run the 48 kHz NCO via `nco_trim=0` (2026-06-28,
+  branch `feature/vob-audio-freerun`) — **has been dead since the 2026-07-02 trim
+  retirement**: `emu.sv` declares `dec_nco_trim = 22'sd0` unconditionally, so that
+  reading was stale for two months while the CONF_STR comment, `docs/`, and the manual
+  all still taught it. What the bit does NOW (since PR #63) is disable the PTS scheduler
+  **wholesale, video included**: `disp_sched.sched_en` (every picture due on arrival ⇒
+  the display free-runs at raster rate), `dvd_audio_decode.sched_en` (drain gate,
+  stale-skip, catch-up, pre-anchor hold) and `iec61937_wrap.sync_armed` (passthrough
+  hold). Off is "no lip sync at all" — a diagnostic arm, never a fallback.
+  ★ **Kept rather than hardwired on (reviewed 2026-09-07, user decision) because it is
+  the only on-hardware way to take the whole scheduler out of a bug report** — the
+  alternative is a custom build per investigation. The rename is what makes keeping it
+  safe: `Field Order` and `Analog CSync = Stock` were DELETED before release precisely
+  because a user could reach for them as a *fix*, and "Audio Genlock" invited exactly
+  that while naming half the behaviour. ⚠ **Any CONF_STR edit re-rolls the pinned fitter
+  SEED**, so this rename was batched into a release build rather than spent on its own.
+  See `docs/fabric_audio.md` §"A/V Sync toggle".
   - *(Prior HPS-decode path, retired: FPGA wrote compressed frames to a DDR3 ring at byte
     `0x30800000` for the standalone `hps/dvd_audio.c` daemon (liba52) to mmap/decode/ALSA.
     HW-confirmed 2026-06-25; see `docs/audio_ddr_path.md` for history.)*

--- a/docs/av_sync.md
+++ b/docs/av_sync.md
@@ -342,8 +342,9 @@ MiB's large (~500 ms, compute-marginal start with underruns re-pinning it random
   active would be harmful: its entry-side set-point differs from the drain-set phase by
   the (variable) buffer occupancy, so the integrator would grind the correct phase away
   at ±0.5 %. `av_sync` remains as the STC generator + re-anchor + drift telemetry
-  (`lead_target` fed 0 so drift reads 0 = in sync); `O[13]` Genlock Off now bypasses the
-  drain gate (free-run, the legacy behaviour).
+  (`lead_target` fed 0 so drift reads 0 = in sync); `O[13]` (renamed `A/V Sync`
+  2026-09-07 — it no longer touches the NCO at all) bypasses the drain gate when Off
+  (free-run, the legacy behaviour).
 - **Bypasses / liveness:** gate inactive when `sched_en` low or STC un-anchored (raw ES).
   A held start always releases (STC advances every refresh once `video_live`); the ring
   drain-watchdog remains the outer guard.
@@ -546,10 +547,12 @@ sched_hold = sched_en && stc_anchored && frame_pts_valid
   than `HOLD_MAX` (≈4 s) ahead is treated as a discontinuity and dispatched (av_sync
   re-anchors off the accompanying video PTS). The `audio_ring` almost_full backpressure +
   ~1.2 s drain watchdog in emu remain the outer safety net.
-- **Composition with the genlock:** the schedule sets phase, the PI holds rate — once the
-  gate places dispatch at `STC + lead_target`, the loop sees error ≈ 0 and trims only
-  residual crystal drift. `sched_en = ~status[13]`, so `O[13] Audio Genlock Off` disables
-  BOTH mechanisms and stays a clean free-run diagnostic.
+- **Composition with the genlock** (HISTORICAL — the PI is retired, see the NCO-trim
+  bullet above): the schedule set phase, the PI held rate — once the gate placed dispatch
+  at `STC + lead_target`, the loop saw error ≈ 0 and trimmed only residual crystal drift.
+  `sched_en = ~status[13]`, so `O[13]` Off disabled both mechanisms. Today only the
+  schedule exists, and that bit (now labelled **A/V Sync**) disables the scheduler for
+  video and passthrough as well — see `docs/fabric_audio.md` "A/V Sync toggle".
 - In steady state (ring parked near-full by backpressure) the gate is what *times* each
   frame's release — the ring becomes a genuine presentation buffer instead of a pure
   elasticity buffer.

--- a/docs/disc_sweep.md
+++ b/docs/disc_sweep.md
@@ -320,9 +320,12 @@ Chapter/stream/flag data from `tools/dvd_census.py` (2026-07-31). Predictions fr
 - **Title end (POST):** VTSM vts=1 PGCN 5 → `LinkPGCN 22` → `JumpSS_VMGM_PGC 2` → `JumpTT 2`
 - **Watch:** the only straight *film* disc of the eight — use it as the A/V regression: 3:2
   film cadence, A/V Offset default 0 ms (was +100 ms before 2026-09-07), subtitle render, chapter skip, scrub. If testing
-  the **Film 24p** progressive raster, the PR fj#158 cadence-slip corrector needs **Frame Drop
-  On** (memory `hdmi-progressive-film-cadence-judder`); drift-free was HW-proven on a 45-min
-  MiB clip — Akira is the second-disc confirmation.
+  the **Film 24p** progressive raster, keep **Frame Drop On** — a drop is how the display
+  catches up on a timeline it has fallen behind (PR #63 ORs `sched_catchup_late` into
+  `frame_late`). ⚠ The reason used to be the PR fj#158 cadence-slip corrector; **PR #63
+  deleted that corrector**, so cite the scheduler, not it (memory
+  `hdmi-progressive-film-cadence-judder` predates the change). Drift-free was HW-proven on
+  a 45-min MiB clip — Akira is the second-disc confirmation.
 - **Result:** _(pending)_
 
 ---

--- a/docs/fabric_audio.md
+++ b/docs/fabric_audio.md
@@ -315,24 +315,39 @@ routing mux were removed as cruft (branch `feature/remove-diagnostic-cruft`). Th
 normal VOB path is unchanged: `mpg_streamer → ps_stream_fifo → ps_demux → ac3_reframer
 → audio_ring → dvd_audio_decode → ac3_front → AUDIO_L/R`.
 
-## Audio Genlock toggle (av_sync free-run) — `O[13]`
+## A/V Sync toggle (scheduler free-run) — `O[13]`
 
-Plays a **VOB through the full pipeline** (video + audio via
-`ps_demux`→`audio_ring`→`dvd_audio_decode`) but lets you **disable the av_sync
-genlock**: `O[13],Audio Genlock,On,Off`. Off forces the decoder's `nco_trim` to 0,
-so the 48 kHz audio NCO **free-runs** instead of being slewed to track the
-video-referenced STC.
+⚠ **RENAMED 2026-09-07: `Audio Genlock` → `A/V Sync`** (`P1O[13],A/V Sync,On,Off`; bit
+span unchanged, `wire av_freerun = status[13]` unchanged). The old name described a
+mechanism that had been dead for two months and hid the one this bit actually controls.
 
-- Implementation (emu.sv): `dec_nco_trim = av_freerun ? 0 : av_nco_trim` feeds
-  `dvd_audio_decode.nco_trim`. That's the decoder's documented free-run fallback
-  (`nco_trim=0`), so no new logic in the decoder.
-- `av_sync` is left **enabled** so the overlay still shows the drift/STC it *would*
-  correct — you can watch how far audio would have drifted while running free.
-- Diagnostic logic (now that the decoder is HW-exonerated, see above):
-  - Pops/cutouts **vanish** with genlock Off → the culprit is av_sync/governor
-    **pacing** (the NCO slew or the governor's bursty delivery).
-  - Pops/cutouts **persist** with genlock Off → it's `audio_ring` drop-on-overflow
-    or `ps_demux` substream filtering, independent of the genlock.
+**What it was.** Off forced `dvd_audio_decode.nco_trim` to 0 so the 48 kHz audio NCO
+free-ran instead of being slewed to track the video-referenced STC — a diagnostic to tell
+`av_sync`/governor *pacing* apart from `audio_ring` overflow and `ps_demux` filtering.
+That reading died with the **NCO trim retirement** (2026-07-02, lip-sync v3): `emu.sv` now
+declares `wire signed [21:0] dec_nco_trim = 22'sd0` unconditionally, so the trim is 0 with
+the option On or Off. See `docs/av_sync.md` for why the slew is gone and must stay gone.
+
+**What it is.** PR #63 (`docs/stc_freerun.md`) made the free-running 90 kHz STC the single
+clock everything presents against, and wired this bit to the enable of that scheduling in
+three places at once:
+
+| Consumer | `sched_en`/`sync_armed` = 0 | Effect |
+|---|---|---|
+| `disp_sched.sv` (`sched_en_dec`, 2-FF into clk_dec) | `pic_due_r`/`next_due_r` forced 1 | every picture is due immediately ⇒ **the display free-runs at raster rate with no PTS pacing** — video, not audio |
+| `dvd_audio_decode.sv` | `drain_en = draining \|\| !sched_en` | bypasses the PTS-scheduled drain start, plus `head_stale`, `head_catchup` and `pre_anchor_hold` |
+| `iec61937_wrap.sv` (`sync_armed`) | `sync_en = sync_armed && stc_anchored` | passthrough free-runs, no A/V hold |
+
+So Off is **"no A/V sync at all"**, for both media — not an audio-rate experiment. It is
+strictly worse for playback and is not a fallback for a sync complaint.
+
+**Why the row survives** (reviewed 2026-09-07): it is the only on-hardware way to remove
+the whole scheduler as a variable, on a scheduler that is three days old at time of
+writing. "Set A/V Sync Off and tell me if the disc plays" separates a scheduler fault from
+a source/decode one in one message, where the alternative is a custom build and a tester
+round-trip. It sits on the `P1,Debug` page, and the rename is what keeps a user from
+reaching for it to *fix* something — the failure mode that got `Field Order` and the
+`Analog CSync` `Stock` arm deleted before release (see `CLAUDE.md`).
 
 ## CSS mute (scrambled-source audio protection, 2026-08-06)
 

--- a/docs/iec61937.md
+++ b/docs/iec61937.md
@@ -304,7 +304,7 @@ classification taps proven for held/real/underrun).
    ⇒ a startup-transient mechanism, H2/H3)
 2. Which tracks flap — AC-3 5.1, AC-3 2.0, DTS, commentary? (codec/bitrate
    dependence; also the handoff's open question)
-3. `O[13]` Audio Genlock **Off**, restart the title: flap gone? (Genlock Off
+3. `O[13]` A/V Sync (was `Audio Genlock`) **Off**, restart the title: flap gone? (Off
    free-runs — no holds at all — so a persisting flap CANNOT be pacing gaps;
    audio will lead video ~1 s, diagnostic only)
 4. Mid-play `O6` Decode→Passthru toggle (no flush fires): locks clean? (clean ⇒

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1646,7 +1646,7 @@ disc's authored menus by default reads as "menus don't work", and the menus-off 
 falls back to the largest-VTS heuristic, which is documented to pick the wrong title on
 some discs. Every other default audited and left as-is (Aspect Auto, Audio On, Audio Out
 Decode HDMI, Player Language English, Interlaced Out Off, Analog Out Auto, Analog Aspect
-Auto, Video Standard Auto, Frame Drop On, Audio Genlock On, Film 24p Auto, A/V Offset
+Auto, Video Standard Auto, Frame Drop On, A/V Sync On, Film 24p Auto, A/V Offset
 +100 ms, Debug Overlay Off, Title VTS Auto). *(2026-09-02: Interlaced Out + Analog Out
 have since been consolidated into `Video Output`, default Auto — see the reversal note
 further down.)*

--- a/dvd/dvd_audio_decode.sv
+++ b/dvd/dvd_audio_decode.sv
@@ -80,7 +80,7 @@ module dvd_audio_decode #(
     //   scheduling the ENTRY to an elastic buffer does not control its EXIT time;
     //   playback phase was dispatch phase minus buffer occupancy, and the occupancy
     //   absorbed any lead change in either direction. See docs/av_sync.md.)
-    // Bypassed only when sched_en is low (O13 Audio Genlock Off). Held from reset
+    // Bypassed only when sched_en is low (O[13] A/V Sync Off). Held from reset
     // otherwise (v3.1 — see the drain-gate controller comment); a stream that never
     // yields a schedulable reference free-runs via the ~2.5 s fallback timer.
     input  logic        sched_en,
@@ -754,7 +754,7 @@ module dvd_audio_decode #(
     //     stalled ring backpressured the shared stream for the ~1.2 s watchdog
     //     window, freezing video ~1 s). Arming from reset guarantees the FIFOs
     //     are EMPTY when the phase reference latches — the transition can't exist.
-    //   BYPASS: only sched_en low (O13 Audio Genlock Off) free-runs the drain.
+    //   BYPASS: only sched_en low (O[13] A/V Sync Off) free-runs the drain.
     //
     // Liveness: STC advances every refresh once video is live, so a held start
     // always releases; and a FALLBACK timer (~2.5 s armed-with-data but no
@@ -780,7 +780,7 @@ module dvd_audio_decode #(
     wire signed [34:0] start_delta =
         $signed({2'b0, stc}) - $signed({2'b0, play_pts}) - 35'($signed(av_ofs));
 
-    // Held from reset; only O13 Genlock Off bypasses (see comment above).
+    // Held from reset; only O[13] A/V Sync Off bypasses (see comment above).
     assign drain_en = draining || !sched_en;
 
     // ---- Playback-position tracker (drift instrument; see dbg_play_err port) ----
@@ -834,7 +834,7 @@ module dvd_audio_decode #(
             end
 
             if (!sched_en) begin
-                // O13 free-run diagnostic: keep the state clear for a clean re-arm
+                // O[13] free-run diagnostic: keep the state clear for a clean re-arm
                 draining       <= 1'b0;
                 play_pts_valid <= 1'b0;
                 seen_valid     <= 1'b0;

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -577,7 +577,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "dev-main"
+`define CORE_VERSION "dev-avsyncname"
 
 parameter CONF_STR = {
     "DVD;;",
@@ -729,17 +729,33 @@ parameter CONF_STR = {
     // cadence on compute-bound (high-motion / PAL) content, drop the next B-frame in the
     // VLD to catch up instead of the governor irregularly repeating late frames. B is
     // never a reference so this cannot corrupt the picture; worst case is a rare dropped
-    // frame for a steadier cadence. Default On — the PR #158 film cadence-slip corrector
-    // rides this path and does NOT run with Frame Drop Off. O[12] (freed when the AC-3
-    // File Test was removed); O[19] is now Aspect Ratio. See docs/motcomp_throughput.md.
+    // frame for a steadier cadence. Default On. The drop request is also how the PTS
+    // scheduler asks the display to catch up (mpeg2video ORs sched_catchup_late into
+    // frame_late), so Frame Drop Off leaves a behind-schedule timeline to recover by
+    // repeating late frames alone. O[12] (freed when the AC-3 File Test was removed);
+    // O[19] is now Aspect Ratio. See docs/motcomp_throughput.md.
+    // ⚠ The pre-2026-09-07 note here credited "the PR #158 film cadence-slip corrector"
+    // to this path; PR #63 deleted that corrector (cad_acc) along with the refresh-counted
+    // STC — see resample_addrgen.v's removal note.
     "P1O[12],Frame Drop,On,Off;",
-    // Audio Genlock: On (default) = av_sync slews the 48 kHz audio NCO to track the
-    // video-referenced STC (PTS-driven A/V sync). Off = free-run the NCO (nco_trim
-    // forced 0) while still playing a VOB through the full pipeline — a diagnostic
-    // to isolate the av_sync/governor PACING variable from audio_ring overflow /
-    // ps_demux filtering. av_sync keeps running so the overlay still shows the drift
-    // it WOULD correct. See docs/av_sync.md / docs/fabric_audio.md.
-    "P1O[13],Audio Genlock,On,Off;",
+    // A/V Sync: On (default) = everything that presents to the viewer is scheduled
+    // against the free-running 90 kHz STC at its PTS (docs/stc_freerun.md). Off is a
+    // DIAGNOSTIC that disables that scheduling wholesale, in three places at once:
+    //   * disp_sched.sched_en  — every picture is due immediately, so the display
+    //     free-runs at raster rate with no PTS pacing (VIDEO, not just audio);
+    //   * dvd_audio_decode.sched_en — bypasses the PTS-scheduled drain start, plus
+    //     the stale-skip / mid-play catch-up / pre-anchor hold;
+    //   * iec61937_wrap.sync_armed — passthrough free-runs, no A/V hold.
+    // It is the only on-hardware way to take the whole scheduler out of the picture,
+    // which is what makes it worth a menu row: "set A/V Sync Off and tell me if it
+    // plays" separates a scheduler fault from a source/decode one in one message.
+    // Off is strictly worse for playback (no lip sync at all) — it is not a fallback.
+    // ⚠ RENAMED from "Audio Genlock" 2026-09-07. The original meaning — slew the
+    // 48 kHz NCO via av_sync's nco_trim — has been dead since the 2026-07-02 trim
+    // retirement (dec_nco_trim is hardwired 0 below, independent of this bit), and the
+    // old name hid the fact that Off also stops pacing the VIDEO. Bit span unchanged.
+    // See docs/stc_freerun.md, docs/av_sync.md, docs/fabric_audio.md.
+    "P1O[13],A/V Sync,On,Off;",
     // Force 4:3 Subpics: present as a 4:3/LETTERBOX display so a disc that authors
     // mode-specific subpicture streams serves its 4:3-mode art instead of the 16:9
     // stream. Motivating case: the MiB "visual commentary" - subpicture logical
@@ -1019,9 +1035,12 @@ wire       ps_vid_valid;
 
 wire       ps_demux_in_ready;   // ps_demux's own ready (input handshake)
 
-// O[13] Audio Genlock: index 1 = "Off" = free-run the audio NCO (ignore av_sync's
-// nco_trim). Lets a VOB play through the full pipeline with the genlock disabled,
-// to tell av_sync/governor pacing apart from audio_ring overflow / ps_demux.
+// O[13] A/V Sync (named "Audio Genlock" before 2026-09-07): index 1 = "Off" = free-run
+// EVERYTHING that the STC schedules — disp_sched (video pictures become due on arrival),
+// dvd_audio_decode's drain gate, and iec61937_wrap's passthrough hold. See the CONF_STR
+// entry above for why the row survives and what it is for.
+// ⚠ The signal keeps its "free-run" name because that is still exactly what it does; it
+// has NOT driven the audio NCO since the trim was retired (dec_nco_trim just below).
 wire       av_freerun = status[13];
 // NCO TRIM RETIRED (2026-07-02, lip-sync v3): the 48 kHz audio NCO and the display
 // raster both derive from the same 27 MHz clk_sys crystal and the governor plays
@@ -3204,8 +3223,8 @@ dvd_audio_decode #(.CLK_HZ(27000000), .AUD_HZ(48000)) dvd_audio_decode_inst (
     .frame_pts       (aud_frame_pts_w),
     .frame_pts_valid (aud_frame_pts_valid_w),
     .frame_pop   (dec_frame_pop),
-    // 48 kHz NCO trim: 0 (free-run) when Audio Genlock=Off; otherwise av_sync's
-    // genlock slew. See dec_nco_trim above.
+    // 48 kHz NCO trim: hardwired 0 since the 2026-07-02 trim retirement — NOT a
+    // function of O[13]. See dec_nco_trim above for why the slew is gone.
     .nco_trim           (dec_nco_trim),
     .dbg_play_cnt       (aud_play_cnt),          // DVD-FORK (telemetry)
     .dbg_gate_cnt       (aud_gate_cnt),          // DVD-FORK (telemetry)
@@ -3214,7 +3233,8 @@ dvd_audio_decode #(.CLK_HZ(27000000), .AUD_HZ(48000)) dvd_audio_decode_inst (
     // PTS-scheduled playback START (lip-sync v3): the 48 kHz drain is held until
     // STC >= first_buffered_pts + av_ofs, setting phase at the PCM-FIFO EXIT (the
     // only place it's settable); underruns re-arm so audio re-enters at phase.
-    // Off together with the genlock (O13) so free-run stays a clean diagnostic.
+    // Off together with the rest of the scheduler (O[13] A/V Sync Off) so free-run
+    // stays a clean diagnostic.
     // ALSO free-run while a DISC MENU is active: menu audio is background music (no
     // lip-sync), and in Smooth mode (keep_vbuf) the video buffer runs deep during a
     // transition so the STC lags - STC-gating the menu audio to that lagging clock
@@ -3961,7 +3981,7 @@ mpeg2video mpeg2video_inst (
     .pts_in       (dec_pts_in),        // DVD-FORK (PTS association): that PES's PTS, crossed into clk_dec
     .pts_in_valid (dec_pts_in_valid),
     .stc_tick     (stc_tick_dec),      // DVD-FORK (PTS scheduling): the 90 kHz tick, clk_sys/300 crossed into clk_dec
-    .sched_en     (sched_en_dec),      // DVD-FORK (PTS scheduling): 0 = free-run (Audio Genlock Off diagnostic)
+    .sched_en     (sched_en_dec),      // DVD-FORK (PTS scheduling): 0 = free-run (O[13] A/V Sync Off diagnostic)
     .half_scan    (half_scan_dec),     // DVD-FORK (PTS scheduling): half the raster's image-scan period, ticks
     .stc          (core_stc),          // DVD-FORK (PTS scheduling): the clock (clk_dec)
     .stc_anchored (core_stc_anchored),

--- a/dvd/iec61937_wrap.sv
+++ b/dvd/iec61937_wrap.sv
@@ -64,7 +64,7 @@ module iec61937_wrap #(
     // delayed to the video display timeline instead of free-running at the demux
     // parse front. Holding until the anchor keeps the receiver's first real burst
     // at the start of the sustained stream (no startup real->null->real flap). ----
-    input  wire        sync_armed,     // sync intended (~av_freerun); holds until anchored
+    input  wire        sync_armed,     // sync intended (~av_freerun = O[13] A/V Sync On); holds until anchored
     input  wire        stc_anchored,   // av_sync STC has anchored on the video timeline
     input  wire [32:0] stc,            // av_sync video-referenced STC
     input  wire signed [17:0] av_ofs,  // A/V offset (90 kHz ticks, O[23:21])

--- a/site/content/playback/settings.md
+++ b/site/content/playback/settings.md
@@ -41,8 +41,9 @@ again. A custom `boot.rom` logo survives the reset.
 
 ## Debug page
 
-The second OSD page. These are tuning and diagnostic levers — two of them affect normal
-playback and are documented properly below; the rest exist for narrowing down problems.
+The second OSD page. These are tuning and diagnostic levers. The three with sections below
+are the ones worth understanding before you touch them; the rest exist for narrowing down
+problems.
 
 | Setting | Options | What it does |
 |---|---|---|

--- a/site/content/playback/settings.md
+++ b/site/content/playback/settings.md
@@ -49,7 +49,7 @@ playback and are documented properly below; the rest exist for narrowing down pr
 | **Debug Overlay** | **Off** / On | In a release build this shows the menu-highlight diagnostic blocks. |
 | **Title VTS Tens** / **Title VTS Units** | **0** / **Auto** | Forces a specific title set instead of the auto-selected one. Diagnostic, for discs where the wrong title is picked with Disc Menus off. |
 | **Frame Drop** | **On** / Off | **Leave this on.** See below. |
-| **Audio Genlock** | **On** / Off | Off free-runs the audio clock instead of slaving it to the video timeline. Diagnostic only. |
+| **A/V Sync** | **On** / Off | Off stops scheduling *both* picture and sound against the disc's timestamps. Diagnostic only — see below. |
 | **Force 4:3 Subpics** | **Off** / On | Forces subpicture geometry to 4:3 for discs that author it inconsistently. |
 | **Line-21 CC** | **On** / Off | Re-inserts closed captions on line 21 of the analog output — see [Closed captions](../video/closed-captions.md). |
 | **CC Test Line** | **Off** / On | Paints the caption waveform on a *visible* line to prove the chain works — see [the CC diagnostic](../video/closed-captions.md#is-it-working-the-test-line). |
@@ -66,10 +66,34 @@ the heaviest content it can fall behind the display cadence. The frame-rate gove
 absorbs this by dropping a B-frame to stay in step. B-frames are never used as references,
 so the picture cannot be corrupted by this, and in practice it is not something you notice.
 
-More importantly, the **cadence-slip corrector runs on the same path**. That is what keeps
-imperfect real-world telecine — discs where the 3:2 pattern is not clean — in step with the
-display. Turning Frame Drop off disables it, so film content drifts. The Off position
-exists to isolate the governor when diagnosing a pacing problem, not as a quality setting.
+It is also how the player catches up when it has fallen behind the disc's own timeline:
+advancing past a frame is the only way to recover time that has already been lost. With
+Frame Drop off there is no such mechanism, so on heavy content the picture simply runs
+progressively later and lip sync drifts with it. The Off position exists to isolate the
+governor when diagnosing a pacing problem, not as a quality setting.
+
+### A/V Sync
+
+Default **On**, and it should stay on.
+
+!!! info "Unreleased"
+    This setting was called **Audio Genlock** in v0.4.0 and earlier. It was renamed
+    because the old name described only half of what it does — and the half it named
+    had not been true for some time.
+
+With it on, everything the player shows you — picture, sound, subtitles, menu highlights,
+captions and bitstream passthrough — is presented at the time the disc asks for, measured
+against one clock. That is what lip sync *is* on this core.
+
+Off switches that scheduling off wholesale, for video as well as audio: pictures are shown
+as soon as they are decoded rather than when they are due, and sound plays as soon as it
+is available. The result is a player with no lip sync at all. It is not a fallback for
+sync problems and it will not improve one.
+
+What it is for is answering one question quickly: if a disc misbehaves and it behaves
+differently with A/V Sync off, the problem is in the player's timing rather than in
+reading or decoding the disc. That is worth a great deal when a bug can only be
+reproduced on someone else's disc, which is why the setting still has a row.
 
 ### A/V Offset
 

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -275,7 +275,9 @@ Set **`Film 24p Out` = `On`**. The disc is probably **hard-telecined**, meaning 
 was baked in at authoring time and carries no flags for Auto to detect. See
 [Film (24p)](../video/film-24p.md).
 
-Also confirm **`Frame Drop` is On** — the cadence corrector runs on that path.
+Also confirm **`Frame Drop` is On** — advancing past a frame is the only way the player
+can recover time once it has fallen behind, so with it off the picture just runs later and
+later.
 
 ### MiSTer reports 1441x478i, or the resolution changes when a disc loads
 

--- a/site/content/video/film-24p.md
+++ b/site/content/video/film-24p.md
@@ -82,9 +82,10 @@ left to detect. Nothing can infer it from the stream, which is why the manual **
 
 ## Related settings
 
-- **`Frame Drop` must stay On.** The cadence-slip corrector, which keeps imperfect
-  real-world telecine in step with the display, runs on the frame-drop governor's path and
-  does nothing without it. See [Settings](../playback/settings.md#frame-drop).
+- **`Frame Drop` must stay On.** Advancing past a frame is how the player recovers time
+  it has lost, and film content on a demanding disc is exactly where it needs to. With it
+  off, the picture runs progressively later and lip sync goes with it. See
+  [Settings](../playback/settings.md#frame-drop).
 - **`A/V Offset` defaults to 0 ms.** There should be no need to change it. (It was
   +100 ms in v0.4.0 and earlier, nulling an offset the current clock no longer has.)
 

--- a/tools/tests/test_status_bits.py
+++ b/tools/tests/test_status_bits.py
@@ -25,7 +25,7 @@ EXPECTED = {
     'Video Output': (9, 10),
     '480i Deint': (11, 11),           # OB -- 'B' is base-32 11
     'Frame Drop': (12, 12),
-    'Audio Genlock': (13, 13),
+    'A/V Sync': (13, 13),
     'Line-21 CC': (14, 14),
     'Force 4:3 Subpics': (15, 15),
     'Video Standard': (16, 17),


### PR DESCRIPTION
## Summary

`P1O[13] Audio Genlock` → **`P1O[13] A/V Sync`**, plus a correction to what both it and
`O[12] Frame Drop` claim to do. No behaviour change: bit spans, defaults and the
`av_freerun` signal name are all unchanged.

**O[13]'s original mechanism has been dead since 2026-07-02.** `emu.sv` declares
`wire signed [21:0] dec_nco_trim = 22'sd0` unconditionally, so the bit cannot slew the
48 kHz audio NCO with the option On or Off. Every description of it — the CONF_STR
comment, `docs/fabric_audio.md`, `docs/av_sync.md` and the manual — still taught that
reading, two months after it stopped being true.

**What the bit does now**, since PR #63 made the free-running STC the one clock everything
presents against:

| Consumer | `sched_en`/`sync_armed` = 0 | Effect |
|---|---|---|
| `disp_sched.sv` | `pic_due_r`/`next_due_r` forced 1 | every picture due on arrival — **the display free-runs at raster rate with no PTS pacing** |
| `dvd_audio_decode.sv` | `drain_en = draining \|\| !sched_en` | bypasses the scheduled drain start, stale-skip, catch-up, pre-anchor hold |
| `iec61937_wrap.sv` | `sync_en = sync_armed && stc_anchored` | passthrough free-runs, no A/V hold |

So Off is *no lip sync at all*, video included — not an audio-rate experiment.

**Why rename rather than delete.** The row is the only on-hardware way to take the whole
scheduler out of a bug report, on a scheduler that is days old; the alternative is a custom
build per investigation. But "Audio Genlock" named half the behaviour and invited a user to
reach for it as a *fix* — the failure mode that got `Field Order` and the `Analog CSync`
`Stock` arm deleted before release. The rename is what makes keeping it safe.

**Also corrected on sight:** the `O[12]` comment, `settings.md`, `troubleshooting.md`,
`film-24p.md` and `docs/disc_sweep.md` all credited Frame Drop to "the PR #158 film
cadence-slip corrector" — PR #63 deleted that corrector (`cad_acc`). Frame Drop is still
load-bearing for a different reason: `mpeg2video` ORs `sched_catchup_late` into
`frame_late`, so a drop is how the display recovers time it has lost.

## Test plan

- [x] `tools/docs_check.py` — OSD/button/extension parity, 22 options (fails on the rename alone if the manual is not updated)
- [x] `tools/tests/test_status_bits.py` — ALL GREEN with the new label; its "options vanished from CONF_STR" arm is what catches a rename
- [x] `mkdocs build --strict` — clean
- [x] `docs-sweep` over `main..HEAD` — found the two remaining cadence-corrector claims in the manual
- [x] README self-anchors resolve
- [ ] Quartus compile — **deliberately not run.** Any CONF_STR edit re-rolls the pinned fitter SEED, so this is batched into the next release build rather than spending a fit on a label.

⚠ `CORE_VERSION` is `dev-avsyncname` on this branch; reset to `dev-main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
