### PR TITLE
fix(audio): the backpressure watchdog must not read a held decoder as a wedged one

### DIFF
--- a/docs/fabric_audio.md
+++ b/docs/fabric_audio.md
@@ -383,6 +383,78 @@ negative), `iec61937_wrap_tb` TEST 8/8b (mute = zero words + drain + consume,
 unmute resumes real bursts), `transport_hud_tb` T13 (popup text, menu
 exemption, slot yield/re-arm, clear).
 
+## Demux backpressure vs a HELD decoder — `aud_bp_wd` (2026-09-08)
+
+**Status: ✅ HW-CONFIRMED 2026-09-08** on Family Feud II, Weakest Link, Thayer's Quest and
+Harry Potter (Hogwarts Challenge). Branch `fix/aud-bp-decode-hold`.
+
+**Report.** On Harry Potter's player-selection screen the speech was **truncated**, and the
+HUD timecode **sped up and jumped to the cell's end (00:01:19)** before stopping. Correct in
+v0.4.0; introduced by PR #63.
+
+★ **The racing timecode is what identified it.** A clock that runs fast means the PARSE
+FRONT is running fast — nothing is throttling delivery — which points at flow control, not
+at the audio decoder. Both symptoms are then one cause.
+
+**Mechanism.** `emu.sv` re-arms the ring drain watchdog `aud_bp_wd` on `aud_frame_pop`, and
+`frame_pop` only fires in the dispatcher's `S_POP` state. While the drain gate is shut the
+48 kHz tick is withheld, the codec's PCM FIFO fills, `sink_ready` drops, `consume` stops and
+the dispatcher stalls in `S_ROUTE` — **never reaching `S_POP`**. After ~1.24 s the watchdog
+reads that deliberate hold as a wedged consumer and disengages demux backpressure
+(`ps_aud_ready` is forced high). The shared stream then races through the cell at disc
+speed: the ring overflows and drops whole frames (the truncated speech) while the parse
+front runs away (the racing timecode, stopping when the cell's data is exhausted).
+
+⚠ **Why PR #63 exposed it.** That PR moved the playback release from `stc_anchored` (the
+parse front) to `disp_anchored` (the display's first tagged pickup), which is strictly
+later — so on a screen whose display anchors slowly the gate stays shut past the watchdog.
+The gate itself is older; what changed is how long it can stay shut.
+
+★★ **The identical failure had already been found and fixed on the PASSTHROUGH path** —
+the IEC 61937 lock flap, where a deliberate A/V-sync hold produced no pop, backpressure
+stayed disengaged and the ring dropped ~25 frames/s for ~46 s (`docs/iec61937.md` "FLAP
+ROOT CAUSE"). Its fix added `pass_hold_active` to the re-arm term, and its comment states
+*"the decode path is unaffected (its stale-skip pops keep the watchdog fed the same way it
+always was)"*. That was true while the gate opened at the parse front. **PR #63 made it
+false, and the comment kept asserting it.** This fix is the decode-path twin of that term.
+
+**Change.** One extra re-arm term:
+
+```
+else if (aud_frame_pop || (pass_mode && pass_hold_active)
+                       || (aud_dec_en && dbg_aud_play_pts_valid && ~dbg_aud_draining))
+```
+
+⚠⚠ **The predicate is NOT a bare `~draining`, and that distinction is load-bearing.**
+`draining` is 0 both when the gate is deliberately shut AND before the decode side has ever
+produced anything — **including when it is dead**. Re-arming on that alone would pin
+backpressure on, stall the shared demux and with it VIDEO: exactly the wedge that the
+"unarmed until the first pop proves the decode side is alive" rule exists to prevent.
+`play_pts_valid` is the proof of life — latched when a PTS-tagged frame has DISPATCHED — so
+`play_pts_valid && ~draining` reads "audio arrived and the gate is holding it back". Bounded
+the same way as the passthrough hold: the gate opens on the release compare or the ~2.5 s
+`arm_timer` fallback. `aud_dec_en` is load-bearing too: with audio OFF the decode path never
+drains and never pops.
+
+⚠ **No sim gate, deliberately.** A bench case was written to pin the premise (a shut gate
+starves `frame_pop`). It measured `frame_pop x0` with the gate shut — but its **control
+failed**: pops did not resume when the gate reopened, so it could not distinguish "held"
+from "dead", and it was removed rather than shipped as false proof. The premise rests on the
+code (`frame_pop = (state == S_POP)`; a full PCM FIFO drops `sink_ready`, so `consume`
+stops) plus the two measured HW symptoms. `emu.sv` has no bench, so the HW A/B is the gate —
+the same standing recorded for `joy_eff` and the subpicture glue.
+
+★ **Choosing the HW discs was a measurement, not a guess.** The failure needs a short cell
+carrying speech that parks on a still, so `tools/dvd_probe_title_stills.py` was run across
+the interactive library and ranked by title-domain still count: Family Feud II/III **936**
+stills / 890 short cells, Weakest Link 76/76, Harry Potter 25/54, Thayer's Quest 20/55.
+Family Feud is ~37× the density of the reported disc, so it fails within seconds if the
+watchdog still mis-fires. ⚠ Atmosfear reads **0** title stills — its stills are
+menu-domain, which is why it was the issue #65 repro and is NOT a test for this one.
+⚠ A film disc is the negative control: this changes when backpressure engages on EVERY
+disc, and the failure mode of an insufficient guard is the opposite symptom — a FREEZE of
+picture and sound together, since backpressure stalls the shared demux and video with it.
+
 ## Open follow-ups
 - DTS in-fabric + IEC 61937 bitstream → Digital I/O board (Toslink).
 - LPCM: 20/24-bit @ 48 kHz stereo ✅ HW-CONFIRMED (PR fj#133, top-16 truncation for HDMI;

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -581,7 +581,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "dev-main"
+`define CORE_VERSION "dev-audbphold"
 
 parameter CONF_STR = {
     "DVD;;",

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -3216,7 +3216,36 @@ always @(posedge clk_sys) begin
     // reaching the front frame's PTS, so this cannot wedge the stream on any
     // stream whose video plays; the decode path is unaffected (its stale-skip
     // pops keep the watchdog fed the same way it always was).
-    else if (aud_frame_pop || (pass_mode && pass_hold_active))
+    // ⚠ AND the same is true of the DECODE path (issue: Harry Potter Hogwarts
+    // Challenge, 2026-09-08). The comment above claimed "the decode path is
+    // unaffected (its stale-skip pops keep the watchdog fed the same way it
+    // always was)". That was true while the drain gate opened at the PARSE front.
+    // PR #63 moved the playback release to disp_anchored -- the DISPLAY's first
+    // tagged pickup -- which is later, so on a screen whose display anchors
+    // slowly the gate stays shut longer. A shut gate withholds the 48 kHz tick,
+    // the codec's PCM FIFO fills, sink_ready drops, the dispatcher stalls in
+    // S_ROUTE and NEVER reaches S_POP -- so frame_pop stops, and after ~1.24 s
+    // this watchdog reads a deliberate hold as a wedged consumer, exactly the
+    // failure the passthrough term above was added to fix.
+    // MEASURED consequence (user, HW): backpressure disengages, the shared demux
+    // races through the cell at disc speed, the ring drops whole frames
+    // (truncated speech) and the parse front runs away -- visible as the HUD
+    // timecode SPEEDING UP and jumping to the cell's end (00:01:19) before
+    // stopping. Both symptoms, one cause.
+    // ⚠⚠ The predicate is NOT a bare `~draining`. `draining` is 0 both when the
+    // gate is deliberately shut AND before the decode side has ever produced
+    // anything -- including when it is DEAD. Re-arming on that would pin
+    // backpressure on, stall the shared demux and with it VIDEO, which is
+    // exactly the wedge the "unarmed until the first pop proves the decode side
+    // is alive" rule above exists to prevent. `play_pts_valid` is the proof of
+    // life: it is latched when a PTS-tagged frame has DISPATCHED, so
+    // `play_pts_valid && ~draining` reads "audio arrived and the gate is holding
+    // it back" -- a deliberate hold, the decode-path twin of pass_hold_active.
+    // Bounded the same way: the gate opens on the release compare or the ~2.5 s
+    // arm_timer fallback. ⚠ aud_dec_en is load-bearing too -- with audio OFF the
+    // decode path never drains and never pops.
+    else if (aud_frame_pop || (pass_mode && pass_hold_active)
+                           || (aud_dec_en && dbg_aud_play_pts_valid && ~dbg_aud_draining))
                              aud_bp_wd <= 25'h1FFFFFF;
     // Freeze the drain watchdog while paused: the audio decoder is held (no
     // frame_pop), so without this the watchdog would expire after ~1.24 s,

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -144,6 +144,23 @@ If sound drifts out of sync **without** a mode change, that is a different probl
 `A/V Offset` on the debug page first, and [report it](reporting-a-bug.md) with the disc and
 roughly how far into the title it started.
 
+### Speech is cut off on a game disc's question or selection screen
+
+!!! info "Unreleased"
+
+    Fixed after v0.4.0. Affects DVD game discs with spoken screens — quiz and board
+    games especially.
+
+A screen that reads a question or a list of choices aloud stopped part-way through. With
+the on-screen display up you could also see the time counter suddenly race ahead and then
+stop, instead of ticking along normally.
+
+The core throttles how fast it reads from the disc so that sound and picture stay together.
+It was mistaking a deliberate pause — audio waiting for its moment to play — for a jammed
+decoder, and switching the throttle off. The disc was then read as fast as it could be, the
+sound buffer overflowed, and whatever did not fit was lost. The racing counter was the same
+thing showing on screen.
+
 ### Menu audio went silent
 
 You changed the audio track while the menu was open. It comes back when you leave the menu.


### PR DESCRIPTION
## The bug

On Harry Potter (Hogwarts Challenge) the player-selection screen's speech was **truncated**,
and — the clue that cracked it — the HUD timecode **sped up and jumped to the cell's end
(00:01:19)** before stopping. Correct in v0.4.0; introduced by #63.

★ **A clock that runs fast means the PARSE FRONT is running fast**, i.e. nothing is
throttling delivery. That points at flow control rather than at the audio decoder, and makes
both symptoms one cause.

## Mechanism

`emu.sv` re-arms the ring drain watchdog `aud_bp_wd` on `aud_frame_pop`, and `frame_pop`
only fires in the dispatcher's `S_POP` state. While the drain gate is shut the 48 kHz tick
is withheld, the codec's PCM FIFO fills, `sink_ready` drops, `consume` stops, and the
dispatcher stalls in `S_ROUTE` — **never reaching `S_POP`**. After ~1.24 s the watchdog
reads that deliberate hold as a wedged consumer and disengages demux backpressure. The
shared stream then races through the cell at disc speed: the ring overflows and drops whole
frames (the truncated speech) while the parse front runs away (the racing timecode).

**Why #63 exposed it:** that PR moved the playback release from `stc_anchored` (the parse
front) to `disp_anchored` (the display's first tagged pickup), which is strictly later — so
on a screen whose display anchors slowly the gate stays shut past the watchdog. The gate is
older; what changed is how long it can stay shut.

★★ **The identical failure was already found and fixed on the PASSTHROUGH path** — the IEC
61937 lock flap, where a deliberate hold produced no pop and the ring dropped ~25 frames/s
for ~46 s. That fix added `pass_hold_active` to the re-arm term, and its comment states
*"the decode path is unaffected (its stale-skip pops keep the watchdog fed the same way it
always was)"*. True while the gate opened at the parse front; **#63 made it false and the
comment kept asserting it.** This is the decode-path twin of that term.

## The fix

```
else if (aud_frame_pop || (pass_mode && pass_hold_active)
                       || (aud_dec_en && dbg_aud_play_pts_valid && ~dbg_aud_draining))
```

⚠⚠ **Not a bare `~draining`, and the distinction is load-bearing.** `draining` is 0 both
when the gate is deliberately shut AND before the decode side has produced anything —
**including when it is dead**. Re-arming on that alone would pin backpressure on and stall
the shared demux and with it VIDEO: exactly the wedge the "unarmed until the first pop
proves the decode side is alive" rule exists to prevent. `play_pts_valid` is the proof of
life, latched when a PTS-tagged frame has DISPATCHED. Bounded like the passthrough hold — the
gate opens on the release compare or the ~2.5 s `arm_timer` fallback. `aud_dec_en` matters
too: with audio OFF the decode path never drains and never pops.

## Verification

⚠ **No sim gate, and deliberately so.** A bench case was written to pin the premise (a shut
gate starves `frame_pop`). It measured `frame_pop x0` with the gate shut — but its
**control failed**: pops did not resume when the gate reopened, so it could not distinguish
"held" from "dead". It was removed rather than shipped as false proof. The premise rests on
the code (`frame_pop = (state == S_POP)`; a full PCM FIFO drops `sink_ready`) plus the two
measured HW symptoms. `emu.sv` has no bench, so the HW A/B is the gate — the same standing
already recorded for `joy_eff` and the subpicture glue.

★ **The HW disc list was measured, not guessed.** `tools/dvd_probe_title_stills.py` ranked
the interactive library by title-domain still count, since the failure needs a short cell
carrying speech that parks on a still:

| disc | title stills | short cells |
|---|---|---|
| Family Feud II / III | **936** | 890 |
| Weakest Link | 76 | 76 |
| Harry Potter | 25 | 54 |
| Thayer's Quest | 20 | 55 |

Family Feud is ~37× the reported disc's density, so it fails within seconds if the watchdog
still mis-fires. ⚠ Atmosfear reads **0** — its stills are menu-domain, so it is not a test
for this one.

- [x] `tools/lint_undriven.sh` PASS
- [x] `dvd_audio_decode_tb` PASS (incl. the RED arm that catches a provisional-anchor release)
- [x] `run_stc_freerun.sh` regression suite green
- [x] Builds clean: clk_dec **88.01 MHz @100C / 90.15 @-40C** vs the 86.0 gate
- [x] `tools/docs_check.py` OK, `mkdocs build --strict` clean
- [x] **HW-CONFIRMED** on Family Feud, Weakest Link, Thayer's Quest and Harry Potter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
