### PR TITLE
Fix the white-rabbit icon blink, the seamless-branch audio dropout, and unreadable rabbit-mode subtitles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1061,11 +1061,14 @@ worse maintenance burden than targeted in-place edits. So:
   on four discs), so Stage 1 extrapolates between tags from the picture flags and
   `frame_rate_code` and needs the vld's new any-reason `skip_ack` (governor AND realign
   drops) to keep that timeline honest.
-  - 🔧 **THE PARSE-FRONT AUDIT (2026-09-08, branch `fix/spu-display-window`) — two
-    consumers #63 changed WITHOUT TOUCHING; sim-proven RED/GREEN against measured disc
-    data, ⏳ HW-confirm pending.** Field report on The Matrix: the "Follow the White
-    Rabbit" icon FLASHES instead of staying solid, and there is an AUDIO DROPOUT at each
-    white-rabbit point *whether or not* white-rabbit mode is entered.
+  - ✅ **THE PARSE-FRONT AUDIT (2026-09-08, PR #75) — two consumers #63 changed WITHOUT
+    TOUCHING; sim-proven RED/GREEN against measured disc data and ✅ HW-CONFIRMED
+    2026-09-08** (build `DVD_spuwindow_20260908_1955.rbf`, SEED 5 first roll, 92 % ALM,
+    clk_dec 87.40/88.85 — passing but the thinnest margin in recent history, worth a
+    seed sweep if a later branch lands near the 86.0 gate). Field report on The Matrix:
+    the "Follow the White Rabbit" icon FLASHES instead of staying solid, and there is an
+    AUDIO DROPOUT at each white-rabbit point *whether or not* white-rabbit mode is
+    entered.
     ★★ **§11 asked which presentation paths were still off the STC. It did not ask the
     other question: which consumers compare a PARSE-FRONT value AGAINST `stc`, and so
     changed meaning when `stc` moved onto the display.** Both defects are that question's
@@ -1105,6 +1108,20 @@ worse maintenance burden than targeted in-place edits. So:
     against the reader's own `cell_i`, not the delivered byte pattern (the reader runs ~2
     sectors ahead). ⏳ `nav_pci`'s `hli_coherent` is untouched and may be a second
     contributor to the icon — `O[2]` `blk1`/`blk7` vs `blk3`/`blk8` separates them on HW.
+    **(3) A STREAM THE PGC DOES NOT DECLARE WAS BEING DISPLAYED (pre-existing, same PR).**
+    Rabbit-mode subtitles read "white on white". PGCN 6 declares logical stream 1 only;
+    pressing Subtitle releases the VM's claim, the user path resolves logical 0 by RAW
+    INDEX to 0x20 (the real subtitle stream) and draws it with PGCN 6's palette, whose
+    three opaque subtitle classes are all `Y=128` (PGCN 1: `[0] Y=16 [8] Y=128 [9] Y=176`).
+    ⚠ **The rule is NARROWED ON A SWEEP, not on the spec alone:** 221 discs / 22,733 title
+    PGCs — class A (declares logical 0) 18,801, class B (declares NOTHING) 3,929 of which
+    **586 rely on the identity fallback**, class C (declares something, not 0) **3**.
+    libdvdnav's unconditional available-bit guard would strip subtitles from those 586
+    across up to 168 discs, so `subp_stream_map.any_present` narrows it to class C —
+    blast radius 3 PGCs. Only the USER path is gated (menu/VM resolutions pick a stream
+    the disc itself chose). Gate: `subp_stream_map_tb`'s 6 directed `stream_absent` arms,
+    RED against BOTH the unconditional version and the pre-fix one; the 2071-vector
+    `phys_streamN` golden contract is untouched.
     Detail: **`docs/stc_freerun.md` §12**, `docs/subpicture.md`, `docs/dvd_nav.md`.
 
 - ✅ **MEM_SHIM_BURST TAG/LRU STORE → M10K — the ALM congestion reclaim (2026-08-27,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1006,9 +1006,16 @@ worse maintenance burden than targeted in-place edits. So:
   half the raster's IMAGE-SCAN period: 750/900/1877/1800); `next_pts` extrapolates from
   the flags × `frame_rate_code` plus every `skip_ack` (deferred if a picture is waiting
   at the output — the depth-1 queue's ordering rule); a tagged picture > 1 frame behind,
-  > 0.5 s ahead, or > 350 ms late re-anchors. `av_sync.sv` is a clk_sys MIRROR now;
+  > 0.5 s ahead, or > 2.7 s late re-anchors (`LATE_MAX_TICKS`; the 350 ms of the original
+  plan was raised in HW round B -- "lateness is not a discontinuity",
+  `docs/stc_freerun.md` §3.7(2)). `av_sync.sv` is a clk_sys MIRROR now;
   every consumer reads the one `stc`; `sched_en`/`sync_armed` lost `~menu_active`,
-  `hl_stc_fresh` is always 1, the STD hold is universal with a ~155 ms no-audio release,
+  the STD hold gained a ~155 ms no-audio release,
+  ⚠ **(corrected 2026-09-08: two items here described the mid-branch commit `2b548b0`, not
+  what merged -- commit `5f49c29` walked both back. `hl_stc_fresh` is NOT tied to 1; it is
+  `~keep_vbuf` as before (`dvd/emu.sv:1541`). The STD hold's `menu_active` exemption was
+  RESTORED; only the `!aud_seen` release is new. `sched_en`/`sync_armed` did lose
+  `~menu_active`.)**
   and `dvd_audio_decode` re-bases `play_anchor` by each anchor delta. The scheduler's
   reset is the VBUF flush, NOT the keep_vbuf pipe reset — that is what makes menus
   safe. ⚠ `disp_sched_tb` scores every pickup against the scenario's TRUE PTS, not the
@@ -1054,6 +1061,52 @@ worse maintenance burden than targeted in-place edits. So:
   on four discs), so Stage 1 extrapolates between tags from the picture flags and
   `frame_rate_code` and needs the vld's new any-reason `skip_ack` (governor AND realign
   drops) to keep that timeline honest.
+  - 🔧 **THE PARSE-FRONT AUDIT (2026-09-08, branch `fix/spu-display-window`) — two
+    consumers #63 changed WITHOUT TOUCHING; sim-proven RED/GREEN against measured disc
+    data, ⏳ HW-confirm pending.** Field report on The Matrix: the "Follow the White
+    Rabbit" icon FLASHES instead of staying solid, and there is an AUDIO DROPOUT at each
+    white-rabbit point *whether or not* white-rabbit mode is entered.
+    ★★ **§11 asked which presentation paths were still off the STC. It did not ask the
+    other question: which consumers compare a PARSE-FRONT value AGAINST `stc`, and so
+    changed meaning when `stc` moved onto the display.** Both defects are that question's
+    answer and neither module was edited by #63.
+    **(1) `spu_decode` commits at the parse front into a SINGLE bitmap.** With `stc`
+    leading, an arriving unit was already due at commit; with `disp_lag ≈ 0` it installs a
+    window ~a VBUF depth in the FUTURE and blanks what is on screen. MEASURED: the icon is
+    one `FSTA_DSP` at PTS 101885 + one `STP_DSP` at 866659 = **8.4975 s solid**, re-sent
+    **byte-identically 8 times, 90090 ticks (1.001 s) apart** — so solid IS the authored
+    behaviour and the blink period is the re-send period. ⚠ The same bug **truncates every
+    ordinary subtitle** by up to a VBUF depth. Fixed at the mechanism (a display-order
+    HOLD at `DCSQ_END` + a CONTIGUITY CLAMP at `COMMIT` + `S_IDLE` resuming at a real unit
+    boundary), NOT by widening `menu_mode`. ⛔ Double-buffering the bitmap is ~102 M10Ks
+    against 55 free. ★ The hold's bound is MEASURED: real subtitle units are never closer
+    than 1034 ms (n=36, median 2369 ms). Gate `bench/dvd/run_spu_window.sh --red`
+    (3 mutations, each caught by its own arm; the harness FAILS a mutation that does not
+    compile — two arms first "passed" on a build error).
+    **(2) A seamless-branch junction is not a content change.** #63's `disc_rephase`
+    resets `audio_ring` + `dvd_audio_decode`, accepted on *"titles re-anchor about once per
+    playback (APOLLO_13)"*. APOLLO_13 is one continuous title; **Matrix VTS_02 PGCN 1 —
+    the PLAIN movie — has the same 9 interleaved cell-pairs as the rabbit PGCN 6**, which
+    is why the dropout ignores white-rabbit mode. MEASURED: the ILVU splices INSIDE a block
+    are continuous (0 irregular steps in 238 AC-3 PTS samples) and the disc authors NO
+    audio gap (`sml_pbi.vob_a[]` all zero), but **entering the cell the PTS restarts near
+    zero (−2 s to −64 s)**; every such cell is byte0 `0x0e` = `seamless_play=1` AND
+    `stc_discontinuity=1`. Fix = ask the disc: `dvd_iso_reader` decodes
+    `cell_playback_t` byte 0 **bit 3** (the byte was already in `cell_cat_mem`; three bits
+    were used) and `flush_ctl` withholds the audio flush there. The CLOCK still
+    re-anchors. ⛔ NOT a "was there a seek/jump recently" window — a looping menu cell
+    re-anchors with genuinely restarting audio and pulses no `seek_ack`. Menus are
+    structurally untouched (`menu_dom` never latches the level). ⚠ 104/106 cells are
+    seamless, so inside a feature the re-phase now fires only at the 2 authored breaks —
+    consistent with the FAMILY FEUD II measurement. Gate
+    `bench/dvd/run_seamless_audio.sh --red`. ⚠ Two bench lessons: the fixture needed a
+    third cell that is seamless but NOT interleaved (byte0 `0x08`) or bits 3 and 2
+    coincide and the wrong bit passes (it did); and a per-cell sample must be phased
+    against the reader's own `cell_i`, not the delivered byte pattern (the reader runs ~2
+    sectors ahead). ⏳ `nav_pci`'s `hli_coherent` is untouched and may be a second
+    contributor to the icon — `O[2]` `blk1`/`blk7` vs `blk3`/`blk8` separates them on HW.
+    Detail: **`docs/stc_freerun.md` §12**, `docs/subpicture.md`, `docs/dvd_nav.md`.
+
 - ✅ **MEM_SHIM_BURST TAG/LRU STORE → M10K — the ALM congestion reclaim (2026-08-27,
   PR #18) — ✅ HW-CONFIRMED 2026-08-28 (user soak: full-length MiB + menu/seek stress,
   no shear/artifacting; build `DVD_shimreclaim_20260828_0259.rbf`).**

--- a/bench/dvd/flush_ctl_tb.sv
+++ b/bench/dvd/flush_ctl_tb.sv
@@ -17,6 +17,7 @@
 //   mode_switch (interlace/film raster)     x     x     x     -        -
 //   aud_switch (audio track)                -     -     -     -        x
 //   disc_rephase (content PTS jump)         -     -     -     -        x
+//   disc_rephase & cell_seamless            -     -     -     -        -
 //
 // mount_flush = the decoder soft-reset request (mpeg2video.soft_flush): fires on a
 // MOUNT ONLY, never on seeks/jumps/mode switches (those need display continuity).
@@ -35,6 +36,7 @@ module flush_ctl_tb;
   reg  rst_n = 0;
   reg  start_streaming = 0, seek_ack = 0, jump_ack = 0;
   reg  mode_switch = 0, aud_switch = 0, keep_vbuf = 0, disc_rephase = 0;
+  reg  cell_seamless = 0;
   wire load_flush, aud_flush, aud_resync, seek_flush, mount_flush;
   wire pipe_rst_n, aud_rst_n;
 
@@ -47,6 +49,7 @@ module flush_ctl_tb;
     .mode_switch     (mode_switch),
     .aud_switch      (aud_switch),
     .disc_rephase    (disc_rephase),
+    .cell_seamless   (cell_seamless),
     .keep_vbuf       (keep_vbuf),
     .load_flush      (load_flush),
     .aud_flush       (aud_flush),
@@ -207,6 +210,37 @@ module flush_ctl_tb;
     disc_rephase = 1;
     fork pulse_and_measure; begin @(posedge clk); disc_rephase <= 0; end join
     check_row(0, 0, 0, 1, 0, "[10b] disc_rephase must fire aud_resync only");
+
+    // [10c] ...but NOT on a cell the author marked seamless_play. A seamless-branch
+    // junction restarts the timestamps while the soundtrack plays straight through
+    // (MEASURED on The Matrix: the PTS restarts near zero entering each interleaved
+    // cell, the ILVU splices inside are continuous, and the disc authors no audio
+    // gap), so flushing there is ~1 s of audio thrown away for a numbering change.
+    // This is the white-rabbit dropout.
+    expect_idle("[10c] not idle before the seamless disc_rephase");
+    cell_seamless = 1;
+    disc_rephase = 1;
+    fork pulse_and_measure; begin @(posedge clk); disc_rephase <= 0; end join
+    check_row(0, 0, 0, 0, 0, "[10c] disc_rephase on a seamless cell must fire NOTHING");
+
+    // [10d] CONTROL: the gate is a level, so it must not disable the re-phase for
+    // good -- the very next non-seamless cell re-phases as before. Without this a
+    // stuck-at-suppressed bug would pass [10c] and look like a fix.
+    cell_seamless = 0;
+    expect_idle("[10d] not idle before the control disc_rephase");
+    disc_rephase = 1;
+    fork pulse_and_measure; begin @(posedge clk); disc_rephase <= 0; end join
+    check_row(0, 0, 0, 1, 0, "[10d] disc_rephase off a seamless cell still fires aud_resync");
+
+    // [10e] CONTROL: cell_seamless must gate ONLY the discontinuity re-phase. An
+    // audio TRACK SWITCH on the same cell is a real content change and must still
+    // reset the chain, or a seamless cell would silently break track switching.
+    cell_seamless = 1;
+    expect_idle("[10e] not idle before aud_switch on a seamless cell");
+    aud_switch = 1;
+    fork pulse_and_measure; begin @(posedge clk); aud_switch <= 0; end join
+    check_row(0, 0, 0, 1, 0, "[10e] aud_switch still fires aud_resync on a seamless cell");
+    cell_seamless = 0;
 
     // [11] core reset mid-flush clears every counter
     start_streaming = 1;

--- a/bench/dvd/iso_reader_ilvu_tb.sv
+++ b/bench/dvd/iso_reader_ilvu_tb.sv
@@ -59,8 +59,28 @@ module iso_reader_ilvu_tb;
     integer cap_n = 0;
     integer n_a1 = 0, n_bb = 0, n_cc = 0;
     reg         seam_seen = 0;                   // did seamless_active ever assert?
+    // The AUTHORED seamless_play bit (cell_playback_t byte 0 bit 3), exported so
+    // flush_ctl can keep a seamless-branch junction from flushing audio. Sampled
+    // against the reader's OWN current cell while it streams, so this measures what
+    // the reader exports per cell rather than restating an RTL expression.
+    wire        cell_seamless;
+    integer     cs_hi_a1 = 0, cs_lo_a1 = 0, cs_hi_cc = 0, cs_lo_cc = 0;
+    integer     cs_hi_dd = 0, cs_lo_dd = 0;
     always @(posedge clk) begin
         if (dut.seamless_active) seam_seen <= 1'b1;
+        // ⚠ SAMPLE AGAINST THE READER'S OWN cell_i, NOT THE BYTE'S VALUE. The reader
+        // runs ~2 sectors ahead of the captured byte stream, so keying off the
+        // delivered byte pattern compares cell N's level with cell N+1's data and
+        // fails against correct RTL. The first version of this arm did exactly that.
+        if (stream_valid) begin
+            if (dut.cell_i == 8'd0) begin
+                if (cell_seamless) cs_hi_a1 = cs_hi_a1 + 1; else cs_lo_a1 = cs_lo_a1 + 1;
+            end else if (dut.cell_i == 8'd1) begin
+                if (cell_seamless) cs_hi_cc = cs_hi_cc + 1; else cs_lo_cc = cs_lo_cc + 1;
+            end else if (dut.cell_i == 8'd2) begin
+                if (cell_seamless) cs_hi_dd = cs_hi_dd + 1; else cs_lo_dd = cs_lo_dd + 1;
+            end
+        end
         if (stream_valid) begin
             cap_n = cap_n + 1;
             case (stream_data)
@@ -83,7 +103,7 @@ module iso_reader_ilvu_tb;
         .chap_pulse(1'b0), .chap_dir(1'b0), .chap_mag(5'd1), .chap_at_start(1'b0),
         .angle_pulse(1'b0), .cur_angle(cur_angle), .angle_count(angle_count),
         .keep_vbuf(),
-        .cur_cell(), .cell_ready(),
+        .cur_cell(), .cell_ready(), .cell_seamless(cell_seamless),
         .sd_lba(sd_lba), .sd_rd(sd_rd), .sd_ack(sd_ack),
         .sd_buff_addr(sd_buff_addr), .sd_buff_dout(sd_buff_dout), .sd_buff_wr(sd_buff_wr),
         .stream_data(stream_data), .stream_valid(stream_valid), .busy(busy),
@@ -219,15 +239,25 @@ module iso_reader_ilvu_tb;
             put_rec(cur,17,2048,8'h02,128'h01,1,cur);
             put_rec(cur,19,4096,       8'h00,"VIDEO_TS.IFO;1",14,cur);
             put_rec(cur,21,6144,       8'h00,"VTS_01_0.IFO;1",14,cur);
-            put_rec(cur,24,12*2048,    8'h00,"VTS_01_1.VOB;1",14,cur);
+            put_rec(cur,24,14*2048,    8'h00,"VTS_01_1.VOB;1",14,cur);
 
             put_vmgi(19, 32'd1);
             put_tt_srpt(20, 16'd1, 8'd1);
             put_vtsi_mat(21, 32'd1);
-            put_pgcit(22, 32'd16, 8'd2, 16'd256);
+            put_pgcit(22, 32'd16, 8'd3, 16'd256);
             // cells: 0 interleaved (seamless branch) first=0 last=9 ; 1 common
-            put_cell(22, 32'd16, 16'd256, 0, 8'h04, 32'd0, 32'd9);    // interleaved bit
+            // 0x0E = seamless_play(3) | interleaved(2) | stc_discontinuity(1) — the
+            // EXACT category byte measured on every Matrix white-rabbit cell
+            // (VTS_02 PGCN 1, cells 4/23/35/55/60/74/80/86/91). Only bit 2 changes the
+            // ILVU walk, so the branch-follow checks below are unaffected.
+            put_cell(22, 32'd16, 16'd256, 0, 8'h0E, 32'd0, 32'd9);    // interleaved
             put_cell(22, 32'd16, 16'd256, 1, 8'h00, 32'd10, 32'd11);  // common
+            // 0x08 = seamless_play ONLY (no interleaved bit) -- the commonest category
+            // on a real feature (68 of the Matrix's 106 cells). This cell is what makes
+            // the arm able to tell bit 3 from bit 2: without it, cells 0/1 have both
+            // bits set / both clear, and reading `interleaved` instead of
+            // `seamless_play` passes unnoticed. (It did, the first time.)
+            put_cell(22, 32'd16, 16'd256, 2, 8'h08, 32'd12, 32'd13);  // seamless, plain
 
             // interleaved VOB: branch A ILVUs + sibling B ILVUs, round-robin.
             // next_vobu is FORWARD-only (bit31 = SRI valid). Branch A skips past
@@ -244,6 +274,8 @@ module iso_reader_ilvu_tb;
             fill_sec(24+9, 8'hA1);
             fill_sec(24+10, 8'hCC);
             fill_sec(24+11, 8'hCC);
+            fill_sec(24+12, 8'hDD);
+            fill_sec(24+13, 8'hDD);
         end
     endtask
 
@@ -272,6 +304,29 @@ module iso_reader_ilvu_tb;
         if (n_a1 !== 3*2048)     begin errors=errors+1; $display("  FAIL: branch-A body != 3 ILVUs (%0d)", n_a1); end
         if (n_cc !== 2*2048)     begin errors=errors+1; $display("  FAIL: common cell != 2 sectors (%0d)", n_cc); end
         if (errors == 0) $display("  ok: branch A followed via next_vobu, sibling ILVUs skipped");
+
+        // cell_seamless must track the AUTHORED bit, per cell, for the whole cell.
+        $display("ILVU seamless_play export: interleaved(0x0E) hi=%0d lo=%0d | plain(0x00) hi=%0d lo=%0d | seamless-only(0x08) hi=%0d lo=%0d",
+                 cs_hi_a1, cs_lo_a1, cs_hi_cc, cs_lo_cc, cs_hi_dd, cs_lo_dd);
+        if (cs_lo_a1 > 8 || cs_hi_a1 === 0) begin
+            errors=errors+1;
+            $display("  FAIL: cell_seamless was LOW for %0d cycles of the seamless cell", cs_lo_a1);
+        end
+        // A few cycles of skew at the boundary are expected and harmless: the level is
+        // re-latched in S_CELL_LOAD2, a couple of cycles after cell_i advances, and its
+        // only consumer (flush_ctl) reads it when the DISPLAY reaches the junction --
+        // about a VBUF depth later. A stuck-high bug would show ~11k, not a handful.
+        if (cs_hi_cc > 8) begin
+            errors=errors+1;
+            $display("  FAIL: cell_seamless stayed HIGH for %0d cycles of the NON-seamless cell", cs_hi_cc);
+        end
+        // Same one-cycle boundary skew as the plain cell above (re-latched in
+        // S_CELL_LOAD2, a couple of cycles after cell_i advances).
+        if (cs_lo_dd > 8 || cs_hi_dd === 0) begin
+            errors=errors+1;
+            $display("  FAIL: cell_seamless LOW for %0d cycles of a seamless-but-NOT-interleaved cell (bit 3 vs bit 2)", cs_lo_dd);
+        end
+        if (errors == 0) $display("  ok: cell_seamless follows the authored seamless_play bit per cell");
 
         if (errors == 0) $display("ISO_READER_ILVU_TB: ALL TESTS PASSED");
         else             $display("ISO_READER_ILVU_TB: %0d FAILURE(S)", errors);

--- a/bench/dvd/mode_realign_chain_tb.sv
+++ b/bench/dvd/mode_realign_chain_tb.sv
@@ -101,6 +101,7 @@ module mode_realign_chain_tb;
 
     // NAV_CAP(8): a small VOBU-align probe budget so TEST7 can exhaust it on this
     // 40-sector title (TEST8 exercises the title-end clamp before the budget runs).
+    wire cell_seamless;   // reader's authored seamless_play level -> flush_ctl
     dvd_iso_reader #(.NAV_CAP(8)) dut (
         .clk(clk), .rst_n(rst_n), .start(start), .file_size(file_size), .title_sel(7'd0), .vbuf_empty(1'b0), .menu_snap(1'b0),
         // Phase-4 DVD-VM ports: legacy mode (vm_mode=0 keeps prior behaviour)
@@ -111,6 +112,7 @@ module mode_realign_chain_tb;
         .seek_pulse(seek_pulse), .seek_natural(1'b0), .seek_cell(seek_cell), .seek_ack(seek_ack),
         .seek_rbn_pulse(rd_seek_pulse), .seek_rbn(rd_seek_rbn),
         .chap_pulse(1'b0), .chap_dir(1'b0), .chap_mag(5'd1),
+        .cell_seamless(cell_seamless),
         .keep_vbuf(keep_vbuf),
         .cur_cell(cur_cell), .cell_ready(cell_ready),
         .sd_lba(sd_lba), .sd_rd(sd_rd), .sd_ack(sd_ack),
@@ -449,6 +451,9 @@ module mode_realign_chain_tb;
         .clk(clk), .rst_n(rst_n),
         .start_streaming(start), .seek_ack(seek_ack), .jump_ack(1'b0),
         .mode_switch(fc_mode_sw), .aud_switch(1'b0), .keep_vbuf(keep_vbuf),
+        // the reader's own authored-seamless level, not a tie-off: this chain bench
+        // is the one place the two modules are wired together outside emu.sv
+        .cell_seamless(cell_seamless),
         .load_flush(load_flush), .aud_flush(aud_flush), .aud_resync(aud_resync),
         .seek_flush(seek_flush), .mount_flush(mount_flush),
         .pipe_rst_n(pipe_rst_n), .aud_rst_n(aud_rst_n)

--- a/bench/dvd/run_seamless_audio.sh
+++ b/bench/dvd/run_seamless_audio.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# run_seamless_audio.sh — a seamless-branch junction must NOT flush audio.
+#
+# PR #63 made the display's re-anchor flush the audio chain (disc_rephase ->
+# aud_resync). That was accepted on "titles re-anchor about once per playback
+# (reanchors=1 over 80 s on APOLLO_13)". APOLLO_13 is one continuous title; a
+# seamless-branch title is not, and the field reported an audio dropout at every
+# "white rabbit" point of The Matrix -- in the PLAIN movie too, because PGCN 1
+# carries the same 9 interleaved cell-pairs.
+#
+# Two halves, each gated and each proven RED:
+#   reader   - cell_seamless exports the AUTHORED seamless_play bit (cell_playback_t
+#              byte 0 bit 3), per cell. RED reads bit 2 (interleaved) instead, which
+#              coincides on the white-rabbit cells and differs on the other 86.
+#   flush_ctl- disc_rephase on such a cell must fire NOTHING, while an audio track
+#              switch on the same cell still resets the chain.
+set -u
+cd "$(dirname "$0")/../.."
+fail=0
+iv() { iverilog -g2012 -I rtl/mpeg2 -o "$@"; }
+
+green() {  # name  pass-regex  sources...
+    local name=$1 pat=$2; shift 2
+    local d; d=$(mktemp -d)
+    if iv "$d/sim" "$@" 2>"$d/build" && vvp "$d/sim" > "$d/log" 2>&1 \
+       && grep -q "$pat" "$d/log"; then
+        echo "  PASS $name"; grep -E '^\s+ok:|^ILVU seamless_play' "$d/log" | sed 's/^/      /'
+    else
+        echo "  FAIL $name"; tail -12 "$d/build" "$d/log" 2>/dev/null | sed 's/^/      /'; fail=1
+    fi
+    rm -rf "$d"
+}
+
+red() {    # name  file-to-mutate  sed  extra-sources...  (bench is last)
+    local name=$1 src=$2 script=$3; shift 3
+    local d; d=$(mktemp -d); local base; base=$(basename "$src")
+    sed "$script" "$src" > "$d/$base"
+    if cmp -s "$d/$base" "$src"; then
+        echo "  FAIL $name: mutation did not apply (anchor moved)"; fail=1
+    elif ! iv "$d/sim" "$d/$base" "$@" 2>"$d/build"; then
+        # a mutation that does not COMPILE proves nothing about the bench
+        echo "  FAIL $name: mutated module did not build"; sed 's/^/      /' "$d/build"; fail=1
+    elif vvp "$d/sim" 2>&1 | tee "$d/log" | grep -qE "ALL TESTS PASSED|ALL TESTS PASSED \(" ; then
+        echo "  FAIL $name: the bench PASSED without the fix"; fail=1
+    else
+        echo "  PASS $name"; grep -E 'FAIL' "$d/log" | head -3 | sed 's/^/      /'
+    fi
+    rm -rf "$d"
+}
+
+echo "== GREEN =="
+green iso_reader_ilvu "ALL TESTS PASSED" dvd/dvd_iso_reader.sv dvd/bcd_time_add.sv bench/dvd/iso_reader_ilvu_tb.sv
+green flush_ctl       "ALL TESTS PASSED" dvd/flush_ctl.sv bench/dvd/flush_ctl_tb.sv
+# the other flush_ctl instantiation must still elaborate with the new port
+green mode_realign_chain "ALL TESTS PASSED" dvd/mode_realign.sv dvd/flush_ctl.sv \
+      dvd/dvd_iso_reader.sv dvd/bcd_time_add.sv bench/dvd/mode_realign_chain_tb.sv
+
+if [ "${1:-}" = "--red" ]; then
+    echo "== RED =="
+    red reader-wrong-bit dvd/dvd_iso_reader.sv \
+        's|wire       cc_seamless_play = cc_rd\[3\];|wire       cc_seamless_play = cc_rd[2];|' \
+        dvd/bcd_time_add.sv bench/dvd/iso_reader_ilvu_tb.sv
+    red flush-no-gate dvd/flush_ctl.sv \
+        's|(disc_rephase \&\& !cell_seamless)|(disc_rephase)|' \
+        bench/dvd/flush_ctl_tb.sv
+fi
+
+[ $fail -eq 0 ] && echo "ALL GREEN" || echo "FAILURES"
+exit $fail

--- a/bench/dvd/run_spu_window.sh
+++ b/bench/dvd/run_spu_window.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# run_spu_window.sh — the SPU display-order gate (PR #63 regression).
+#
+# GREEN: bench/dvd/spu_window_tb.sv against the shipping module.
+# RED  : three sed-mutated copies, because a bench cannot mutate a module it
+#        instantiates. Each mutation removes ONE half of the fix and must be
+#        caught by the arm that half exists for -- a fix whose removal no arm
+#        notices is not gated, it is just present.
+#          red-clamp : the contiguity clamp  -> [A] the icon must blink again
+#          red-hold  : the display-order hold -> [B] the subtitle must truncate
+#          red-both  : the pre-#63 behaviour   -> both
+# Also re-runs spu_decode_tb, which must pass UNCHANGED: it is the evidence that
+# the golden-model bitmap, the menu path and the spec-max/over-spec handling are
+# untouched.
+set -u
+cd "$(dirname "$0")/../.."
+fail=0
+iv() { iverilog -g2012 -I rtl/mpeg2 -o "$1" "${@:2}"; }
+
+echo "== GREEN: shipping module =="
+if iv /tmp/spu_win_green dvd/spu_decode.sv bench/dvd/spu_window_tb.sv \
+   && vvp /tmp/spu_win_green | tee /tmp/spu_win_green.log | grep -q "RESULT: PASS"; then
+    sed -n 's/^  \[/  [/p' /tmp/spu_win_green.log
+    echo "  PASS spu_window"
+else
+    echo "  FAIL spu_window (green)"; tail -20 /tmp/spu_win_green.log; fail=1
+fi
+
+echo "== GREEN: spu_decode_tb must be unchanged =="
+if iv /tmp/spu_dec_green dvd/spu_decode.sv bench/dvd/spu_decode_tb.sv \
+   && vvp /tmp/spu_dec_green | grep -q "RESULT: PASS"; then echo "  PASS spu_decode"
+else echo "  FAIL spu_decode"; fail=1; fi
+
+red() {   # name  sed-script  expected-failing-arm
+    local name=$1 script=$2 arm=$3
+    local d; d=$(mktemp -d)
+    sed "$script" dvd/spu_decode.sv > "$d/spu_decode.sv"
+    if cmp -s "$d/spu_decode.sv" dvd/spu_decode.sv; then
+        echo "  FAIL $name: the mutation did not apply (anchor moved)"; fail=1
+    elif ! iv "$d/sim" "$d/spu_decode.sv" bench/dvd/spu_window_tb.sv 2>"$d/build"; then
+        # A mutation that does not COMPILE proves nothing about the bench.
+        echo "  FAIL $name: the mutated module did not build"; sed 's/^/      /' "$d/build"
+        fail=1
+    elif vvp "$d/sim" > "$d/log" 2>&1 && grep -q "RESULT: PASS" "$d/log"; then
+        echo "  FAIL $name: the bench PASSED without the fix (arm $arm proves nothing)"
+        fail=1
+    else
+        echo "  PASS $name (expected arm $arm; caught $(grep -c 'FAIL \[' "$d/log"))"
+        grep 'FAIL \[' "$d/log" | sed 's/^/      /'
+    fi
+    rm -rf "$d"
+}
+
+if [ "${1:-}" = "--red" ]; then
+    echo "== RED arms =="
+    red red-clamp 's|c_show  <= (spu_contig \&\& !spu_due) ? stc : w_show_eff;|c_show  <= w_show_eff;|' A
+    red red-hold  's|if (c_valid \&\& !spu_due \&\& !menu_mode) state <= S_HOLD;|if (menu_mode \&\& !menu_mode) state <= S_HOLD;|' B
+    red red-both  's|c_show  <= (spu_contig \&\& !spu_due) ? stc : w_show_eff;|c_show  <= w_show_eff;|; s|if (c_valid \&\& !spu_due \&\& !menu_mode) state <= S_HOLD;|if (menu_mode \&\& !menu_mode) state <= S_HOLD;|' A+B
+fi
+
+[ $fail -eq 0 ] && echo "ALL GREEN" || echo "FAILURES"
+exit $fail

--- a/bench/dvd/run_subpic.sh
+++ b/bench/dvd/run_subpic.sh
@@ -39,3 +39,8 @@ iverilog -g2012 -D__IVERILOG__ -I rtl/mpeg2 -o bench/dvd/crt_ov_map_sim \
   rtl/mpeg2/wrappers.v rtl/mpeg2/fwft.v rtl/mpeg2/xfifo_sc.v rtl/mpeg2/xilinx_fifo_dc.v \
   bench/dvd/crt_ov_map_tb.sv 2>/dev/null
 vvp bench/dvd/crt_ov_map_sim | grep -E "PASS|FAIL"
+
+echo "=== display-order commit (PR #63 regression: the white-rabbit blink + subtitle tails) ==="
+# Kept as its own script because it carries RED arms; run it with --red when touching
+# spu_decode's commit path. See docs/subpicture.md "The COMMIT contract".
+bash "$(dirname "$0")/run_spu_window.sh"

--- a/bench/dvd/spu_window_tb.sv
+++ b/bench/dvd/spu_window_tb.sv
@@ -1,0 +1,250 @@
+// =============================================================================
+// bench/dvd/spu_window_tb.sv — SPU DISPLAY-ORDER commit (PR #63 regression gate)
+// =============================================================================
+// PR #63 moved the STC from a parse-front clock that LED the display by the VBUF
+// depth onto the displayed picture itself. spu_decode was not touched, but its
+// `stc` input changed meaning: a subpicture unit arriving at the parse front now
+// commits a show window ~a VBUF depth in the FUTURE, and because there is a single
+// bitmap the arriving unit destroys the one on screen before its authored window
+// has expired.
+//
+// What this bench measures is what the SCREEN gets — `sp_active`, sampled every
+// tick — never a signal the fix names, so it cannot become a golden model that
+// agrees with its RTL by construction.
+//
+//   [A] THE REPORTED DEFECT, to the disc's own numbers. The Matrix's "Follow the
+//       White Rabbit" icon: MEASURED as one FSTA_DSP at PTS 101885 and one STP_DSP
+//       at 866659 (8.4975 s), with the same unit re-sent BYTE-IDENTICALLY 8 times,
+//       90090 ticks (1.001 s) apart, and NO intermediate stop. A conforming player
+//       shows one unbroken icon. RED: the icon blinks once per re-send.
+//   [B] SUBTITLES, the same bug quietly truncating every line: an authored gap
+//       between two lines must be preserved — line A must keep its full window
+//       instead of being blanked when line B arrives early.
+//   [C] THE HOLD'S BOUND IS A PROMISE: a unit arriving no sooner than the hold
+//       bound after the previous one is never lost. (Real subtitle units are never
+//       closer than 1034 ms — n=36, median 2369 ms — which is why the bound is set
+//       below that.)
+//   [D] CONTROL: an authored gap that is genuinely long must still go dark. A fix
+//       that simply never blanks would pass [A] and [B] and be wrong.
+//
+// 1 STC tick per clock here (the real ratio is clk_sys/300) so a 1 s VBUF lead is
+// 90k cycles rather than 27 M; HOLD_CYCLES is scaled to match (700 ms in ticks).
+// =============================================================================
+`timescale 1ns/1ps
+module spu_window_tb;
+
+    // ---- scaled timing -------------------------------------------------------
+    localparam int TICK_HOLD = 63000;      // 700 ms in 90 kHz ticks = the real bound
+    localparam int LEAD      = 90000;      // 1 s VBUF lead (parse front vs display)
+    localparam int RESEND    = 90090;      // 1.001 s — the disc's measured re-send period
+    localparam int GAP       = 30000;      // 0.33 s authored gap between subtitle lines.
+                                           // Deliberately SHORTER than LEAD, so line B
+                                           // arrives while line A is still on screen —
+                                           // if it arrived after A had expired the arm
+                                           // would pass against broken RTL.
+    localparam int DUR_A     = 184320;     // 180<<10 ticks ~ 2.05 s: line A's window
+    localparam logic [32:0] P0 = 33'd101885;   // the disc's own first icon PTS
+
+    logic clk=0, rst_n=0;
+    always #5 clk=~clk;
+
+    logic [7:0]  sp_byte = 8'd0;
+    logic        sp_valid=0, sp_frame_start=0, sp_pts_valid=0;
+    logic [32:0] sp_pts = 0;
+    logic [32:0] stc = 0;
+    logic        enable = 1'b1, menu_mode = 1'b0;
+    logic [11:0] q_x=0, q_y=0;
+    wire  [1:0]  q_idx;  wire q_inside, sp_active;
+    wire [3:0]   alpha0, alpha1, alpha2, alpha3, col0, col1, col2, col3;
+
+    spu_decode #(.HOLD_CYCLES(TICK_HOLD)) dut (
+        .clk(clk), .rst_n(rst_n), .enable(enable), .interlaced(1'b0),
+        .menu_mode(menu_mode),
+        .sp_byte(sp_byte), .sp_valid(sp_valid), .sp_frame_start(sp_frame_start),
+        .sp_pts(sp_pts), .sp_pts_valid(sp_pts_valid),
+        .stc(stc), .q_x(q_x), .q_y(q_y), .q_idx(q_idx), .q_inside(q_inside),
+        .alpha0(alpha0), .alpha1(alpha1), .alpha2(alpha2), .alpha3(alpha3),
+        .col0(col0), .col1(col1), .col2(col2), .col3(col3),
+        .sp_active(sp_active)
+    );
+
+    // the display clock: one 90 kHz tick per cycle (see the header)
+    logic stc_run = 1'b0;
+    always @(posedge clk) if (stc_run) stc <= stc + 33'd1;
+
+    int errors = 0;
+
+    // ---- synthetic SPU builder ----------------------------------------------
+    // Minimal but format-real: 2 lines of "fill to end of line" RLE (four zero
+    // nibbles) and a DCSQ carrying STA_DSP + SET_DAREA + SET_DSPXA, optionally a
+    // second DCSQ carrying STP_DSP at a delay. Only visibility is under test, so
+    // the bitmap content is deliberately trivial.
+    byte unsigned spu [0:255];
+    int spu_len;
+    task automatic mk_spu(input bit has_stp, input int stp_delay);
+        int p, dcsq0, dcsq1;
+        begin
+            spu[4]=8'h00; spu[5]=8'h00;          // top-field RLE    -> fill line
+            spu[6]=8'h00; spu[7]=8'h00;          // bottom-field RLE -> fill line
+            dcsq0 = 8;
+            spu[2]=dcsq0[15:8]; spu[3]=dcsq0[7:0];
+            p = dcsq0 + 4;                        // after delay(2) + next(2)
+            spu[p]=8'h01; p++;                                     // STA_DSP
+            spu[p]=8'h05; p++;                                     // SET_DAREA 0..15 x 0..1
+            spu[p]=8'h00; p++; spu[p]=8'h00; p++; spu[p]=8'h0F; p++;
+            spu[p]=8'h00; p++; spu[p]=8'h00; p++; spu[p]=8'h01; p++;
+            spu[p]=8'h06; p++;                                     // SET_DSPXA top=4 bot=6
+            spu[p]=8'h00; p++; spu[p]=8'h04; p++;
+            spu[p]=8'h00; p++; spu[p]=8'h06; p++;
+            spu[p]=8'hFF; p++;                                     // end of this DCSQ
+            if (!has_stp) begin
+                spu[dcsq0]=8'h00; spu[dcsq0+1]=8'h00;              // delay 0
+                spu[dcsq0+2]=dcsq0[15:8]; spu[dcsq0+3]=dcsq0[7:0]; // next == self => end
+            end else begin
+                dcsq1 = p;
+                spu[dcsq0]=8'h00; spu[dcsq0+1]=8'h00;
+                spu[dcsq0+2]=dcsq1[15:8]; spu[dcsq0+3]=dcsq1[7:0];
+                // DCSQ delay is in 1/90000 s units scaled by 1024 (spu_decode: <<10)
+                spu[dcsq1]   = (stp_delay >> 8) & 8'hFF;
+                spu[dcsq1+1] =  stp_delay       & 8'hFF;
+                spu[dcsq1+2] = dcsq1[15:8]; spu[dcsq1+3] = dcsq1[7:0];  // next == self
+                p = dcsq1 + 4;
+                spu[p]=8'h02; p++;                                 // STP_DSP
+                spu[p]=8'hFF; p++;
+            end
+            spu_len = p;
+            spu[0]=spu_len[15:8]; spu[1]=spu_len[7:0];             // SPDSZ
+        end
+    endtask
+
+    task automatic feed(input logic [32:0] ptsval);
+        for (int i=0;i<spu_len;i++) begin
+            @(negedge clk);
+            sp_byte = spu[i]; sp_valid = 1'b1;
+            sp_frame_start = (i==0);
+            sp_pts = ptsval; sp_pts_valid = (i==0);
+        end
+        @(negedge clk); sp_valid=0; sp_frame_start=0; sp_pts_valid=0;
+    endtask
+
+    // run the display clock until it reaches `target`, watching sp_active
+    int    act_falls, act_rises; logic act_prev; logic saw_active;
+    logic  watch_en;
+    always @(posedge clk) begin
+        if (watch_en) begin
+            if ( act_prev && !sp_active) act_falls++;
+            if (!act_prev &&  sp_active) act_rises++;
+            if (sp_active) saw_active <= 1'b1;
+            act_prev <= sp_active;
+        end
+    end
+    task automatic watch_reset; begin
+        act_falls=0; act_rises=0; saw_active=0; act_prev=sp_active; watch_en=1'b1;
+    end endtask
+    task automatic run_to(input logic [32:0] target);
+        begin stc_run = 1'b1; while (stc < target) @(posedge clk); end
+    endtask
+
+    initial begin
+        watch_en = 0; act_prev = 0;
+        repeat (4) @(posedge clk); rst_n = 1;
+
+        // =====================================================================
+        // [A] the white-rabbit re-send chain, to the disc's measured numbers
+        // =====================================================================
+        stc = P0 - LEAD; stc_run = 1'b0;
+        mk_spu(1'b0, 0);                                   // persistent: no STP_DSP
+        feed(P0);                                          // unit 0, a lead early
+        run_to(P0);                                        // its authored show time
+        if (!sp_active) begin
+            $display("  FAIL [A] icon never appeared at its authored PTS"); errors++;
+        end
+        watch_reset();
+        for (int k=1; k<8; k++) begin                      // units 1..7, identical
+            run_to(P0 + (k*RESEND) - LEAD);
+            feed(P0 + (k*RESEND));
+            run_to(P0 + (k*RESEND));
+        end
+        run_to(P0 + (8*RESEND));
+        if (act_falls != 0) begin
+            $display("  FAIL [A] icon BLINKED %0d times across 7 identical re-sends (authored: one solid 8.5 s display)", act_falls); errors++;
+        end else
+            $display("  [A] white-rabbit re-send chain: icon SOLID across 7 re-sends");
+
+        // =====================================================================
+        // [B] a subtitle's authored window survives the next line arriving early
+        // =====================================================================
+        rst_n = 0; repeat (4) @(posedge clk); rst_n = 1;
+        stc_run = 1'b0; stc = 33'd1_000_000;
+        begin : arm_b
+            logic [32:0] pa, pb; int dur_a;
+            pa = 33'd1_100_000;
+            dur_a = 180;                                   // 180<<10 = DUR_A ticks
+            pb = pa + DUR_A + GAP;                         // an authored gap after A
+            mk_spu(1'b1, dur_a);
+            feed(pa);                                      // A arrives a lead early
+            run_to(pa + 33'd10);
+            if (!sp_active) begin
+                $display("  FAIL [B] line A never showed"); errors++; end
+            // B arrives a full lead before its own show time, while A is still up.
+            // ⚠ ARM THE WATCHER BEFORE FEEDING B. The blank this arm exists to catch
+            // happens AT B's commit, so a watch_reset() afterwards samples an already
+            // -low sp_active and the arm passes against broken RTL -- which is exactly
+            // what run_spu_window.sh's red-hold arm reported the first time.
+            run_to(pb - LEAD);
+            watch_reset();
+            mk_spu(1'b1, dur_a);
+            feed(pb);
+            run_to(pa + DUR_A - 33'd200);                  // still inside A's window
+            if (!sp_active) begin
+                $display("  FAIL [B] line A is dark inside its own authored window"); errors++;
+            end
+            if (act_falls != 0) begin
+                $display("  FAIL [B] line A was blanked %0d times early by B's arrival", act_falls); errors++;
+            end else
+                $display("  [B] subtitle A kept its authored window despite B arriving early");
+        end
+
+        // =====================================================================
+        // [D] CONTROL: the authored gap must still go dark
+        // =====================================================================
+        run_to(33'd1_100_000 + DUR_A + (GAP/2));
+        if (sp_active) begin
+            $display("  FAIL [D] the authored gap after A did not go dark (a fix that never blanks is not a fix)"); errors++;
+        end else
+            $display("  [D] authored gap between the two lines still goes dark");
+        run_to(33'd1_100_000 + DUR_A + GAP + 33'd10);
+        if (!sp_active) begin
+            $display("  FAIL [D] line B never showed at its authored time"); errors++;
+        end else
+            $display("  [D] line B appeared at its authored time");
+
+        // =====================================================================
+        // [C] the hold's bound is a promise: a unit arriving >= the bound after
+        //     the previous one is never lost
+        // =====================================================================
+        rst_n = 0; repeat (4) @(posedge clk); rst_n = 1;
+        stc_run = 1'b0; stc = 33'd2_000_000;
+        begin : arm_c
+            logic [32:0] pc, pd;
+            pc = 33'd2_100_000;
+            pd = pc + TICK_HOLD + 33'd2000;                // just past the bound
+            mk_spu(1'b0, 0);
+            feed(pc);
+            run_to(pd - LEAD);
+            mk_spu(1'b0, 0);
+            feed(pd);
+            run_to(pd + 33'd2000);
+            if (dut.c_pts !== pd) begin
+                $display("  FAIL [C] the second unit was LOST (c_pts=%0d, expected %0d)", dut.c_pts, pd); errors++;
+            end else
+                $display("  [C] a unit arriving past the hold bound is not lost");
+        end
+
+        if (errors==0) $display("RESULT: PASS (spu_window)");
+        else           $display("RESULT: FAIL (%0d errors)", errors);
+        $finish;
+    end
+
+    initial begin #400_000_000; $display("RESULT: FAIL timeout"); $finish; end
+endmodule

--- a/bench/dvd/subp_stream_map_tb.sv
+++ b/bench/dvd/subp_stream_map_tb.sv
@@ -27,6 +27,8 @@ module subp_stream_map_tb;
     reg  [3:0]  logical;
     reg  [31:0] ctl_sel;
     wire [4:0]  phys_streamN;
+    wire        stream_absent;
+    reg         any_present = 1'b0;
 
     subp_stream_map dut (
         .map_valid    (map_valid),
@@ -36,7 +38,9 @@ module subp_stream_map_tb;
         .ctl_sel      (ctl_sel),
         .wide         (wide),
         .disp_mode    (disp_mode),
-        .phys_streamN (phys_streamN)
+        .any_present  (any_present),
+        .phys_streamN (phys_streamN),
+        .stream_absent(stream_absent)
     );
 
     integer i, errors = 0, n = 0;
@@ -76,6 +80,67 @@ module subp_stream_map_tb;
             $display("FAIL: only %0d menu vectors resolve to a NON-ZERO substream --", n_menu_fix);
             $display("      the vectors do not exercise issues #60/#61 at all");
         end
+        // ---- STREAM AVAILABILITY (the white-rabbit subtitle case) ------------
+        // The 2071 packed vectors above pin phys_streamN, which this output does not
+        // touch; they run with any_present=0 and are unaffected. These directed arms
+        // pin stream_absent, using the REAL disc words: The Matrix VTS_02 PGCN 6
+        // declares logical 1 only (0x80020300), so a user asking for logical 0 -- an
+        // entry that reads all-zero -- must be told the stream is absent rather than
+        // being shown 0x20 under a palette that renders every subtitle class as one
+        // flat grey.
+        begin : avail_arms
+            map_valid = 1; dom_tt = 1; ctx_menu = 0; wide = 1; disp_mode = 0;
+
+            // [1] class C: the table declares SOMETHING, but not this entry -> absent
+            any_present = 1; logical = 4'd0; ctl_sel = 32'h00000000; #1;
+            if (stream_absent !== 1'b1) begin
+                errors = errors + 1;
+                $display("FAIL [avail-1]: undeclared entry in a PGC that declares others must be ABSENT");
+            end
+
+            // [2] the SAME entry when the PGC declares NOTHING (class B, 586 PGCs in
+            //     the library sweep) -> NOT absent; the identity fallback must stand,
+            //     or those discs silently lose their subtitles.
+            any_present = 0; logical = 4'd0; ctl_sel = 32'h00000000; #1;
+            if (stream_absent !== 1'b0) begin
+                errors = errors + 1;
+                $display("FAIL [avail-2]: a PGC that declares NO stream must keep the identity fallback");
+            end
+
+            // [3] a declared entry is never absent (the normal case, 18,801 PGCs)
+            any_present = 1; logical = 4'd0; ctl_sel = 32'h80000100; #1;
+            if (stream_absent !== 1'b0) begin
+                errors = errors + 1;
+                $display("FAIL [avail-3]: a DECLARED stream must not be reported absent");
+            end
+
+            // [4] the rabbit's own stream stays selectable (logical 1, 0x80020300)
+            any_present = 1; logical = 4'd1; ctl_sel = 32'h80020300; #1;
+            if (stream_absent !== 1'b0 || phys_streamN !== 5'd2) begin
+                errors = errors + 1;
+                $display("FAIL [avail-4]: the rabbit's declared stream must resolve to 0x22 and not be absent (abs=%b phys=%0d)",
+                         stream_absent, phys_streamN);
+            end
+
+            // [5] no usable table at all -> never absent, whatever any_present says
+            map_valid = 0; any_present = 1; logical = 4'd0; ctl_sel = 32'h00000000; #1;
+            if (stream_absent !== 1'b0) begin
+                errors = errors + 1;
+                $display("FAIL [avail-5]: an unparsed table must not report absence");
+            end
+            map_valid = 1;
+
+            // [6] wrong domain (a menu resolution against a title table) -> not absent
+            ctx_menu = 1; any_present = 1; logical = 4'd0; ctl_sel = 32'h00000000; #1;
+            if (stream_absent !== 1'b0) begin
+                errors = errors + 1;
+                $display("FAIL [avail-6]: an out-of-domain table must not report absence");
+            end
+            ctx_menu = 0;
+
+            if (errors == 0) $display("  stream_absent: 6 directed arms PASS (class C absent, class B preserved)");
+        end
+
         if (errors == 0)
             $display("SUBP_STREAM_MAP_TB: ALL %0d VECTORS PASSED (%0d menu arms map to a non-zero substream)",
                      n, n_menu_fix);

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -1963,6 +1963,33 @@ the reported blink when PR #63 put the STC on the displayed picture. Fixed in
 `sp_route_en` (its `SetSTN` pre-command opens routing) and was read as covering
 `menu_mode` too. It does not.
 
+**⚠ THE DISC OFFERS NO SUBTITLES IN RABBIT MODE, AND FORCING ONE USED TO SHOW
+UNREADABLE TEXT (2026-09-08).** Field report: *"subtitles in the white rabbit mode are
+missing the black outline -- white on white and hard to read."* MEASURED, and the cause is
+neither colour sharing with the rabbit nor a decode fault:
+
+| substream | content | authored colours |
+|---|---|---|
+| 0x20 / 0x21 | the real subtitles (wide / letterbox) | `COLOR[0,8,9,0] CONTR[15,15,15,0]` |
+| 0x22 / 0x23 | the rabbit icon ONLY -- no subtitles anywhere | `COLOR[14,14,14,14] CONTR[0,0,0,0]` |
+
+PGCN 1 declares logical stream 0 only; **PGCN 6 declares logical stream 1 only**. Pressing
+the Subtitle button releases the VM's claim (`emu.sv`: `if (sub_edge) vm_owns_sp <= 1'b0`),
+after which the USER path resolves logical 0 **by raw index** to 0x20 -- which really is the
+subtitle stream -- and draws it with **PGCN 6's palette**:
+
+    PGCN 1 palette  [0] Y=16   [8] Y=128  [9] Y=176   -> fill, outline, black edge
+    PGCN 6 palette  [0] Y=128  [8] Y=128  [9] Y=128   -> one flat grey, no outline
+
+PGCN 6's palette has only two meaningful entries (14 = white, the rabbit; 15 = green),
+because nothing else is meant to draw with it. Showing that stream is our invention, not the
+disc's intent. `subp_stream_map` now reports `stream_absent` and `emu` withholds the USER
+path's route. ⚠ **The rule is narrowed on a measurement**: applying the available bit
+unconditionally (as libdvdnav does) would strip subtitles from the **586 class-B PGCs** (up
+to 168 discs) that rely on the identity fallback -- see `dvd/subp_stream_map.sv` for the
+221-disc sweep and the A/B/C classes. Gate: `subp_stream_map_tb`'s six directed
+`stream_absent` arms, whose RED arm is the unconditional version.
+
 **What is done (this branch):**
 - **Render un-gate** (`emu.sv`): `in_title_hli = menus_on && !menu_active && hl_btns_armed`
   feeds `sp_route_en` so an in-title armed HLI routes its button subpicture (the highlight

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -1934,6 +1934,35 @@ the movie you are watching — it is an entire **alternate branch** you switch t
    except via the HLI highlight colour), command **`SetGPRM g[9]=1; LinkTailPGC`** → the PGC
    POST commands `CallSS VMGM (pgc 10..18)` based on `g[9]` → the behind-the-scenes featurette.
 
+**THE ICON IS AUTHORED SOLID — MEASURED, so it never has to be re-established
+(2026-09-08).** A field report after PR #63 said the icon had started flashing. It had, and
+the disc settles what "correct" means:
+
+| | |
+|---|---|
+| subpicture (physical 0x22, via `SetSTN SPSTN=0x41` -> `subp_control[1]=0x80020300`) | `SPDSZ=1572`, ONE DCSQ: `FSTA_DSP SET_COLOR[14,14,14,14] SET_CONTR[0,0,0,0] SET_DSPXA(4,769) SET_DAREA(0,719,2,479)` |
+| display window | one `FSTA_DSP` at PTS **101885**, one `STP_DSP` at **866659** = **8.4975 s continuous**, with **no intermediate stop command anywhere** |
+| delivery | the same unit re-sent **byte-identically 8 times**, exactly **90090 ticks (1.001 s)** apart -- a conforming player treats a re-send as a no-op |
+| HLI | 17 records alternating `hli_ss = 1,2,1,2...` whose windows are **exactly back-to-back** (`s_ptm[n] == e_ptm[n-1]`: 101885 -> 191975 -> ... -> 867650), identical button content throughout, `fosl` 1 then 0 = arm once and hold |
+
+★ The re-sends and the repeated `ss=1` exist for random access and ILVU branch entry, not
+to blink. ⚠ `SET_CONTR[0,0,0,0]` means the SPU is **invisible on its own** -- the icon
+appears only through the HLI recolour -- so a flash can come from EITHER the subpicture or
+the highlight, and the `O[2]` blocks are what separate them (`blk1`/`blk7` = the arm,
+`blk3`/`blk8` = the subpicture).
+
+**⚠ THE SINGLE-BUTTON HLI FALLS OUTSIDE `menu_mode`, AND THAT MATTERED.** `emu.sv`'s
+`sp_menu_early` rides `nav_pci.hli_seen`, which requires **more than one button**
+(`nxt_btn_ns > 1`); the rabbit is one `fosl=1` button, so `menu_mode` is 0 and it runs
+`spu_decode`'s windowed path. That was harmless while the STC led the display, and became
+the reported blink when PR #63 put the STC on the displayed picture. Fixed in
+`spu_decode` itself (a display-order hold + a contiguity clamp) rather than by widening
+`menu_mode` -- the same defect was truncating ordinary subtitles. See
+`docs/stc_freerun.md` §12.1 and `docs/subpicture.md`.
+⚠ `dvd/emu.sv`'s note that the rabbit "doesn't need" the early gate is true of
+`sp_route_en` (its `SetSTN` pre-command opens routing) and was read as covering
+`menu_mode` too. It does not.
+
 **What is done (this branch):**
 - **Render un-gate** (`emu.sv`): `in_title_hli = menus_on && !menu_active && hl_btns_armed`
   feeds `sp_route_en` so an in-title armed HLI routes its button subpicture (the highlight
@@ -2084,6 +2113,34 @@ angles and normal titles are byte-for-byte unchanged).
 
 **HW verdict (✅ 2026-07-12):** Matrix white-rabbit chapters + T2 extended scenes play smoothly
 at the problem spots (skipping gone). Confirmed on real hardware.
+
+**★ THE JUNCTION IS TIME-CONTINUOUS, AND SINCE 2026-09-08 THAT IS ENFORCED AGAINST THE
+DISPLAY SCHEDULER TOO.** The reader has always performed the ILVU hop with no flush, no
+`seek_ack` and no A/V re-anchor because it is continuous. PR #63 then added a path that
+INFERRED a discontinuity from the stream and flushed audio behind the reader's back
+(`disp_sched.anchor_disc` -> `flush_ctl.disc_rephase` -> `aud_resync`), which is what the
+field reported as an audio dropout at every white-rabbit point -- in the PLAIN movie as
+much as the rabbit branch, because **PGCN 1 carries the same 9 interleaved cell-pairs**.
+
+MEASURED on the disc, and worth recording because the obvious guess is wrong:
+
+| | |
+|---|---|
+| the ILVU splices *inside* a block | **continuous** -- 0 irregular steps in 238 AC-3 PTS samples along the real played sector walk of cell 4 |
+| entering the interleaved cell | the PTS **restarts near zero**: audio steps of **-2 s to -64 s** across cells 4/23/35/55/60/74/80/86/91 |
+| authored audio gap (`sml_pbi.vob_a[8].{stp_ptm,gap_len}`, DSI-rel 0x34) | **none** -- every entry zero. ⚠ Neither `nav_dsi.sv` nor `nav_extract.py` parses these fields at all; that is a real gap, just not this bug |
+| cell category byte | **0x0e** on all nine -- `seamless_play=1` AND `stc_discontinuity=1` |
+
+So the timestamps renumber at the block entry while the soundtrack plays straight through.
+`dvd_iso_reader` now decodes `cell_playback_t` byte 0 **bit 3 `seamless_play`** (the whole
+byte was already in `cell_cat_mem`; only three bits were ever used) and exports
+`cell_seamless`, which `flush_ctl` uses to withhold the audio flush. The clock still
+re-anchors -- the display must follow a real timeline change -- only the audio flush
+narrows. Gate: `bench/dvd/run_seamless_audio.sh`. Full reasoning and the measurements:
+`docs/stc_freerun.md` §12.2.
+⚠ 104 of the Matrix's 106 cells are `seamless_play=1`, so inside a feature the re-phase now
+fires only at the 2 authored non-seamless cells. Menus are structurally untouched: the
+`menu_dom` branch of `S_CELL_LOAD2` never latches the level.
 
 **Not in scope (deferred, separate feature gaps that share the "in-title, not menu" theme):**
 the in-title PCI/HLI **button highlight** (the white-rabbit *icon* itself; `nav_pci` arms

--- a/docs/stc_freerun.md
+++ b/docs/stc_freerun.md
@@ -984,8 +984,10 @@ against correct RTL.
 
 ### 12.3 What is still open here
 
-⏳ **Neither fix is HW-confirmed.** Both are sim-proven with RED/GREEN arms against measured
-disc data.
+✅ **Both fixes are HW-CONFIRMED (2026-09-08, PR #75)** — build
+`DVD_spuwindow_20260908_1955.rbf`: audio plays smoothly through the white-rabbit clips and
+the icon is solid. A third fix rode along in the same PR (a stream the PGC does not declare
+was being displayed — the "white on white" rabbit-mode subtitles); see `docs/dvd_nav.md`.
 ⏳ **`nav_pci`'s `hli_coherent` is untouched and may be a second contributor to the icon.**
 The icon needs the highlight as well as the subpicture (`SET_CONTR[0,0,0,0]` — the SPU is
 invisible on its own), and #63 tightened `stc_trusted` from a disjunction to a conjunction

--- a/docs/stc_freerun.md
+++ b/docs/stc_freerun.md
@@ -847,6 +847,148 @@ can check the skip count before changing anything.
 ⏳ Also untouched and still open: the `iec61937_wrap` half (HW-gate on a receiver), and the
 pre-existing film-detector flapping on mixed content.
 
+## 12. THE PARSE-FRONT AUDIT (2026-09-08) — two consumers #63 changed without touching
+
+Reported from the field on The Matrix, after #63: **the "Follow the White Rabbit" icon
+flashes instead of staying solid, and there is an audio dropout at each white-rabbit
+point — whether or not white-rabbit mode is entered.**
+
+Two separate defects, one shared cause class. §11 audited which presentation paths were
+still off the STC. It did not ask the other question:
+
+> **which consumers were comparing a PARSE-FRONT value against `stc`, and therefore
+> changed meaning when `stc` moved onto the display?**
+
+Both defects here are that question's answer, and neither module was edited by #63.
+
+### 12.1 `spu_decode` — a single bitmap committed at the parse front
+
+`spu_decode` decodes an arriving SPU straight into its one full-frame bitmap and commits
+`c_show` from the SPU PES's parse-front PTS, while visibility is
+`stc >= c_show && stc < c_hide`. While `stc` LED the display by the VBUF depth a unit was
+already due at commit; with `disp_lag ≈ 0` each unit now commits a window ~a VBUF depth in
+the FUTURE, and the arriving unit destroys the one on screen before its authored window
+has expired.
+
+**MEASURED on the disc.** The icon is one `FSTA_DSP` at PTS 101885 and one `STP_DSP` at
+866659 — **8.4975 s solid, no intermediate stop** — with the same unit re-sent
+**byte-identically 8 times, 90090 ticks (1.001 s) apart**, and an HLI whose 17 records
+alternate `hli_ss = 1,2,1,2…` over windows that are exactly back-to-back
+(`s_ptm[n] == e_ptm[n-1]`). Solid is unambiguously the authored behaviour, and the
+predicted blink period is the re-send period. `spu_decode.sv`'s own header had already
+described this failure for MENUS and scoped its guard to them, ending *"Titles keep the
+decode-early pipeline (their subpics are muxed near their PTS and are NOT re-sent)"* —
+false for an in-title HLI button graphic, which is authored exactly like a menu's.
+
+The rabbit escapes the menu guard because `menu_mode` rides `nav_pci.hli_seen`, which
+requires **more than one button** (`nxt_btn_ns > 1`); the rabbit is a single `fosl=1`
+button.
+
+⚠ **The same defect quietly truncates every ordinary subtitle** — line B arrives a VBUF
+depth early and blanks line A before A's window ends. Nobody reported it because dialogue
+gaps usually exceed the lead.
+
+**Fixed at the mechanism, not with another `menu_mode` exemption.** The RLE decode is the
+only destructive step and `DCSQ_END` is its single entry point, reached with `w_show` /
+`w_hide` / DAREA / palette all known:
+
+- a **hold** between `DCSQ_END` and `RLE_LINE`, leaving on due / a new unit start / a
+  bounded ~700 ms cap;
+- a **contiguity clamp** at `COMMIT`: when the author wrote no gap between the outgoing
+  unit and this one, show immediately rather than invent a hole. A persistent unit (no
+  `STP_DSP` ⇒ all-ones `c_hide`) is contiguous with every successor by construction, which
+  is exactly the re-send chain;
+- `S_IDLE` now resumes at a genuine unit start (`sp_frame_start && sp_pts_valid`, the rule
+  `S_DRAIN` already used), because the hold lengthens the busy window.
+
+⛔ **Double-buffering was not available**: 720×576 at 2 bpp is ~102 M10Ks for a second copy
+and the design fits in 498/553 RAM blocks at 98 % ALMs.
+
+★ **The hold's bound is MEASURED, not picked.** Cutting the hold short costs nothing (the
+clamp stops it opening a hole), but being *in* the hold when the next unit arrives costs
+that unit its head bytes — `spu_decode` has no backpressure onto `ps_demux`. On a real
+subtitle stream consecutive units are **never closer than 1034 ms** (n=36, p10 1335 ms,
+median 2369 ms; mux lead measured at ≈0, median −50 ms), so a bound below that can never
+be the reason a line is lost.
+
+**Gate: `bench/dvd/run_spu_window.sh` (+ `--red`).** Three mutations, each caught by the
+arm it exists for: `red-clamp` by [A] (the icon blinks — the bench reports exactly 7 blinks
+across the 7 re-sends), `red-hold` by [B] (the subtitle truncates), `red-both` by all. [D]
+is the control: an authored gap must still go dark, or a fix that simply never blanks would
+pass. ⚠ The RED harness **fails a mutation that does not compile**, because that proves
+nothing about the bench — two arms initially "passed" on a build error.
+⚠ [B] first passed against broken RTL because the watcher was armed *after* feeding line B,
+sampling an already-low `sp_active`. `red-hold` is what reported it.
+
+### 12.2 A seamless-branch junction is not a content change
+
+`disc_rephase` (§3.7) turns the display's re-anchor into `aud_resync`, which resets
+`audio_ring` **and** `dvd_audio_decode`. It was accepted on the note at `dvd/emu.sv`:
+*"titles re-anchor about once per playback (MEASURED: reanchors=1 over 80 s on
+APOLLO_13)"*.
+
+**APOLLO_13 is one continuous title. A seamless-branch title is not.** Matrix VTS_02 PGCN 1
+— the PLAIN movie — carries **9 interleaved cell-pairs**, the same ones as the rabbit
+PGCN 6, which is why the dropout is independent of white-rabbit mode.
+
+**MEASURED on the disc:**
+
+| | |
+|---|---|
+| entering each interleaved cell (4/23/35/55/60/74/80/86/91) | the PTS **restarts near zero** — audio steps of **−2 s to −64 s** |
+| the ILVU splices *inside* the block | **continuous**: 0 irregular steps in 238 AC-3 PTS samples along the real played sector walk |
+| authored audio gap (`sml_pbi.vob_a[8]`) | **none** — every entry zero on every junction |
+| cell category byte | **0x0e** on all nine: `seamless_play=1` AND `stc_discontinuity=1` |
+
+So the timestamps renumber and the soundtrack plays straight through. Flushing costs ~1 s
+of audio twice over: the queued ring frames are discarded, and the drain gate then cannot
+re-open until the display clock walks up to a `play_pts` re-latched from the parse front.
+Video runs through the silence untouched (`av_vid_hold` arms off `load_flush`, not
+`aud_resync`) — the reported shape exactly.
+
+**Fix: ask the disc.** `cell_playback_t` byte 0 bit 3 `seamless_play` is the author saying
+"this cell continues the previous one". The whole byte was already in `cell_cat_mem`; only
+three bits were ever decoded. `dvd_iso_reader` now exports `cell_seamless`, and
+`flush_ctl` withholds the audio flush on such a cell. **The CLOCK still re-anchors** — the
+display must follow a real timeline change — only the audio flush narrows, which is why
+`anchor_disc` is a distinct qualifier from `disc_w` in the first place.
+
+★ This is the direction `dvd/disp_sched.sv` already named — key on the AUTHORED event
+rather than an inferred PTS step — reached from the opposite side: the backward leg does
+not under-cover, it **over-covers**.
+⛔ **Deliberately NOT a "was there a seek/jump recently" window**: a looping menu cell
+re-anchors with genuinely restarting audio and pulses no `seek_ack`, so a navigation-event
+gate would silently drop the menu case #63 was built for. `cell_seamless` is 0 in every
+menu — the `menu_dom` branch of `S_CELL_LOAD2` never latches it — so menus are untouched
+structurally, not by luck.
+
+⚠ **The gate is broad inside a title and that is deliberate:** 104 of the Matrix's 106
+cells are `seamless_play=1`, so within a feature the audio re-phase now fires only at the
+2 authored non-seamless cells. That is consistent with the FAMILY FEUD II measurement,
+where a title-domain re-phase discarded the ring and cost the host's question its middle.
+
+**Gate: `bench/dvd/run_seamless_audio.sh` (+ `--red`).** ⚠ Two bench lessons worth keeping:
+the fixture needed a **third** cell that is `seamless_play=1` but NOT `interleaved`
+(byte0 `0x08`, the commonest category on a real feature — 68 of 106) because with only the
+white-rabbit category bits 3 and 2 coincide and reading the wrong bit passes unnoticed —
+it did. And the per-cell sample must be phased against **the reader's own `cell_i`**, not
+against the delivered byte pattern: the reader runs ~2 sectors ahead of the byte stream, so
+the first version of the arm compared cell N's level with cell N+1's data and failed
+against correct RTL.
+
+### 12.3 What is still open here
+
+⏳ **Neither fix is HW-confirmed.** Both are sim-proven with RED/GREEN arms against measured
+disc data.
+⏳ **`nav_pci`'s `hli_coherent` is untouched and may be a second contributor to the icon.**
+The icon needs the highlight as well as the subpicture (`SET_CONTR[0,0,0,0]` — the SPU is
+invisible on its own), and #63 tightened `stc_trusted` from a disjunction to a conjunction
+whose new term clears on every re-anchor. It should *delay* an arm rather than make it
+flap, because `off_due` requires the same trust and disarms are held off too — but it is
+not measured. Fixing 12.2 removes most re-anchors at these junctions and so quiets it
+either way. The `O[2]` blocks separate the two on hardware: `blk1`/`blk7` flickering is
+`nav_pci`; `blk1`/`blk7` steady with `blk3`/`blk8` flickering is `spu_decode`.
+
 ## 4. HW rounds
 
 - **Round A (Stage 0 build `DVD_stcfree_20260906_1357.rbf`, SEED 5 first roll,

--- a/docs/stc_freerun.md
+++ b/docs/stc_freerun.md
@@ -901,8 +901,14 @@ only destructive step and `DCSQ_END` is its single entry point, reached with `w_
 - `S_IDLE` now resumes at a genuine unit start (`sp_frame_start && sp_pts_valid`, the rule
   `S_DRAIN` already used), because the hold lengthens the busy window.
 
-⛔ **Double-buffering was not available**: 720×576 at 2 bpp is ~102 M10Ks for a second copy
-and the design fits in 498/553 RAM blocks at 98 % ALMs.
+⛔ **Double-buffering was not available**: 720×576 at 2 bpp is ~102 M10Ks for a second copy,
+against **55 free RAM blocks** (498/553, a figure unchanged in every build since v0.4.0).
+RAM, not ALMs, is what rules it out.
+⚠ **An earlier draft of this section cited "98 % ALMs" as the design's state. That was wrong**
+— 41,059/41,910 is the *unmerged* `feature/seek-preview` branch, not `main`. The build
+carrying both fixes measures **39,113/41,910 = 93 %**, SEED 5 held on the first roll, clk_dec
+95.57 @100C / 92.68 @-40C against the 86.0 gate. Read a fit number off the branch it came
+from before quoting it as the design's.
 
 ★ **The hold's bound is MEASURED, not picked.** Cutting the hold short costs nothing (the
 clamp stops it opening a hole), but being *in* the hold when the next unit arrives costs

--- a/docs/subpicture.md
+++ b/docs/subpicture.md
@@ -195,6 +195,57 @@ SET_COLOR/CONTR/DAREA/DSPXA (show it); DCSQ1 (delay = duration) issues STP_DSP (
 
 ---
 
+## The COMMIT contract — display order, not parse order (2026-09-08)
+
+A subpicture unit is **decoded when it arrives** but must **become visible when it is
+due**, and those are not the same moment. `spu_decode` has ONE full-frame bitmap, so the
+RLE decode is destructive: decoding an arriving unit replaces whatever is on screen.
+
+Until PR #63 that was invisible. `stc` was anchored on the demux parse front and LED the
+displayed picture by the VBUF depth, so a unit arriving at the parse front was already due
+(`stc >= c_show`) at the moment it committed. PR #63 put `stc` on the displayed picture
+(`disp_lag ≈ 0`), and the same commit now installs a window **~a VBUF depth in the future**
+— blanking the outgoing unit and showing nothing until the clock catches up.
+
+Two symptoms, one bug:
+
+- **A re-sent button graphic blinks.** The Matrix's white-rabbit icon is re-sent
+  byte-identically every 1.001 s (measured), so it blanked once per re-send.
+- **Every ordinary subtitle is truncated** by up to a VBUF depth when the next line
+  arrives early. Less visible only because dialogue gaps usually exceed the lead.
+
+**The contract now enforced:**
+
+1. **Hold** — between `DCSQ_END` (where `w_show`/`w_hide`/DAREA/palette are all known) and
+   `RLE_LINE` (the destructive step), defer while a unit is committed and this one is not
+   yet due. Leave on due, on a new genuine unit start, or on a bounded cap.
+2. **Never open a hole the author did not write** — at `COMMIT`, if the outgoing unit's
+   window abuts or contains this one's start (`w_show <= c_hide`, or the outgoing unit is
+   persistent), commit as already-due. If the author DID write a gap, keep the authored
+   time and let the outgoing unit hide on its own schedule.
+3. **Resume at a unit boundary** — `S_IDLE` requires `sp_frame_start && sp_pts_valid` (the
+   rule `S_DRAIN` already used). `spu_decode` does not backpressure `ps_demux`, so bytes
+   arriving while it is busy are dropped; the hold lengthens that window, and resuming at
+   an arbitrary byte would read a continuation byte as an `SPDSZ` header.
+
+⛔ **Double-buffering the bitmap is not an option** and should not be re-proposed without
+new numbers: 720×576 at 2 bpp = 829,440 bits, and at ×2 width an M10K holds 4,096 entries
+⇒ ~102 M10Ks for a second copy, against 55 free (498/553) at 98 % ALMs.
+
+★ **The hold's bound is measured, not chosen.** Cutting the hold short costs nothing (rule
+2 stops it opening a hole), but being *in* the hold when the next unit arrives costs that
+unit its head bytes. On a real subtitle stream consecutive units are **never closer than
+1034 ms** (n=36, p10 1335 ms, median 2369 ms; the mux lead itself is ≈0, median −50 ms), so
+a bound below that minimum can never be why a line was lost. Re-measure before retuning it.
+
+⚠ **`menu_mode` is excluded from the hold and unchanged.** It bypasses the window entirely
+and has its own re-send discriminator; menus stay bit-identical. ⚠ Note the menu re-send
+discriminator (`sp_pts <= c_pts`) does **not** catch the white-rabbit chain — those
+re-sends carry *increasing* PTS — so "just reuse the menu skip" is not a fix.
+
+Gate: `bench/dvd/run_spu_window.sh` (+ `--red`); design history in `docs/stc_freerun.md`
+§12.1.
+
 ## v1 scope & decisions to make (write them down as you go)
 
 - **Palette (the main deferral):** the real 4 colours + alpha come from the **IFO PGC

--- a/docs/subpicture.md
+++ b/docs/subpicture.md
@@ -230,7 +230,9 @@ Two symptoms, one bug:
 
 ⛔ **Double-buffering the bitmap is not an option** and should not be re-proposed without
 new numbers: 720×576 at 2 bpp = 829,440 bits, and at ×2 width an M10K holds 4,096 entries
-⇒ ~102 M10Ks for a second copy, against 55 free (498/553) at 98 % ALMs.
+⇒ ~102 M10Ks for a second copy, against 55 free (498/553). RAM is the binding constraint
+here, not ALMs — 498/553 has held in every build since v0.4.0, and the build carrying this
+fix measures 39,113/41,910 ALMs (93 %) with SEED 5 and clk_dec 95.57/92.68 vs the 86.0 gate.
 
 ★ **The hold's bound is measured, not chosen.** Cutting the hold short costs nothing (rule
 2 stops it opening a hole), but being *in* the hold when the next unit arrives costs that

--- a/dvd/dvd_iso_reader.sv
+++ b/dvd/dvd_iso_reader.sv
@@ -147,6 +147,9 @@ module dvd_iso_reader #(
     output reg        seek_ack,      // pulse: a seek was accepted (drives load_flush)
     output     [7:0]  cur_cell,      // currently-playing cell index (for UI)
     output            cell_ready,    // 1 = cell-mode active (seek available)
+    // 1 = the cell being streamed is authored seamless_play (see cc_seamless_play):
+    // its content continues the previous cell even if the timestamps restart.
+    output            cell_seamless,
 
     // ---------------------------------------------------------------------
     // MULTI-ANGLE (Phase 9). A multi-angle segment is an interleaved block:
@@ -692,6 +695,21 @@ reg [7:0]  cc_rd;                          // registered category byte for cell_
 wire       cc_is_angle = (cc_rd[5:4] == 2'd1);        // block_type == angle block
 wire       cc_blk_first= cc_is_angle && (cc_rd[7:6] == 2'd1);
 wire       cc_interleaved = cc_rd[2];                 // interleaved (seamless-branch) cell
+// ★ SEAMLESS PLAY (libdvdread cell_playback_t byte 0: [7:6] block_mode, [5:4]
+// block_type, [3] seamless_play, [2] interleaved, [1] stc_discontinuity,
+// [0] seamless_angle). The whole byte has always been stored in cell_cat_mem;
+// only the three bits above were ever decoded.
+//
+// This bit is the author saying "this cell continues the previous one WITHOUT a
+// break", and it is what tells a player that a timestamp restart at the cell
+// boundary is a NUMBERING change, not a content change. MEASURED on The Matrix
+// VTS_02 PGCN 1: every white-rabbit interleaved cell (4/23/35/55/60/74/80/86/91)
+// is byte0=0x0e -- seamless_play=1 AND stc_discontinuity=1 -- and the PTS
+// restarts near zero there (audio steps measured -2 s to -64 s). The soundtrack
+// across that boundary is unbroken; only the numbers jump.
+// emu.sv uses this to keep the display's re-anchor from flushing audio that is
+// still perfectly good -- see the CONTENT-DISCONTINUITY AUDIO RE-PHASE block.
+wire       cc_seamless_play = cc_rd[3];               // seamless with the previous cell
 reg [7:0]  block_first;                     // first (angle-1) cell of the block
 reg [7:0]  block_last;                      // last angle cell (block_first+count-1)
 reg        angle_active;                    // 1 = streaming an angle-block cell
@@ -699,6 +717,7 @@ reg        angle_resolved;                  // 1 = angle cell chosen (skip re-sc
 reg [7:0]  ang_scan_i;                      // angle-count scan cursor
 reg        angle_pulse_d;                   // rising-edge detect for angle_pulse
 reg        seamless_active;                 // 1 = streaming an interleaved (non-angle) cell
+reg        cell_seamless_r;                 // 1 = this cell is authored seamless_play
 
 // NV_PCK snoop: capture DSI fields off the sd_buff write stream of a nav
 // sector's DSI region (sector bytes 0x400..0x5FF, DSI data @0x407). Angle + seamless.
@@ -1772,6 +1791,7 @@ always @(posedge clk or negedge rst_n) begin
         angle_active <= 1'b0;
         angle_resolved <= 1'b0;
         seamless_active <= 1'b0;
+        cell_seamless_r <= 1'b0;
         block_first  <= 8'd0;
         block_last   <= 8'd0;
         ang_scan_i   <= 8'd0;
@@ -2405,6 +2425,7 @@ always @(posedge clk or negedge rst_n) begin
             angle_active   <= 1'b0;
             angle_count    <= 4'd0;
             seamless_active <= 1'b0;
+            cell_seamless_r <= 1'b0;
             ilvu_armed     <= 1'b0;
             seek_pending <= 1'b0;
             seek_ack     <= 1'b1;          // tell emu.sv to pulse load_flush
@@ -3675,6 +3696,7 @@ always @(posedge clk or negedge rst_n) begin
                 angle_active   <= 1'b0;
                 angle_count    <= 4'd0;
                 seamless_active <= 1'b0;
+                cell_seamless_r <= 1'b0;
                 ilvu_armed     <= 1'b0;
                 cur_angle      <= 4'd1;
                 state      <= S_CELL_LOAD;
@@ -3726,6 +3748,7 @@ always @(posedge clk or negedge rst_n) begin
                     // two are mutually exclusive (cc_is_angle vs !cc_is_angle).
                     angle_active    <= cc_is_angle && angle_resolved;
                     seamless_active <= cc_interleaved && !cc_is_angle;
+                    cell_seamless_r <= cc_seamless_play;
                     ilvu_armed  <= 1'b0;
                     strm_idx    <= eff_base;
                     seek_cum    <= 32'd0;
@@ -4543,6 +4566,7 @@ end
 // Transport read-backs (for gamepad seek + future UI)
 assign cur_cell             = cell_i;
 assign cell_ready           = cell_mode;
+assign cell_seamless        = cell_seamless_r;
 
 // Menu-domain read-backs (Phase 2)
 assign menu_active          = menu_dom;

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -1238,6 +1238,7 @@ assign BUTTONS = {1'b0, osd_btn};
 // "next" at the last cell, causes no glitch). See docs/dvd_nav.md "Transport".
 wire [7:0] cur_cell;         // from dvd_iso_reader
 wire       cell_ready;       // from dvd_iso_reader (cell-mode active)
+wire       cell_seamless;    // from dvd_iso_reader: this cell is authored seamless_play
 // Linear transport (VCD/SVCD raw .bin, flat .mpg/.VOB): the reader seeks the
 // whole file by RBN — raw mode snaps to a CD sector (= MPEG pack) boundary,
 // flat mode is qualified by ps_demux having seen a pack (ps_saw_pack) and
@@ -2436,6 +2437,7 @@ flush_ctl flush_ctl_i (
     .keep_vbuf       (keep_vbuf),
     .load_flush      (load_flush),
     .disc_rephase    (aud_disc_rephase),   // content PTS jump -> audio-only re-phase (VLC's RESET_PCR analogue)
+    .cell_seamless   (cell_seamless),      // ...unless the author says this cell continues the last one
     .aud_flush       (aud_flush),
     .aud_resync      (aud_resync),
     .seek_flush      (seek_flush),
@@ -2618,6 +2620,7 @@ dvd_iso_reader dvd_iso_reader_inst (
     .seek_ack       (seek_ack),
     .cur_cell       (cur_cell),
     .cell_ready     (cell_ready),
+    .cell_seamless  (cell_seamless),
 
     .jump_pulse     (vm_jump_pulse),      // Phase 4: the DVD-VM owns all jumps
     .jump_domain    (vm_jump_domain),
@@ -3711,11 +3714,22 @@ pts_cdc #(.W(35)) pts_cdc_delta (        // each re-anchor's delta + whether it 
 // but it never carries buffered audio across a discontinuity. We did, and each
 // re-anchor left a lip-sync step nothing could heal (4-6 a minute in menus).
 //
+// ⚠ A SEAMLESS-BRANCH junction must NOT flush audio: the qualifier lives in
+// dvd/flush_ctl.sv (cell_seamless), which is where every flush decision is made
+// and the only one of the two with a bench. The full reasoning and the disc
+// measurements behind it are at that site.
+// ⚠ A suppressed pulse still burns the cooldown below. That is deliberate and
+// conservative -- the alternative is the same test written in two places.
 // ⚠ RATE LIMITED to one re-phase per ~0.5 s. A re-phase costs a short audio gap
 // (the drain gate re-fills), and disc_w can fire twice around one junction as the
 // new timeline settles; without the cooldown a burst of re-anchors would machine-gun
-// the audio. Titles are unaffected either way -- they re-anchor about once per
-// playback (MEASURED: reanchors=1 over 80 s on APOLLO_13).
+// the audio.
+// ⛔ THIS USED TO READ "Titles are unaffected either way -- they re-anchor about once per
+// playback (MEASURED: reanchors=1 over 80 s on APOLLO_13)". APOLLO_13 is ONE CONTINUOUS
+// TITLE. A seamless-branch title re-anchors at every branch point -- The Matrix has nine,
+// in the plain movie as well as the rabbit branch -- and each one cost about a second of
+// audio. That is the measurement the cell_seamless gate above exists for; do not read the
+// old sentence as evidence that a title cannot re-anchor often.
 reg  [23:0] rephase_cool;                       // 2^24 / 27 MHz ~ 0.62 s
 wire        rephase_req = av_anchor_delta_valid && av_anchor_delta_w[34];
 always @(posedge clk_sys or negedge reset_n)

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -2266,6 +2266,16 @@ wire        menu_sp_ctx   = (menus_on && menu_active) || sp_menu_early;
 wire [3:0]  sp_sel_log    = menu_sp_ctx  ? 4'd0 :
                             vm_owns_route ? vm_spstn[3:0] : {1'b0, sp_user_log};
 wire [31:0] subp_ctl_sel  = subp_ctl_mem[sp_sel_log];                 // single 16:1 mux
+// Does the loaded PGC declare ANY subpicture stream? 16 flop reads, no mux -- this is
+// what separates "the table does not offer this stream" from "there is no table".
+wire subp_any_present = subp_ctl_mem[ 0][31] | subp_ctl_mem[ 1][31] |
+                        subp_ctl_mem[ 2][31] | subp_ctl_mem[ 3][31] |
+                        subp_ctl_mem[ 4][31] | subp_ctl_mem[ 5][31] |
+                        subp_ctl_mem[ 6][31] | subp_ctl_mem[ 7][31] |
+                        subp_ctl_mem[ 8][31] | subp_ctl_mem[ 9][31] |
+                        subp_ctl_mem[10][31] | subp_ctl_mem[11][31] |
+                        subp_ctl_mem[12][31] | subp_ctl_mem[13][31] |
+                        subp_ctl_mem[14][31] | subp_ctl_mem[15][31];
 // 16:9 display mode: override -> letterbox; else Crop=pan&scan, Letterbox=letterbox,
 // else wide (Fit/HDMI anamorphic — the common case; O[4:3] refines it, HW-tunable).
 wire [1:0]  sp_disp_mode = force_43_subp        ? 2'd1 :
@@ -2280,6 +2290,7 @@ wire [1:0]  sp_disp_mode = force_43_subp        ? 2'd1 :
 wire [1:0]  sp_disp_mode_eff = menu_sp_ctx ? 2'd0 : sp_disp_mode;
 
 wire [4:0]  sp_phys_streamN;
+wire        sp_stream_absent;
 subp_stream_map u_subp_map (
     .map_valid    (pgc_ctl_valid),
     .dom_tt       (pgc_dom_tt),
@@ -2290,8 +2301,24 @@ subp_stream_map u_subp_map (
     // decoded stream's; the two are the same signal on every non-menu path.
     .wide         (ar_wide_auto_eff),
     .disp_mode    (sp_disp_mode_eff),
-    .phys_streamN (sp_phys_streamN)
+    .any_present  (subp_any_present),
+    .phys_streamN (sp_phys_streamN),
+    .stream_absent(sp_stream_absent)
 );
+
+// ---- USER-SELECTED STREAM THE PGC DOES NOT DECLARE (2026-09-08) --------------
+// Only the USER path, mirroring sp_track_eff's own condition below: the menu and VM
+// paths resolve a stream the disc itself selected, so an absent entry there is a
+// different question (and menu PGCs were NOT in the sweep that bounded this).
+//
+// The reported case: The Matrix's white-rabbit PGC declares logical 1 only. Pressing
+// the Subtitle button releases the VM's claim (vm_owns_sp above), the user path
+// resolves logical 0 by RAW INDEX to 0x20 -- the real subtitle stream -- and it is
+// then drawn with that PGC's palette, whose three opaque subtitle classes are all
+// Y=128. The text renders as one flat grey with no outline. Showing nothing is what
+// a conforming player does; showing it illegibly is our own invention.
+// Bound: 3 title PGCs in a 221-disc/22,733-PGC sweep (see subp_stream_map.sv).
+wire sp_user_absent = sp_stream_absent & ~(menu_sp_ctx | vm_owns_route | force_43_subp);
 
 // VM streams ALWAYS map (in-title HLI). The user path maps only under Force 4:3 Subpics
 // (a user-selected commentary track -> its letterbox physical substream, MiB logical 3 ->
@@ -4862,10 +4889,11 @@ assign ov_b  = 8'd0;
 // hide the menu - Phase 3). Drives BOTH spu_decode.enable and ps_demux.sp_enable
 // (the demux gate was missed in round 1 -> no button graphics unless subtitles
 // were already on).
-assign sp_route_en = sub_on | (menus_on && menu_active)
+assign sp_route_en = ~sp_user_absent &
+                   ( sub_on | (menus_on && menu_active)
                    | (menus_on && vm_owns_sp && vm_spstn[6]) // Phase 4: SetSTN sp display
                    | in_title_hli                            // in-title button (white rabbit)
-                   | sp_menu_early;                          // in-title multi-button menu (Scene It): open early
+                   | sp_menu_early );                        // in-title multi-button menu (Scene It): open early
 wire       sp_en = sp_route_en;
 wire [1:0] sp_q_idx;
 wire       sp_q_inside;

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -581,7 +581,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "dev-audbphold"
+`define CORE_VERSION "dev-spuwindow"
 
 parameter CONF_STR = {
     "DVD;;",

--- a/dvd/flush_ctl.sv
+++ b/dvd/flush_ctl.sv
@@ -47,6 +47,11 @@ module flush_ctl (
     input  wire aud_switch,       // 1-cycle pulse: audio track switch
     input  wire disc_rephase,     // display re-anchored on a content PTS jump (dvd/disp_sched.sv)
     input  wire keep_vbuf,        // level (reader): menu->menu transition keeps the VBUF
+    // level (reader): the cell being streamed is authored seamless_play, so its
+    // content continues the previous cell even when the timestamps restart. See the
+    // disc_rephase block below -- this is what stops a seamless-branch junction being
+    // read as a content change.
+    input  wire cell_seamless,
 
     output wire load_flush,       // ~64-cycle level -> pipe_rst_n scope (demux/av_sync/nav)
     output wire aud_flush,        // ~64-cycle level -> audio chain reset (with aud_resync)
@@ -119,7 +124,30 @@ always @(posedge clk) begin
     // silence -- play_pts can only re-latch from a NEW dispatch, and dispatch stalls
     // on the full decode FIFOs (v5.3, HW-observed). Resetting the chain is what makes
     // the re-phase safe, and is exactly why VLC flushes rather than re-times.
-    else if (aud_switch || disc_rephase) aud_resync_cnt <= 7'd64;
+    // ⚠⚠ NOT ON AN AUTHORED-SEAMLESS CELL (2026-09-08). disc_rephase was accepted on
+    // the measurement "titles re-anchor about once per playback (reanchors=1 over 80 s
+    // on APOLLO_13)". APOLLO_13 is one continuous title; a SEAMLESS-BRANCH title is
+    // not. The field reported an audio dropout at every "white rabbit" point of The
+    // Matrix -- in the PLAIN movie as much as the rabbit branch, because PGCN 1
+    // carries the same 9 interleaved cell-pairs.
+    // MEASURED on the disc: entering each interleaved cell the PTS RESTARTS near zero
+    // (audio steps -2 s to -64 s), which trips disc_jump_w every time; the ILVU
+    // splices INSIDE the block are continuous (0 irregular steps in 238 AC-3 samples)
+    // and the disc authors NO audio gap (every sml_pbi.vob_a[] entry is zero). Nothing
+    // about the sound is broken there -- the numbers renumber, the soundtrack plays on.
+    // Flushing costs ~1 s of audio twice over: the queued ring frames are discarded,
+    // and the drain gate then cannot re-open until the display clock walks up to a
+    // play_pts re-latched from the parse front. Video runs through it untouched
+    // (av_vid_hold arms off load_flush, not aud_resync) -- the reported shape exactly.
+    // cell_playback_t byte 0 bit 3 `seamless_play` is the author saying so; every
+    // white-rabbit cell is byte0=0x0e (seamless_play=1 AND stc_discontinuity=1). The
+    // CLOCK still re-anchors -- the display must follow a real timeline change -- only
+    // the audio flush is withheld.
+    // ⛔ Deliberately NOT a "was there a seek/jump recently" window: a looping menu
+    // cell re-anchors with genuinely restarting audio and pulses no seek_ack, so a
+    // navigation-event gate would silently drop the menu case #63 was built for.
+    // cell_seamless is 0 in every menu, so menus keep their re-phase untouched.
+    else if (aud_switch || (disc_rephase && !cell_seamless)) aud_resync_cnt <= 7'd64;
     else if (aud_resync)     aud_resync_cnt <= aud_resync_cnt - 7'd1;
 end
 

--- a/dvd/spu_decode.sv
+++ b/dvd/spu_decode.sv
@@ -26,7 +26,7 @@
 module spu_decode #(
     parameter int BMP_N   = 414720,   // 720*576 (covers NTSC 720*480 and PAL 720*576)
     parameter int STRIDE  = 720,
-    parameter int SPU_CAP = 53248      // max buffered SPU bytes >= the DVD-Video SPEC
+    parameter int SPU_CAP = 53248,     // max buffered SPU bytes >= the DVD-Video SPEC
                                        // MAXIMUM of 53,220 (spec-hardening Phase 2).
                                        // Subtitles are < 2 KB, but MENU subpictures
                                        // (full-frame button/highlight graphics) are large,
@@ -42,6 +42,11 @@ module spu_decode #(
                                        // a malformed > SPU_CAP unit whose DCSQ start lies
                                        // beyond the cap is DROPPED cleanly (pre-Phase-2 the
                                        // 15-bit truncation aliased it into garbage).
+    parameter int HOLD_CYCLES = 18_900_000  // ~700 ms at 27 MHz: the display-order
+                                       // hold's hard bound. A PARAMETER so a bench can
+                                       // shrink it -- at 27 MHz the real value is 70 M
+                                       // simulation cycles, which no Icarus run reaches.
+                                       // Bound rationale at the S_HOLD state below.
 ) (
     input  wire        clk,           // clk_sys 27 MHz
     input  wire        rst_n,
@@ -67,8 +72,21 @@ module spu_decode #(
     // yet - the on-screen menu graphic (and with it the button highlight)
     // blinks at the stream's stall cadence. In menu mode a NEW packet is
     // only accepted once ITS PTS is due; early re-sends are discarded
-    // (lossless: they repeat). Titles keep the decode-early pipeline
-    // (their subpics are muxed near their PTS and are NOT re-sent).
+    // (lossless: they repeat). Titles keep the decode-early pipeline.
+    //
+    // ⚠ THAT LAST CLAUSE USED TO READ "their subpics are muxed near their PTS and
+    // are NOT re-sent" AND IT IS FALSE FOR AN IN-TITLE HLI BUTTON GRAPHIC. The Matrix's
+    // "Follow the White Rabbit" icon is authored exactly like a menu's: MEASURED on the
+    // disc, one FSTA_DSP at PTS 101885 and one STP_DSP at 866659 (8.4975 s solid), with
+    // the SAME unit re-sent BYTE-IDENTICALLY 8 times, 90090 ticks (1.001 s) apart. It is
+    // a single-button HLI (btn_ns==1), so nav_pci's hli_seen (>1 button) never fires and
+    // emu's menu_mode stays 0 -- it runs the windowed path below.
+    // That was harmless while the STC LED the display: a re-send arriving at the parse
+    // front was already due at commit. PR #63 moved the STC onto the displayed picture
+    // (disp_lag ~0), so each re-send began committing a show window ~a VBUF depth in the
+    // FUTURE and blanked the icon until the clock caught up -- the ~1 s blink reported
+    // from the field. The fix is not another menu_mode exemption: see the HOLD and the
+    // CONTIGUITY CLAMP below, which fix the mechanism for subtitles too.
     input  wire        menu_mode,
     input  wire [32:0] sp_pts,
     input  wire        sp_pts_valid,
@@ -139,7 +157,7 @@ module spu_decode #(
         GETB0, GETB1,
         D_DLY0, D_DLY1, D_NXT0, D_NXT1, D_CMD,
         RP_LOOP, RP_STORE, RP_DONE, SKIP_LOOP,
-        DCSQ_END,
+        DCSQ_END, S_HOLD,
         RLE_LINE, RLE_ACC, RLE_LOAD, RLE_EMIT, RLE_EOL,
         COMMIT
     } state_t;
@@ -179,6 +197,42 @@ module spu_decode #(
     reg  [32:0] c_show, c_hide;
     reg         c_valid;
     reg  [32:0] c_pts;         // PTS of the committed SPU (menu re-send discriminator)
+
+    // ------------------------------------------------------------------
+    // DISPLAY-ORDER COMMIT (2026-09-08). The RLE decode is the ONLY destructive
+    // step -- it overwrites the single full-frame bitmap, so committing a unit
+    // early destroys the one on screen before its authored window has expired.
+    // Two guards, both keyed off values the DCSQ walk has already produced by the
+    // time DCSQ_END is reached (w_show/w_hide/DAREA/palette are all known there,
+    // strictly BEFORE `state <= RLE_LINE`).
+    //
+    // ⛔ Double-buffering the bitmap is not available: 720*576 at 2 bpp = 829,440
+    // bits, and at x2 width an M10K holds 4,096 entries => ~102 M10Ks for a second
+    // copy. The design fits in 498/553 RAM blocks and 41,059/41,910 ALMs, so the
+    // guards have to be free. They are: one counter and two compares.
+    reg  [24:0] hold_tmr;
+
+    // the unit's effective show time (COMMIT's own default when no STA_DSP delay)
+    wire [32:0] w_show_eff = w_has_show ? w_show : pts_latched;
+    // due against the DISPLAY clock. Signed on the low 32 bits so a 33-bit PTS wrap
+    // cannot park the hold (the bounded timer is the backstop, not the primary).
+    wire        spu_due    = $signed(w_show_eff[31:0] - stc[31:0]) <= 0;
+    // "stay if no STP_DSP" is encoded as an all-ones c_hide; a plain compare against
+    // that sentinel wraps and reads as NOT contiguous, which is the one case that
+    // matters most here (a persistent button graphic), so test it explicitly.
+    wire        c_hide_inf = &c_hide;
+    // CONTIGUITY: the author wrote no gap between the committed unit and this one,
+    // so blanking between them would invent a hole that is not on the disc. A
+    // persistent unit (c_hide_inf) is contiguous with every successor by
+    // construction -- which is exactly the white-rabbit re-send chain.
+    wire        spu_contig = c_valid &&
+                             (c_hide_inf ||
+                              ($signed(w_show_eff[31:0] - c_hide[31:0]) <= 0));
+    // a genuine SPU START: sp_frame_start pulses on the first byte of EVERY
+    // subpicture PES, but only the first PES of a unit carries a PTS (see the
+    // sp_frame_start port comment in ps_demux.sv), so this is the same boundary
+    // rule S_DRAIN already uses.
+    wire        spu_unit_start = sp_valid && sp_frame_start && sp_pts_valid;
 
     // RLE state
     reg  [11:0] width, height;
@@ -276,6 +330,7 @@ module spu_decode #(
             bmp_we   <= 1'b0;
             wr_ptr   <= '0;
             rd_ptr   <= '0;
+            hold_tmr <= 25'd0;
             c_a0 <= 0; c_a1 <= 0; c_a2 <= 0; c_a3 <= 0;
             // Default palette indices = identity (idx k -> palette entry k) so a SPU
             // lacking SET_COLOR (rare) still maps to distinct entries.
@@ -288,7 +343,16 @@ module spu_decode #(
             case (state)
             // ---- wait for the first byte of a new SPU ----
             S_IDLE: begin
-                if (sp_valid) begin
+                // ⚠ spu_unit_start, NOT a bare sp_valid. spu_decode does not
+                // backpressure ps_demux, so every byte arriving while it is busy is
+                // dropped and S_IDLE used to resume at an ARBITRARY byte -- reading a
+                // continuation byte as an SPDSZ header. That was survivable while
+                // "busy" was one RLE pass; the display-order hold below makes the busy
+                // window far longer, so resume at a real unit boundary instead.
+                // Every SPU's first PES carries a PTS by construction (MEASURED: 37
+                // PTS-bearing subpicture PES = 37 units over 40,000 sectors of a real
+                // title), which is why S_DRAIN has always been able to use this rule.
+                if (spu_unit_start) begin
                     // MENU re-send discriminator (fixes "highlight only on the 2nd loop
                     // after returning from a submenu"): a menu cell RE-SENDS the same
                     // subpicture(s) every loop, and some menus author MORE THAN ONE per
@@ -473,7 +537,18 @@ module spu_decode #(
                         field    <= 1'b0; lif <= 12'd0; abs_line <= 12'd0;
                         nib_cnt  <= 2'd0;
                         rd_ptr   <= w_top;
-                        state    <= RLE_LINE;
+                        hold_tmr <= 25'd0;
+                        // HOLD when committing now would destroy a unit that is still
+                        // inside its authored window. Every register the RLE pass needs
+                        // is set above, so S_HOLD only defers the transition.
+                        // menu_mode is excluded: it bypasses the window entirely and
+                        // has its own re-send discriminator, so menus stay bit-identical.
+                        // (if/else, not a ternary: an enum-typed ternary needs an
+                        // explicit cast, and this project has been bitten by Quartus 17
+                        // mis-compiling casts that simulate correctly -- memory
+                        // quartus-sizecast-netlist-cosim.)
+                        if (c_valid && !spu_due && !menu_mode) state <= S_HOLD;
+                        else                                   state <= RLE_LINE;
                     end else begin
                         state <= S_IDLE;   // malformed; drop
                     end
@@ -483,6 +558,27 @@ module spu_decode #(
                     ret      <= D_DLY0;
                     state    <= GETB0;
                 end
+            end
+
+            // ---- DISPLAY-ORDER HOLD: wait until this unit is actually due ----
+            // Leaves on whichever comes first:
+            //   spu_due        - the authored moment; the outgoing unit got its full
+            //                    window and this one lands on time (the fix);
+            //   spu_unit_start - a NEW unit is arriving and there is only one buffer,
+            //                    so decode this one now rather than strand it;
+            //   HOLD_MAX       - a hard ~700 ms bound.
+            // ⚠ THE BOUND IS MEASURED, NOT PICKED. Cutting the hold short costs
+            // nothing (the contiguity clamp at COMMIT stops it opening a hole), but
+            // being IN the hold when the next unit arrives costs that unit its head
+            // bytes. On a real subtitle stream consecutive units are never closer than
+            // 1034 ms (n=36; p10 1335 ms, median 2369 ms), so a bound safely under
+            // that minimum keeps the hold from ever being the reason a line is lost,
+            // while still covering the VBUF lead in the normal case.
+            S_HOLD: begin
+                if (spu_due || spu_unit_start || (hold_tmr == HOLD_CYCLES[24:0]))
+                    state <= RLE_LINE;
+                else
+                    hold_tmr <= hold_tmr + 25'd1;
             end
 
             // ---- start a new RLE line ----
@@ -567,7 +663,14 @@ module spu_decode #(
                 c_sx <= w_sx; c_ex <= w_ex; c_sy <= w_sy; c_ey <= w_ey;
                 c_a0 <= w_a0; c_a1 <= w_a1; c_a2 <= w_a2; c_a3 <= w_a3;
                 c_c0 <= w_c0; c_c1 <= w_c1; c_c2 <= w_c2; c_c3 <= w_c3;
-                c_show  <= w_has_show ? w_show : pts_latched;
+                // CONTIGUITY CLAMP: never open a hole the author did not write. If
+                // the hold was cut short, w_show_eff is still in the future and
+                // committing it would blank the outgoing unit -- which is the whole
+                // defect. When the two windows abut (or the outgoing one is
+                // persistent), show immediately instead; when the author DID write a
+                // gap, keep the authored time and let the outgoing unit hide on its
+                // own schedule.
+                c_show  <= (spu_contig && !spu_due) ? stc : w_show_eff;
                 c_hide  <= w_has_hide ? w_hide : 33'h1_FFFF_FFFF;  // stay if no STP_DSP
                 c_valid <= 1'b1;
                 c_pts   <= pts_latched;    // remember this unit's PTS (menu re-send guard)

--- a/dvd/spu_decode.sv
+++ b/dvd/spu_decode.sv
@@ -213,8 +213,11 @@ module spu_decode #(
     //
     // ⛔ Double-buffering the bitmap is not available: 720*576 at 2 bpp = 829,440
     // bits, and at x2 width an M10K holds 4,096 entries => ~102 M10Ks for a second
-    // copy. The design fits in 498/553 RAM blocks and 41,059/41,910 ALMs, so the
-    // guards have to be free. They are: one counter and two compares.
+    // copy. RAM is the binding constraint and has sat at 498/553 blocks (90%) in
+    // EVERY build since v0.4.0 -- 55 free against the ~102 needed -- so the guards
+    // have to be near-free. They are: one counter and two compares. (MEASURED with
+    // them in: 39,113/41,910 ALMs = 93%, SEED 5 held, clk_dec 95.57/92.68 vs the
+    // 86.0 gate.)
     reg  [24:0] hold_tmr;
 
     // the unit's effective show time (COMMIT's own default when no STA_DSP delay)

--- a/dvd/spu_decode.sv
+++ b/dvd/spu_decode.sv
@@ -47,6 +47,11 @@ module spu_decode #(
                                        // shrink it -- at 27 MHz the real value is 70 M
                                        // simulation cycles, which no Icarus run reaches.
                                        // Bound rationale at the S_HOLD state below.
+                                       // ⚠ Must stay under 2^25 (hold_tmr's width); a
+                                       // larger value truncates. That fails SAFE -- a
+                                       // shorter hold degrades toward the pre-fix
+                                       // behaviour rather than stalling -- but it would
+                                       // silently not be the bound you wrote.
 ) (
     input  wire        clk,           // clk_sys 27 MHz
     input  wire        rst_n,

--- a/dvd/subp_stream_map.sv
+++ b/dvd/subp_stream_map.sv
@@ -59,13 +59,21 @@ module subp_stream_map (
     input  wire [31:0] ctl_sel,       // subp_control[logical], muxed by emu
     input  wire        wide,          // content is 16:9 (ar_wide_auto_eff)
     input  wire [1:0]  disp_mode,     // 0 = wide, 1 = letterbox, 2 = pan&scan
-    output wire [4:0]  phys_streamN   // -> ps_demux.sp_track
+    // OR of the "available" bit across all 16 subp_control entries of the loaded
+    // PGC (emu computes it; this module only ever sees the ONE selected word).
+    input  wire        any_present,
+    output wire [4:0]  phys_streamN,  // -> ps_demux.sp_track
+    // 1 = the loaded PGC has a usable table and it does NOT declare this logical
+    // stream, so there is nothing to show. See the STREAM AVAILABILITY note below.
+    output wire        stream_absent
 );
 
     // The table is trustworthy only when the reader has finished streaming it
     // AND it belongs to the domain this resolution is for.
     wire dom_ok  = ctx_menu ? ~dom_tt : dom_tt;
-    wire use_map = map_valid && dom_ok && ctl_sel[31];
+    // the table is usable for this context (says nothing about THIS entry)
+    wire use_map_dom = map_valid && dom_ok;
+    wire use_map = use_map_dom && ctl_sel[31];
 
     // Explicit case mux, not a variable part-select (the Quartus-17
     // netlist-mangling lesson, docs/mpeg1.md: keep the indexing boring).
@@ -81,6 +89,36 @@ module subp_stream_map (
     assign phys_streamN = !use_map ? {1'b0, logical}     :  // fall back: identity
                           !wide    ? ctl_sel[28:24]      :  // 4:3 content
                                      phys_wide;
+
+    // ---- STREAM AVAILABILITY (2026-09-08) -----------------------------------
+    // libdvdnav guards the WHOLE resolution on the available bit
+    // (vmget.c: `if(pgc->subp_control[subpN] & 0x80000000)`), leaving the stream
+    // unselected when it is clear. This core instead falls back to identity, which
+    // is right when there is no usable table and wrong when there is one that
+    // simply does not offer this stream.
+    //
+    // ★ THE FIELD CASE: The Matrix's "Follow the White Rabbit" PGC (VTS_02 PGCN 6)
+    // declares logical stream 1 ONLY -- the rabbit icon on 0x22. Pressing the
+    // Subtitle button releases the VM's claim (emu: `if (sub_edge) vm_owns_sp<=0`),
+    // the user path resolves logical 0 by raw index to 0x20 (which IS the real
+    // subtitle stream), and it is then drawn with PGCN 6's palette -- where the
+    // three opaque subtitle classes are ALL Y=128. MEASURED on the disc:
+    //   PGCN 1 palette  [0] Y=16  [8] Y=128 [9] Y=176   -> fill/outline/black edge
+    //   PGCN 6 palette  [0] Y=128 [8] Y=128 [9] Y=128   -> one flat grey
+    // Reported as "subtitles are white on white with no black outline".
+    //
+    // ⚠ THE RULE IS NARROWED ON A MEASUREMENT, not on the spec alone. A 221-disc,
+    // 22,733-PGC sweep classified every title PGC:
+    //   A  declares logical 0                     18,801
+    //   B  declares NOTHING                        3,929  (586 in a VTS that has
+    //                                                     subpicture streams)
+    //   C  declares something, but not logical 0       3
+    // Applying the available bit unconditionally would strip subtitles from the 586
+    // class-B PGCs (up to 168 discs) that rely on the identity fallback today. So
+    // `any_present` narrows it to class C: a PGC that declares SOME stream has a
+    // working table, and an entry it omits really is unavailable. Blast radius: 3
+    // PGCs library-wide, which is the case that was reported.
+    assign stream_absent = use_map_dom && any_present && !ctl_sel[31];
 
 endmodule
 

--- a/site/content/reference/compatibility.md
+++ b/site/content/reference/compatibility.md
@@ -62,6 +62,17 @@ set-top player would not.
 **Interactive DVD games are incomplete.** Some game discs mis-navigate their dispatcher
 logic, and individual minigames can misbehave. Film and TV discs are the supported path.
 
+**Some discs offer no subtitles in an alternate viewing mode.** A few titles build a second
+version of the film as its own program chain — The Matrix's "Follow the White Rabbit" is the
+best-known — and that version can declare a different subpicture stream from the main one, or
+none at all. Where the disc offers no subtitle stream for the mode you are in, the subtitle
+button will not produce subtitles. This matches a set-top player.
+
+!!! info "Unreleased"
+    Before this change the player would show such a stream anyway, using a colour palette
+    that was never meant for it — the text came out as flat grey with no black outline and
+    was very hard to read. It is now simply not shown.
+
 **Seeking on a seamless-branch disc is unreliable.** Some special editions store two cuts
 of the film — theatrical and extended — woven together in the same part of the disc, and
 the player chooses between them as it goes. Seeking into a woven stretch can drop you into

--- a/tools/nav_extract.py
+++ b/tools/nav_extract.py
@@ -134,6 +134,28 @@ def be16(b, o): return struct.unpack('>H', b[o:o+2])[0]
 #
 # This is the golden reference for dvd/dvd_iso_reader.sv (cc_interleaved /
 # seamless_active snoop->arm->jump) and bench/dvd/iso_reader_ilvu_tb.sv.
+# sml_pbi (DSI-rel 0x20 -> sector 0x427), libdvdread dsi.h dsi_sml_pbi_t:
+#   category u16 @0x00, ilvu_ea u32 @0x02, ilvu_sa u32 @0x06, size u16 @0x0a,
+#   vob_v_s_s_ptm u32 @0x0c, vob_v_e_e_ptm u32 @0x10,
+#   vob_a[8] @0x14, 16 B each: {stp_ptm1, stp_ptm2, gap_len1, gap_len2} (all u32)
+# The vob_a[] entries are the AUTHORED AUDIO GAP at a seamless junction -- the span a
+# player is told to mute because the two branches' audio cannot both be sample-continuous.
+# NOTHING in the RTL parses them (dvd/nav_dsi.sv reads only sml_pbi.category), so they are
+# printed here to answer "does this disc author a gap at all?" without a scratch script.
+# MEASURED on The Matrix: every entry is zero on every white-rabbit junction, which is what
+# ruled the authored gap out as the cause of the PR #63 audio dropout (docs/stc_freerun.md
+# section 12.2).
+def _sml_audio_gap(sec):
+    """Return the non-zero sml_pbi.vob_a[] entries as [(idx, stp1, stp2, gap1, gap2)]."""
+    b, out = 0x427 + 0x14, []
+    for i in range(8):
+        o = b + i * 16
+        e = (be32(sec, o), be32(sec, o + 4), be32(sec, o + 8), be32(sec, o + 12))
+        if any(e):
+            out.append((i,) + e)
+    return out
+
+
 def _dsi_fields(sec):
     """Return (is_nav, category, vobu_ea, next_vobu) from a 2048-B sector's DSI."""
     isnav = sec[0x400:0x404] == b'\x00\x00\x01\xbf' and sec[0x406] == 0x01
@@ -176,13 +198,24 @@ def dump_ilvu(f, vts):
         if not interleaved or block_type == 1:      # skip normal + multi-angle cells
             continue
         n_inter += 1
+        b0 = e[0]
+        print("  cell %2d: category byte0=0x%02x [block_mode=%d block_type=%d "
+              "seamless_play=%d interleaved=%d stc_discontinuity=%d seamless_angle=%d]"
+              % (c, b0, b0 >> 6, (b0 >> 4) & 3, (b0 >> 3) & 1, (b0 >> 2) & 1,
+                 (b0 >> 1) & 1, b0 & 1))
         first = be32(e, 8); ile = be32(e, 12); last = be32(e, 20)
         rbn = first; played = 0; jumps = 0; skipped = 0; hops = 0; nav_ok = True
         chain = []
+        gaps = 0
         while hops < 4000:
             good, cat, ea, nxt = dsi_at(rbn)
             if not good:
                 nav_ok = False; break
+            f.seek((vob_lba + rbn) * 2048)
+            for g in _sml_audio_gap(f.read(2048)):
+                gaps += 1
+                print("      RBN %d sml_pbi.vob_a[%d]: stp_ptm=%d/%d gap_len=%d/%d"
+                      % (rbn, g[0], g[1], g[2], g[3], g[4]))
             off = nxt & 0x3fffffff
             is_last = (cat & 0xf000) == 0x5000
             iend = rbn + ea                          # last sector of this VOBU
@@ -199,9 +232,9 @@ def dump_ilvu(f, vts):
             if rbn > last + 3000:
                 nav_ok = False; break
         ok = nav_ok and chain and chain[-1][2] is None
-        print("  cell %2d: first=%d ilvu_end=%d last=%d | ILVUs=%d jumps=%d "
-              "played=%d skipped(sibling)=%d nav_ok=%s %s"
-              % (c, first, ile, last, len(chain), jumps, played, skipped, nav_ok,
+        print("      first=%d ilvu_end=%d last=%d | ILVUs=%d jumps=%d "
+              "played=%d skipped(sibling)=%d audio_gap_entries=%d nav_ok=%s %s"
+              % (first, ile, last, len(chain), jumps, played, skipped, gaps, nav_ok,
                  "OK" if ok else "*** CHAIN DID NOT REACH END_OF_CELL ***"))
     if n_inter == 0:
         print("  (no interleaved cells in PGCN 1 - this title is not seamless-branch)")


### PR DESCRIPTION
Three defects reported on The Matrix, all traced to PR #63 moving `stc` from a
parse-front clock that *led* the display onto the displayed picture itself. None of the
affected modules were edited by #63 — only the meaning of an input changed, which is why
nothing caught them.

## 1. The white-rabbit icon flashed (and every subtitle was being truncated)

`spu_decode` decodes an arriving SPU straight into its single full-frame bitmap and commits
`c_show` from the SPU's **parse-front** PTS. With `stc` leading, a unit was already due at
commit; with `disp_lag ≈ 0` it now installs a window ~a VBUF depth in the *future* and
blanks whatever is on screen.

MEASURED on the disc: the icon is one `FSTA_DSP` at PTS 101885 and one `STP_DSP` at 866659
— **8.4975 s solid** — re-sent byte-identically 8 times, 90090 ticks (1.001 s) apart. Solid
is the authored behaviour and the blink period is the re-send period.

The same bug quietly truncates **every ordinary subtitle** when the next line arrives early.

Fixed at the mechanism rather than by widening the `menu_mode` escape hatch: a display-order
**hold** between `DCSQ_END` and `RLE_LINE` (the only destructive step), plus a **contiguity
clamp** at `COMMIT` so a commit can never open a hole the author did not write. `S_IDLE` now
resumes at a genuine unit start.

⛔ Double-buffering was not available: a second 720×576 2 bpp bitmap is ~102 M10Ks against
55 free RAM blocks. ★ The hold's bound is measured, not picked — real subtitle units are
never closer than 1034 ms (n=36, median 2369 ms).

## 2. An audio dropout at every seamless-branch junction

#63's `disc_rephase` resets `audio_ring` + `dvd_audio_decode` at a display re-anchor,
accepted on "titles re-anchor about once per playback (APOLLO_13)". APOLLO_13 is one
continuous title; **VTS_02 PGCN 1 — the plain movie — carries the same 9 interleaved
cell-pairs as the rabbit PGCN 6**, which is why the dropout ignored white-rabbit mode.

MEASURED, and the obvious guess was wrong: the ILVU splices *inside* a block are continuous
(0 irregular steps in 238 AC-3 PTS samples) and the disc authors **no** audio gap
(`sml_pbi.vob_a[]` all zero) — but entering the cell the PTS restarts near zero (−2 s to
−64 s). Every such cell is category `0x0e` = `seamless_play` **and** `stc_discontinuity`.

Fix = ask the disc. `dvd_iso_reader` decodes `cell_playback_t` byte 0 bit 3 (the byte was
already in `cell_cat_mem`; three bits were used) and `flush_ctl` withholds the audio flush
there. The **clock still re-anchors** — only the audio flush narrows.

⛔ Not a "was there a seek/jump recently" window: a looping menu cell re-anchors with
genuinely restarting audio and pulses no `seek_ack`. Menus are untouched structurally.

## 3. Subtitles unreadable in white-rabbit mode (pre-existing)

PGCN 6 declares logical subpicture stream 1 only. Pressing Subtitle releases the VM's claim,
the user path resolves logical 0 by raw index to 0x20 — the real subtitle stream — and draws
it with PGCN 6's palette, where the three opaque subtitle classes are all `Y=128`:

    PGCN 1  [0] Y=16   [8] Y=128  [9] Y=176    fill, outline, black edge
    PGCN 6  [0] Y=128  [8] Y=128  [9] Y=128    one flat grey

⚠ The rule is **narrowed on a measurement**. A 221-disc / 22,733-PGC sweep: class A (declares
logical 0) 18,801; class B (declares nothing) 3,929, of which **586** rely on the identity
fallback; class C (declares something, not 0) **3**. Applying the available bit
unconditionally would strip subtitles from those 586 across up to 168 discs, so
`any_present` narrows it to class C — blast radius 3 PGCs, the reported case.

## Test plan

- [x] `run_spu_window.sh --red` — 3 mutations, each caught by its own arm; the harness fails
      a mutation that does not compile
- [x] `run_seamless_audio.sh --red` — reader bit + flush gate, both proven RED
- [x] `subp_stream_map_tb` — 2071 golden vectors unchanged + 6 directed availability arms,
      RED against both the unconditional and the pre-fix versions
- [x] `run_subpic.sh`, `run_stc_freerun.sh` (incl. all 11 scheduler mutations),
      `run_mode_realign.sh`, `run_mgl.sh`, `run_seek_realign.sh`, `dvd_audio_decode_tb`,
      `flush_ctl_tb`, six reader benches
- [x] `tools/docs_check.py`, `mkdocs build --strict`
- [x] Build: 38,732/41,910 ALMs (92 %), SEED 5 first roll, clk_dec 87.40 @100 °C / 88.85
      @−40 °C vs the 86.0 gate
- [x] **HW-CONFIRMED**: audio smooth through the white-rabbit clips, icon solid

🤖 Generated with [Claude Code](https://claude.com/claude-code)
