### PR TITLE
docs: retire the post-merge CORE_VERSION reset

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Cut and publish a GitHub release of the MiSTer DVD core — gather release notes from every PR merged since the previous release, land the one release commit that sets CORE_VERSION and reconciles the manual, build the timing-clean .rbf, create the draft that CI packages (Main + install zip), smoke-test it, publish, and set the version back to dev-main. Use when the user asks to cut, make, or publish a release.
+description: Cut and publish a GitHub release of the MiSTer DVD core — gather release notes from every PR merged since the previous release, land the one release commit that sets CORE_VERSION and reconciles the manual, build the timing-clean .rbf, create the draft that CI packages (Main + install zip), smoke-test it, and move the version off the semver. Use when the user asks to cut, make, or publish a release.
 ---
 
 # Cutting a DVD core release
@@ -14,9 +14,12 @@ from the PRs merged since the last release.
 > A bare semver lives in **exactly one commit per release** — the release commit. Any
 > build whose OSD shows `v0.4.0` came from that commit and no other.
 
-- **`CORE_VERSION` in `dvd/emu.sv`** carries `dev-<slug>` on a feature branch and
-  `dev-main` on `main`. Step 0 below sets it to `v<semver>` for the release; the last step
-  sets it back to `dev-main`. Shown in the OSD as `` `CORE_VERSION` `BUILD_DATE` ``.
+- **`CORE_VERSION` in `dvd/emu.sv`** carries `dev-<slug>` on a feature branch. On `main` it
+  carries **whatever the last merged feature left** — there is no post-merge reset (retired
+  2026-09-08, by user decision; see `CLAUDE.md` "Merging a PR"). Step 0 below sets it to
+  `v<semver>` for the release; the last step moves it OFF the semver again, which is the one
+  remaining reset and is not optional (see step 7). Shown in the OSD as
+  `` `CORE_VERSION` `BUILD_DATE` ``.
   `build_release.sh` refuses a `dev-` string on a publishable `--release` build and refuses
   a bare semver on a dev build, so the invariant is mechanical rather than remembered.
 - **Release tag = `v<semver>`** (e.g. `v0.4.0`); title = `v<semver> — <headline>`.
@@ -40,8 +43,8 @@ from the PRs merged since the last release.
 - **The manual matches what is shipping.** `python3 tools/docs_check.py` and
   `mkdocs build --strict` both pass. If a release note would claim something the manual
   does not say, fix the manual first — it is the published contract.
-- `CORE_VERSION` currently reads `dev-main` (it is set to the semver by step 0, not
-  before). Decide the number against the **whole** unreleased delta on `main`, not the last
+- `CORE_VERSION` currently reads whatever the last merged feature left (a `dev-<slug>`);
+  it is set to the semver by step 0, not before. Decide the number against the **whole** unreleased delta on `main`, not the last
   branch merged — several patch-looking merges can add up to a minor release. The
   patch/minor/major rules are in `CLAUDE.md` "Versioning and publishing releases".
 
@@ -68,7 +71,7 @@ would cost a second compile.
    The headline you write here decides the version (patch / minor / major — see `CLAUDE.md`).
 
 2. **Land ONE release commit** on `main`, containing the docs-sweep edits **and**:
-   - `CORE_VERSION` in `dvd/emu.sv` → `"v<semver>"` (from `"dev-main"`).
+   - `CORE_VERSION` in `dvd/emu.sv` → `"v<semver>"` (from whatever `dev-<slug>` main carries).
    - `extra.released_version` in `mkdocs.yml` → `<semver>` (no `v`). The release workflow
      **refuses to package** if this disagrees with the tag: it drives the "latest release is
      vX.Y.Z" banner on every manual page.
@@ -120,9 +123,12 @@ would cost a second compile.
    Publishing creates the tag. The `/releases/latest` URL the README links to updates
    automatically — no README edit per release.
 
-7. **Set `CORE_VERSION` back to `"dev-main"`** in `dvd/emu.sv` and commit. This is what
-   preserves the invariant: the semver now exists in exactly one commit, so no later dev
-   build can advertise a released version.
+7. **Move `CORE_VERSION` OFF the semver** in `dvd/emu.sv` and commit — `"dev-main"` is the
+   conventional value. ⚠ This is the ONE version reset that survives (the post-merge one was
+   retired 2026-09-08): it preserves the invariant that the semver exists in exactly one
+   commit, so no later dev build can advertise a released version. Leaving it would also
+   make the next `build_release.sh` **refuse** — it rejects a bare semver on a dev build —
+   so skipping this step blocks the next build rather than merely mislabelling it.
 
 ## Release assets (attach all three)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2867,7 +2867,7 @@ Two identifiers, deliberately at different granularities:
   | Where | `` `CORE_VERSION `` | OSD line |
   |---|---|---|
   | feature branch | `dev-<slug>` | `DVD dev-seekrealign 260903` |
-  | `main` between releases | `dev-main` | `DVD dev-main 260903` |
+  | `main` between releases | whatever the last merge left (no reset — see "Merging a PR") | `DVD dev-seekrealign 260903` |
   | the release commit, only | `v0.4.0` | `DVD v0.4.0 260903` |
 
   Set `dev-<slug>` as the **first commit of a feature branch**, named after the feature.
@@ -3065,11 +3065,15 @@ long markdown with backticks and checklists does not survive shell quoting relia
 gh pr merge <number> --merge        # or --squash / --rebase
 ```
 
-**★ After the merge, reset `` `CORE_VERSION `` to `"dev-main"`** in `dvd/emu.sv` on `main`
-(a one-line commit) if the merged branch left its own `dev-<slug>` there. Otherwise a build
-made from `main` advertises the last-merged feature's slug while containing much more than
-that feature. It costs nothing: `main` is not compiled between merges, so the netlist change
-is absorbed by whichever build comes next. See "Versioning and publishing releases".
+**⛔ Do NOT open a follow-up commit or PR to reset `` `CORE_VERSION `` after a merge**
+(rule retired 2026-09-08, by user decision — it used to say "reset it to `dev-main` on
+`main`"). `main` simply keeps whatever the last merged feature or release left there, and
+the next feature branch overwrites it with its own `dev-<slug>` in its first commit.
+Accepted consequence: a dev build cut from `main` between features advertises the
+last-merged slug while containing more than that feature — which is why a build for testing
+should come from a named feature branch, not from `main`. The release invariant is
+unaffected: a bare semver still lives in exactly one commit per release, and
+`build_release.sh` still refuses a `dev-` string on a `--release` build.
 
 ### Updating a PR description
 


### PR DESCRIPTION
By user decision: no follow-up commit or PR to reset `CORE_VERSION` after a merge. `main` keeps whatever the last merged feature or release left there.

Marked ⛔ in `CLAUDE.md` so a future session does not reinstate it, with the accepted consequence recorded (a dev build from `main` between features carries the last-merged slug — so test builds should come from a named feature branch).

⚠ The release skill's step 7 survives and is now marked as the one remaining reset: it moves `CORE_VERSION` off the **semver** after a release, which keeps a bare semver in exactly one commit and stops a later dev build advertising a released version. Skipping it would make the next `build_release.sh` refuse outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)