### PR TITLE
fix(css): CSS ENCRYPTED verdict by density, not a 4-marker count (#59)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2513,8 +2513,15 @@ menus too, yields to user popups then re-arms), and **mutes both audio paths**
 (decode: `AUDIO_L/R`=0; passthrough: `iec61937_wrap.mute_i` = PCM-silence bursts
 that still drain the ring — no STD wedge). Video keeps playing so the disc is
 identifiable.
-🔧 **THE VERDICT IS NOW A DENSITY, NOT A COUNT — issue #59, 2026-09-08, branch
-`fix/css-density`; sim-proven RED/GREEN + mutation-checked, ⏳ HW-confirm pending.**
+✅ **THE VERDICT IS NOW A DENSITY, NOT A COUNT — issue #59, 2026-09-08;
+sim-proven RED/GREEN + mutation-checked, and ✅ HW-CONFIRMED 2026-09-08** (build
+`DVD_cssdensity_20260908_2056.rbf`, SEED 5 first roll, clk_dec 92.07/91.16):
+**both** directions on the maintainer's rig — the encrypted discs tried were still
+detected and muted, and several unencrypted discs were no longer flagged.
+⏳ **NOT specifically reported, so still open: whether a static BURST is audible at
+mount** on an encrypted disc now that the latch takes ~92 checked headers instead
+of ~21. If one ever is, the answer is NOT a smaller `LATCH_HITS` — it is a
+provisional mute on the first marker that the bucket confirms or releases.
 Multiple users lost **all audio** on discs that play perfectly, the reported case a
 physical disc `MiSTer_DVDcss` was decrypting correctly. The old rule counted **4
 markers per session, however far apart, and latched permanently** — while a real

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2513,7 +2513,7 @@ menus too, yields to user popups then re-arms), and **mutes both audio paths**
 (decode: `AUDIO_L/R`=0; passthrough: `iec61937_wrap.mute_i` = PCM-silence bursts
 that still drain the ring — no STD wedge). Video keeps playing so the disc is
 identifiable.
-✅ **THE VERDICT IS NOW A DENSITY, NOT A COUNT — issue #59, 2026-09-08;
+✅ **THE VERDICT IS NOW A DENSITY, NOT A COUNT — issue #59, PR #76, 2026-09-08;
 sim-proven RED/GREEN + mutation-checked, and ✅ HW-CONFIRMED 2026-09-08** (build
 `DVD_cssdensity_20260908_2056.rbf`, SEED 5 first roll, clk_dec 92.07/91.16):
 **both** directions on the maintainer's rig — the encrypted discs tried were still

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2507,15 +2507,63 @@ encrypted data. Works on ISO files, not just physical drives.
 2026-08-06 (PR fj#160).** A raw (undecrypted) rip
 green-screens with loud audio static (FAIRYTOPIA.iso was the motivating case —
 ~19% of packs still scrambled; VLC plays it only because libdvdcss decrypts on
-the fly). The core now detects `PES_scrambling_control != 0` in `ps_demux`
-(`pes_scrambled` pulse), latches sticky `css_scrambled` in emu (4-pulse
-threshold; survives jumps — ps_demux resets per-jump via pipe_rst_n; clears on
-fresh mount only), shows a **persistent `CSS ENCRYPTED` HUD popup** (visible in
+the fly). The core detects `PES_scrambling_control != 0` in `ps_demux`
+(`pes_scrambled` pulse), shows a **persistent `CSS ENCRYPTED` HUD popup** (visible in
 menus too, yields to user popups then re-arms), and **mutes both audio paths**
 (decode: `AUDIO_L/R`=0; passthrough: `iec61937_wrap.mute_i` = PCM-silence bursts
 that still drain the ring — no STD wedge). Video keeps playing so the disc is
-identifiable. Sim: `ps_demux_scram_tb`, `iec61937_wrap_tb` T8, `transport_hud_tb`
-T13. Detail: `docs/fabric_audio.md` "CSS mute", `docs/transport_hud.md`.
+identifiable.
+🔧 **THE VERDICT IS NOW A DENSITY, NOT A COUNT — issue #59, 2026-09-08, branch
+`fix/css-density`; sim-proven RED/GREEN + mutation-checked, ⏳ HW-confirm pending.**
+Multiple users lost **all audio** on discs that play perfectly, the reported case a
+physical disc `MiSTer_DVDcss` was decrypting correctly. The old rule counted **4
+markers per session, however far apart, and latched permanently** — while a real
+CSS source gives one every ~5 packs. It could not tell 4 from 400,000.
+★★ **THE COMMENT THAT SAID IT WAS SAFE IS WHAT LET IT SHIP:** `docs/fabric_audio.md`
+claimed the `'10'` marker gate made "false positives impossible". True of the marker
+BITS, false of the VERDICT — a random byte passes `'10'` 1 time in 4 and 3 of those
+carry a non-zero scrambling field, so **any byte mistaken for a PES-flags byte is a
+marker with probability ~3/16**. Two routes: a lost frame (after a resync `S_HUNT`
+locks onto any byte-aligned start code — the unhandled `PES_packet_length == 0` and
+a flush that misses a pack boundary), and a marker that survived decryption
+(libdvdcss clears the bits at the **fixed sector offset 0x14** and only in its
+non-zero-title-key branch).
+★★ **AND THE OFFLINE ORACLE HAD BEEN RIGHT ALL ALONG WHILE CLAIMING TO BE THE
+MODEL.** `tools/css_scan.py` said it "mirrors `ps_demux.sv S_PES_HDR_FLAGS1`
+exactly"; it never did — it checks only the **first PES after the pack header**,
+the RTL checked every checkable PES it dispatched. That divergence is why the tool
+called the same media clean while the core flagged it. **The RTL was changed to
+match the tool.** ⚠ Same class as `dvd_vm_ref.py` agreeing with its RTL: a model
+written from, or asserted to mirror, its subject proves nothing.
+**Fix (1)** `pack_fresh` in `ps_demux`: a marker scores only on a pack's own PES
+(a DVD pack is 2048 B = one checkable PES; `0xBB`/`0xBE`/`0xBF` never reach
+`S_PES_HDR_FLAGS1`, so nothing genuine is lost). ⚠ **Spend the arm IN
+`S_PES_HDR_FLAGS1`, not at the `S_HUNT` dispatch** — the dispatch is two states
+earlier, so clearing there clears it before the flags byte is examined and NOTHING
+can ever score (measured: every arm read 0).
+**Fix (2)** new **`dvd/css_detect.sv`** (extracted from `emu.sv`, which has no
+bench — same reason as `flush_ctl.sv`/`dpad_seek.sv`): a **leaky bucket** — a marker
+adds one, every `LEAK_CLEAN=64` clean headers repay one, latch at `LATCH_HITS=16`.
+The bucket rises only above a **density knee of 1/(K+1) = 1.54 %**. Measured: real
+CSS (p=0.19) latches in **92 headers (~0.15 s)**, p=0.05 in 289, ≤0.004 never.
+⛔ **NOT "reset after N consecutive clean headers"** (the obvious form, written
+first): it has no density meaning, only a longest-gap — and **a VOBU is 200–500
+packs**, so a stray once per VOBU never sees an N=512 clean run and latches anyway.
+⚠ **Below the knee the bucket is a negative-drift RANDOM WALK, not a pinned zero:**
+measured at p=0.008 it still latched after ~67,000 headers. "Exponentially longer
+the further below p\*", and a session is finite. ⚠ The knee rests on **one** measured
+real-CSS density (19 %); if an encrypted rip is ever seen below ~5 %, raise
+`LEAK_CLEAN` and move the bench's knee band (the bench fails if they disagree).
+⚠ **Mechanism-justified, NOT reproduced** — a library sweep was dropped by decision;
+it could not have seen the mis-framing route anyway. If it is the wrong route the
+warning persists and nothing regresses, since the change only makes the detector
+harder to trip. **Accepted trade:** genuine CSS below 1.5 % now ticks instead of
+muting — which is the regime where a miss costs least.
+Sim: **`bench/dvd/run_css.sh`** (`css_detect_tb` 10 arms, A1 asserting the DELETED
+rule latches where the new one does not, **8 mutations each caught**;
+`ps_demux_scram_tb` 8 arms, T2/T4 RED against the pre-fix demux which `--red`
+rebuilds out of git), plus `iec61937_wrap_tb` T8, `transport_hud_tb` T13.
+Detail: `docs/fabric_audio.md` "CSS mute", `docs/transport_hud.md`.
 
 **DVD drive region tool (`main/Scripts/set_dvd_region.sh`, 2026-08-30) — ✅ READ +
 gamepad menu HW-CONFIRMED (2026-08-31, re-confirmed 2026-09-04 on the rewritten script);

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -78,6 +78,10 @@ set_global_assignment -name SYSTEMVERILOG_FILE dvd/av_sync.sv
 # Flush/reset trigger matrix (extracted from emu.sv 2026-08-28 for TB coverage of
 # the mount/seek/jump/mode_switch flush trio). See bench/dvd/flush_ctl_tb.sv.
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/flush_ctl.sv
+# CSS-scramble DENSITY verdict (extracted from emu.sv 2026-09-08, issue #59: the
+# inline 4-marker-per-session rule false-positived on discs that play perfectly and
+# muted all their audio). See bench/dvd/css_detect_tb.sv, run via run_css.sh.
+set_global_assignment -name SYSTEMVERILOG_FILE dvd/css_detect.sv
 set_global_assignment -name SYSTEMVERILOG_FILE dvd/dvd_telem.sv
 # PAL/NTSC verdict from the parsed frame height, hardened so a garbage sequence header
 # cannot flip it (issue #42 leg 2): a pal_eff change restarts the raster with NO flush.

--- a/bench/dvd/css_detect_tb.sv
+++ b/bench/dvd/css_detect_tb.sv
@@ -1,0 +1,277 @@
+// css_detect_tb.sv — the CSS density verdict (issue #59).
+//
+// The rule this replaces counted four scrambled PES headers per session, however
+// far apart, and latched permanently. A genuinely scrambled source gives a marker
+// about every 5 packs; a stray gives a handful in an hour. The old rule could not
+// tell them apart, so discs that play perfectly lost all their audio.
+//
+// ★ HOW THIS BENCH AVOIDS BEING VACUOUS. A bench that pokes 16 markers, sees a
+// latch and stops would pass with the leak deleted, with LEAK_CLEAN wrong, and with
+// the denominator ignored. So:
+//   - it carries a VERBATIM copy of the deleted rule (leg_*) and asserts that the
+//     old rule latches on stimulus the new one must refuse. Every RED claim here is
+//     an assertion, not a comment;
+//   - it MEASURES how many headers a latch took and asserts a band, never "!= 0";
+//   - it finds the density knee and the periodic-stimulus boundary by SEARCH and
+//     compares them against numbers DERIVED from the parameters, so changing a
+//     parameter without changing the bench fails.
+//
+// Arms: A1/A2 the false positive (RED vs the old rule) · A3 real density latches
+// promptly · A4 density sweep finds the knee · A5 periodic adversary finds the
+// boundary · A6 exact latch index · A7 the denominator is load-bearing · A8 the
+// leak is load-bearing · A9 sticky, and what clears it · A10 census saturates.
+`timescale 1ns/1ps
+`default_nettype none
+
+module css_detect_tb;
+    localparam int LATCH_HITS = 16;
+    localparam int LEAK_CLEAN = 64;
+
+    logic clk = 0, rst_n = 0;
+    logic mount = 0, eject = 0, hdr_ok = 0, scrambled = 0;
+    logic css;
+    logic [15:0] hdr_census, scram_census;
+
+    always #5 clk = ~clk;
+
+    css_detect #(.LATCH_HITS(LATCH_HITS), .LEAK_CLEAN(LEAK_CLEAN)) dut (
+        .clk(clk), .rst_n(rst_n),
+        .mount(mount), .eject(eject),
+        .hdr_ok(hdr_ok), .scrambled(scrambled),
+        .css_scrambled(css), .hdr_census(hdr_census), .scram_census(scram_census)
+    );
+
+    // ---- the rule being deleted, verbatim from dvd/emu.sv, as a reference model ----
+    reg [2:0] leg_cnt;
+    reg       leg_latched;
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n)                            begin leg_cnt <= 0; leg_latched <= 0; end
+        else if (mount || eject)               begin leg_cnt <= 0; leg_latched <= 0; end
+        else if (scrambled && !leg_latched) begin
+            leg_cnt <= leg_cnt + 3'd1;
+            if (leg_cnt == 3'd3) leg_latched <= 1'b1;   // 4th scrambled PES
+        end
+    end
+
+    // ---- instruments ----
+    int hdr_n = 0, latch_at = -1, fails = 0;
+    always @(posedge clk) if (rst_n) begin
+        if (hdr_ok) hdr_n <= hdr_n + 1;
+        if (css && latch_at < 0) latch_at <= hdr_n;
+    end
+
+    integer rseed = 32'h1234_5678;
+    function automatic int rnd1m;
+        int v;
+        begin
+            v = $random(rseed);
+            if (v < 0) v = -v;
+            rnd1m = v % 1000000;
+        end
+    endfunction
+
+    task automatic tick(input bit s);
+        begin
+            hdr_ok    <= 1'b1;
+            scrambled <= s;
+            @(posedge clk);
+            hdr_ok    <= 1'b0;
+            scrambled <= 1'b0;
+            @(posedge clk);
+        end
+    endtask
+
+    // n headers; a marker every `period` (period 0 = random at ppm/1e6).
+    task automatic feed(input int n, input int ppm, input int period);
+        int i;
+        begin
+            for (i = 0; i < n; i++) begin
+                if (period > 0) tick((i % period) == 0);
+                else            tick(rnd1m() < ppm);
+            end
+        end
+    endtask
+
+    task automatic new_media;
+        begin
+            mount <= 1'b1; @(posedge clk); mount <= 1'b0; @(posedge clk);
+            hdr_n = 0; latch_at = -1; rseed = 32'h1234_5678;
+        end
+    endtask
+
+    task automatic chk(input string name, input bit want, input bit got);
+        begin
+            if (want !== got) begin
+                $display("  FAIL %s: got %0d, expected %0d", name, got, want);
+                fails = fails + 1;
+            end
+        end
+    endtask
+
+    int i, p, knee_lo, knee_hi, bound;
+    int dens [0:10];
+    initial begin
+        repeat (4) @(posedge clk);
+        rst_n = 1;
+        @(posedge clk);
+        $display("=== css_detect: CSS density verdict (LATCH_HITS=%0d LEAK_CLEAN=%0d) ===",
+                 LATCH_HITS, LEAK_CLEAN);
+        $display("    knee p* = 1/(LEAK_CLEAN+1) = %0.4f", 1.0/(LEAK_CLEAN+1));
+
+        // ---- A1: the issue #59 regression. Four markers, 4096 headers apart.
+        new_media;
+        feed(4*4096, 0, 4096);
+        $display("A1 4 strays 4096 apart          old rule latched=%0d  new=%0d",
+                 leg_latched, css);
+        chk("A1 old rule must latch (else the stimulus proves nothing)", 1'b1, leg_latched);
+        chk("A1 new rule must NOT latch",                                1'b0, css);
+
+        // ---- A2: the reported shape -- a handful of strays at irregular spacing.
+        new_media;
+        for (i = 0; i < 8; i++) begin
+            feed(400 + i*370, 0, 0);      // clean run
+            tick(1'b1);                   // one stray
+        end
+        $display("A2 8 strays, gaps 400..2990     old rule latched=%0d  new=%0d",
+                 leg_latched, css);
+        chk("A2 old rule must latch", 1'b1, leg_latched);
+        chk("A2 new rule must NOT latch", 1'b0, css);
+
+        // ---- A3: a real CSS density must still latch, and FAST.
+        new_media;
+        feed(5000, 190000, 0);            // p = 0.19, the measured figure
+        $display("A3 p=0.19                       latched=%0d after %0d headers (expect ~%0d)",
+                 css, latch_at, (LATCH_HITS*1000)/(190 - (810/LEAK_CLEAN)));
+        chk("A3 must latch at real CSS density", 1'b1, css);
+        if (css && (latch_at < LATCH_HITS || latch_at > 300)) begin
+            $display("  FAIL A3: latched after %0d headers, expected 16..300", latch_at);
+            fails = fails + 1;
+        end
+
+        // ---- A4: sweep the density and locate the knee by search.
+        $display("A4 density sweep:");
+        knee_lo = 0; knee_hi = 1000000;
+        dens[0]=0; dens[1]=100; dens[2]=1000; dens[3]=4000; dens[4]=8000;
+        dens[5]=30000; dens[6]=50000; dens[7]=100000; dens[8]=190000;
+        dens[9]=500000; dens[10]=1000000;
+        for (i = 0; i <= 10; i++) begin
+            new_media;
+            feed(dens[i] <= 8000 ? 100000 : 20000, dens[i], 0);
+            $display("     p=%0.6f  latched=%0d  headers=%0d",
+                     dens[i]/1000000.0, css, latch_at);
+            if (css) begin if (dens[i] < knee_hi) knee_hi = dens[i]; end
+            else     begin if (dens[i] > knee_lo) knee_lo = dens[i]; end
+        end
+        $display("     measured knee between p=%0.6f and p=%0.6f (design p*=%0.6f)",
+                 knee_lo/1000000.0, knee_hi/1000000.0, 1.0/(LEAK_CLEAN+1));
+        // ⚠ THE MEASURED KNEE SITS BELOW THE DESIGN KNEE, AND THAT IS REAL, NOT AN
+        // ARTEFACT. Below p* the bucket is a random walk with NEGATIVE drift, not a
+        // pinned zero: it still reaches LATCH_HITS on a rare excursion, and the
+        // longer the session the likelier that is. Measured here at p=0.008 (about
+        // half the knee): latched after ~67,000 headers. So the honest claim is
+        // "the further below p*, the exponentially longer it takes", and a session
+        // is finite. The false positive this fixes is three orders of magnitude
+        // lower (a handful of markers, i.e. p ~ 1e-5), where 100,000 headers do not
+        // move the bucket off zero at all.
+        // The assertion is therefore a factor-of-four band around the DERIVED knee,
+        // which still fails on any parameter change the bench was not told about
+        // (deleting the leak drops the measured knee to ~0.001, an order out).
+        if (!(knee_hi*4*(LEAK_CLEAN+1) >= 1000000 && knee_lo*(LEAK_CLEAN+1) <= 4000000)) begin
+            $display("  FAIL A4: measured knee %0.6f..%0.6f is not within 4x of p*=%0.6f",
+                     knee_lo/1000000.0, knee_hi/1000000.0, 1.0/(LEAK_CLEAN+1));
+            fails = fails + 1;
+        end
+
+        // ---- A5: the periodic adversary that kills a "reset after N clean" rule.
+        // Deterministic: a marker every P headers latches iff P <= LEAK_CLEAN.
+        $display("A5 periodic adversary:");
+        bound = 0;
+        for (i = 0; i < 7; i++) begin
+            p = (i == 0) ? 8   : (i == 1) ? 16  : (i == 2) ? 32  : (i == 3) ? 64 :
+                (i == 4) ? 65  : (i == 5) ? 250 : 1000;
+            new_media;
+            feed(p*40 > 60000 ? 60000 : p*40, 0, p);
+            $display("     period=%0d  latched=%0d", p, css);
+            if (css && p > bound) bound = p;
+            chk($sformatf("A5 period %0d", p), (p <= LEAK_CLEAN), css);
+        end
+        $display("     largest latching period = %0d (LEAK_CLEAN = %0d)", bound, LEAK_CLEAN);
+        if (bound !== LEAK_CLEAN) begin
+            $display("  FAIL A5: boundary %0d, expected LEAK_CLEAN = %0d", bound, LEAK_CLEAN);
+            fails = fails + 1;
+        end
+
+        // ---- A6: latches on exactly the LATCH_HITS'th marker, not the one before.
+        new_media;
+        feed(LATCH_HITS-1, 0, 1);
+        chk("A6 must not latch on hit 15", 1'b0, css);
+        tick(1'b1);
+        chk("A6 must latch on hit 16", 1'b1, css);
+        repeat (2) @(posedge clk);   // latch_at is captured non-blocking on the edge
+        if (latch_at !== LATCH_HITS) begin
+            $display("  FAIL A6: latched at header %0d, expected %0d", latch_at, LATCH_HITS);
+            fails = fails + 1;
+        end
+
+        // ---- A7: the denominator is load-bearing -- scrambled without hdr_ok is
+        // not evidence. Guards against a future ps_demux edit that drops it.
+        new_media;
+        for (i = 0; i < 64; i++) begin
+            scrambled <= 1'b1; @(posedge clk); scrambled <= 1'b0; @(posedge clk);
+        end
+        $display("A7 64 markers with hdr_ok low   latched=%0d census=%0d/%0d",
+                 css, scram_census, hdr_census);
+        chk("A7 must not latch", 1'b0, css);
+        if (hdr_census !== 0 || scram_census !== 0) begin
+            $display("  FAIL A7: census moved without hdr_ok");
+            fails = fails + 1;
+        end
+
+        // ---- A8: the leak is load-bearing. 15 hits repaid in full, 20 times over.
+        new_media;
+        for (i = 0; i < 20; i++) begin
+            feed(15, 0, 1);                       // 15 back-to-back markers
+            feed(LEAK_CLEAN*15, 0, 0);            // exactly enough clean to repay them
+        end
+        $display("A8 15 hits repaid x20           latched=%0d scram_census=%0d (expect 300)",
+                 css, scram_census);
+        chk("A8 must not latch", 1'b0, css);
+        if (scram_census !== 300) begin
+            $display("  FAIL A8: scram_census %0d, expected 300 (were the hits delivered?)",
+                     scram_census);
+            fails = fails + 1;
+        end
+
+        // ---- A9: sticky, and only media changes clear it.
+        new_media;
+        feed(5000, 190000, 0);
+        chk("A9 latched to begin with", 1'b1, css);
+        feed(100000, 0, 0);
+        chk("A9 stays latched through 100k clean headers", 1'b1, css);
+        new_media;
+        chk("A9 mount clears it", 1'b0, css);
+        feed(4*4096, 0, 4096);
+        chk("A9 does not re-latch on strays after a mount", 1'b0, css);
+        feed(5000, 190000, 0);
+        chk("A9 latched again", 1'b1, css);
+        eject <= 1'b1; @(posedge clk); eject <= 1'b0; @(posedge clk);
+        chk("A9 eject clears it", 1'b0, css);
+
+        // ---- A10: the census saturates rather than wrapping.
+        new_media;
+        feed(70000, 0, 0);
+        $display("A10 70000 clean headers         hdr_census=%0d (expect 65535)", hdr_census);
+        if (hdr_census !== 16'hFFFF) begin
+            $display("  FAIL A10: census %0d, expected saturation at 65535", hdr_census);
+            fails = fails + 1;
+        end
+
+        if (fails != 0) begin
+            $display("FAIL: %0d check(s) failed", fails);
+            $fatal(1);
+        end
+        $display("PASS: density verdict -- strays cannot latch; real CSS (p=0.19) latched");
+        $finish;
+    end
+endmodule
+`default_nettype wire

--- a/bench/dvd/ps_demux_scram_tb.sv
+++ b/bench/dvd/ps_demux_scram_tb.sv
@@ -1,13 +1,28 @@
-// ps_demux_scram_tb.sv — CSS-scrambled PES detection (pes_scrambled pulse).
+// ps_demux_scram_tb.sv — CSS-scramble marker detection (pes_scrambled/pes_hdr_ok).
 //
-// A CSS-encrypted rip carries PES_scrambling_control != 0 (bits [5:4] of the
-// first PES-flags byte — the byte itself is never scrambled). ps_demux must
-// pulse pes_scrambled once per such PES (video 0xE0 AND private_stream_1 0xBD),
-// and must NOT pulse for clean packets. Payload routing is unchanged either
-// way (the payload passes through scrambled — emu mutes/warns downstream).
+// A CSS-encrypted rip carries PES_scrambling_control != 0 (bits [5:4] of the first
+// PES-flags byte — that byte itself is never scrambled). ps_demux pulses
+// pes_scrambled once per such PES, and pes_hdr_ok once per CHECKABLE PES header
+// (scrambled or not) as the denominator dvd/css_detect.sv divides into it.
 //
-// Stream: pack + clean video PES (no pulse) + scrambled video PES (pulse) +
-//         scrambled AC-3 audio PES (pulse) + clean audio PES (no pulse).
+// ★ WHAT THIS BENCH IS FOR (issue #59). The old version fed ONE pack followed by
+// FOUR PES packets and asserted "exactly 2 pulses". That stimulus is not DVD: a
+// DVD pack is 2048 bytes and carries exactly ONE checkable PES, so the old bench
+// could not distinguish "a marker on a real pack" from "a marker on something the
+// demux found while it had lost framing" -- which is how a clean disc came to show
+// CSS ENCRYPTED and lose all audio. T2/T4 are that distinction, and they FAIL
+// against the pre-fix RTL on purpose (bench/dvd/run_css.sh --red).
+//
+// Arms:
+//   T1 four packs, one PES each: clean E0, scrambled E0, scrambled BD, clean BD
+//   T2 the OLD stimulus verbatim (one pack, four PES) -- only the first counts
+//   T3 a false start code inside a payload the length field covers -> invisible
+//   T4 a PES that ends early, then planted false headers in the same pack, then a
+//      genuine pack + scrambled E0 -- the desync case: 0 during garbage, 1 after
+//   T5 a NAV pack's BB/BF/BF do not consume the pack's arm
+//   T6 MP2 C0-C7: the selected track is checkable, an unselected one is not
+//   T8 a bad '10' marker pulses neither output
+//   T7 runs continuously: pes_scrambled implies pes_hdr_ok, totals ordered
 `timescale 1ns/1ps
 `default_nettype none
 
@@ -17,69 +32,208 @@ module ps_demux_scram_tb;
     logic        in_valid;
     logic        in_ready;
     logic        scram;
+    logic        hdr_ok;
+    logic  [2:0] aud_track = 3'd0;
 
     always #5 clk = ~clk;
 
     ps_demux dut (
         .clk(clk), .rst_n(rst_n),
         .in_byte(in_byte), .in_valid(in_valid), .in_ready(in_ready),
-        .aud_track(3'd0),
+        .aud_track(aud_track),
         .vid_byte(), .vid_valid(), .vid_ready(1'b1),
         .aud_byte(), .aud_valid(), .aud_type(), .aud_frame_start(), .aud_ready(1'b1),
         .vid_pts(), .vid_pts_valid(), .aud_pts(), .aud_pts_valid(),
+`ifndef NO_HDR_OK
+        .pes_hdr_ok(hdr_ok),
+`endif
         .pes_scrambled(scram)
     );
+`ifdef NO_HDR_OK
+    assign hdr_ok = 1'b0;          // pre-fix RTL has no denominator to connect
+`endif
 
-    // pack header, then four PES packets:
-    //  video clean     : flags1 0x80 (marker '10', sc=00)
-    //  video scrambled : flags1 0xB0 (marker '10', sc=11)
-    //  audio scrambled : flags1 0x90 (marker '10', sc=01), AC-3 sub-header
-    //  audio clean     : flags1 0x80
-    localparam int N = 14 + 13 + 13 + 15 + 15;
-    logic [7:0] stim [0:N-1] = '{
-        // pack header
-        8'h00,8'h00,8'h01,8'hBA,
-        8'h44,8'h44,8'h44,8'h44,8'h44,8'h44,8'h44,8'h44,8'h44,
-        8'h00,
-        // clean video PES, len 7: flags1 80, flags2 00, hdrlen 00, 4 payload
-        8'h00,8'h00,8'h01,8'hE0, 8'h00,8'h07,
-        8'h80,8'h00,8'h00, 8'hDE,8'hAD,8'hBE,8'hEF,
-        // SCRAMBLED video PES (sc=11), len 7
-        8'h00,8'h00,8'h01,8'hE0, 8'h00,8'h07,
-        8'hB0,8'h00,8'h00, 8'h12,8'h34,8'h56,8'h78,
-        // SCRAMBLED audio PES (sc=01), len 9: flags+hdrlen+substream 0x80+3 sub + 2 payload
-        8'h00,8'h00,8'h01,8'hBD, 8'h00,8'h09,
-        8'h90,8'h00,8'h00, 8'h80,8'h01,8'h00,8'h01, 8'h0B,8'h77,
-        // clean audio PES, len 9
-        8'h00,8'h00,8'h01,8'hBD, 8'h00,8'h09,
-        8'h80,8'h00,8'h00, 8'h80,8'h01,8'h00,8'h01, 8'h0B,8'h77
-    };
+    // ---------------- instruments ----------------
+    int pulses = 0, hdrs = 0, fails = 0;
+    always_ff @(posedge clk) if (rst_n) begin
+        if (scram)  pulses <= pulses + 1;
+        if (hdr_ok) hdrs   <= hdrs   + 1;
+        // [T7] the numerator can never fire without the denominator
+        if (scram && !hdr_ok) begin
+`ifndef NO_HDR_OK
+            $display("FAIL [T7]: pes_scrambled without pes_hdr_ok");
+            fails <= fails + 1;
+`endif
+        end
+    end
 
-    int pulses = 0;
-    always_ff @(posedge clk) if (rst_n && scram) pulses <= pulses + 1;
+    // ---------------- stimulus builder ----------------
+    logic [7:0] stim [0:1023];
+    int n = 0;
+    int base_p, base_h;
 
-    int i;
-    initial begin
-        in_valid = 0; in_byte = 0;
-        repeat (4) @(posedge clk);
-        rst_n = 1;
-        @(posedge clk);
-        for (i = 0; i < N; i++) begin
+    task push(input [7:0] b); begin stim[n] = b; n = n + 1; end endtask
+
+    // A DVD pack header: 00 00 01 BA, 9 bytes (top nibble 0100 = MPEG-2), stuffing 0.
+    task push_pack; begin
+        push(8'h00); push(8'h00); push(8'h01); push(8'hBA);
+        repeat (9) push(8'h44);
+        push(8'h00);
+    end endtask
+
+    // A PES with no optional header and `pay` payload bytes of 8'hA5.
+    task push_pes(input [7:0] sid, input [7:0] flags1, input int pay);
+        int len; begin
+        len = 3 + pay;
+        push(8'h00); push(8'h00); push(8'h01); push(sid);
+        push(len[15:8]); push(len[7:0]);
+        push(flags1); push(8'h00); push(8'h00);
+        repeat (pay) push(8'hA5);
+    end endtask
+
+    // private_stream_1: substream id + 3 AC-3 sub-header bytes, then `pay` payload.
+    task push_pes_bd(input [7:0] flags1, input int pay);
+        int len; begin
+        len = 3 + 4 + pay;
+        push(8'h00); push(8'h00); push(8'h01); push(8'hBD);
+        push(len[15:8]); push(len[7:0]);
+        push(flags1); push(8'h00); push(8'h00);
+        push(8'h80); push(8'h01); push(8'h00); push(8'h01);
+        repeat (pay) push(8'hA5);
+    end endtask
+
+    // A PES header pattern planted as raw bytes -- no payload follows it here, so
+    // whether it is ever parsed depends entirely on where the demux is looking.
+    task push_fake_hdr(input [7:0] sid, input [7:0] flags1); begin
+        push(8'h00); push(8'h00); push(8'h01); push(sid);
+        push(8'h00); push(8'h03);
+        push(flags1); push(8'h00); push(8'h00);
+    end endtask
+
+    task send;
+        int i; begin
+        for (i = 0; i < n; i++) begin
             in_byte  <= stim[i];
             in_valid <= 1'b1;
             @(posedge clk);
             while (!in_ready) @(posedge clk);
         end
-        in_valid <= 0;
+        in_valid <= 1'b0;
         repeat (20) @(posedge clk);
+    end endtask
 
-        $display("=== ps_demux CSS-scramble detection test ===");
-        $display("pes_scrambled pulses = %0d (expected 2)", pulses);
-        if (pulses !== 2) begin
-            $display("FAIL: expected exactly 2 pulses (1 video + 1 audio scrambled PES)");
+    task start_arm; begin n = 0; base_p = pulses; base_h = hdrs; end endtask
+
+    task check(input string name, input int exp_p, input int exp_h);
+        int gp, gh; begin
+        gp = pulses - base_p;
+        gh = hdrs   - base_h;
+        $display("  %-38s pulses=%0d (exp %0d)  hdr_ok=%0d (exp %0d)",
+                 name, gp, exp_p, gh, exp_h);
+        if (gp !== exp_p) begin
+            $display("  FAIL %s: pes_scrambled %0d, expected %0d", name, gp, exp_p);
+            fails = fails + 1;
+        end
+`ifndef NO_HDR_OK
+        if (gh !== exp_h) begin
+            $display("  FAIL %s: pes_hdr_ok %0d, expected %0d", name, gh, exp_h);
+            fails = fails + 1;
+        end
+`endif
+    end endtask
+
+    initial begin
+        in_valid = 0; in_byte = 0;
+        repeat (4) @(posedge clk);
+        rst_n = 1;
+        @(posedge clk);
+
+        $display("=== ps_demux CSS-scramble marker detection ===");
+
+        // ---- T1: DVD-shaped. One PES per pack; two of the four are scrambled.
+        start_arm;
+        push_pack; push_pes(8'hE0, 8'h80, 4);      // clean video
+        push_pack; push_pes(8'hE0, 8'hB0, 4);      // scrambled video  (sc=11)
+        push_pack; push_pes_bd(8'h90, 2);          // scrambled audio  (sc=01)
+        push_pack; push_pes_bd(8'h80, 2);          // clean audio
+        send; check("T1 one PES per pack", 2, 4);
+
+        // ---- T2: the OLD stimulus. Four PES crammed into one pack -- only the
+        // first can carry a genuine CSS marker, so the two later "scrambled"
+        // headers must be ignored. RED against the pre-fix RTL (it counts 2).
+        start_arm;
+        push_pack;
+        push_pes(8'hE0, 8'h80, 4);
+        push_pes(8'hE0, 8'hB0, 4);
+        push_pes_bd(8'h90, 2);
+        push_pes_bd(8'h80, 2);
+        send; check("T2 four PES in one pack", 0, 1);
+
+        // ---- T3: a false start code sitting INSIDE a payload the length field
+        // covers. Framing holds, so the demux never looks at it.
+        start_arm;
+        push_pack;
+        n = n;                                     // build the PES by hand
+        push(8'h00); push(8'h00); push(8'h01); push(8'hE0);
+        push(8'h00); push(8'h0C);                  // len 12 = 3 + 9 payload
+        push(8'h80); push(8'h00); push(8'h00);
+        push(8'h00); push(8'h00); push(8'h01); push(8'hE0);   // planted, as payload
+        push(8'h00); push(8'h07); push(8'hB0); push(8'h00); push(8'h00);
+        push(8'hA5);
+        send; check("T3 false header inside payload", 0, 1);
+
+        // ---- T4: the desync. The real PES ends early, the demux returns to
+        // S_HUNT inside the same pack and finds planted headers there. Post-fix
+        // the pack's arm is already spent, so none of them can score; the
+        // genuine pack that follows still does. RED pre-fix (it counts 2 then 3).
+        start_arm;
+        push_pack;
+        push_pes(8'hE0, 8'h80, 2);                 // real, clean, ends here
+        push_fake_hdr(8'hE0, 8'hB0);               // planted scrambled video
+        push_fake_hdr(8'hBD, 8'h90);               // planted scrambled audio
+        send; check("T4 planted headers after a PES", 0, 0);
+        start_arm;
+        push_pack; push_pes(8'hE0, 8'hB0, 4);      // a genuine one still scores
+        send; check("T4b genuine pack after the garbage", 1, 1);
+
+        // ---- T5: a NAV pack's non-checkable packets must not consume the arm.
+        start_arm;
+        push_pack;
+        push_fake_hdr(8'hBB, 8'h00);               // system header
+        push_fake_hdr(8'hBF, 8'h00);               // PCI
+        push_fake_hdr(8'hBF, 8'h00);               // DSI
+        push_pes(8'hE0, 8'hB0, 4);                 // scrambled video, same pack
+        send; check("T5 BB/BF/BF do not disarm", 1, 1);
+
+        // ---- T6: MP2. Only the SELECTED track reaches the flags byte.
+        aud_track = 3'd1;
+        start_arm;
+        push_pack; push_pes(8'hC1, 8'hB0, 4);      // selected   -> checkable
+        send; check("T6a MP2 selected track", 1, 1);
+        start_arm;
+        push_pack; push_pes(8'hC2, 8'hB0, 4);      // unselected -> skipped
+        send; check("T6b MP2 unselected track", 0, 0);
+        aud_track = 3'd0;
+
+        // ---- T8: marker bits are still load-bearing.
+        start_arm;
+        push_pack; push_pes(8'hE0, 8'h30, 4);      // marker '00', sc=11
+        send; check("T8 bad '10' marker", 0, 0);
+
+        // ---- T7 totals
+        $display("  totals: pes_scrambled=%0d pes_hdr_ok=%0d", pulses, hdrs);
+`ifndef NO_HDR_OK
+        if (pulses > hdrs) begin
+            $display("  FAIL [T7]: more markers than checkable headers");
+            fails = fails + 1;
+        end
+`endif
+
+        if (fails != 0) begin
+            $display("FAIL: %0d check(s) failed", fails);
             $fatal(1);
         end
-        $display("PASS: scrambled PES detected, clean PES silent");
+        $display("PASS: markers scored only on the first checkable PES of a pack");
         $finish;
     end
 endmodule

--- a/bench/dvd/ps_demux_scram_tb.sv
+++ b/bench/dvd/ps_demux_scram_tb.sv
@@ -191,7 +191,10 @@ module ps_demux_scram_tb;
         push_pes(8'hE0, 8'h80, 2);                 // real, clean, ends here
         push_fake_hdr(8'hE0, 8'hB0);               // planted scrambled video
         push_fake_hdr(8'hBD, 8'h90);               // planted scrambled audio
-        send; check("T4 planted headers after a PES", 0, 0);
+        // hdr_ok is 1, not 0: the pack's own clean E0 is a legitimate checkable
+        // header and belongs in the denominator. It is the two PLANTED headers
+        // that must score nothing -- pre-fix they scored 2.
+        send; check("T4 planted headers after a PES", 0, 1);
         start_arm;
         push_pack; push_pes(8'hE0, 8'hB0, 4);      // a genuine one still scores
         send; check("T4b genuine pack after the garbage", 1, 1);

--- a/bench/dvd/run_css.sh
+++ b/bench/dvd/run_css.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# run_css.sh -- CSS-scramble detection suite (issue #59).
+#
+#   (no args)   GREEN: the density verdict + the pack-framing filter
+#   --red       RED:   the same scramble bench against the PRE-FIX ps_demux, which
+#                      must FAIL, and the mutation check on css_detect.sv
+#   --mutate    just the mutation check
+#
+# The RED arm rebuilds the pre-fix demux out of git rather than keeping a frozen
+# copy in the tree: the filter has no runtime switch, so "run the old RTL" is the
+# only honest way to show the defect, and doing it from history keeps it
+# reproducible from the repo alone. That build needs -DNO_HDR_OK because the
+# pre-fix module has no denominator port.
+set -u
+cd "$(dirname "$0")/../.."
+ROOT=$PWD
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+rc=0
+
+build_run() { # name  expect_pass(0/1)  sources...
+    local name=$1 want=$2; shift 2
+    if ! iverilog -g2012 -o "$TMP/sim" "$@" 2>"$TMP/err"; then
+        echo "  $name: COMPILE FAILED"; sed -n '1,5p' "$TMP/err"; rc=1; return
+    fi
+    local out; out=$(vvp "$TMP/sim" 2>&1)
+    if echo "$out" | grep -q '^PASS'; then
+        if [ "$want" = 1 ]; then echo "  $name: PASS"
+        else echo "  $name: *** PASSED but should have FAILED ***"; rc=1; fi
+    else
+        if [ "$want" = 0 ]; then
+            echo "  $name: FAILED as expected --"
+            echo "$out" | grep -E 'FAIL|pulses=' | sed 's/^/      /'
+        else
+            echo "  $name: FAIL"; echo "$out" | tail -20 | sed 's/^/      /'; rc=1
+        fi
+    fi
+}
+
+mutate() {
+    echo "== css_detect.sv mutation check (each must be caught) =="
+    python3 - "$ROOT" <<'PY'
+import os, subprocess, sys, tempfile
+root = sys.argv[1]
+src = open(os.path.join(root, "dvd/css_detect.sv")).read()
+tmp = tempfile.mkdtemp()
+MUT = [
+ ("M1 leak deleted", "if (bucket != '0) bucket <= bucket - 1'b1;", ""),
+ ("M2 leak on every clean header",
+  "end else if (leak_cnt == LEAK_W'(LEAK_CLEAN - 1)) begin", "end else if (1'b1) begin"),
+ ("M3 latch at 4, not LATCH_HITS",
+  "bucket == BUCKET_W'(LATCH_HITS - 1)", "bucket == BUCKET_W'(4 - 1)"),
+ ("M4 hdr_ok qualifier dropped",
+  "end else if (hdr_ok) begin", "end else if (hdr_ok || scrambled) begin"),
+ ("M5 verdict released when the bucket empties (not sticky)",
+  """    end else if (css_scrambled) begin
+        // Latched: hold everything. The verdict cannot be revisited until the media
+        // changes (see the anti-flap note in the header).""",
+  """    end else if (css_scrambled) begin
+        if (hdr_ok && !scrambled) begin
+            if (leak_cnt == LEAK_W'(LEAK_CLEAN - 1)) begin
+                leak_cnt <= '0;
+                if (bucket != '0) bucket <= bucket - 1'b1;
+                else css_scrambled <= 1'b0;
+            end else leak_cnt <= leak_cnt + 1'b1;
+        end"""),
+ ("M6 mount clear dropped", "end else if (mount || eject) begin", "end else if (eject) begin"),
+ ("M7 latch off by one",
+  "bucket == BUCKET_W'(LATCH_HITS - 1)", "bucket == BUCKET_W'(LATCH_HITS - 2)"),
+ ("M8 leak_cnt reset on a clean header, not a hit",
+  """            leak_cnt <= '0;
+            if (bucket == BUCKET_W'(LATCH_HITS - 1)) css_scrambled <= 1'b1;""",
+  """            if (bucket == BUCKET_W'(LATCH_HITS - 1)) css_scrambled <= 1'b1;"""),
+]
+rc = 0
+for name, old, new in MUT:
+    if src.count(old) != 1:
+        print("  %-56s ANCHOR MOVED" % name); rc = 1; continue
+    open(tmp + "/mut.sv", "w").write(src.replace(old, new, 1))
+    if subprocess.run(["iverilog", "-g2012", "-o", tmp + "/sim", tmp + "/mut.sv",
+                       root + "/bench/dvd/css_detect_tb.sv"], capture_output=True).returncode:
+        print("  %-56s DID NOT COMPILE" % name); rc = 1; continue
+    out = subprocess.run(["vvp", tmp + "/sim"], capture_output=True, text=True).stdout
+    if any(l.startswith("PASS") for l in out.splitlines()):
+        print("  %-56s *** SURVIVED ***" % name); rc = 1
+    else:
+        arms = sorted({w for l in out.splitlines() if "FAIL" in l
+                         for w in l.split() if w.startswith("A") and w[1:].isdigit()})
+        print("  %-56s caught by %s" % (name, " ".join(arms)))
+sys.exit(rc)
+PY
+    [ $? -ne 0 ] && rc=1
+}
+
+case "${1:-}" in
+--mutate)
+    mutate
+    ;;
+--red)
+    echo "== RED: the pre-fix demux must fail the pack-framing arms =="
+    # The commit that introduced the filter; its parent is the pre-fix RTL.
+    fix=$(git log --format=%H -1 -S pack_fresh -- dvd/ps_demux.sv)
+    if [ -z "$fix" ]; then echo "  cannot locate the fix commit"; exit 1; fi
+    git show "$fix^:dvd/ps_demux.sv" > "$TMP/ps_demux_prefix.sv"
+    if ! iverilog -g2012 -DNO_HDR_OK -o "$TMP/red" "$TMP/ps_demux_prefix.sv" \
+            bench/dvd/ps_demux_scram_tb.sv 2>"$TMP/err"; then
+        echo "  COMPILE FAILED"; sed -n '1,5p' "$TMP/err"; exit 1
+    fi
+    out=$(vvp "$TMP/red" 2>&1)
+    if echo "$out" | grep -q '^PASS'; then
+        echo "  *** the pre-fix demux PASSED -- the bench does not prove anything ***"; rc=1
+    else
+        echo "  pre-fix demux FAILED as expected:"
+        echo "$out" | grep -E 'FAIL T|T2 |T4 ' | sed 's/^/      /'
+    fi
+    echo
+    mutate
+    ;;
+*)
+    echo "== GREEN =="
+    build_run "css_detect_tb   (density verdict)" 1 dvd/css_detect.sv bench/dvd/css_detect_tb.sv
+    build_run "ps_demux_scram_tb (pack framing)" 1 dvd/ps_demux.sv bench/dvd/ps_demux_scram_tb.sv
+    ;;
+esac
+
+[ $rc -eq 0 ] && echo "ALL GREEN" || echo "FAILURES"
+exit $rc

--- a/docs/fabric_audio.md
+++ b/docs/fabric_audio.md
@@ -363,7 +363,7 @@ resets on every `load_flush` via `pipe_rst_n` — a demux-local latch would flap
 leak pops at every menu jump/seek) and clears only on a fresh media mount, an
 eject, or a core reset.
 
-### ⚠ The rule was "4 markers, ever" until 2026-09-08, and it false-positived (issue #59)
+### ⚠ The rule was "4 markers, ever" until 2026-09-08, and it false-positived (issue #59, PR #76)
 
 **The sentence that used to stand here said the `'10'` marker gate made "false
 positives impossible". That is true of the marker BITS and false of the VERDICT,

--- a/docs/fabric_audio.md
+++ b/docs/fabric_audio.md
@@ -349,18 +349,98 @@ round-trip. It sits on the `P1,Debug` page, and the rename is what keeps a user 
 reaching for it to *fix* something — the failure mode that got `Field Order` and the
 `Analog CSync` `Stock` arm deleted before release (see `CLAUDE.md`).
 
-## CSS mute (scrambled-source audio protection, 2026-08-06)
+## CSS mute (scrambled-source audio protection, 2026-08-06; density verdict 2026-09-08)
 
 A CSS-encrypted rip (raw disc copy without decryption) still *plays* — the
 IFOs and PES headers are never scrambled, so navigation works and the ~80%
 unscrambled sectors show recognizable video — but the scrambled AC-3/DTS/LPCM
 payloads decode to **loud static bursts**. Detection: `ps_demux` pulses
-`pes_scrambled` for every video/audio PES whose `PES_scrambling_control != 0`
-(bits [5:4] of the first PES-flags byte, checked with the `'10'` marker bits so
-false positives are impossible); emu accumulates 4 pulses into a sticky
-`css_scrambled` latch that survives jumps (ps_demux itself resets on every
-`load_flush` via `pipe_rst_n` — a demux-local latch would flap and leak pops at
-every menu jump/seek) and clears only on a fresh media mount.
+`pes_scrambled` for a PES whose `PES_scrambling_control != 0` (bits [5:4] of the
+first PES-flags byte, checked with the `'10'` marker bits), and `pes_hdr_ok` for
+every checkable PES header whether marked or not; `dvd/css_detect.sv` turns the
+ratio into a sticky `css_scrambled` verdict. It survives jumps (ps_demux itself
+resets on every `load_flush` via `pipe_rst_n` — a demux-local latch would flap and
+leak pops at every menu jump/seek) and clears only on a fresh media mount, an
+eject, or a core reset.
+
+### ⚠ The rule was "4 markers, ever" until 2026-09-08, and it false-positived (issue #59)
+
+**The sentence that used to stand here said the `'10'` marker gate made "false
+positives impossible". That is true of the marker BITS and false of the VERDICT,
+and believing it is what let this ship.** A random byte passes `'10'` one time in
+four, and three of those four carry a non-zero scrambling field — so any byte the
+demux mistakes for a PES-flags byte is a marker with probability ~3/16. Two ways
+that happens on a disc with nothing wrong with it:
+
+1. **A lost frame.** Payload is length-counted, so a `00 00 01 E0` inside a payload
+   is normally invisible. After a resync it is not: `S_HUNT` locks onto whatever
+   byte-aligned start code it finds. The known hazards are the unhandled
+   `PES_packet_length == 0` and a flush that does not land on a pack boundary.
+2. **A marker that survived decryption.** libdvdcss (`src/libdvdcss.c`) clears the
+   bits with `_p_buffer[0x14] &= 0x8f` — at a FIXED sector offset, and only in the
+   non-zero-title-key branch; an all-zero key takes a branch that neither
+   descrambles nor clears.
+
+Either gives a handful of markers in a session. The old rule counted four, anywhere,
+however far apart, and latched **permanently** — so a disc that plays perfectly lost
+all of its audio and told its owner to go and install libdvdcss they did not need.
+Multiple users reported it; the reported case was a physical disc being decrypted
+correctly by `MiSTer_DVDcss`.
+
+**Two changes fix it.**
+
+**(1) `ps_demux` scores a marker only on a pack's own PES** (`pack_fresh`, armed at
+the `0xBA` dispatch, spent in `S_PES_HDR_FLAGS1`). A DVD pack is 2048 bytes and
+carries exactly one checkable PES — a NAV pack's `0xBB`/`0xBF` and a short PES's
+`0xBE` padding never reach that state — so this loses no genuine marker, while a
+header found after losing framing is by construction not preceded by a pack header.
+⚠ It must be spent in `S_PES_HDR_FLAGS1` and **not** at the `S_HUNT` dispatch: the
+dispatch is two states earlier, so clearing there clears the arm before the flags
+byte is ever examined and nothing can score at all (measured — every bench arm read
+zero). ★ `tools/css_scan.py` had **always** used this model while claiming to mirror
+the RTL; the divergence between an oracle and its subject is what hid the bug, and
+the RTL was changed to match the tool.
+
+**(2) The verdict is a density, not a count** (`dvd/css_detect.sv`): a marker adds
+one to a bucket, every `LEAK_CLEAN` clean headers repay one, and the verdict latches
+at `LATCH_HITS`. The bucket therefore rises only while the scrambled *fraction*
+exceeds `1/(LEAK_CLEAN+1)`. With `LEAK_CLEAN=64`, `LATCH_HITS=16` that knee is
+**1.54 %**, measured by `bench/dvd/css_detect_tb.sv`:
+
+| source | scrambled fraction | headers to latch |
+|---|---|---|
+| real CSS (FAIRYTOPIA, measured by `css_scan.py`) | 0.19 | **92** (~0.15 s of stream) |
+| lightly scrambled | 0.05 | 289 |
+| 0.03 | 0.03 | 543 |
+| knee | 0.0154 | — |
+| one marker per VOBU | ~0.004 | never |
+| a handful per session | ≤1e-4 | never |
+
+⛔ **Not "reset the counter after N consecutive clean headers"**, which is the
+obvious form and was written first. It has no density interpretation, only a longest
+tolerable gap — and **a VOBU is 200–500 packs**, so a stray produced once per VOBU
+never sees an N=512 clean run and latches anyway. Raising N only moves the
+resonance. Bench arm A5 is that adversary and finds the boundary by search.
+
+⚠ **Below the knee the bucket is a random walk with negative drift, not a pinned
+zero.** Measured at p=0.008 (about half the knee): still latched, after ~67,000
+headers. The honest claim is "exponentially longer the further below p\*", and a
+session is finite. The false positive being fixed is three orders of magnitude
+lower. ⚠ The knee rests on **one** measured real-CSS density (19 %, FAIRYTOPIA — the
+image is not in the local library). If a genuinely encrypted rip is ever measured
+below ~5 %, raise `LEAK_CLEAN` (the knee moves as `1/(K+1)`) and move the bench's
+knee band with it; the bench fails if the two disagree.
+
+⚠ **This fix is mechanism-justified, not reproduced.** It closes both routes above
+without knowing which one the reporter's disc took, and if it is the wrong one the
+warning simply persists — nothing regresses, because the change only makes the
+detector harder to trip. The acceptance test is hardware.
+
+**Accepted trade:** a genuinely encrypted source below the 1.5 % knee no longer
+mutes, so the user hears occasional ticks instead of silence. Below the knee fewer
+than one audio frame in 60 is garbage, so the regime where a miss costs least is the
+regime where the rule declines to act — against total, permanent, unexplained
+silence on a disc that plays perfectly, which is what shipped.
 
 While latched:
 
@@ -378,10 +458,13 @@ While latched:
   and the transport HUD shows the persistent `CSS ENCRYPTED` popup
   (`docs/transport_hud.md`).
 
-Sim: `bench/dvd/ps_demux_scram_tb.sv` (detection, video+audio PES, clean
-negative), `iec61937_wrap_tb` TEST 8/8b (mute = zero words + drain + consume,
-unmute resumes real bursts), `transport_hud_tb` T13 (popup text, menu
-exemption, slot yield/re-arm, clear).
+Sim: **`bench/dvd/run_css.sh`** — `css_detect_tb` (10 arms; A1 asserts that the
+DELETED rule latches on 4 strays 4096 headers apart while the new one does not, so
+the issue #59 regression is an assertion and not a comment; mutation-checked, 8
+mutations each caught) and `ps_demux_scram_tb` (8 arms; T2/T4 are RED against the
+pre-fix demux, which `--red` rebuilds out of git). Also `iec61937_wrap_tb` TEST 8/8b
+(mute = zero words + drain + consume, unmute resumes real bursts) and
+`transport_hud_tb` T13 (popup text, menu exemption, slot yield/re-arm, clear).
 
 ## Demux backpressure vs a HELD decoder — `aud_bp_wd` (2026-09-08)
 

--- a/docs/fabric_audio.md
+++ b/docs/fabric_audio.md
@@ -349,7 +349,7 @@ round-trip. It sits on the `P1,Debug` page, and the rename is what keeps a user 
 reaching for it to *fix* something — the failure mode that got `Field Order` and the
 `Analog CSync` `Stock` arm deleted before release (see `CLAUDE.md`).
 
-## CSS mute (scrambled-source audio protection, 2026-08-06; density verdict 2026-09-08)
+## CSS mute (scrambled-source audio protection, 2026-08-06; density verdict 2026-09-08 — ✅ HW-CONFIRMED)
 
 A CSS-encrypted rip (raw disc copy without decryption) still *plays* — the
 IFOs and PES headers are never scrambled, so navigation works and the ~80%
@@ -434,7 +434,13 @@ knee band with it; the bench fails if the two disagree.
 ⚠ **This fix is mechanism-justified, not reproduced.** It closes both routes above
 without knowing which one the reporter's disc took, and if it is the wrong one the
 warning simply persists — nothing regresses, because the change only makes the
-detector harder to trip. The acceptance test is hardware.
+detector harder to trip. The acceptance test was therefore hardware, and it passed:
+✅ **HW-CONFIRMED 2026-09-08** (`DVD_cssdensity_20260908_2056.rbf`) in **both**
+directions — encrypted discs still detected and muted, unencrypted discs no longer
+flagged. ⏳ Not separately reported, so still open: whether a static burst is
+audible at mount on an encrypted disc now the latch takes ~92 checked headers
+rather than ~21. If one ever is, the answer is **not** a smaller `LATCH_HITS` but a
+provisional mute on the first marker that the bucket confirms or releases.
 
 **Accepted trade:** a genuinely encrypted source below the 1.5 % knee no longer
 mutes, so the user hears occasional ticks instead of silence. Below the knee fewer

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1677,7 +1677,8 @@ Phase-2 proto-nav with "no button highlights (Phase 3) or nav-command execution
 Three failure modes produced no explanation on screen, each an undiagnosable bug
 report. All three reuse the proven `CSS ENCRYPTED` persistent-HUD path (PR fj#160):
 `transport_hud`'s `pop_type` gains 5/6/7 (it was already 3 bits, so 0..7 fits with no
-width change), and the detectors live next to the `css_scrambled` latch in `emu.sv`.
+width change), and the detectors live next to the CSS verdict in `emu.sv` (the
+verdict itself moved to `dvd/css_detect.sv` on 2026-09-08, issue #59).
 
 1. **Unplayable image** → persistent **`UNSUPPORTED IMAGE`**, menu-exempt.
    **★ The discriminator is deliberately BEHAVIOURAL, not the file extension.** The
@@ -1730,7 +1731,8 @@ it**); warnings re-appear after a user audio/subtitle popup. Two defects found:
    `media_seen`, set by the first `start_streaming`, gates the counter.
 2. **On a CSS-scrambled disc the audio notice appeared first, then CSS.** These levels
    do not assert together: `aud_warn` arms at `nav_ready` (IFO parsed) while
-   `css_scrambled` needs 4 scrambled PES, i.e. a moment of real stream — so the
+   `css_scrambled` needs a sustained scrambled DENSITY (4 markers outright until
+   2026-09-08, issue #59), i.e. a moment of real stream — so the
    narrower notice won the slot and held it for its full 2.5 s before the root cause
    could speak. Two-part fix: `aud_unsupported` is now gated on `~css_scrambled` (CSS
    already mutes audio, so a format notice is redundant AND misleading about the

--- a/docs/transport_hud.md
+++ b/docs/transport_hud.md
@@ -99,7 +99,7 @@ Rendered with `a2g()` letters only — `hud_font.mem` untouched. Tests:
 `transport_hud_tb` T21.
 
 **CSS warning popup (`css_warn`, 2026-08-06):** popup type 4 renders
-`CSS ENCRYPTED` (accent, cols 0–12) when emu's sticky `css_scrambled` latch is
+`CSS ENCRYPTED` (accent, cols 0–12) when the sticky `css_scrambled` verdict is
 set — the loaded image still carries CSS-scrambled sectors
 (`PES_scrambling_control != 0` seen by `ps_demux`; such a rip decodes as green
 macroblock garbage, so the popup is the "your rip isn't decrypted" diagnostic —
@@ -108,8 +108,15 @@ keys by design). Two deliberate exceptions to the normal popup rules: it is
 **persistent** (a level input, lowest priority — user popups take the slot for
 their 2.5 s, then the warning re-arms) and it is **NOT menu-suppressed**
 (scrambled discs green-screen in the menu domain first — that's where the user
-is staring). Clears only on a fresh media mount. The same latch mutes both
-audio paths (see `docs/fabric_audio.md` "CSS mute").
+is staring). Clears on a fresh media mount, an eject, or a core reset. The same
+verdict mutes both audio paths (see `docs/fabric_audio.md` "CSS mute").
+
+⚠ **The verdict is a DENSITY, and since 2026-09-08 it lives in
+`dvd/css_detect.sv`, not in `emu.sv`** (issue #59). Until then it latched on the
+4th scrambled PES header of a session however far apart they were, so a stray
+marker raised this popup — and muted all audio — on discs that play perfectly.
+A stray can no longer raise it; a genuinely scrambled source still does, within
+about 90 checked packs of the mount.
 
 ### `dvd/seek_bar.sv` — scrub feedback + progress popup
 

--- a/dvd/css_detect.sv
+++ b/dvd/css_detect.sv
@@ -1,0 +1,123 @@
+// ============================================================================
+// css_detect.sv — is this source CSS-scrambled? A DENSITY verdict.
+// ============================================================================
+// A CSS-encrypted rip (a raw disc copy with no decryption — VLC plays one because
+// libdvdcss decrypts on the fly; this core never sees keys BY DESIGN, decryption is
+// a PC-side rip step or the MiSTer_DVDcss Main's job) decodes as green macroblock
+// garbage and LOUD AUDIO STATIC. So the core detects it from the PES headers
+// (PES_scrambling_control != 0 — the headers themselves are never scrambled), warns
+// via the transport HUD ("CSS ENCRYPTED", persistent, visible in menus too) and
+// MUTES both audio paths. Video keeps playing so the disc stays identifiable.
+//
+// ★ WHY THIS IS A SEPARATE MODULE (issue #59, 2026-09-08). The rule used to be four
+// lines inside emu.sv:
+//
+//     else if (ps_pes_scrambled && !css_scrambled) begin
+//         css_det_cnt <= css_det_cnt + 3'd1;
+//         if (css_det_cnt == 3'd3) css_scrambled <= 1'b1;   // 4th scrambled PES
+//     end
+//
+// which has NO NOTION OF DENSITY OR TIME: four markers anywhere in a session —
+// seconds or an hour apart — latch it permanently. A genuinely scrambled source
+// gives a marker about every 5 packs (~19% of checked packs, measured on
+// FAIRYTOPIA.iso by tools/css_scan.py). The rule could not tell 4 from 400,000, and
+// multiple users lost all audio on discs that play perfectly. emu.sv has no
+// testbench, which is why the rule could not be gated where it lived; extracted
+// here for the same reason flush_ctl.sv, dpad_seek.sv and mode_realign.sv were.
+//
+// ★ THE RULE: A LEAKY BUCKET.
+//     a scrambled header  -> bucket++ (latch at LATCH_HITS), leak counter reset
+//     a clean header      -> every LEAK_CLEAN of them repay one bucket entry
+// so the bucket drifts upward if and only if the scrambled FRACTION exceeds
+// 1/(LEAK_CLEAN+1). With LEAK_CLEAN=64 that knee is p* = 1.54%:
+//
+//     real CSS (measured)   p=0.19    latches after ~90 checked headers (~0.15 s)
+//     lightly scrambled     p=0.05    latches after ~455
+//     knee                  p=0.0154  never
+//     one stray per VOBU    p=0.004   never — DETERMINISTICALLY, not just unlikely
+//     a handful per session p<=1e-4   never
+//
+// ⛔ NOT "reset the counter after N consecutive clean headers", which is the obvious
+// form and was written first. It has no density interpretation, only a longest
+// tolerable gap — and a VOBU is 200-500 packs, so a stray produced once per VOBU
+// (the most plausible structure-driven periodicity on a DVD) never sees an N=512
+// clean run and latches anyway. Raising N only moves the resonance. Below the knee
+// the leak pins the bucket at zero, which a bench can prove rather than estimate.
+//
+// ⚠ scrambled without hdr_ok is IGNORED, and that is a benched property: it stops a
+// future ps_demux edit that forgets the denominator from silently restoring the old
+// count-anything behaviour.
+//
+// ⚠ STICKY PER MOUNT, DELIBERATELY. ps_demux resets on every jump via pipe_rst_n, so
+// a latch that could drop would flap across menu jumps and seeks and leak static
+// pops through the mute. It clears only on reset, a fresh mount, or an eject — NOT
+// on load_flush/seek_ack/jump_ack.
+//
+// Parameters, not localparams, so the bench pins them explicitly and a retune is a
+// reviewed edit. If a genuinely encrypted rip is ever measured below ~5% scrambled,
+// raise LEAK_CLEAN (the knee moves as 1/(K+1)) and move css_detect_tb's knee band
+// with it — the bench fails if the two disagree.
+//
+// Design note + the measured density table: docs/fabric_audio.md "CSS mute".
+// Gate: bench/dvd/css_detect_tb.sv via bench/dvd/run_css.sh.
+// ============================================================================
+`default_nettype none
+
+module css_detect #(
+    parameter int LATCH_HITS = 16,   // scrambled headers in the bucket that latch
+    parameter int LEAK_CLEAN = 64,   // clean headers that repay one bucket entry
+    parameter int CENSUS_W   = 16    // width of the saturating diagnostic counters
+) (
+    input  wire clk,                 // clk_sys
+    input  wire rst_n,               // async, active low (emu reset_n, OSD Reset included)
+    input  wire mount,               // 1-cycle: fresh media -> re-evaluate
+    input  wire eject,               // 1-cycle: slot emptied -> drop the verdict
+    input  wire hdr_ok,              // 1-cycle: a checkable PES header was parsed
+    input  wire scrambled,           // 1-cycle, coincident with hdr_ok: it was marked
+
+    output reg  css_scrambled,       // sticky per mount -> HUD popup + both audio mutes
+    output reg  [CENSUS_W-1:0] hdr_census,   // saturating: checkable headers seen
+    output reg  [CENSUS_W-1:0] scram_census  // saturating: of those, marked scrambled
+);
+
+localparam int BUCKET_W = $clog2(LATCH_HITS + 1);
+localparam int LEAK_W   = $clog2(LEAK_CLEAN);
+
+reg [BUCKET_W-1:0] bucket;
+reg [LEAK_W-1:0]   leak_cnt;
+
+always @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+        bucket        <= '0;
+        leak_cnt      <= '0;
+        css_scrambled <= 1'b0;
+        hdr_census    <= '0;
+        scram_census  <= '0;
+    end else if (mount || eject) begin
+        bucket        <= '0;
+        leak_cnt      <= '0;
+        css_scrambled <= 1'b0;
+        hdr_census    <= '0;
+        scram_census  <= '0;
+    end else if (css_scrambled) begin
+        // Latched: hold everything. The verdict cannot be revisited until the media
+        // changes (see the anti-flap note in the header).
+    end else if (hdr_ok) begin
+        if (~&hdr_census) hdr_census <= hdr_census + 1'b1;      // saturate, never wrap:
+        if (scrambled) begin                                    // a wrapped census would
+            if (~&scram_census) scram_census <= scram_census + 1'b1;  // lie in a bug report
+            leak_cnt <= '0;
+            if (bucket == BUCKET_W'(LATCH_HITS - 1)) css_scrambled <= 1'b1;
+            else                                     bucket <= bucket + 1'b1;
+        end else if (leak_cnt == LEAK_W'(LEAK_CLEAN - 1)) begin
+            leak_cnt <= '0;
+            if (bucket != '0) bucket <= bucket - 1'b1;
+        end else begin
+            leak_cnt <= leak_cnt + 1'b1;
+        end
+    end
+end
+
+endmodule
+
+`default_nettype wire

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -360,7 +360,7 @@ wire        pass_mode  = status[6];   // O6: 1 = IEC 61937 passthrough
 wire        pass_bswap = status[7];   // O7: 1 = swap payload byte order
 assign AUDIO_S      = 1;
 assign AUDIO_MIX    = 2'd0;
-// css_scrambled: CSS-encrypted source detected (sticky latch by the demux
+// css_scrambled: CSS-encrypted source detected (dvd/css_detect.sv, fed by the demux
 // instance below) — mute the PCM out (scrambled AC-3 decodes to loud static).
 // probe taps (declared unconditionally — the instantiation below always
 // connects them; the tone logic itself is behind the define)
@@ -2865,43 +2865,51 @@ ps_demux ps_demux_inst (
     // before samples drain, and track switches reset audio_ring+dvd_audio_decode.
     .aud_lpcm_quant   (ps_aud_lpcm_quant),
 
-    // CSS detection pulse -> the css_scrambled sticky latch below
+    // CSS detection: marker + denominator -> the css_detect density verdict below
     .pes_scrambled    (ps_pes_scrambled),
+    .pes_hdr_ok       (ps_pes_hdr_ok),
     .saw_pack         (ps_saw_pack)
 );
 
 // =========================================================================
 // CSS-SCRAMBLED SOURCE DETECTION. A CSS-encrypted rip (raw disc copy without
 // decryption — VLC plays it because libdvdcss decrypts on the fly; this core
-// never sees keys BY DESIGN, decryption is a PC-side rip step) decodes as
-// green macroblock garbage + loud audio static. Detect it from the PES
-// headers (PES_scrambling_control != 0; headers themselves are never
-// scrambled), warn via the transport HUD popup ("CSS ENCRYPTED", persistent,
-// visible in menus too), and MUTE both audio paths (decode PCM forced to 0;
-// passthrough emits PCM-silence bursts while draining the ring normally).
-// Video keeps playing — the ~80% unscrambled sectors let the user identify
-// the disc. The latch lives HERE (not in ps_demux, which resets on every
-// jump via pipe_rst_n) and clears only on a fresh media mount, so the mute
-// can't flap (and leak static pops) across menu jumps and seeks. A 4-pack
-// threshold debounces against stray corruption; at real CSS density (~20%
-// of packs) it trips within a few sectors of mount.
+// never sees keys BY DESIGN, decryption is a PC-side rip step or the
+// MiSTer_DVDcss Main's job) decodes as green macroblock garbage + loud audio
+// static, so the verdict drives the HUD popup ("CSS ENCRYPTED", persistent,
+// visible in menus too) and MUTES both audio paths. Video keeps playing so
+// the disc stays identifiable.
+//
+// The verdict lives in dvd/css_detect.sv, NOT here and NOT in ps_demux:
+//  - not in ps_demux, which resets on every jump via pipe_rst_n, so a
+//    demux-local latch would flap and leak static pops across menu jumps;
+//  - not inline here, because emu.sv has no testbench and the rule that used
+//    to sit at this spot — four scrambled PES headers per session, however
+//    far apart — could not be gated. It false-positived on discs that play
+//    perfectly and cost their owners all audio (issue #59).
+// The rule, its density knee and the measured numbers are in that file's
+// header and in docs/fabric_audio.md "CSS mute". Gate: bench/dvd/run_css.sh.
 // =========================================================================
 wire ps_pes_scrambled;
+wire ps_pes_hdr_ok;
 wire ps_saw_pack;
-reg  [2:0] css_det_cnt;
-reg        css_scrambled;
-always @(posedge clk_sys or negedge reset_n) begin
-    if (!reset_n) begin
-        css_det_cnt   <= 3'd0;
-        css_scrambled <= 1'b0;
-    end else if (start_streaming) begin      // fresh media mount: re-evaluate
-        css_det_cnt   <= 3'd0;
-        css_scrambled <= 1'b0;
-    end else if (ps_pes_scrambled && !css_scrambled) begin
-        css_det_cnt <= css_det_cnt + 3'd1;
-        if (css_det_cnt == 3'd3) css_scrambled <= 1'b1;   // 4th scrambled PES
-    end
-end
+wire css_scrambled;
+// Saturating census of what the verdict was decided on. ⚠ CURRENTLY UNCONSUMED,
+// so Quartus dead-strips both counters -- they exist so that surfacing them (a
+// DEBUG_OVERLAY row, or the delivered-vs-medium census sketched in
+// docs/bug_reports.md) is a one-line change rather than an RTL round trip.
+wire [15:0] css_hdr_census, css_scram_census;
+css_detect #(.LATCH_HITS(16), .LEAK_CLEAN(64)) css_det (
+    .clk           (clk_sys),
+    .rst_n         (reset_n),
+    .mount         (start_streaming),   // fresh media: re-evaluate
+    .eject         (img_ejected),       // slot emptied: drop the verdict
+    .hdr_ok        (ps_pes_hdr_ok),
+    .scrambled     (ps_pes_scrambled),
+    .css_scrambled (css_scrambled),
+    .hdr_census    (css_hdr_census),
+    .scram_census  (css_scram_census)
+);
 
 // =========================================================================
 // Phase-2 failure messaging (docs/roadmap.md "Public alpha release prep").

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -581,7 +581,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "dev-spuwindow"
+`define CORE_VERSION "dev-cssdensity"
 
 parameter CONF_STR = {
     "DVD;;",

--- a/dvd/ps_demux.sv
+++ b/dvd/ps_demux.sv
@@ -153,10 +153,27 @@ module ps_demux (
     // CSS detection: one-cycle pulse when a video/audio PES header carries
     // PES_scrambling_control != 0 (bits [5:4] of the first PES-flags byte) — the
     // payload is CSS-scrambled and will decode as garbage (green macroblocks /
-    // audio static). emu.sv accumulates these into a sticky per-mount latch
-    // (ps_demux itself resets on every jump via pipe_rst_n, so the latch can't
-    // live here) that drives the HUD "CSS ENCRYPTED" popup + the audio mute.
+    // audio static). dvd/css_detect.sv accumulates these into a sticky per-mount
+    // latch (ps_demux itself resets on every jump via pipe_rst_n, so the latch
+    // can't live here) that drives the HUD "CSS ENCRYPTED" popup + the audio mute.
+    //
+    // ⚠ ONLY THE FIRST CHECKABLE PES AFTER A PACK HEADER CAN SCORE (`pack_fresh`,
+    // issue #59). A DVD pack is 2048 bytes and carries exactly ONE checkable PES —
+    // a NAV pack's 0xBB/0xBF and a short PES's 0xBE padding never reach here — so
+    // this loses no genuine marker, while a header the hunt found after LOSING
+    // FRAMING is by construction not preceded by a pack header. Without it, one
+    // desync inside a payload manufactures markers at ~3/16 per false header
+    // (a random byte passes the '10' marker 1 time in 4, and 3 of those 4 have a
+    // non-zero scrambling field), which is how discs that play perfectly came to
+    // show CSS ENCRYPTED and lose all their audio.
     output logic        pes_scrambled,
+
+    // The DENOMINATOR: one-cycle pulse, in the same cycle pes_scrambled would
+    // pulse, for every checkable PES header carrying a valid '10' marker in the
+    // position where a genuine CSS marker can appear — scrambled or not.
+    // css_detect divides one by the other, because a threshold on the numerator
+    // alone cannot tell 4 strays in a session from 4 packs in a row.
+    output logic        pes_hdr_ok,
 
     // ---- Audio-substream observation (2026-08-27, menu-link/audio-map fix) ----
     // A PASSIVE tap beside the FSM (which is untouched): which audio-class
@@ -254,6 +271,9 @@ logic        aud_pes_has_pts;  // current PES carried a PTS (set at PES_HDR_FLAG
 logic  [7:0] es_code;          // saved video start-code byte (e.g. 0xB3 seq header)
 logic  [1:0] es_emit_idx;      // index into reconstructed 00 00 01 <code> preamble
 logic        ever_seen_pack;   // a 0xBA pack was seen -> stream is PS, lock out ES mode
+logic        pack_fresh;       // a pack header has been dispatched and its one
+                               // checkable PES has not been parsed yet -> only that
+                               // PES may score a CSS marker (see pes_scrambled)
 logic        mpeg1_ps;         // stream flavour, re-latched at every pack marker:
                                // 1 = MPEG-1 system stream (VCD), 0 = MPEG-2 PS (DVD)
 assign saw_pack = ever_seen_pack;
@@ -430,11 +450,14 @@ always_ff @(posedge clk or negedge rst_n) begin
         aud_pts        <= 33'd0;
         aud_pts_valid  <= 1'b0;
         pes_scrambled  <= 1'b0;
+        pes_hdr_ok     <= 1'b0;
+        pack_fresh     <= 1'b0;
     end else begin
         // PTS-valid strobes are one-cycle pulses
         vid_pts_valid <= 1'b0;
         aud_pts_valid <= 1'b0;
         pes_scrambled <= 1'b0;
+        pes_hdr_ok    <= 1'b0;
 
         // ES preamble emit advances on the OUTPUT handshake (input is held).
         if (state == S_ES_EMIT) begin
@@ -457,7 +480,7 @@ always_ff @(posedge clk or negedge rst_n) begin
                 if (start_code_detected) begin
                     stream_id_r <= in_byte;
                     casez (in_byte)
-                        8'hBA:   begin ever_seen_pack <= 1'b1; bytes_remaining <= 16'd9; state <= S_PACK_SKIP; end
+                        8'hBA:   begin ever_seen_pack <= 1'b1; pack_fresh <= 1'b1; bytes_remaining <= 16'd9; state <= S_PACK_SKIP; end
                         8'hE0:   state <= S_PES_LEN_HI;   // video
                         8'hBD:   state <= S_PES_LEN_HI;   // private stream 1 (audio)
                         // MPEG audio 0xC0-0xC7 (DVD-spec MP2, MPEG-1 Layer II).
@@ -559,8 +582,20 @@ always_ff @(posedge clk or negedge rst_n) begin
             S_PES_HDR_FLAGS1: begin
                 // '10' marker bits + PES_scrambling_control[1:0] in bits [5:4]:
                 // nonzero = this PES payload is CSS-scrambled (undecryptable here).
-                if (in_byte[7:6] == 2'b10 && in_byte[5:4] != 2'b00)
-                    pes_scrambled <= 1'b1;
+                // pack_fresh: and this is the pack's own PES, not something the
+                // hunt found after losing framing — see the pes_scrambled port.
+                if (in_byte[7:6] == 2'b10 && pack_fresh) begin
+                    pes_hdr_ok <= 1'b1;
+                    if (in_byte[5:4] != 2'b00) pes_scrambled <= 1'b1;
+                end
+                // ⚠ SPEND THE ARM HERE, not at the S_HUNT dispatch: the dispatch is
+                // two states earlier, so clearing there would clear it before this
+                // byte is ever examined and nothing could ever score. This state is
+                // reached ONLY by 0xE0 / 0xBD / a selected MP2 track, so 0xBB, 0xBE,
+                // 0xBF and an unselected MP2 cannot disarm a pack they share a
+                // sector with. Spent even on a bad marker: the pack's PES has been
+                // seen either way, and the next 0xBA re-arms.
+                pack_fresh <= 1'b0;
                 pes_length <= pes_length - 16'd1;
                 state <= S_PES_HDR_FLAGS2;
             end

--- a/site/content/playback/on-screen-messages.md
+++ b/site/content/playback/on-screen-messages.md
@@ -5,7 +5,7 @@ themselves; the ones that persist are describing a condition, not an event.
 
 | Message | Meaning | What to do |
 |---|---|---|
-| `CSS ENCRYPTED` | The image or disc is CSS-encrypted and nothing available can decrypt it. Audio is muted so you get silence rather than static; video keeps playing so the disc stays identifiable. | Install libdvdcss, or use a decrypted rip — see [What you need](../getting-started/what-you-need.md). |
+| `CSS ENCRYPTED` | The core is seeing scrambled sectors, so nothing available is decrypting this disc or image. Audio is muted to give you silence rather than static; video keeps playing so the disc stays identifiable. | Install libdvdcss, or use a decrypted rip — see [What you need](../getting-started/what-you-need.md). If the picture is perfect and only the sound is missing, the message is wrong — please [report it](../reference/reporting-a-bug.md). |
 | `UNSUPPORTED IMAGE` | Not an ISO9660 DVD image — a UDF-only image, for instance — or not a playable stream at all. | Check the file is a whole-disc DVD image. See [Compatibility](../reference/compatibility.md). |
 | `AUDIO UNSUPPORTED` | The selected audio track is in a format the core cannot decode. | Cycle to another track with B7, or use [passthrough](../audio/passthrough.md) if it is DTS. |
 | `TITLE VTS nn` | Which title was auto-selected. Only shown with **Disc Menus** off. | Informational. If it picked the wrong one, `Title VTS` on the Debug page forces a choice. |

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -57,12 +57,26 @@ what you will see from slow media.
 
 ### `CSS ENCRYPTED`
 
-The image or disc is encrypted and nothing available can decrypt it. Audio is muted
-deliberately so you get silence rather than static; video keeps playing so you can still
-identify the disc.
+The core is seeing scrambled sectors, so nothing available is decrypting this disc or
+image. Audio is muted deliberately so you get silence rather than static; video keeps
+playing so you can still identify the disc.
 
 **Fix:** install `MiSTer_DVDcss` and libdvdcss, or use a decrypted rip. See
 [What you need](../getting-started/what-you-need.md).
+
+!!! warning "If the picture is perfect and only the sound is gone"
+
+    Then the message is wrong. A scrambled disc looks obviously broken — blocky green
+    rubbish over most of the picture — so a clean picture with silent audio means the
+    core mis-read a handful of bytes and muted for no reason.
+
+    Releases up to **v0.4.0** could do this: the warning latched after only four
+    suspicious bytes anywhere in a whole session, which a perfectly good disc can
+    produce. Later builds require sustained evidence instead, so an isolated glitch no
+    longer trips it.
+
+    If you see it on a build after v0.4.0, please
+    [send a report](reporting-a-bug.md) — it means something is still wrong.
 
 ### The core loads but a physical disc does nothing
 

--- a/tools/css_scan.py
+++ b/tools/css_scan.py
@@ -7,9 +7,19 @@ DETECTS this on-board (persistent `CSS ENCRYPTED` HUD popup + audio mute), but t
 right place to catch a bad rip is offline, before it ever reaches the SD card --
 especially now that the dvd_ripper project mass-produces ISOs.
 
-Detection mirrors dvd/ps_demux.sv S_PES_HDR_FLAGS1 exactly: a pack whose first PES
-optional-header flags byte has the '10' marker bits AND PES_scrambling_control
-(bits [5:4]) != 0 is scrambled. Layout per sampled 2048-byte sector:
+Detection: a pack whose FIRST PES optional-header flags byte has the '10' marker
+bits AND PES_scrambling_control (bits [5:4]) != 0 is scrambled.
+
+★ That "first PES" qualifier used to be undocumented, and the docstring here
+claimed this tool "mirrors dvd/ps_demux.sv S_PES_HDR_FLAGS1 exactly". It never
+did: this tool has always checked only the first PES after the pack header, while
+the RTL checked EVERY checkable PES it dispatched. That divergence is how issue
+#59 stayed hidden -- the oracle reported the same media clean while the core
+flagged it in the field, because the oracle was quietly applying the stricter and
+correct model. The RTL was changed to match this tool (dvd/ps_demux.sv
+`pack_fresh`), not the other way round.
+
+Layout per sampled 2048-byte sector:
     [0..3]   00 00 01 BA        pack start (DVD sectors are pack-aligned)
     [4..12]  9 fixed pack-header bytes
     [13]     low 3 bits = stuffing count S
@@ -22,12 +32,21 @@ optional header and are skipped, exactly as the RTL skips them.
 Motivating case: FAIRYTOPIA.iso -- ~19% of packs scrambled (a raw rip); a clean
 rip (e.g. MEN_IN_BLACK.iso) reports 0.
 
+Verdicts follow the CORE's rule (dvd/css_detect.sv), so this tool answers the
+question a user actually has -- "will the core mute this?" -- rather than "is
+there a single odd byte anywhere on the disc":
+    ENCRYPTED  above the core's density knee, 1/(LEAK_CLEAN+1) = 1.5%  -> muted
+    MARGINAL   some markers, but below the knee                        -> NOT muted
+    CLEAN      none
+MARGINAL exits 2 rather than being folded into CLEAN: a rip with stray markers is
+worth looking at even though the core will play it.
+
 Usage:
     tools/css_scan.py <iso-or-dir> [...]     # sampled scan (~20k packs/disc, seconds)
     tools/css_scan.py --full <iso>           # every sector (minutes on 8 GB)
 
-Exit status: 0 = all scanned images clean, 1 = any scrambling found (scriptable
-as a ripper post-check).
+Exit status: 0 = every image clean, 1 = any image ENCRYPTED, 2 = none encrypted
+but at least one MARGINAL (scriptable as a ripper post-check).
 """
 import os
 import struct
@@ -35,8 +54,20 @@ import sys
 
 SEC = 2048
 TARGET_SAMPLES = 20000          # sampled mode: aim for this many sectors per image
-# stream ids that carry the MPEG-2 PES optional header (=> have a flags byte)
-CHECKABLE = set(range(0xE0, 0xF0)) | set(range(0xC0, 0xE0)) | {0xBD}
+
+# Stream ids the CORE checks -- deliberately the RTL's set and not the wider set of
+# ids that merely CARRY an MPEG-2 optional header. dvd/ps_demux.sv routes only
+# 0xE0 (video; E1-EF go to the skip-by-length path), 0xBD (private_stream_1) and
+# MP2 0xC0-0xC7 to S_PES_HDR_FLAGS1. An oracle that is not the model is how this
+# class of bug survives, so match it.
+CHECKABLE = {0xE0, 0xBD} | set(range(0xC0, 0xC8))
+
+# The core's density rule, from dvd/css_detect.sv -- SOURCE OF TRUTH IS THAT FILE.
+# The bucket rises only while the scrambled fraction exceeds 1/(LEAK_CLEAN+1), so
+# that ratio is the threshold between "the core will mute this" and "it will not".
+CORE_LATCH_HITS = 16
+CORE_LEAK_CLEAN = 64
+CORE_KNEE_PCT = 100.0 / (CORE_LEAK_CLEAN + 1)     # 1.54%
 
 
 def scan(path, full=False):
@@ -45,6 +76,7 @@ def scan(path, full=False):
     stride = 1 if full else max(1, nsec // TARGET_SAMPLES)
     packs = checked = scrambled = 0
     first_hits = []
+    gaps, last_hit = [], None
     with open(path, 'rb') as f:
         for s in range(0, nsec, stride):
             f.seek(s * SEC)
@@ -63,9 +95,12 @@ def scan(path, full=False):
             checked += 1
             if (flags & 0xC0) == 0x80 and (flags & 0x30) != 0:
                 scrambled += 1
+                if last_hit is not None:
+                    gaps.append(checked - last_hit)
+                last_hit = checked
                 if len(first_hits) < 3:
                     first_hits.append((s, sid))
-    return nsec, stride, packs, checked, scrambled, first_hits
+    return nsec, stride, packs, checked, scrambled, first_hits, sorted(gaps)
 
 
 def main(argv):
@@ -81,21 +116,37 @@ def main(argv):
     if not paths:
         print(__doc__)
         return 2
-    any_bad = False
+    any_enc = any_marg = False
     for p in paths:
-        nsec, stride, packs, checked, scrambled, hits = scan(p, full)
+        nsec, stride, packs, checked, scrambled, hits, gaps = scan(p, full)
         pct = (100.0 * scrambled / checked) if checked else 0.0
-        verdict = "CLEAN" if scrambled == 0 else "ENCRYPTED (%.1f%% of checked packs)" % pct
-        if scrambled:
-            any_bad = True
+        if scrambled == 0:
+            verdict = "CLEAN"
+        elif pct >= CORE_KNEE_PCT:
+            verdict = "ENCRYPTED (%.1f%% of checked packs -- the core will mute)" % pct
+            any_enc = True
+        else:
+            # Stray markers. Below the core's knee it plays them, so saying
+            # "ENCRYPTED" here would send the user off to install libdvdcss they do
+            # not need -- which is exactly what the core itself used to do (#59).
+            verdict = ("MARGINAL (%.3f%% -- below the core's %.1f%% threshold, "
+                       "it will NOT mute)" % (pct, CORE_KNEE_PCT))
+            any_marg = True
         print("%-52s %s" % (os.path.basename(p), verdict))
         print("    sectors=%d stride=%d packs=%d pes_checked=%d scrambled=%d"
               % (nsec, stride, packs, checked, scrambled))
+        if gaps:
+            # The separation the core's rule keys on: real CSS hits every few
+            # headers, a stray leaves thousands of clean ones between.
+            print("    gap between hits (checked packs): min=%d median=%d max=%d"
+                  % (gaps[0], gaps[len(gaps)//2], gaps[-1]))
         for s, sid in hits:
             print("    first hit: sector %d stream_id 0x%02X" % (s, sid))
         if checked == 0 and packs == 0:
             print("    ?? no MPEG packs found -- not a DVD-Video image?")
-    return 1 if any_bad else 0
+    if any_enc:
+        return 1
+    return 2 if any_marg else 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #59.

`CSS ENCRYPTED` latched — and muted **both** audio paths — on discs that play
perfectly. The reported case was a physical disc that `MiSTer_DVDcss` was
decrypting correctly; clean video proves the payload reaching the core was
descrambled, so the detector was believing evidence that is not a scrambled pack.

## Why it fired

The rule had no notion of density or time:

```systemverilog
if (css_det_cnt == 3'd3) css_scrambled <= 1'b1;   // 4th scrambled PES
```

**Four markers anywhere in a session — seconds or an hour apart — latched it
permanently.** A genuinely scrambled source gives one marker every ~5 packs
(~19 % of checked packs). The rule could not tell 4 from 400,000.

Two things manufacture markers on a healthy disc:

1. **A lost frame.** Payload is length-counted, so a `00 00 01 E0` inside a payload
   is normally invisible — after a resync it is not, and a random byte passes the
   `'10'` marker test 1 time in 4 with 3 of those 4 carrying a non-zero scrambling
   field: **~3/16 per false header.**
2. **A marker that survived decryption.** libdvdcss clears the bits with
   `_p_buffer[0x14] &= 0x8f` — at a *fixed* sector offset, and only in its
   non-zero-title-key branch.

★ **`tools/css_scan.py` claimed to "mirror `S_PES_HDR_FLAGS1` exactly" and never
did** — it only ever checked the first PES after a pack header, while the RTL
checked every one it dispatched. That divergence is why the offline oracle called
the same media clean while the core flagged it in the field. The RTL was changed to
match the tool.

## The fix

**1. `ps_demux` scores a marker only on a pack's own PES** (`pack_fresh`). A DVD
pack is 2048 bytes and carries exactly one checkable PES — `0xBB`/`0xBE`/`0xBF`
never reach `S_PES_HDR_FLAGS1` — so nothing genuine is lost, while a header found
after losing framing is by construction not preceded by a pack header.

⚠ The arm must be spent **in `S_PES_HDR_FLAGS1`**, not at the `S_HUNT` dispatch:
the dispatch is two states earlier, so clearing there clears it before the flags
byte is examined and nothing can ever score. (Measured — every bench arm read 0.)

**2. The verdict is a density** — new `dvd/css_detect.sv`, extracted from `emu.sv`
because `emu.sv` has no testbench. A leaky bucket: a marker adds one, every 64
clean headers repay one, latch at 16. The bucket rises only above a **knee of
1/(K+1) = 1.54 %**.

| source | fraction | headers to latch |
|---|---|---|
| real CSS (measured) | 0.19 | **92** (~0.15 s) |
| lightly scrambled | 0.05 | 289 |
| knee | 0.0154 | — |
| one marker per VOBU | ~0.004 | never |
| a handful per session | ≤1e-4 | never |

⛔ **Not "reset the counter after N consecutive clean headers"** — the obvious form,
written first. It has no density meaning, only a longest tolerable gap, and **a
VOBU is 200–500 packs**, so a stray once per VOBU never sees an N=512 clean run and
latches anyway.

⚠ **Below the knee the bucket is a negative-drift random walk, not a pinned zero.**
Measured at p=0.008 it still latched, after ~67,000 headers. Documented rather than
glossed, along with the fact that the knee rests on a **single** measured real-CSS
density (19 %).

**Accepted trade:** genuine CSS below 1.5 % now ticks instead of muting — the
regime where a miss costs least, against total unexplained silence on a good disc.

## Test plan

- [x] `bench/dvd/run_css.sh` GREEN — `css_detect_tb` (10 arms) + `ps_demux_scram_tb` (8 arms)
- [x] `run_css.sh --red` — rebuilds the **pre-fix demux out of git** and it fails T2/T4 as it must
- [x] A1 asserts the **deleted** rule latches on 4 strays 4096 apart where the new one does not — the regression, as an assertion
- [x] Mutation-checked: 8 mutations, each caught (M4 and M8 by a single arm)
- [x] Every `ps_demux` bench: es, esrecover, lpcm, m1, mp2, nav, ps2, seqend, subpic, substream, `ps_demux_tb`, `ps_chain` (real Matrix VOB)
- [x] `run_mgl.sh`, `run_vcd.sh` (`vcd_chain_tb` 27648 samples **bit-exact**), `run_mp2.sh`, `run_subpic.sh`, `run_spu_window.sh`
- [x] `tools/lint_undriven.sh` PASS · `tools/docs_check.py` OK · `mkdocs build --strict` clean
- [x] `css_scan.py` verdicts verified on all three branches (ENCRYPTED/MARGINAL/CLEAN, exit 1/2/0); a real library rip still CLEAN
- [x] Build `DVD_cssdensity_20260908_2056.rbf` — **SEED 5 first roll**, clk_dec 92.07 @100C / 91.16 @-40C (gate 86.0), ALM 92 %
- [x] **HW-CONFIRMED 2026-09-08, both directions** — encrypted discs still detected and muted; unencrypted discs no longer flagged
- [ ] Not separately reported: whether a static burst is audible at mount now the latch takes ~92 headers instead of ~21. If one ever is, the answer is a provisional mute on the first marker, **not** a smaller `LATCH_HITS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
