### PR TITLE
fix(menu): remove the still cold re-decode — it was vestigial (#65)

### DIFF
--- a/bench/dvd/iso_reader_menu_tb.sv
+++ b/bench/dvd/iso_reader_menu_tb.sv
@@ -671,58 +671,74 @@ module iso_reader_menu_tb;
         chk(kv_last_jump === 1'b1, "T8 keep_vbuf=1 on menu->menu jump");
 
         // =============================================================
-        // TEST 9 - §5 MENU STILL COLD RE-DECODE. A menu still whose frame was decoded
-        // mid-stream shows pixelated unless re-decoded cleanly, so on a still the reader
-        // flushes + re-streams the still cell (a seek_ack with keep_vbuf=0), ONCE per
-        // entry (still_flushed). Trigger = menu_snap (Snappy: immediate) OR vbuf_empty
-        // (Smooth: after the transition drains). Land on the VTSM Root still (PGCN 2 cell
-        // 1 = 0xD1), then:
-        //   (a) menu_snap=0, vbuf_empty=0 -> stays parked, no flush, no re-stream.
-        //   (b) vbuf_empty=1              -> one seek_ack keep_vbuf=0, 0xD1 re-streams.
+        // TEST 9 - A MENU STILL IS PARKED AND HELD, NEVER RE-STREAMED (issue #65).
+        //
+        // §5 used to flush and re-stream the whole still cell here, once per menu
+        // entry, on menu_snap (Snappy) or vbuf_empty (Smooth). It existed because
+        // a still never reached the display on its own -- getbits starved at the
+        // cell's terminating 00 00 01 B7 with no trailing bytes, so the VLD never
+        // reached STATE_SEQUENCE_END and motcomp_picbuf never emitted the held
+        // frame. Both halves of that were fixed elsewhere afterwards (ps_demux
+        // S_VID_FLUSH supplies the trailing bytes; motcomp_picbuf's fwd/bwd swap
+        // gained ~vld_last_frame), so the re-stream did no work the decoder had
+        // not already done -- and on a still carrying narration it replayed the
+        // AUDIO, which is what issue #65 reported.
+        //
+        // These checks are RED against the pre-fix reader: (b) and (c) measured
+        // one seek_ack and a 2048-byte re-stream there.
+        //   (a) idle              -> parked, no flush, no re-stream
+        //   (b) vbuf_empty=1      -> STILL parked, no flush, no re-stream
+        //   (c) menu_snap=1       -> likewise (the Snappy path is gone; emu has
+        //                            hardwired menu_snap 0 since the toggle went)
+        //   (d) a jump still EXITS the still -- the control that stops (a)-(c)
+        //       being satisfied by a wedged reader that can never leave.
         // =============================================================
         menu_snap = 1'b0; vbuf_empty = 1'b0;
         do_jump(2'd2, 8'd1, 8'd0, 4'd3, 8'd0);
         t = 0; while (still_active && t < 200000) begin @(posedge clk); t = t + 1; end
         t = 0; while (!still_active && t < 4000000) begin @(posedge clk); t = t + 1; end
-        // (a) neither trigger armed: no cold re-decode
+        // (a) idle
         cap_mark = cap_n; n_seek_ack = 0;
         repeat (2000) @(posedge clk);
         $display("TEST9a idle: bytes=%0d seek_acks=%0d still=%b",
                  cap_n - cap_mark, n_seek_ack, still_active);
-        chk(still_active === 1'b1, "T9a stays parked while neither trigger is armed");
-        chk(n_seek_ack == 0, "T9a no cold re-decode before vbuf_empty / menu_snap");
-        chk(cap_n - cap_mark <= 2, "T9a no re-stream before the trigger (only pipeline drain)");
-        // (b) vbuf_empty (Smooth) -> cold re-decode fires once
-        cap_mark = cap_n; n_seek_ack = 0; kv_last_seek = 1'bx;
+        chk(still_active === 1'b1, "T9a stays parked while idle");
+        chk(n_seek_ack == 0, "T9a no flush while idle");
+        chk(cap_n - cap_mark <= 2, "T9a no re-stream while idle (only pipeline drain)");
+
+        // (b) vbuf_empty -- the old Smooth trigger. Must now do NOTHING.
+        cap_mark = cap_n; n_seek_ack = 0;
         vbuf_empty = 1'b1;
-        t = 0; while (still_active && t < 200000) begin @(posedge clk); t = t + 1; end  // leaves S_STILL to re-decode
-        t = 0; while (!still_active && t < 4000000) begin @(posedge clk); t = t + 1; end // re-parks
-        repeat (400) @(posedge clk);
-        $display("TEST9b vbuf_empty=1: bytes=%0d seek_acks=%0d kv_seek=%b still=%b",
-                 cap_n - cap_mark, n_seek_ack, kv_last_seek, still_active);
-        chk(n_seek_ack == 1, "T9b exactly one cold re-decode (still_flushed stops a loop)");
-        chk(kv_last_seek === 1'b0, "T9b cold re-decode forces vbuf_flush (keep_vbuf=0)");
-        chk(cap_n - cap_mark == 2048, "T9b re-streamed the still cell (2048 B of 0xD1)");
-        expect_range(cap_mark, 2048, 8'hD1);
-        chk(still_active === 1'b1, "T9b re-parked on the still after the cold re-decode");
+        repeat (200000) @(posedge clk);
+        $display("TEST9b vbuf_empty=1: bytes=%0d seek_acks=%0d still=%b",
+                 cap_n - cap_mark, n_seek_ack, still_active);
+        chk(n_seek_ack == 0, "T9b vbuf_empty does NOT trigger a cold re-decode");
+        chk(cap_n - cap_mark == 0, "T9b the still cell is NOT re-streamed");
+        chk(still_active === 1'b1, "T9b stays parked on the still");
         vbuf_empty = 1'b0;
 
-        // (c) menu_snap (Snappy) fires the cold re-decode IMMEDIATELY (vbuf_empty stays 0).
-        //     Park first with the triggers OFF (still_flushed re-armed by the fresh jump),
-        //     THEN raise menu_snap - so the only seek_ack we count is the snap re-decode.
-        //     Key behaviour: keep_vbuf=0 without waiting for vbuf_empty (re-park itself is
-        //     covered by (b), identical code path).
-        vbuf_empty = 1'b0; menu_snap = 1'b0;
-        do_jump(2'd2, 8'd1, 8'd0, 4'd3, 8'd0);      // fresh entry re-arms still_flushed
-        t = 0; while (!still_active && t < 4000000) begin @(posedge clk); t = t + 1; end
-        repeat (50) @(posedge clk);
-        n_seek_ack = 0;
-        menu_snap = 1'b1;                            // now fire the snap
-        t = 0; while (n_seek_ack == 0 && t < 4000000) begin @(posedge clk); t = t + 1; end
-        $display("TEST9c menu_snap=1 (vbuf_empty=0): seek_acks=%0d", n_seek_ack);
-        // keep_vbuf=0 on this re-decode is proven by (b) - identical S_STILL code path.
-        chk(n_seek_ack >= 1, "T9c Snappy re-decodes the still immediately (no vbuf_empty)");
+        // (c) menu_snap -- the old Snappy trigger. Also gone.
+        cap_mark = cap_n; n_seek_ack = 0;
+        menu_snap = 1'b1;
+        repeat (200000) @(posedge clk);
+        $display("TEST9c menu_snap=1: bytes=%0d seek_acks=%0d still=%b",
+                 cap_n - cap_mark, n_seek_ack, still_active);
+        chk(n_seek_ack == 0, "T9c menu_snap does NOT trigger a cold re-decode");
+        chk(cap_n - cap_mark == 0, "T9c the still cell is NOT re-streamed");
         menu_snap = 1'b0;
+
+        // (d) CONTROL: a real jump must still leave the still. Without this,
+        // (a)-(c) would all pass on a reader that had simply wedged in S_STILL.
+        cap_mark = cap_n;
+        do_jump(2'd2, 8'd1, 8'd0, 4'd3, 8'd0);
+        t = 0; while (still_active && t < 400000) begin @(posedge clk); t = t + 1; end
+        chk(still_active === 1'b0, "T9d a jump EXITS the still (not wedged)");
+        t = 0; while (!still_active && t < 4000000) begin @(posedge clk); t = t + 1; end
+        repeat (200) @(posedge clk);
+        $display("TEST9d after a jump: re-parked still=%b bytes=%0d",
+                 still_active, cap_n - cap_mark);
+        chk(still_active === 1'b1, "T9d re-parks on the new menu still");
+        chk(cap_n - cap_mark > 0,  "T9d the new menu DID stream (the reader still works)");
 
         // =============================================================
         // TEST 10 - subp_control is streamed in the MENU domain (issues #60/#61)

--- a/bench/dvd/iso_reader_timedstill_tb.sv
+++ b/bench/dvd/iso_reader_timedstill_tb.sv
@@ -522,8 +522,8 @@ module iso_reader_timedstill_tb;
         // 3 s heuristic timed still (0xD0) and cell1 an indefinite still (0xD1).
         // Expect: stream 0xD0 -> HOLD ~3 s (still_active, timed) -> auto-advance
         // and stream 0xD1 -> park on the indefinite still. SEC_DIV=1000 -> 3s=3000 clk.
-        // A menu still is COLD RE-DECODED (clean frame) on vbuf_empty; the timer then
-        // counts down.
+        // The still is HELD, not re-decoded (issue #65 removed the cold re-decode);
+        // the timer counts down and the PGC advances.
         // =============================================================
         vbuf_empty = 1'b0; menu_snap = 1'b0;
         cap_mark = cap_n;
@@ -539,18 +539,23 @@ module iso_reader_timedstill_tb;
         chk(cap_n - cap_mark == 2048,   "only cell0 (0xD0) streamed on the first pass");
         expect_range(cap_mark, 2048, 8'hD0);
 
-        // 2) FRAME-DISPLAY FIX: with vbuf_empty=1 a TIMED still cold-re-decodes
-        //    (seek_ack) and RE-STREAMS its cell so the frame shows clean (else pixelated).
+        // 2) NO COLD RE-DECODE (issue #65). vbuf_empty used to flush and re-stream
+        //    the timed still's cell so its frame displayed clean. That re-decode is
+        //    gone -- ps_demux S_VID_FLUSH now supplies the trailing bytes past the
+        //    cell's 00 00 01 B7 that the VLD needs to reach STATE_SEQUENCE_END and
+        //    emit the held frame, and motcomp_picbuf's ~vld_last_frame guard removed
+        //    the corrupt-frame case. So the still must simply HOLD, and crucially the
+        //    TIMER must keep running (a stalled timer would strand the still forever).
+        //    RED against the pre-fix reader: seek_acks=1 and 2048 bytes re-streamed.
         n_seek_ack = 0; cap_mark = cap_n;
         vbuf_empty = 1'b1;
-        t = 0; while ((cap_n-cap_mark) < 2048 && t < 4000000) begin @(posedge clk); t = t + 1; end
-        repeat (100) @(posedge clk);
-        $display("T2 cold re-decode: seek_acks=%0d re-streamed=%0d timed=%b",
-                 n_seek_ack, cap_n-cap_mark, dut.still_timed);
-        chk(n_seek_ack >= 1,            "timed still cold-re-decoded (frame displays clean)");
-        chk(cap_n - cap_mark == 2048,   "still cell (0xD0) re-streamed for display");
-        expect_range(cap_mark, 2048, 8'hD0);
-        chk(dut.still_timed === 1'b1,   "still TIMED after the re-decode (timer intact)");
+        repeat (2000) @(posedge clk);
+        $display("T2 no re-decode: seek_acks=%0d re-streamed=%0d timed=%b still=%b",
+                 n_seek_ack, cap_n-cap_mark, dut.still_timed, still_active);
+        chk(n_seek_ack == 0,            "timed still is NOT cold-re-decoded");
+        chk(cap_n - cap_mark == 0,      "timed still cell is NOT re-streamed");
+        chk(dut.still_timed === 1'b1,   "still TIMED (timer intact)");
+        chk(still_active === 1'b1,      "still parked while the timer runs");
         vbuf_empty = 1'b0;
 
         // 3) after the timer the still advances to cell1 (0xD1, indefinite)

--- a/docs/dvd_menu_refinements.md
+++ b/docs/dvd_menu_refinements.md
@@ -343,7 +343,18 @@ Matrix submenus similarly; MiB/BBB menus unchanged; normal playback (O[1] Off) u
 
 ---
 
-## 5. Menu stills don't reach their final frame — cold re-decode (clean), with a FAST trigger
+## 5. Menu stills don't reach their final frame — cold re-decode ⛔ REMOVED 2026-09-08
+
+> **⛔ STATUS 2026-09-08 (issue #65): THE COLD RE-DECODE IS REMOVED. It was
+> VESTIGIAL — both problems it compensated for had been fixed elsewhere, months
+> after §5 was validated, and nobody re-checked whether it was still needed.**
+> HW-confirmed on Atmosfear and Harry Potter: the stills land and hold with the
+> re-decode gone. Everything below is kept as the record of why it existed; read
+> §5g for what replaced it and why the July attempt to remove it failed for an
+> unrelated reason.
+
+### 5 (historical). The cold re-decode as it was built
+
 
 > **★ 2026-08-26 — SEPARATE ROOT CAUSE FOUND for the PIXELATED half: the decoder was
 > writing the new picture INTO the frame slot the display was scanning out.**
@@ -379,7 +390,8 @@ Matrix submenus similarly; MiB/BBB menus unchanged; normal playback (O[1] Off) u
 > a blocky flash of a frame or two). Any residual after the fix has a second cause.
 
 
-> **Status (2026-07-12): the PR fj#85 cold re-decode is the CORRECT mechanism and is KEPT.**
+> **Status (2026-07-12, SUPERSEDED — see the 2026-09-08 removal above): the PR fj#85
+> cold re-decode is the CORRECT mechanism and is KEPT.**
 > The §5b trailing-byte flush primer that briefly replaced it was **HW-reverted** — it made
 > the still appear fast but **PIXELATED** (see §5b), because it shoves out the *mid-stream*
 > decoded frame (stale references) instead of re-decoding the cell cleanly. So the cold
@@ -838,6 +850,85 @@ reader/menu/nav/vm/ps2 suites green. **HW-CONFIRMED (2026-07-14):** MiB root men
 loops indefinitely with the highlight armed and Select responsive; Matrix menu still works.
 
 ---
+
+### 5g. The cold re-decode was vestigial — removed (issue #65)
+
+**Status: ✅ HW-CONFIRMED 2026-09-08** (Atmosfear reads its line once; Harry Potter's
+still menus land). Branch `fix/menu-still-no-redecode`.
+
+**Report.** On Atmosfear's character-selection screens the host's voice-over played
+through to the end and then **played a second time** before the screen settled. Present
+in v0.4.0, so it predates the free-running STC work.
+
+**Both hypotheses in the issue were wrong, and the disc's own IFO ruled them out offline.**
+The screens are VTS_01 VTSM **PGCN 8..13**, one cell each,
+`still=255  cell_cmd=0  pbtime=3..4s`:
+
+- `cell_cmd_nr == 0`, so the Phase-3 CELL-LOOP heuristic cannot fire (it needs
+  `cm_rd[7:0] != 0`, and it would loop forever rather than twice).
+- `still == 255`, so `S_STILL` **is** reached — the authored still was being honoured.
+
+**Cause: the §5 cold re-decode itself.** It re-streamed the entire still cell — video *and*
+audio — once per menu entry, gated on `vbuf_empty`, i.e. only after the clip had already
+played out. Hence exactly two plays, then a park.
+
+★★ **Why it was no longer needed, and why nobody noticed.** §5b records the real reason a
+still used to need a nudge: the cell ends `00 00 01 B7` followed by padding packs the demux
+drops, and `getbits` needs a full 64-bit word **past** the B7 to reach `vld.v`'s
+`STATE_SEQUENCE_END`, which asserts `last_frame` so `motcomp_picbuf`'s `STATE_LAST_FRAME`
+emits the held frame. Without trailing bytes the VLD starves at the B7 and the screen keeps
+showing the previous frame. **Both halves of that were fixed elsewhere, after §5 was
+validated:**
+
+1. **`ps_demux` `S_VID_FLUSH`** emits 24 filler bytes whenever a video PES ends on a B7 —
+   which is exactly how these cells end. MEASURED on Atmosfear: `SEQ_END` at ES offset
+   **156,469 of 156,473**, i.e. the last 4 bytes of the video ES.
+2. **`motcomp_picbuf`'s fwd/bwd swap gained `~vld_last_frame`** (2026-08-26), removing the
+   corrupt-flushed-frame case.
+
+★★ **And (2) is precisely why the July attempt to remove it failed.** §5b replaced the
+re-decode with the `vidfeed_flush_primer`, which was HW-reverted because the frame it
+flushed was **pixelated** — corrupted by the picbuf slot-alias bug that was not fixed for
+another six weeks. So the primer was judged on a decoder defect, not on its own merits, and
+**"remove the re-decode and let `S_VID_FLUSH` finish the sequence" had never been tried.**
+
+⚠ **A stale status marker hid this for weeks.** §5's header said the re-decode "is the
+CORRECT mechanism and is KEPT", written 2026-07-12 and never revisited after either fix
+landed. The 2026-08-26 addendum in §5 even states *"the filler fires, so the still's I-frame
+does fully decode"* — the evidence was recorded in the same document and not acted on.
+
+⚠ **Its only live trigger was `vbuf_empty`.** `menu_snap` has been hardwired 0 in `emu.sv`
+since the Snappy/Smooth toggle was removed ("universal Smooth"), and `vbuf_empty` means the
+decoder has already consumed everything — so by the time it fired, the work was done.
+
+**Change.** `S_STILL` now simply parks and holds. `still_flushed` and its six re-arm sites
+are deleted (it was exclusive to the re-decode); `vbuf_empty` stays — it is load-bearing for
+the Phase-B tail drain.
+
+**⛔ Two alternatives rejected, recorded so they are not re-proposed:**
+
+1. **Mute the re-decode's audio** (a `ps_demux.aud_mute` driven by `still_flushed`). Built,
+   gated and working — but it suppresses the *symptom* of an action that should not happen,
+   and leaves the 193-sector re-stream and the settle delay in place. Abandoned once the
+   re-decode was shown to be vestigial.
+2. **Re-decode only the cell's last VOBU.** MEASURED and impossible: each cell is 6-8 VOBUs
+   with the entire `SEQ GOP PIC:I SEQ_END` inside **VOBU 0** (ending at sector 81 of 193),
+   and sectors 82→end carry **AC-3 only**. The last VOBU has **no I-frame at all**.
+
+**Gate.** `iso_reader_menu_tb` TEST 9 rewritten to measure the new contract, and it is RED
+against the pre-fix reader (T9b measured `seek_acks=1`, `bytes=2048` there):
+
+| check | asserts |
+|---|---|
+| T9a | parked while idle: no flush, no re-stream |
+| T9b | `vbuf_empty` — the old Smooth trigger — does nothing |
+| T9c | `menu_snap` — the old Snappy trigger — does nothing |
+| **T9d** | **control: a jump still EXITS the still.** Without it, T9a-T9c would all pass on a reader that had simply wedged in `S_STILL` |
+
+**HW.** Atmosfear PGCN 8-13: narration once, screen settles. Harry Potter's still menus
+land. ⏳ T2's Jump-Into-Timeline cubes and mission-profile slides, and Matrix/MiB scene
+pages, are the remaining §5 cases worth a look — they are what the mechanism was originally
+built for.
 
 ## 6. Menu aspect ratio — 16:9 anamorphic menu shown squished as 4:3 — ✅ HW-CONFIRMED 2026-07-10 (PR fj#86, IFO V_ATR)
 

--- a/dvd/dvd_iso_reader.sv
+++ b/dvd/dvd_iso_reader.sv
@@ -910,7 +910,6 @@ reg [31:0] menu_blocks;               // menu VOB length in 2048-sectors (cell b
 reg [7:0]  play_vtsn;                 // VTS of the loaded TITLE (cur_vts export)
 reg        nav_ready;                 // VIDEO_TS walk finished (jumps accepted)
 reg        still_pend;                // menu still reached: drain cache then S_STILL
-reg        still_flushed;             // menu still already cold-re-decoded (§5, once per entry)
 // TIMED STILLS (Phase 5): an authored ad/copyright/menu-intro still holds for a
 // bounded time then auto-advances (libdvdnav honours the same). still_timed marks
 // a finite (1..254 s) hold; still_secs counts it down at 1 Hz in S_STILL;
@@ -1839,7 +1838,6 @@ always @(posedge clk or negedge rst_n) begin
         sel_ret      <= 1'b0;
         nav_ready    <= 1'b0;
         still_pend   <= 1'b0;
-        still_flushed <= 1'b0;
         adv_pend     <= 1'b0;
         jttn_l       <= 7'd0;
         jpgn_l       <= 8'd0;
@@ -2268,7 +2266,6 @@ always @(posedge clk or negedge rst_n) begin
             sel_ret         <= 1'b0;
             nav_ready       <= 1'b0;
             still_pend      <= 1'b0;
-            still_flushed   <= 1'b0;
             adv_pend        <= 1'b0;
             follow_cnt      <= 2'd0;
             jttn_l          <= 7'd0;
@@ -2283,7 +2280,6 @@ always @(posedge clk or negedge rst_n) begin
             jump_pending <= 1'b0;
             seek_pending <= 1'b0;       // a jump outranks a pending seek
             still_pend   <= 1'b0;
-            still_flushed <= 1'b0;      // new menu entry: re-arm the still-cell cold re-decode
             adv_pend     <= 1'b0;
             vmw_pgc_pend <= 1'b0;
             jump_ack     <= 1'b1;
@@ -2401,7 +2397,6 @@ always @(posedge clk or negedge rst_n) begin
             // (ps_demux/audio_ring/av_sync) re-anchors on the new cell's PTS.
             strm_done    <= 1'b0;
             still_pend   <= 1'b0;
-            still_flushed <= 1'b0;         // new cell target: re-arm the still-cell cold re-decode
             adv_pend     <= 1'b0;
             vmw_pgc_pend <= 1'b0;
             wr_ptr       <= 0;
@@ -3667,7 +3662,6 @@ always @(posedge clk or negedge rst_n) begin
                 cell_i     <= (use_jcell && jcell_l < cell_count) ? jcell_l : 8'd0;
                 cell_raddr <= (use_jcell && jcell_l < cell_count) ? jcell_l : 8'd0;
                 use_jcell  <= 1'b0;
-                still_flushed <= 1'b0;  // fresh PGC = new menu: re-arm the still-cell cold re-decode
                 jpgn_l     <= 8'd0;    // program-start latch consumed
                 strm_done  <= 1'b0;
                 wr_ptr     <= 0;
@@ -4128,7 +4122,6 @@ always @(posedge clk or negedge rst_n) begin
                         state        <= S_VM_WAIT;
                     end else if (adv_pend) begin
                         adv_pend   <= 1'b0;
-                        still_flushed <= 1'b0;    // next_pgcn = new menu: re-arm cold re-decode
                         seek_ack   <= 1'b1;   // emu: load_flush (+vbuf if not menu)
                         keep_vbuf  <= menu_dom;   // menu next_pgcn advance: hold VBUF
                         wr_ptr     <= 0;
@@ -4154,29 +4147,34 @@ always @(posedge clk or negedge rst_n) begin
             // watchdog so the last decoded frame - the authored menu still -
             // stays on screen indefinitely. Exits via jump_go / seek_jump.
             //
-            // The still's FINAL frame (T2 numbered scene-range cubes, mission-profile
-            // slides, ad/copyright/menu-end frames) was decoded MID-STREAM (entered via a
-            // keep_vbuf transition, so with stale references) and would show PIXELATED if
-            // merely flushed to the display. So COLD RE-DECODE it: re-stream JUST this still
-            // cell (from its own sequence header) as a clean decode - the I-frame
-            // reconstructs correctly and the frame displays sharp. Trigger:
-            //   - menu_snap (P1O[18] Snappy): fire IMMEDIATELY - the emu deep-flush already
-            //     emptied the buffer, so the re-decode is fast (a buffered transition is cut,
-            //     which Snappy accepts).
-            //   - else vbuf_empty (Smooth): wait until the authored transition has fully
-            //     played out (buffer drained), THEN re-decode - transition NOT cut.
-            // Once per entry (still_flushed); menu stills only; a real jump/seek exits first.
+            //
+            // ⛔ NO COLD RE-DECODE (issue #65, 2026-09-08). §5 used to flush and
+            // re-stream the whole still cell here, once per menu entry, because a
+            // still never reached the display on its own: getbits starves at the
+            // cell's terminating 00 00 01 B7 with no trailing bytes, so the VLD
+            // never reaches STATE_SEQUENCE_END, never asserts last_frame, and
+            // motcomp_picbuf never emits the held frame
+            // (docs/dvd_menu_refinements.md §5b). BOTH halves of that were fixed
+            // elsewhere, AFTER §5 was validated:
+            //   * ps_demux S_VID_FLUSH emits 24 filler bytes whenever a video PES
+            //     ends on a B7 -- which is exactly how these cells end (MEASURED
+            //     on Atmosfear: SEQ_END at ES offset 156469 of 156473, i.e. the
+            //     last 4 bytes of the video ES);
+            //   * motcomp_picbuf's fwd/bwd swap gained ~vld_last_frame
+            //     (2026-08-26), removing the corrupt-flushed-frame case that sank
+            //     the §5b primer -- which is the ONLY reason the July attempt to
+            //     drop the re-decode failed.
+            // The re-stream was therefore doing no work the decoder had not
+            // already done, and on a still cell carrying narration (Atmosfear's
+            // character screens: still=255, cell_cmd=0, ~3-4 s of speech) it
+            // replayed the audio, which is what issue #65 reported. The reader
+            // now simply parks and holds, which is what the authored still asks
+            // for. HW-confirmed 2026-09-08: the line reads once.
+            // ⚠ Its only live trigger was vbuf_empty -- menu_snap has been
+            // hardwired 0 since the Snappy/Smooth toggle was removed -- and
+            // vbuf_empty means the decoder had already consumed everything.
             S_STILL: begin
-                if (menu_dom && !still_flushed && (menu_snap || vbuf_empty)) begin
-                    still_flushed <= 1'b1;
-                    cell_raddr    <= cell_i;   // re-load THIS still cell (cell_i unchanged)
-                    strm_done     <= 1'b0;
-                    still_pend    <= 1'b0;
-                    wr_ptr        <= 0;
-                    seek_ack      <= 1'b1;     // emu: load_flush + (keep_vbuf=0) vbuf_flush
-                    keep_vbuf     <= 1'b0;     // FORCE the clean cold decode of the still cell
-                    state         <= S_CELL_LOAD;
-                end else if (still_timed && sec_tick) begin
+                if (still_timed && sec_tick) begin
                     // TIMED hold: count down at 1 Hz, then run the deferred action
                     // (a menu button that fires a VM jump exits earlier via jump_go).
                     if (still_secs <= 16'd1) begin

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -581,7 +581,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "dev-main"
+`define CORE_VERSION "dev-noredecode"
 
 parameter CONF_STR = {
     "DVD;;",

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -401,6 +401,22 @@ it also closes the OSD again.
 
 ## Navigation
 
+### A menu screen says something, finishes, then says it again
+
+!!! info "Unreleased"
+
+    Fixed after v0.4.0.
+
+On menu screens that hold on a still picture with a voice-over — character-selection
+screens on DVD games are the usual case — the audio played through, then played a second
+time before the screen settled.
+
+The core used to re-read that part of the disc once, to make sure the still picture came up
+sharp rather than half-drawn. That re-read stopped being necessary a while ago, when two
+unrelated fixes landed in the decoder, but it was still happening — and it replayed the
+sound along with the picture. It no longer runs at all, so menu stills settle a little
+faster too.
+
 ### A menu option does the wrong thing, or `LINK FAIL`
 
 `LINK FAIL nn` means a menu jump failed and the core recovered by re-entering the last


### PR DESCRIPTION
Fixes #65.

## The bug

On Atmosfear's character-selection screens the host's voice-over played through to the
end, then **played a second time** before the screen settled.

**Both hypotheses in the issue are ruled out by the disc's own IFO, offline.** The screens
are VTS_01 VTSM **PGCN 8..13**, one cell each, `still=255  cell_cmd=0  pbtime=3..4s`:

* `cell_cmd_nr == 0`, so the Phase-3 CELL-LOOP heuristic cannot fire — and it would loop
  forever rather than twice.
* `still == 255`, so `S_STILL` **is** reached: the authored still was being honoured.

The cause was **§5's cold re-decode**, which re-streamed the entire still cell — video *and*
audio — once per menu entry, gated on `vbuf_empty`, i.e. only after the clip had already
played out. Hence exactly two plays, then a park.

## It was vestigial

§5b records why a still used to need a nudge: the cell ends `00 00 01 B7` followed by
padding the demux drops, and `getbits` needs a full 64-bit word **past** the B7 to reach
`vld`'s `STATE_SEQUENCE_END`, which asserts `last_frame` so `motcomp_picbuf` emits the held
frame. Without trailing bytes the VLD starves and the screen keeps showing the previous
frame.

**Both halves were fixed elsewhere, after §5 was validated:**

1. `ps_demux` **`S_VID_FLUSH`** emits 24 filler bytes when a video PES ends on a B7 —
   exactly how these cells end. MEASURED on Atmosfear: `SEQ_END` at ES offset **156,469 of
   156,473**, the last 4 bytes of the video ES.
2. `motcomp_picbuf`'s fwd/bwd swap gained **`~vld_last_frame`** (2026-08-26).

And (2) is *why the July attempt to remove it failed*: §5b replaced the re-decode with the
`vidfeed_flush_primer`, reverted for showing a **pixelated** frame — corrupted by the picbuf
slot-alias bug that was not fixed for another six weeks. So the primer was judged on a
decoder defect, and **"remove the re-decode and let `S_VID_FLUSH` finish the sequence" had
never been tried.**

A stale status marker hid this. §5's header said the re-decode *"is the CORRECT mechanism
and is KEPT"*, written 2026-07-12 and never revisited. The 2026-08-26 addendum in the same
file even says *"the filler fires, so the still's I-frame does fully decode"*.

Its only live trigger was `vbuf_empty` — `menu_snap` has been hardwired 0 since the
Snappy/Smooth toggle was removed — and `vbuf_empty` means the decoder had already consumed
everything, so by the time it fired the work was done.

## Change

`S_STILL` parks and holds. `still_flushed` and its six re-arm sites are deleted (exclusive
to the re-decode). `vbuf_empty` stays — load-bearing for the Phase-B tail drain.

**Rejected, recorded in `docs/dvd_menu_refinements.md` §5g so they are not re-proposed:**

* **Muting the re-decode's audio** — built and gated, but it suppresses the symptom of an
  action that should not happen, and leaves the 193-sector re-stream and the settle delay.
* **Re-decoding only the last VOBU** — MEASURED impossible: the whole `SEQ GOP PIC:I
  SEQ_END` is in **VOBU 0**, ending at sector 81 of 193, and sectors 82→end are AC-3 only.
  The last VOBU has **no I-frame at all**.

## Test plan

- [x] `iso_reader_menu_tb` TEST 9 rewritten — T9b/T9c: the old Smooth and Snappy triggers do
      nothing. **RED against the pre-fix reader: `seek_acks=1`, `bytes=2048`.**
- [x] T9d control — a jump still **exits** the still. Without it, T9a–T9c would pass on a
      reader wedged in `S_STILL`.
- [x] `iso_reader_timedstill_tb` T2 — timed stills held, not re-decoded; **T3 confirms the
      timer still expires and advances** (a stalled timer would strand the still forever).
- [x] 27/31 reader benches pass; the 3 that do not (atmos, attr, tpsw_boot) fail
      identically on `main`.
- [x] `tools/docs_check.py` OK, `mkdocs build --strict` clean.
- [x] **HW-CONFIRMED**: Atmosfear reads its line once; Harry Potter's stills land.
- [ ] T2's Jump-Into-Timeline cubes / mission-profile slides and Matrix/MiB scene pages —
      the remaining §5 cases, worth a look since they are what the mechanism was built for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
