### PR TITLE
chore: reset CORE_VERSION to dev-main after #70

### DIFF
--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -581,7 +581,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "dev-noredecode"
+`define CORE_VERSION "dev-main"
 
 parameter CONF_STR = {
     "DVD;;",


### PR DESCRIPTION
Housekeeping missed after #70 merged: main carried `dev-noredecode`, so a build from main would advertise that one feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)