### PR TITLE
docs: no version resets at all; the branch slug becomes mandatory

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Cut and publish a GitHub release of the MiSTer DVD core — gather release notes from every PR merged since the previous release, land the one release commit that sets CORE_VERSION and reconciles the manual, build the timing-clean .rbf, create the draft that CI packages (Main + install zip), smoke-test it, and move the version off the semver. Use when the user asks to cut, make, or publish a release.
+description: Cut and publish a GitHub release of the MiSTer DVD core — gather release notes from every PR merged since the previous release, land the one release commit that sets CORE_VERSION and reconciles the manual, build the timing-clean .rbf, create the draft that CI packages (Main + install zip), and smoke-test it. Use when the user asks to cut, make, or publish a release.
 ---
 
 # Cutting a DVD core release
@@ -17,8 +17,8 @@ from the PRs merged since the last release.
 - **`CORE_VERSION` in `dvd/emu.sv`** carries `dev-<slug>` on a feature branch. On `main` it
   carries **whatever the last merged feature left** — there is no post-merge reset (retired
   2026-09-08, by user decision; see `CLAUDE.md` "Merging a PR"). Step 0 below sets it to
-  `v<semver>` for the release; the last step moves it OFF the semver again, which is the one
-  remaining reset and is not optional (see step 7). Shown in the OSD as
+  `v<semver>` for the release, and it STAYS there — nothing resets it afterwards. The next
+  feature branch sets its own `dev-<slug>` in its first commit. Shown in the OSD as
   `` `CORE_VERSION` `BUILD_DATE` ``.
   `build_release.sh` refuses a `dev-` string on a publishable `--release` build and refuses
   a bare semver on a dev build, so the invariant is mechanical rather than remembered.
@@ -123,12 +123,12 @@ would cost a second compile.
    Publishing creates the tag. The `/releases/latest` URL the README links to updates
    automatically — no README edit per release.
 
-7. **Move `CORE_VERSION` OFF the semver** in `dvd/emu.sv` and commit — `"dev-main"` is the
-   conventional value. ⚠ This is the ONE version reset that survives (the post-merge one was
-   retired 2026-09-08): it preserves the invariant that the semver exists in exactly one
-   commit, so no later dev build can advertise a released version. Leaving it would also
-   make the next `build_release.sh` **refuse** — it rejects a bare semver on a dev build —
-   so skipping this step blocks the next build rather than merely mislabelling it.
+⛔ **There is NO version-reset step after publishing** (retired 2026-09-08, by user
+decision). `main` keeps the release semver until the next feature branch sets its own
+`dev-<slug>`, which is that branch's FIRST commit — see `CLAUDE.md` "Versioning and
+publishing releases". The invariant still holds mechanically: `build_release.sh` **refuses**
+a bare semver on a dev build, so the first build on the next branch fails fast with a
+message naming the fix, rather than shipping a build that advertises a released version.
 
 ## Release assets (attach all three)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2867,13 +2867,24 @@ Two identifiers, deliberately at different granularities:
   | Where | `` `CORE_VERSION `` | OSD line |
   |---|---|---|
   | feature branch | `dev-<slug>` | `DVD dev-seekrealign 260903` |
-  | `main` between releases | whatever the last merge left (no reset — see "Merging a PR") | `DVD dev-seekrealign 260903` |
+  | `main` between releases | whatever the last merge left — no reset | `DVD dev-seekrealign 260903` |
+  | `main` after a release | the release semver — no reset | `DVD v0.4.0 260903` |
   | the release commit, only | `v0.4.0` | `DVD v0.4.0 260903` |
 
-  Set `dev-<slug>` as the **first commit of a feature branch**, named after the feature.
+  **★ SET `dev-<slug>` AS THE FIRST COMMIT OF EVERY FEATURE BRANCH, named after the
+  feature. This is mandatory, not conventional.** Nothing resets `` `CORE_VERSION `` any
+  more — not after a merge, and not after a release (both resets retired 2026-09-08, by
+  user decision) — so `main` carries whatever the last feature or release left, and setting
+  the slug on the branch is the ONLY thing that keeps a build labelled correctly.
+  It is also what UNBLOCKS the build: after a release `main` carries a bare semver, and
+  `build_release.sh` **refuses** a bare semver on a dev build, so the first build on a
+  branch that skipped this step fails immediately with a message naming the fix. That is
+  the intended failure — fast and self-explanatory, rather than a build that quietly
+  advertises a released version.
   `build_release.sh` **gates this mechanically** before the compile (so a wrong value costs
   a second, not 40 minutes): a bare semver on a dev build and a `dev-` string on a
-  publishable `--release` build are both refused.
+  publishable `--release` build are both refused. It additionally WARNS when the slug does
+  not resemble the branch name — the "left over from another branch" mistake.
   **⛔ This REPLACES the retired 2026-08-26 rule ("bump `` `CORE_VERSION `` to the
   speculated next semver at the start of every feature branch").** That rule made every
   pre-release test build advertise a version that did not exist yet: a build sent out for
@@ -2997,6 +3008,11 @@ undone by a later commit. The publishing rules below exist because of that, and 
 override the default instinct to push early and open a PR as soon as a branch exists.
 
 - **Never commit directly to `main`.** If `main` is checked out when a feature is requested, automatically create a feature branch (e.g. `feature/<short-description>`) before writing any code.
+- **Set `` `CORE_VERSION `` to `dev-<slug>` in that branch's FIRST commit** (`dvd/emu.sv`),
+  named after the feature. Nothing resets it any more, so `main` carries the last feature's
+  slug or the last release's semver — and after a release `build_release.sh` will REFUSE to
+  build until the branch sets its own slug. Details and the reasoning: "Versioning and
+  publishing releases".
 - **Never push a branch or open a PR until explicitly asked to.** Work locally and commit
   freely; a feature branch is a private workspace until its author decides otherwise.
   Experimental and dead-end branches must not reach the public remote at all. Do not
@@ -3067,8 +3083,10 @@ gh pr merge <number> --merge        # or --squash / --rebase
 
 **⛔ Do NOT open a follow-up commit or PR to reset `` `CORE_VERSION `` after a merge**
 (rule retired 2026-09-08, by user decision — it used to say "reset it to `dev-main` on
-`main`"). `main` simply keeps whatever the last merged feature or release left there, and
-the next feature branch overwrites it with its own `dev-<slug>` in its first commit.
+`main`"). The post-release reset is retired too, so `main` simply keeps whatever the last
+merged feature **or release** left there, and the next feature branch overwrites it with
+its own `dev-<slug>` in its first commit — which is now mandatory, see "Versioning and
+publishing releases".
 Accepted consequence: a dev build cut from `main` between features advertises the
 last-merged slug while containing more than that feature — which is why a build for testing
 should come from a named feature branch, not from `main`. The release invariant is


### PR DESCRIPTION
Follows on from #73. The release skill no longer moves `CORE_VERSION` off the semver after publishing either — `main` keeps whatever the last feature or release left there.

That makes one thing load-bearing, now stated as mandatory in three places rather than implied in one:

- **Versioning and publishing releases** — ★ set `dev-<slug>` as the FIRST commit of every feature branch. It is the only thing left keeping a build labelled correctly, **and** it is what unblocks the build: after a release `main` carries a bare semver, and `build_release.sh` refuses a bare semver on a dev build, so a branch that skips it fails immediately with a message naming the fix. That fast, self-explanatory failure is the intended behaviour.
- **Source Control branch-creation rule** — where a reader actually starts a feature.
- **Merging a PR** — notes the release reset is retired as well.

The release skill's step 7 is replaced by a ⛔ explaining why there is no reset step, so it does not get reinstated. The versioning table gains a `main` after a release row. Mechanical gates are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)