### PR TITLE
chore: reset CORE_VERSION to dev-main after #76

### DIFF
--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -581,7 +581,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "dev-cssdensity"
+`define CORE_VERSION "dev-main"
 
 parameter CONF_STR = {
     "DVD;;",


### PR DESCRIPTION
Routine post-merge reset after #76, per the versioning rule in CLAUDE.md.

Without it a build made from `main` shows `dev-cssdensity` in the OSD while
containing much more than that feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
