### PR TITLE
nav_diff: a cell with buttons is not yet a park

### DIFF
--- a/.claude/skills/hil-testing/SKILL.md
+++ b/.claude/skills/hil-testing/SKILL.md
@@ -104,6 +104,14 @@ tools/nav_diff.py <disc> --no-board                # oracle only, no hardware
   that cost the oracle milliseconds cost the board minutes.
 - **Only well-defined inputs are comparable.** Pressing a button that does not exist at
   that park is undefined, not a difference.
+- **A step that never parked was not measured.** Excluded, not diffed.
+- **After the first divergence, nothing downstream is an independent finding** — the next
+  button is pressed at two different menus, so a difference is guaranteed and meaningless.
+- **A disc whose navigation uses `rnd` cannot be diffed** (the core's LFSR and libdvdnav's
+  RNG disagree by design). Detected by running the oracle twice under different seeds.
+- **Do not compare VTS.** libdvdnav's is domain-relative (-1 in VMGM), the board's is the
+  reader's absolute VTS; on a board game with 70+ title sets one says 72 where the other
+  says 1 and neither is wrong. PGCN is the comparable field.
 
 ## Before believing a finding
 

--- a/.claude/skills/hil-testing/SKILL.md
+++ b/.claude/skills/hil-testing/SKILL.md
@@ -42,12 +42,20 @@ tools/mister.py restore         # stock Main, harness files gone, saved settings
 | `mister.py options` | every OSD option and key name, derived from the RTL |
 | `hud_read.py read/blocks <png>` | decode a screenshot's HUD / `O[2]` diagnostic blocks |
 | `dvd_explore.py <iso> --minutes 30` | unattended soak with self-tested oracles |
+| `audio_check.py <iso>` | is every audio track the disc offers actually audible? |
 | `nav_diff.py <disc> --script "1 2"` | diff the core's navigation against libdvdnav |
 | `lipsync_measure.py` + `sync_disc.py` | A/V **offset** measurement (see the warning below) |
 
 Gates, all hardware-free: `bench/dvd/run_telem.sh`.
 
 ## Traps that have cost real time
+
+**★ Resolve the capture card BY NAME, and go through PipeWire.** ALSA card numbers and
+`/dev/videoN` are USB enumeration order and they move; a stale index does not error, it
+records the *wrong device* and hands back a confident silent file. And a raw `hw:N,0`
+fails "Device or resource busy" when the sound server owns the card, which ffmpeg reports
+as an input error rather than as "something else has it". `mister.py capture_devices()`
+handles both.
 
 **★ Telemetry field names come from `main/support/dvd/dvd_ctl.cpp`'s `fprintf`, never from
 the RTL port names.** Word 11 is `disp_lag` in `dvd_telem.sv` and `disp_lag_ms` in the JSON
@@ -112,6 +120,26 @@ tools/nav_diff.py <disc> --no-board                # oracle only, no hardware
 - **Do not compare VTS.** libdvdnav's is domain-relative (-1 in VMGM), the board's is the
   reader's absolute VTS; on a board game with 70+ title sets one says 72 where the other
   says 1 and neither is wrong. PGCN is the comparable field.
+
+## Checking audio is actually there (audio_check)
+
+```bash
+tools/audio_check.py <iso-on-the-mister> --secs 6
+tools/audio_check.py <iso> --red            # prove the finding path fires
+```
+
+Cycles the core's own `AUDIO n/N` popup, captures each track and measures its
+level. **The disc's other tracks are the control** — a quiet passage silences all of
+them equally, so a track that is digitally silent while its siblings are audible did
+not decode. That is the acmod signature (`dvd/ac3` supports acmod 2 and 7 only; quad
+and others are silent), which historically reached us as user reports.
+
+- A capture card **is** the right instrument here. The offsets-not-rates rule is about
+  frame sampling; silence is an amplitude question and amplitude is measured faithfully.
+- Digital silence reads **−999 dBFS**; genuinely quiet programme material measured
+  **−66 dBFS**. The gate is −80.
+- If *every* track is silent the result is INCONCLUSIVE, not a finding — there is no
+  working control on that disc.
 
 ## Before believing a finding
 

--- a/.claude/skills/hil-testing/SKILL.md
+++ b/.claude/skills/hil-testing/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: hil-testing
+description: Drive the maintainer's real MiSTer over ssh to test the DVD core — flash a build, launch a disc, press transport keys, pull back a decoded screenshot, read the decoder's live pacing counters, soak a disc unattended, or diff the core's navigation against libdvdnav. Use whenever a question would otherwise be answered by asking the user to test something on hardware, or when a change needs confirming on the board.
+---
+
+# Hardware-in-the-loop testing
+
+The rig is reachable over ssh and can be driven end to end from here: flash, launch a
+disc, press buttons, screenshot, read the decoder's own counters. **Prefer this to asking
+the user to test something.** It turns "please try this and tell me what you see" into a
+measurement you make yourself.
+
+Design notes and the full evidence trail live in **`docs/hil_harness.md`** — this skill is
+the operating manual.
+
+## Setup (once per session)
+
+```bash
+cat tools/.mister_host          # e.g. root@192.168.1.x  (gitignored, never commit it)
+tools/mister.py state           # core, running Main, key daemon, recent log
+```
+
+`tools/mister.py deploy --agent` starts the key daemon and arms telemetry.
+Add `--rbf releases/DVD_x.rbf` to flash a core, `--main main/.build/MiSTer_DVDcss` for a
+custom Main.
+
+**Put the rig back when you are done** — the maintainer uses it:
+
+```bash
+tools/mister.py restore         # stock Main, harness files gone, saved settings restored
+```
+
+## The tools
+
+| Command | What it does |
+|---|---|
+| `mister.py launch <iso> --opt "Name=Value"` | write settings, mount, load core (via MGL) |
+| `mister.py key menu down select` | press transport keys (names derived from `kbd_map.sv`) |
+| `mister.py shot --decode` | screenshot + decode the HUD to structured state |
+| `mister.py telem --watch 120` | the decoder's pacing counters, as rates |
+| `mister.py osd "A/V Offset=+50ms"` | change a setting LIVE, no relaunch |
+| `mister.py options` | every OSD option and key name, derived from the RTL |
+| `hud_read.py read/blocks <png>` | decode a screenshot's HUD / `O[2]` diagnostic blocks |
+| `dvd_explore.py <iso> --minutes 30` | unattended soak with self-tested oracles |
+| `nav_diff.py <disc> --script "1 2"` | diff the core's navigation against libdvdnav |
+| `lipsync_measure.py` + `sync_disc.py` | A/V **offset** measurement (see the warning below) |
+
+Gates, all hardware-free: `bench/dvd/run_telem.sh`.
+
+## Traps that have cost real time
+
+**★ Telemetry field names come from `main/support/dvd/dvd_ctl.cpp`'s `fprintf`, never from
+the RTL port names.** Word 11 is `disp_lag` in `dvd_telem.sv` and `disp_lag_ms` in the JSON
+— renamed AND pre-scaled to ms. `.get('disp_lag', 0)` returns a constant zero and produces
+a **dead oracle that no selftest can see**, because selftests feed synthetic dicts. This
+has happened twice.
+
+**★ Signals get RETIRED. Check a telemetry field is alive before believing it.** PR #63
+tied word 5 (`vid_err`) to a literal `16'd0`; an oracle reading it was silently dead for
+months. `dvd_explore` now prints a liveness report naming any field that never changed.
+
+**★ Screenshots are the CORE's raw raster, taken upstream of the MiSTer OSD** (ascal's
+input buffer). So a shot never contains the OSD, popups or scaling — and **you cannot see
+the OSD at all**, which is why options are set by writing the settings file, not by
+navigating menus.
+
+**★ A sampled capture card measures OFFSETS, not RATES.** It holds the last complete frame
+rather than integrating, so its "drift" figure changes with the capture frame rate (60 fps
+gave +31 ms/min, 50 fps +40 ms/min on the same playback). `lipsync_measure` suppresses
+drift figures from captures for this reason. For anything rate-shaped use `mister.py
+telem`, whose ratios are counters in one clock domain.
+
+**★ Never overwrite the running `MiSTer_DVDcss`.** It reboots the box (`execl` on a
+deleted exe → `app_restart` → `reboot(1)`). `deploy --main` handles this; it installs under
+a hash-derived name and repoints `[DVD] main=`.
+
+**★ `launch` overwrites the user's saved OSD settings** (it writes `config/DVD_v<N>.CFG`).
+It backs them up once; `restore` puts them back. Do not leave a session without restoring.
+
+**★ Ask "is the PICTURE frozen or is the MACHINE frozen?"** That one question separates an
+HPS-side stall from a core-side one before any code is read.
+
+## Reading the board's navigation state
+
+With `--opt "Debug Overlay=On"` the HUD's `CH n/N` field becomes `{reader PGCN, VTS}`, and
+the `O[2]` blocks appear (block 1 = `hl_btns_armed`). That is how `nav_diff` knows where
+the core landed and whether it is waiting for input.
+
+## Diffing navigation (nav_diff)
+
+```bash
+tools/nav_diff.py interactive/SOME.iso --script "1 2" --settle 3
+tools/nav_diff.py <disc> --script "1" --red 2      # prove the comparison can fail
+tools/nav_diff.py <disc> --no-board                # oracle only, no hardware
+```
+
+- **libdvdnav is the oracle, not `dvd_vm_ref.py`.** The golden model was written from the
+  RTL and shares its assumptions; it agreed with the hardware all through the POST-only PGC
+  bug. Use `dvd_vm_ref` only as a third opinion when the two disagree.
+- **A park is where the disc waits for INPUT** — `buttons=N` in libdvdnav,
+  `hl_btns_armed` on the board. Not a fixed sleep, not a still picture, not a settled PGCN
+  (a First Play logo holds one PGCN for many seconds).
+- **libdvdnav runs at CPU speed; the board plays every cell in real time.** Boot chains
+  that cost the oracle milliseconds cost the board minutes.
+- **Only well-defined inputs are comparable.** Pressing a button that does not exist at
+  that park is undefined, not a difference.
+
+## Before believing a finding
+
+1. Does it **reproduce**?
+2. Would it change if you changed something **unrelated to the core** (capture rate, settle
+   time, disc)? If so it is the harness.
+3. Is the instrument **validated for the thing being claimed**? An offset validation says
+   nothing about rates.
+4. Is the control arm **capable of failing**? Prove it with a deliberate mutation.
+
+Every one of those caught a wrong conclusion of mine that was already written down as fact.

--- a/.claude/skills/hil-testing/SKILL.md
+++ b/.claude/skills/hil-testing/SKILL.md
@@ -43,6 +43,7 @@ tools/mister.py restore         # stock Main, harness files gone, saved settings
 | `hud_read.py read/blocks <png>` | decode a screenshot's HUD / `O[2]` diagnostic blocks |
 | `dvd_explore.py <iso> --minutes 30` | unattended soak with self-tested oracles |
 | `audio_check.py <iso>` | is every audio track the disc offers actually audible? |
+| `acmod_scan.py [iso...]` | what acmod does each AC-3 track really carry, vs what the RTL accepts? (no hardware) |
 | `nav_diff.py <disc> --script "1 2"` | diff the core's navigation against libdvdnav |
 | `lipsync_measure.py` + `sync_disc.py` | A/V **offset** measurement (see the warning below) |
 
@@ -131,8 +132,20 @@ tools/audio_check.py <iso> --red            # prove the finding path fires
 Cycles the core's own `AUDIO n/N` popup, captures each track and measures its
 level. **The disc's other tracks are the control** — a quiet passage silences all of
 them equally, so a track that is digitally silent while its siblings are audible did
-not decode. That is the acmod signature (`dvd/ac3` supports acmod 2 and 7 only; quad
-and others are silent), which historically reached us as user reports.
+not decode. That is the acmod signature, which historically reached us as user reports.
+
+⛔ **DO NOT go hunting acmod silence without running `tools/acmod_scan.py` first.**
+`dvd/ac3` has decoded **acmod 1..7 since 2026-08-31**; only acmod 0 (1+1 dual mono)
+is still rejected, and prose saying otherwise (including an older line in this file
+and in CLAUDE.md) cost a session real hardware time. `acmod_scan.py` reads the
+accepted set out of `bsi_parse.sv` so it cannot go stale, and a 223-image sweep on
+2026-09-08 found **zero** unsupported streams in the local library.
+
+⚠ **The IFO's channel count is NOT the acmod** — it is a number the authoring tool
+wrote, the `progressive_frame` class again. Screening on the IFO flagged three discs;
+the bitstream cleared one outright (declares 4ch, carries plain acmod 2). And locate
+the syncframe via the PES `first_access_unit_pointer`, never by searching `0x0B77` —
+that pattern appears inside payload and yields a plausible WRONG acmod.
 
 - A capture card **is** the right instrument here. The offsets-not-rates rule is about
   frame sampling; silence is an amplitude question and amplitude is measured faithfully.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1294,11 +1294,42 @@ worse maintenance burden than targeted in-place edits. So:
   functions elsewhere (`to_s16`, `bin2gray`, `bndtab`, `compute_mask`) ship fine —
   functions are not banned, but **when sim says correct and silicon says broken,
   suspect a recently-added function FIRST.** Memory: `verilog-function-hazards`.
-  **Still unsupported (and "unsupported" means SILENCE, not distortion): acmod
-  0/3/4/5/6** — only **2** library discs have such a DEFAULT track (both 2/2 quad)
-  plus the Residents, whose entire AC-3 layer is acmod 6.
-  Those need real multichannel downmix coefficients, unlike mono which needed none.
-  All three bug ISOs are clean rips (`css_scan` 0 scrambled packs).
+  ⛔ **THE "still unsupported: acmod 0/3/4/5/6" LINE THAT STOOD HERE WAS STALE and
+  sent a later session hunting a defect that no longer exists.** `bsi_parse.sv`
+  has decoded **acmod 1..7** since 2026-08-31 (the same commit as mono); the only
+  value still rejected is **acmod 0 (1+1 dual mono)**, and deliberately — it
+  carries a SECOND dialnorm/compr/langcod/audprodi block that the bsi FSM does
+  not walk, so accepting it would desync bsi and produce GARBAGE instead of
+  silence, a strictly worse failure. Read `dvd/ac3/bsi_parse.sv:186-204`, which
+  says exactly this; the CLAUDE.md summary simply had not been flipped with it.
+  ✅ **AND THE "absent from the measured library" CLAIM THAT REJECTION RESTS ON IS
+  NOW MEASURED, NOT ASSERTED (2026-09-08), BY A COMMITTED TOOL: `tools/acmod_scan.py`
+  over 223 images / 1521 AC-3 streams found acmod 2 ×1150, 7 ×354, 1 ×11, 5 ×3,
+  6 ×3, and ZERO acmod 0, 3 or 4** — so every AC-3 stream in the library is inside
+  what the core decodes today, and it exits 0.
+  ★ **THE TOOL READS THE ACCEPTED SET OUT OF `bsi_parse.sv` INSTEAD OF RESTATING
+  IT, and that is the actual lesson of this round.** The previous census's verdict
+  lived only as prose here; when the RTL grew acmod 3..6 the prose did not follow,
+  and a later session spent hardware time hunting a defect fixed months earlier.
+  A table that cannot go stale beats a correct one. (RED-proven: mutate the guard
+  back to the old `{2,7}` rule and the tool reports acmod 5 as silent and exits 1.)
+  ⚠ Scope stated honestly in the tool: it samples the head of each VTS's VOBS, so
+  a substream first appearing later is not sampled; acmod is a per-stream constant,
+  which is what makes that sound.
+  ⚠⚠ **AND THE IFO's CHANNEL COUNT IS NOT THE ACMOD — it is a number the AUTHORING
+  TOOL wrote, the `progressive_frame` failure class again.** Screening the library
+  on the IFO flagged 3 discs; the bitstream cleared one of them outright
+  (life_of_brian declares 4ch on VTS_03 and carries plain acmod 2) and moved
+  another's (DVD_VIDEO_20260806 VTS_08 declares 6ch, carries acmod 5). Locate the
+  syncframe through the PES `first_access_unit_pointer`, never by searching for
+  `0x0B77` — that pattern occurs inside payload and yields a plausible wrong acmod.
+  ✅ **HW-MEASURED on the rig 2026-09-08** with `tools/audio_check.py`, which reads
+  the capture card rather than an ear: The Residents (the disc that reported the
+  bug; HUD `CH 1/30` under `Debug Overlay=On` confirms the playing VTS is 30,
+  which the sweep confirms is acmod 6 quad) → **−29.5 dBFS**; THSCOUT VTS_05, the
+  one genuine acmod 5 (3/1) default track → both tracks audible; and a 6-track
+  disc whose track 6 is **mono** → all 6 audible. Nothing in this library is
+  silent any more.
 - 🔧 **FAILED MENU LINK RE-ENTERS THE MENU, NEVER THE MOVIE (2026-08-27, PR #17)
   — MERGED; HW no-regression pass 2026-08-27 (menus/boot unaffected); ⏳ the
   positive case (a disc whose menu link actually fails — the reporter's Blade

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2628,6 +2628,21 @@ Tested by `tools/test_set_dvd_region.py` (fakes the drive incl. post-change faul
 the menus through a pty, **mutation-checked** 5/5, `SET_DVD_REGION_SH=` points it at another
 copy to prove RED). Design + ioctl details: `docs/physical_disc.md`.
 
+### ★ There is a real MiSTer you can drive — use it instead of asking
+
+The maintainer's rig is reachable over ssh and the harness in `tools/` flashes a build,
+launches a disc, presses transport keys, pulls back a decoded screenshot, reads the
+decoder's live pacing counters, soaks a disc unattended, and diffs the core's navigation
+against libdvdnav. **Skill: `.claude/skills/hil-testing/`** (operating manual + the traps).
+Design record and evidence: `docs/hil_harness.md`.
+
+Prefer measuring to asking. Two rules worth carrying even if you read nothing else:
+**telemetry field names come from `main/support/dvd/dvd_ctl.cpp`'s `fprintf`, not the RTL
+port names** (a renamed field reads as a constant zero and silently kills the oracle
+reading it — this has happened twice), and **a sampled capture card measures OFFSETS, not
+RATES** (its drift figure changes with the capture frame rate). Put the rig back with
+`tools/mister.py restore` — the maintainer uses it.
+
 ### User bug reports arrive as sparse-sector nav bundles, not ISOs
 
 **`tools/dvd_report.py` (2026-08-31) — the answer to "the disc that breaks it is

--- a/docs/hil_harness.md
+++ b/docs/hil_harness.md
@@ -309,6 +309,14 @@ reporting itself as the core.
 libdvdnav does something else, and neither is wrong. Out-of-range buttons are
 skipped, never diffed.
 
+⚠ **And three more the first sweep found, all the same shape** -- a step that
+never parked was compared anyway; everything downstream of a divergence was
+counted as an independent finding when the next press lands at two different
+menus; and a disc whose navigation uses `rnd` cannot be diffed at all (detected
+by running the oracle twice under different seeds, not by parsing commands).
+⚠ **VTS is NOT comparable**: libdvdnav's is domain-relative, the board's is the
+reader's absolute VTS. Only PGCN is diffed.
+
 **Result so far (SHERLOCK_HOLMES):** the board and libdvdnav agree on both paths
 tested -- button 1 -> PGC 3, button 2 -> PGC 27 -- and `--red` proves the
 comparison can fail.

--- a/docs/hil_harness.md
+++ b/docs/hil_harness.md
@@ -260,6 +260,59 @@ Things worth knowing before touching it:
 - **Not behind an `ifdef`.** Gating it would mean a rebuild and a fitter-seed
   re-roll every time telemetry is wanted, which is the cost it exists to remove.
 
+## ★ There is a SKILL for this: `.claude/skills/hil-testing/`
+
+Sessions kept re-deriving the tooling from this note. The skill is the operating
+manual (commands, traps, how to put the rig back); this file stays the design
+record and evidence trail. Read the skill first.
+
+## Track E phase 2: navigation differential (`tools/nav_diff.py`)
+
+The soak can see a core that has CRASHED. It cannot see one that navigated
+somewhere WRONG, because a wrong menu looks exactly like a right one. `nav_diff`
+drives **libdvdnav** and the **board** with the same button path and diffs the
+landing.
+
+```bash
+tools/nav_diff.py interactive/SOME.iso --script "1 2" --settle 3
+tools/nav_diff.py <disc> --script "1" --red 2    # prove the comparison can fail
+tools/nav_diff.py <disc> --no-board              # oracle only
+```
+
+**libdvdnav is the oracle, not `tools/dvd_vm_ref.py`.** The golden model was
+written from the RTL and holds its assumptions -- through the POST-only PGC
+dispatcher bug (70 of 505 discs) it agreed with the hardware the whole way.
+libdvdnav settled that bug and it is what this diffs against.
+
+**The button NUMBER is the unit.** libdvdnav's `<N>` token is
+`dvdnav_button_select_and_activate(N)` and the core decodes a DIGIT KEY to
+exactly that, so neither side has to walk a D-pad -- a walk would leave any
+disagreement ambiguous between "wrong landing" and "different route".
+
+⚠ **Four ways it lied before it worked, all of them the harness:**
+
+| attempt at "the board has landed" | why it was wrong |
+|---|---|
+| fixed sleep | the board was still walking its boot chain (PGC 90 -> 2 -> 1) while the script pressed buttons -- two confident false differences |
+| picture stopped moving | a MOTION menu loops forever, so it times out on exactly the discs worth testing |
+| PGCN settled | a First Play LOGO cell holds one PGCN for many seconds |
+| **highlight armed AND settled** | correct -- `buttons=N` in libdvdnav, `hl_btns_armed` (O[2] block 1) on the board: the same question |
+
+⚠ **libdvdnav runs at CPU speed; the board PLAYS every cell in real time**, so a
+boot chain costing the oracle milliseconds costs the board minutes. The budget is
+240 s and the tool now REFUSES to compare from an unsettled start rather than
+reporting itself as the core.
+
+⚠ **Only well-defined inputs are comparable.** Pressing button 2 at a park with
+`buttons=1` gave a reproducible, confident "difference" that was undefined input
+-- the board correctly ignores a digit for a button that does not exist and
+libdvdnav does something else, and neither is wrong. Out-of-range buttons are
+skipped, never diffed.
+
+**Result so far (SHERLOCK_HOLMES):** the board and libdvdnav agree on both paths
+tested -- button 1 -> PGC 3, button 2 -> PGC 27 -- and `--red` proves the
+comparison can fail.
+
 ## Track E: exploratory soak (`tools/dvd_explore.py`)
 
 Drives a disc unattended and watches for anything wrong. Seeded and fully

--- a/docs/hil_harness.md
+++ b/docs/hil_harness.md
@@ -365,11 +365,76 @@ new tracer reports NO PARK at all, the board itself:
 rebuild or you are testing the old binary:
 `DVD_REPOS=<path> tools/build_dvd_trace.sh`.
 
-**Result (SHERLOCK_HOLMES):** every path tested agrees -- button 1 -> PGC 3,
-button 2 -> PGC 27, button 3 -> PGC 15, and `3 3` -> PGC 15 (the case that used
-to differ; the board's trajectory `26 15* 15* 15*` shows it passing THROUGH the
-clip exactly as the disc authors it). `--red` still proves the comparison can
-fail.
+### ★ AND THE BOARD'S PARK RULE HAD THE SAME DEFECT -- the sixth way it lied
+
+Fixing the oracle exposed it, because the two errors had been CANCELLING. The
+board rule was `hl_btns_armed` + a stable `(PGCN, VTS)` -- the exact mirror of
+the tracer's old rule, and just as unable to tell a menu from a transient clip
+with a highlight up. The first re-sweep reported SIX differences; all six were
+this.
+
+MEASURED on the board (screenshots 8 s apart, `Debug Overlay=On`):
+
+```
+24_DVD_BOARD_GAME   t= 8..32s  CH 2  0:04/0:24 -> 0:19/0:24, 0:08/0:35 -> 0:22/0:35
+                    t=40..96s  CH 3  0:00/0:29 0:13 0:26 | 0:10 0:24 | 0:08 0:21
+tomb_raider_pal     25 -> 26 -> 24 (1:33) -> PGC 1 VTS 3 at t=80s
+```
+
+Both come to rest exactly where libdvdnav does. A park is now confirmed the same
+way the oracle confirms one -- **by a still or by a loop**: `still_active`
+(O[2] block 6), or the HUD clock WRAPPING with the **total unchanged**. Both
+signals were already being read.
+⚠ The total must be unchanged or a multi-cell intro reads as a loop: PGC 2 above
+resets its clock too, but its total moves `0:24 -> 0:35` because a new CELL
+started. ⚠ Neither test works alone -- still-only times out on a looping motion
+menu (row 2 of the table above), loop-only never fires on a menu still. A landing
+that reaches the budget with neither is FLAGGED and reported, never compared.
+
+**And the same bug one level up, in the tracer's own probation:** it could still
+confirm a park by SURVIVING A BLOCK BUDGET, and SHERLOCK_HOLMES VMGM PGC 13 is a
+**117 s clip** (`cells=1 still=0 pbtime=117s`, POST `HL_BTNN=btn1; LinkPGCN 27`)
+-- past any sane cap. Same shape on SPEED RACER (title PGC 8 -> 13) and
+tomb_raider (1 -> 2). **The budget arm is REMOVED**: every genuine interactive
+screen either stills or loops, so a candidate that does neither is never
+confirmed and the step is reported unreadable rather than given an invented
+landing.
+
+Two more the sweep exposed, both scored as findings by exit code: `auto_script`
+could emit **button 10** (the board presses buttons with DIGIT KEYS, so only 1-9
+exist) which aborted 4 of 24 discs; and a 120 s **ssh timeout** raised through
+`board_landing` and killed a run with a traceback. A lost screenshot is a retry,
+not evidence.
+
+## Sweep result (24 interactive discs, 2026-09-09)
+
+Run with `--auto 3 --seed 1 --boot-timeout 300 --action-timeout 180`, ~2.5 h of
+board time.
+
+| verdict | n | meaning |
+|---|---|---|
+| CLEAN | 16 | every comparable step agreed with libdvdnav |
+| NONDET | 3 | disc navigation uses `rnd`; a differential cannot apply |
+| SKIPPED | 5 | no confirmed park to compare from -- reported, not guessed |
+| **DIFFERENCE** | **0** | |
+
+⚠ **The SKIPPED five are a coverage cost, and it is the deliberate trade.** Three
+(THEBRAINGAME, Scourge Disc 2, Thayer's Quest) are "the oracle found no button
+menu"; Mad Dog 2 holds one PGCN armed for 300 s without ever stilling or looping;
+deal_or_no_deal never produced a readable HUD. Each previously produced an answer
+that was not trustworthy. An honest "cannot tell" is the point -- but Thayer's
+timed-still choice cells in particular are worth revisiting, since the finite-
+still arm ought to catch them.
+
+⚠ **The earlier "fully clean" verdicts on this set are VOID** -- they were
+reached when both sides made the same mistake. That is this project's recurring
+shape (see the field-order/sync entry in `CLAUDE.md`): two errors that cancel
+read as agreement, and fixing one is what exposes the other.
+
+**Per-path result (SHERLOCK_HOLMES):** button 1 -> PGC 3, button 2 -> PGC 27,
+button 3 -> PGC 15, `3 3` -> PGC 15, and button 5 -> PGC 27 with the board's
+trajectory visibly playing through the 117 s clip (`13` x15) first. `--red` still
+proves the comparison can fail.
 
 ## Track E: exploratory soak (`tools/dvd_explore.py`)
 

--- a/docs/hil_harness.md
+++ b/docs/hil_harness.md
@@ -317,9 +317,59 @@ by running the oracle twice under different seeds, not by parsing commands).
 ⚠ **VTS is NOT comparable**: libdvdnav's is domain-relative, the board's is the
 reader's absolute VTS. Only PGCN is diffed.
 
-**Result so far (SHERLOCK_HOLMES):** the board and libdvdnav agree on both paths
-tested -- button 1 -> PGC 3, button 2 -> PGC 27 -- and `--red` proves the
-comparison can fail.
+### ★ A CELL WITH BUTTONS IS NOT YET A PARK -- the fifth and worst way it lied
+
+The four rows above are about the BOARD's park detection. The fifth was the
+ORACLE's, it survived them all, and it is the one that produced the last
+surviving "difference" in the first sweep.
+
+`trace_nav` parked on "a cell whose PCI carries buttons". That is true of a
+looping video menu and **false of a short authored clip that happens to carry an
+HLI**, and the two are indistinguishable at the instant the buttons appear.
+
+MEASURED, from the discs themselves:
+
+| disc | PGC | what it really is |
+|---|---|---|
+| SHERLOCK_HOLMES | VMGM 26 | 1 cell, `still=0`, `pbtime=9s`, POST `HL_BTNN=btn4; LinkPGCN 15` -- a 9 s clip that links itself to PGC 15, whose cell is `still=255` (the real menu) |
+| 24_DVD_BOARD_GAME | VMGM 2 | 5-cell ~24 s intro, POST `JumpSS VTSM (vts 1, menu 4)` |
+| 24_DVD_BOARD_GAME | VTSM 3 / 78 / 79 | `cell_cmd=1` -> `LinkPGN 1` -- the cell REPLAYS ITSELF. This is what a looping menu looks like |
+| INCREDIBLE_HULK | VTSM 11 | 39 s transition, POST `LinkPGCN 10`; PGC 10 is `cell_cmd=1` -> `LinkCN 1`, a self-loop |
+| PAW_PATROL_MEET_EVEREST | VMGM 14 | ONE button, `fosl=1`, behind a **10 s FINITE still** -- a screen the viewer really can press |
+
+It cost twice over. The transient clip was reported as the LANDING (so the
+board's correct 26 -> 15 read as a divergence when the divergence was the
+tracer's), and **the next button was applied there** -- on a screen the board
+never sits on, so every step after it compared two different walks.
+
+`trace_nav` now puts a button-bearing cell on **PROBATION** and confirms it only
+when it behaves like a screen rather than a clip -- by reaching a STILL (finite
+or indefinite: PAW_PATROL is why finite counts, and the blanket "auto-skip
+finite stills" must not apply while buttons are up), by the VM RETURNING to the
+same `(domain, vts, pgc, cell)` after a cell change (a loop), or by surviving
+`PROBE_MAX_BLOCKS`. ⚠ The identity includes the **cell**, or a multi-cell intro
+reads as a loop on its own PGC number. ⚠ It is normally settled at the candidate
+cell's own END rather than at the cap, so it is CHEAPER than the old rule, not
+dearer (BACKPACKER3DVD 6.3 s -> 0.3 s).
+
+**Validated against a disc or the board on every case where old and new
+disagree** -- an IFO reading for the table above, and for the two discs where the
+new tracer reports NO PARK at all, the board itself:
+
+| disc | old tracer | new | evidence |
+|---|---|---|---|
+| BATMAN_BEGINS | parks VTSM v3 PGC 1 | no park | **board** walks it through to the feature (`CH 1/ 1`, 2:19:52) and never parks |
+| Beverly_Hills_Chihuahua_3 | parks VTSM v6 PGC 21 | no park | **board** walks a trailer chain (VTS 12 -> 16), never parks |
+
+⚠ **`tools/bin/` is GITIGNORED** -- after editing `tools/dvd_trace/*.c` you must
+rebuild or you are testing the old binary:
+`DVD_REPOS=<path> tools/build_dvd_trace.sh`.
+
+**Result (SHERLOCK_HOLMES):** every path tested agrees -- button 1 -> PGC 3,
+button 2 -> PGC 27, button 3 -> PGC 15, and `3 3` -> PGC 15 (the case that used
+to differ; the board's trajectory `26 15* 15* 15*` shows it passing THROUGH the
+clip exactly as the disc authors it). `--red` still proves the comparison can
+fail.
 
 ## Track E: exploratory soak (`tools/dvd_explore.py`)
 

--- a/tools/acmod_scan.py
+++ b/tools/acmod_scan.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""acmod_scan.py -- what audio coding mode does each AC-3 track ACTUALLY carry?
+
+`dvd/ac3/bsi_parse.sv` accepts a fixed set of acmod values and sets sticky
+`err_unsupported` for the rest -> `ac3_err` -> an `ac3_front` self-heal reset
+EVERY frame -> TOTAL SILENCE. That failure reached users as bug reports twice
+(mono, and the 2/2 quad Residents disc) because nothing measured it.
+
+★ THE IFO'S CHANNEL COUNT IS NOT THE ACMOD. It is a number the AUTHORING TOOL
+wrote -- the same class as `progressive_frame` being a bit the ENCODER wrote.
+Screening this library on the IFO flagged three discs; the bitstream cleared one
+of them outright (a disc declaring 4 channels carries plain acmod 2) and moved
+another's acmod. So this tool reads the SYNCFRAME.
+
+⚠ AND IT LOCATES THE SYNCFRAME VIA THE PES `first_access_unit_pointer`, NOT by
+searching for 0x0B77 -- that pattern occurs inside compressed payload often
+enough to give a false sync and a plausible-looking WRONG acmod.
+
+⚠ Scope, stated honestly: it samples the first `--sectors` of each VTS's VOBS
+and stops once every declared AC-3 substream has been seen `--frames` times.
+acmod is a per-stream constant, so more frames buy nothing -- but a substream
+that first appears LATER than that window is not sampled.
+
+Usage:
+    tools/acmod_scan.py                       # the whole library
+    tools/acmod_scan.py <iso> [<iso> ...]
+    tools/acmod_scan.py --all                 # list every stream, not just gaps
+"""
+import argparse
+import glob
+import os
+import re
+import struct
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from dvd_vm_ref import IsoNav                                   # noqa: E402
+from nav_extract import parse_vts_attr                          # noqa: E402
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BSI_PARSE = os.path.join(REPO, 'dvd', 'ac3', 'bsi_parse.sv')
+
+# ATSC A/52 Table 5.8.
+ACMOD = {0: '1+1 dual-mono', 1: '1/0 mono', 2: '2/0 stereo', 3: '3/0',
+         4: '2/1', 5: '3/1', 6: '2/2 quad', 7: '3/2'}
+
+
+def supported_acmods():
+    """Read the accepted set OUT OF THE RTL rather than restating it here.
+
+    ⚠ THIS FUNCTION IS THE POINT OF THE TOOL AS MUCH AS THE SCAN IS. The
+    previous census's verdict lived only as prose in CLAUDE.md; when the RTL
+    grew acmod 3..6 the prose did not follow, and a later session spent a
+    hardware session hunting a defect that had been fixed months earlier. A
+    table that cannot go stale is worth more than a correct one.
+
+    `bsi_parse.sv`'s B_ACMOD state rejects by comparing `data_in[2:0]` against
+    literals; everything it does not name is accepted. If the shape ever stops
+    matching we say so loudly instead of guessing.
+    """
+    try:
+        src = open(BSI_PARSE).read()
+    except OSError as e:
+        print(f'acmod_scan: cannot read {BSI_PARSE} ({e}); assuming 1..7',
+              file=sys.stderr)
+        return {1, 2, 3, 4, 5, 6, 7}, 'ASSUMED'
+    # ⚠ There are TWO `B_ACMOD: begin` sites -- a one-line REQUEST stage that
+    # only sets req/nbits, and the DECODE stage that carries the guard. Taking
+    # the first match reads the wrong one and silently reports "unverified", so
+    # pick the block that actually contains the rejection.
+    body = ''
+    for m in re.finditer(r'B_ACMOD:\s*begin', src):
+        chunk = src[m.end():m.end() + 2000]
+        chunk = re.split(r'\n\s*B_[A-Z]+\s*:', chunk)[0]
+        if 'err_unsupported' in chunk:
+            body = chunk
+            break
+    # every literal compared against data_in[2:0] inside the guard is a REJECT
+    rejected = {int(v) for v in
+                re.findall(r"data_in\[2:0\]\s*==\s*3'd(\d)", body)}
+    if not body or not re.search(r'err_unsupported\s*<=\s*1\'b1', body):
+        print('acmod_scan: WARNING -- could not read the acmod guard out of '
+              f'{os.path.relpath(BSI_PARSE, REPO)}; the supported set below may '
+              'be stale. Check B_ACMOD by hand.', file=sys.stderr)
+        return {1, 2, 3, 4, 5, 6, 7}, 'UNVERIFIED'
+    return set(range(8)) - rejected, 'from bsi_parse.sv'
+
+
+def scan_vob(f, start_lba, n_sectors, frames_wanted, expect_subs):
+    """-> {substream_id: {acmod: count}} over the head of one VTS's VOBS."""
+    seen = {}
+    for i in range(n_sectors):
+        f.seek((start_lba + i) * 2048)
+        sec = f.read(2048)
+        if len(sec) < 2048 or sec[:4] != b'\x00\x00\x01\xba':
+            continue
+        p = 14 + (sec[13] & 7)          # pack header + its stuffing
+        while p + 6 < 2048:
+            if sec[p:p + 3] != b'\x00\x00\x01':
+                break
+            sid = sec[p + 3]
+            plen = struct.unpack('>H', sec[p + 4:p + 6])[0]
+            body = p + 6
+            if sid == 0xBD:                          # private_stream_1
+                sub = body + 3 + sec[body + 2]       # past the PES opt header
+                ssid = sec[sub] if sub < 2048 else 0
+                if 0x80 <= ssid <= 0x87:             # AC-3 substream
+                    nframes = sec[sub + 1]
+                    fap = struct.unpack('>H', sec[sub + 2:sub + 4])[0]
+                    # fap counts from the byte AFTER the 4-byte substream header
+                    q = sub + 4 + (fap - 1)
+                    if nframes and fap and q + 7 < 2048 and \
+                            sec[q] == 0x0B and sec[q + 1] == 0x77:
+                        acmod = (sec[q + 6] >> 5) & 7
+                        seen.setdefault(ssid, {})
+                        seen[ssid][acmod] = seen[ssid].get(acmod, 0) + 1
+            p = body + plen
+        if (len(seen) >= expect_subs and seen and
+                all(sum(v.values()) >= frames_wanted for v in seen.values())):
+            break
+    return seen
+
+
+def scan_iso(path, args, ok):
+    nav = IsoNav(path)
+    rows, bad = [], []
+    for vn, ifo_lba in sorted(nav.vts_ifo.items()):
+        mat = nav.sec(ifo_lba)
+        vobs = struct.unpack('>I', mat[0xC0:0xC4])[0]   # VTS_VOBS, IFO-relative
+        if not vobs:
+            continue
+        declared = parse_vts_attr(mat)[2]
+        nsub = sum(1 for a in declared if a[0] == 0)    # fmt 0 == AC-3
+        seen = scan_vob(nav.f, ifo_lba + vobs, args.sectors, args.frames,
+                        max(nsub, 1))
+        for ssid in sorted(seen):
+            for acmod, n in sorted(seen[ssid].items()):
+                row = (vn, ssid, acmod, n)
+                rows.append(row)
+                if acmod not in ok:
+                    bad.append(row)
+    nav.f.close()
+    return rows, bad
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('images', nargs='*')
+    ap.add_argument('--sectors', type=int, default=3000,
+                    help='sectors of each VTS VOBS to sample (default 3000)')
+    ap.add_argument('--frames', type=int, default=8,
+                    help='syncframes per substream before moving on (default 8)')
+    ap.add_argument('--all', action='store_true',
+                    help='list every stream, not just unsupported ones')
+    args = ap.parse_args()
+
+    ok, prov = supported_acmods()
+    print('acmod_scan: core accepts {' +
+          ', '.join(str(a) for a in sorted(ok)) + '}  (' + prov + ')')
+
+    images = args.images
+    if not images:
+        root = os.environ.get('DVD_ISO_DIR', os.path.expanduser('~/dvd-isos'))
+        images = sorted(glob.glob(os.path.join(root, '**', '*.iso'),
+                                  recursive=True) +
+                        glob.glob(os.path.join(root, '**', '*.ISO'),
+                                  recursive=True))
+        print(f'acmod_scan: {len(images)} images under {root}')
+
+    tally, n_bad, n_err = {}, 0, 0
+    for path in images:
+        name = os.path.basename(path)
+        try:
+            rows, bad = scan_iso(path, args, ok)
+        except Exception as e:                       # a bad rip is not a crash
+            print(f'ERR  {name}: {e}')
+            n_err += 1
+            continue
+        for _, _, acmod, _ in rows:
+            tally[acmod] = tally.get(acmod, 0) + 1
+        show = rows if args.all else bad
+        if show:
+            print(f'\n{"" if args.all else "!! "}{name}')
+            for vn, ssid, acmod, n in show:
+                mark = '' if acmod in ok else '   <-- UNSUPPORTED (SILENT)'
+                print(f'    VTS_{vn:02d} sub 0x{ssid:02x}: acmod {acmod} '
+                      f'({ACMOD[acmod]}) x{n}{mark}')
+        n_bad += len(bad)
+
+    print('\n=== acmod tally (streams seen) ===')
+    for a in sorted(tally):
+        mark = '' if a in ok else '   <-- UNSUPPORTED (SILENT)'
+        print(f'  acmod {a} ({ACMOD[a]:14}) {tally[a]:5}{mark}')
+    print(f'\n{n_bad} unsupported stream(s), {n_err} unreadable image(s)')
+    return 1 if n_bad else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/audio_check.py
+++ b/tools/audio_check.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+audio_check.py -- is every audio track the disc offers actually AUDIBLE?
+
+The bug class this exists for reached us as user reports rather than as a test
+failure: dvd/ac3 supports only acmod 2 (2/0) and 7 (3/2), so a MONO or QUAD
+track sets err_unsupported -> ac3_err -> a self-heal reset every frame ->
+SILENCE. A 505-disc census found 26 discs with an unsupported acmod on some
+track and 11 on a DEFAULT track. Nothing in the harness could see it, because
+silence looks exactly like a quiet passage.
+
+★ THE DISC'S OTHER TRACKS ARE THE CONTROL. A quiet passage, a menu, a fade --
+all of them silence EVERY track equally. A track that is digitally silent while
+its siblings are audible, at the same instant of the same title, is not a quiet
+passage: it is a track that did not decode. That within-disc comparison is what
+makes this measurable without knowing anything about the content.
+
+⚠ A CAPTURE CARD IS THE RIGHT INSTRUMENT HERE, unlike for drift. The harness's
+standing rule is that a sampled card measures OFFSETS, not RATES -- because it
+holds whole frames and beats against the source. Silence is neither: it is an
+AMPLITUDE question, and amplitude is exactly what the card reports faithfully.
+
+Usage:
+    audio_check.py <iso-on-the-mister> [--secs 6] [--max-tracks 8]
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import mister as M              # noqa: E402
+import hud_read as H            # noqa: E402
+
+# MEASURED, and the margin matters. A decode failure produces EXACT digital
+# silence, which reads -999 dBFS (a true zero sample block). Real but quiet
+# programme material measured -66.0 dBFS on a film's second track -- only 4 dB
+# from an earlier -70 guess, which would eventually have called a quiet passage
+# a defect. -80 sits in the wide gap between the two and cannot reach either.
+SILENT_DBFS = -80.0
+
+
+def rms_dbfs(wav):
+    import numpy as np
+    import wave
+    with wave.open(wav, 'rb') as w:
+        n = w.getnframes()
+        if n == 0:
+            return -999.0, -999.0
+        raw = w.readframes(n)
+    a = np.frombuffer(raw, dtype='<i2').astype(np.float32) / 32768.0
+    if a.size == 0:
+        return -999.0, -999.0
+    rms = float(np.sqrt((a * a).mean()))
+    peak = float(np.abs(a).max())
+    to_db = lambda v: (20.0 * __import__('math').log10(v)) if v > 1e-9 else -999.0
+    return to_db(rms), to_db(peak)
+
+
+def capture_audio(adev, afmt, secs, path):
+    r = subprocess.run(['ffmpeg', '-hide_banner', '-loglevel', 'error', '-y',
+                        '-f', afmt, '-ac', '2', '-ar', '48000', '-i', adev,
+                        '-t', str(secs), path],
+                       capture_output=True, timeout=secs + 60)
+    if not os.path.exists(path):
+        # Loud, not silent: a failed capture reads as digital silence and would
+        # be reported as a FINDING. Never let that pass as data.
+        sys.stderr.write(r.stderr.decode(errors='replace')[-300:] + '\n')
+        return False
+    return True
+
+
+def board_audio_track(tmpdir, step):
+    """Press Audio and read the track the core reports from the HUD popup.
+
+    The popup is the core's own answer to "which track is selected and how many
+    are there", so the loop follows the disc rather than assuming a count.
+    """
+    M.cmd_key(argparse.Namespace(names=['audio']))
+    time.sleep(1.5)
+    png = os.path.join(tmpdir, f'aud{step:02d}.png')
+    rc, _ = M.ssh('''
+rm -f /media/fat/screenshots/audc.png
+echo 'screenshot audc.png' > /dev/MiSTer_cmd
+for i in $(seq 1 16); do
+  sleep 0.25
+  if [ -f /media/fat/screenshots/audc.png ]; then
+    a=$(stat -c %s /media/fat/screenshots/audc.png); sleep 0.2
+    b=$(stat -c %s /media/fat/screenshots/audc.png)
+    [ "$a" = "$b" ] && [ "$a" != 0 ] && exit 0
+  fi
+done
+exit 1
+''', check=False)
+    if rc != 0:
+        return None, None, None
+    r = subprocess.run(['scp', *M.SSH_OPTS, '-q',
+                        f'{M.host()}:/media/fat/screenshots/audc.png', png],
+                       capture_output=True)
+    if r.returncode != 0:
+        return None, None, None
+    w, h, buf = H.load_image(png)
+    res = H.decode(H.Frame(w, h, buf))
+    pop = (res.get('popup_text') or '')
+    m = re.search(r'AUDIO\s+(\d+)\s*/\s*(\d+)\s*(\S*)', pop)
+    if not m:
+        return None, None, pop
+    return int(m.group(1)), int(m.group(2)), m.group(3)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('image', help='absolute path ON THE MISTER')
+    ap.add_argument('--secs', type=float, default=6.0)
+    ap.add_argument('--max-tracks', type=int, default=8)
+    ap.add_argument('--adev')
+    ap.add_argument('--afmt', choices=('alsa', 'pulse'))
+    ap.add_argument('--red', action='store_true',
+                    help='mute one track deliberately, to prove the finding path fires')
+    ap.add_argument('--settle', type=float, default=6.0)
+    args = ap.parse_args()
+
+    _, auto_a, auto_fmt = M.capture_devices()
+    adev = args.adev or auto_a
+    afmt = args.afmt or auto_fmt
+    if not adev:
+        sys.exit('audio_check: no capture card found (set --adev, e.g. hw:0,0)')
+    tmpdir = tempfile.mkdtemp(prefix='audiochk_')
+    print(f'audio_check: {os.path.basename(args.image)}')
+    print(f'  capture: {adev} ({afmt})   window: {args.secs}s per track')
+
+    # Disc Menus Off so the main title auto-plays -- we need PROGRAMME material,
+    # and a menu's audio (or lack of it) says nothing about the title's tracks.
+    M.cmd_launch(argparse.Namespace(
+        image=args.image, opt=['Debug Overlay=On', 'Disc Menus=Off',
+                               'Video Output=Progressive'],
+        delay=2, timeout=90, no_wait=False))
+    time.sleep(args.settle + 6)
+
+    rows, seen = [], set()
+    for i in range(args.max_tracks):
+        cur, total, lang = board_audio_track(tmpdir, i)
+        if cur is None:
+            print(f'  step {i}: no AUDIO popup on screen '
+                  f'({"no HUD" if lang is None else repr(lang)})')
+            break
+        if cur in seen:
+            break                      # wrapped around the disc's own list
+        seen.add(cur)
+        # ⚠ RED PROOF. The FINDING path must be shown to fire, or "all tracks
+        # audible" means nothing. --red mutes the core for ONE track, so exactly
+        # one reads silent while its siblings do not -- which is the signature
+        # this tool exists to detect, produced on demand. It exercises the whole
+        # pipeline: capture, level measurement, and the within-disc comparison.
+        if args.red and len(seen) == 1:
+            M.cmd_osd(argparse.Namespace(setting='Audio=Off'))
+            time.sleep(3)
+        wav = os.path.join(tmpdir, f'trk{cur}.wav')
+        ok = capture_audio(adev, afmt, args.secs, wav)
+        r, pk = rms_dbfs(wav) if ok else (-999.0, -999.0)
+        if args.red and len(seen) == 1:
+            M.cmd_osd(argparse.Namespace(setting='Audio=On'))
+            time.sleep(2)
+        rows.append(dict(track=cur, total=total, lang=lang, rms=r, peak=pk))
+        print(f'  track {cur}/{total} {lang:<4} rms {r:7.1f} dBFS   '
+              f'peak {pk:7.1f} dBFS' + ('   <- SILENT' if r < SILENT_DBFS else ''))
+        if total and len(seen) >= total:
+            break
+
+    if not rows:
+        print('\n  no audio tracks were reported by the core -- nothing to check')
+        return 2
+
+    silent = [r for r in rows if r['rms'] < SILENT_DBFS]
+    audible = [r for r in rows if r['rms'] >= SILENT_DBFS]
+    print()
+    if args.red:
+        ok = bool(silent and audible)
+        print(f'  RED PROOF: {"PASS" if ok else "FAIL"} -- a deliberately muted '
+              f'track {"was" if ok else "was NOT"} reported against its audible '
+              'siblings')
+        if not ok:
+            print('    The within-disc comparison cannot fire. Do not trust a '
+                  'clean run.')
+        return 0 if ok else 3
+
+    if silent and audible:
+        # The within-disc control fired: same title, same instant, siblings loud.
+        for r in silent:
+            print(f'  !! FINDING: track {r["track"]}/{r["total"]} ({r["lang"]}) '
+                  f'is digitally silent at {r["rms"]:.0f} dBFS while '
+                  f'{len(audible)} other track(s) on the same title are audible')
+        print('     Unsupported AC-3 acmod is the known cause of exactly this '
+              '(dvd/ac3 supports acmod 2 and 7 only); confirm with '
+              'tools/dvd_census.py --audio on this disc.')
+        return 1
+    if silent and not audible:
+        # Cannot separate "all tracks broken" from "an authored silent passage".
+        print('  INCONCLUSIVE: every track was silent, so there is no working '
+              'control on this disc.')
+        print('     Either the passage is authored silent, or audio is dead '
+              'disc-wide. Re-run further into the title before concluding.')
+        return 2
+    print(f'  all {len(rows)} track(s) audible')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/dvd_explore.py
+++ b/tools/dvd_explore.py
@@ -61,6 +61,27 @@ BAD_POPUPS = ('LINK FAIL', 'CSS ENCRYPTED', 'UNSUPPORTED', 'BAD IMAGE')
 
 # Actions that legitimately disturb the counters: a seek flushes buffers and
 # re-arms the audio drain gate, a menu hop stalls video against the STC.
+# ⚠ THE JSON KEY IS `disp_lag_ms`, NOT `disp_lag`, AND IT IS ALREADY IN
+# MILLISECONDS -- main/support/dvd/dvd_ctl.cpp converts word 11 (signed, 1 LSB =
+# 16 ticks of the 90 kHz STC) before publishing. Reading `disp_lag` gets a
+# MISSING KEY, which `.get(k, 0)` turns into a constant zero and a dead oracle.
+# That is exactly how this check's predecessor died, and I repeated it here on
+# the first attempt; the liveness report below is what surfaced it. Take field
+# names from dvd_ctl.cpp's fprintf, never from the RTL port names.
+DISP_LAG_KEY = 'disp_lag_ms'
+# Threshold, MEASURED not guessed: 90/90 steady-playback samples of a real film
+# sat at -16.7 ms (exactly one 59.94 Hz refresh -- a fire-when-due scheduler is
+# one frame behind by construction), worst excursion 25.1 ms, 3 distinct values.
+# 120 ms is ~5x that worst case: quiet on healthy content, and still catches a
+# display several frames off its schedule.
+DISP_LAG_MAX_MS = 120.0
+
+# Fields that MUST move while a picture is playing. A constant one is a RETIRED
+# INSTRUMENT, not a quiet disc, and any oracle reading it is dead. Fields that
+# may legitimately stay put (aud_gate, drops, lates on healthy content) are
+# deliberately NOT listed -- flagging those would cry wolf on every clean run.
+MUST_VARY = ('refreshes', 'pickups', DISP_LAG_KEY)
+
 PERTURBING = {'next-chapter', 'prev-chapter', 'menu', 'title', 'return',
               'select', 'pause', 'up', 'down', 'left', 'right'}
 
@@ -92,6 +113,8 @@ class Explorer:
         # Downsampled previous frame, for "is the picture actually moving?".
         self.prev_small = None
         self.frozen_for = 0
+        # key -> (min, max) across the run, for the liveness report
+        self.telem_range = {}
 
     def log(self, **kw):
         kw['step'] = self.step
@@ -221,14 +244,23 @@ exit 1
         if d_gate:
             raise Finding(f'audio drain gate closed {d_gate}x during steady '
                           'playback -- audio is being held')
-        # RATE of change, not the absolute value: vid_err carries whatever it
-        # accumulated across the last menu or seek until the next re-anchor, so
-        # its magnitude says nothing. Its slope during steady play does.
-        dt = max(0.5, tel.get('t', 0) - prev.get('t', 0))
-        d_err = abs(tel.get('vid_err', 0) - prev.get('vid_err', 0)) / dt
-        if d_err > 8:
-            raise Finding(f'vid_err moving {d_err:.1f} refresh/s during steady '
-                          'playback (video losing the timeline)')
+        # ⚠⚠ THIS ORACLE USED TO READ `vid_err`, WHICH PR #63 RETIRED -- emu.sv
+        # now ties telemetry word 5 to a literal 16'd0. The check therefore
+        # computed a slope of exactly zero on every sample and COULD NOT FIRE,
+        # on hardware, silently, for as long as it shipped. The selftest kept
+        # passing because it feeds synthetic dicts: it proves the oracle's LOGIC
+        # fires, and says nothing about whether its INPUT is alive. See the
+        # liveness report at the end of a run, which is the guard for that.
+        #
+        # `disp_lag` (word 11) is the modern signal and a better one: it is the
+        # displayed picture's PTS minus the STC, so it is a BOUNDED error, not
+        # an accumulator -- an absolute threshold means something, where
+        # vid_err's magnitude never did.
+        if DISP_LAG_KEY in tel:
+            lag_ms = tel[DISP_LAG_KEY]
+            if abs(lag_ms) > DISP_LAG_MAX_MS:
+                raise Finding(f'display {lag_ms:+.0f} ms from its schedule '
+                              'during steady playback')
         d_drop = (tel.get('drops', 0) - prev.get('drops', 0)) & 0xFFFF
         if d_drop > 60:
             raise Finding(f'{d_drop} frames dropped between samples')
@@ -281,6 +313,10 @@ exit 1
             png, tel, hud = None, {}, {}
             try:
                 tel = self.telem()
+                for k, v in tel.items():
+                    if isinstance(v, (int, float)):
+                        lo, hi = self.telem_range.get(k, (v, v))
+                        self.telem_range[k] = (min(lo, v), max(hi, v))
                 png = self.shot()
                 if png:
                     hud = self.check_frame(png)
@@ -310,6 +346,24 @@ exit 1
             if png and os.path.exists(png):
                 os.remove(png)                          # keep only findings
             time.sleep(self.args.settle)
+
+        # ⚠ LIVENESS: an oracle whose input never moved could not have fired,
+        # however green its selftest is. This is what would have caught the
+        # retired vid_err word within one run instead of shipping dead.
+        if self.telem_range:
+            dead = [k for k in MUST_VARY
+                    if k in self.telem_range
+                    and self.telem_range[k][0] == self.telem_range[k][1]]
+            missing = [k for k in MUST_VARY if k not in self.telem_range]
+            if dead or missing:
+                print('\n  !! TELEMETRY LIVENESS:')
+                for k in dead:
+                    print(f'     {k} never changed (constant '
+                          f'{self.telem_range[k][0]}) -- retired instrument? '
+                          'any oracle reading it is DEAD')
+                for k in missing:
+                    print(f'     {k} absent from the telemetry -- core/Main '
+                          'older than the field, or the word was removed')
 
         print(f'\ndvd_explore: {self.step} steps, {len(self.findings)} finding(s)')
         for i, f in enumerate(self.findings, 1):
@@ -388,7 +442,8 @@ def selftest():
     arm('CONTROL: clock held in a menu', held_in_menu, False)
 
     print('[telemetry]')
-    base = dict(t=0.0, aud_gate=0, vid_err=0, drops=0, flags=playing['flags'])
+    base = dict(t=0.0, aud_gate=0, **{DISP_LAG_KEY: 0.0},
+                drops=0, flags=playing['flags'])
     def gate():
         e.quiet = 0
         e.check_telem(dict(base, t=2.0, aud_gate=3), base)
@@ -397,15 +452,49 @@ def selftest():
         e.quiet = 2
         e.check_telem(dict(base, t=2.0, aud_gate=3), base)
     arm('CONTROL: same, just after a seek', gate_quiet, False)
-    def slope():
+    # disp_lag is in units of 16 STC ticks; 1000 LSB = 178 ms, over the threshold.
+    def lag():
         e.quiet = 0
-        e.check_telem(dict(base, t=2.0, vid_err=60), base)
-    arm('vid_err slope during steady play', slope, True)
-    def slope_menu():
+        e.check_telem(dict(base, t=2.0, **{DISP_LAG_KEY: 178.0}), base)
+    arm('display far from its schedule', lag, True)
+    def lag_ok():
+        e.quiet = 0
+        e.check_telem(dict(base, t=2.0, **{DISP_LAG_KEY: 36.0}), base)  # healthy
+    arm('CONTROL: small lag is normal', lag_ok, False)
+    def lag_menu():
         e.quiet = 0
         menu = dict(base, flags={'video_live': 1, 'pause': 0, 'still': 0, 'menu': 1})
-        e.check_telem(dict(menu, t=2.0, vid_err=60), menu)
-    arm('CONTROL: same, but in a menu', slope_menu, False)
+        e.check_telem(dict(menu, t=2.0, **{DISP_LAG_KEY: 178.0}), menu)
+    arm('CONTROL: same, but in a menu', lag_menu, False)
+    def lag_frozen():
+        e.quiet = 0
+        e.frozen_for = 3
+        e.check_telem(dict(base, t=2.0, **{DISP_LAG_KEY: 178.0}), base)
+        e.frozen_for = 0
+    arm('CONTROL: same, but the picture is a still', lag_frozen, False)
+
+    print('[liveness guard]')
+    # The failure this exists for: an oracle wired to a RETIRED telemetry word.
+    e2 = Explorer(args)
+    for _ in range(4):
+        e2.telem_range = {'refreshes': (1, 900), 'pickups': (1, 450),
+                          DISP_LAG_KEY: (0.0, 0.0)}
+    dead = [k for k in MUST_VARY
+            if k in e2.telem_range
+            and e2.telem_range[k][0] == e2.telem_range[k][1]]
+    ok = dead == [DISP_LAG_KEY]
+    print(f"  {'PASS' if ok else 'FAIL'} names a constant field as dead: {dead}")
+    if not ok:
+        fails += 1
+    e2.telem_range = {'refreshes': (1, 900), 'pickups': (1, 450),
+                      DISP_LAG_KEY: (-40.0, 55.0)}
+    dead = [k for k in MUST_VARY
+            if k in e2.telem_range
+            and e2.telem_range[k][0] == e2.telem_range[k][1]]
+    ok = dead == []
+    print(f"  {'PASS' if ok else 'FAIL'} CONTROL: a live field is not flagged")
+    if not ok:
+        fails += 1
 
     print('dvd_explore selftest:', 'ALL GREEN' if not fails else f'{fails} FAILURE(S)')
     return 1 if fails else 0

--- a/tools/dvd_trace/trace_nav.c
+++ b/tools/dvd_trace/trace_nav.c
@@ -13,6 +13,9 @@
  *   mR    dvdnav_menu_call(Root)      mT = Title
  *   wK    passive: let K more cell-changes pass before the next park is honored
  *
+ * A button-bearing cell is only a PROVISIONAL park -- see the PROBATION note
+ * above main() -- so it is confirmed before it is dumped or acted on.
+ *
  * When the script is exhausted the tracer dumps the final park and exits, so
  *   trace_nav disc.iso ""          # just show the first interactive screen
  *   trace_nav disc.iso "2"         # press button 2 on the first screen, show next
@@ -121,11 +124,54 @@ static int apply_action(dvdnav_t *nav) {
   return 1;
 }
 
+/* --- PROBATION: a cell with buttons is only a PROVISIONAL park -------------
+ *
+ * "A cell whose PCI carries buttons is an interactive screen" is a HEURISTIC,
+ * and it is FALSE for a short authored clip that happens to carry an HLI. The
+ * two are indistinguishable at the instant the buttons appear.
+ *
+ * MEASURED (SHERLOCK_HOLMES, VMGM PGC 26): cells=1, cell still=0, pbtime=9s,
+ * POST = `HL_BTNN = button 4; LinkPGCN 15`. The disc AUTHORS a 9 s clip with a
+ * highlight up which then links itself to PGC 15, whose cell still=255 -- the
+ * real, indefinite menu still. Same shape on 24_DVD_BOARD_GAME, whose boot
+ * VMGM PGC 2 is a 5-cell ~24 s intro with POST `JumpSS VTSM (vts 1, menu 4)`.
+ *
+ * Stopping at the first button-bearing cell cost twice over. It reported the
+ * transient clip as the LANDING (making the board's correct 26 -> 15 look like
+ * a divergence when the divergence was the tracer's), and it APPLIED THE NEXT
+ * BUTTON THERE -- on a screen the board never sits on, so every step after it
+ * compared two different walks.
+ *
+ * So a candidate is confirmed only when it behaves like a screen rather than a
+ * clip. Confirmed by ANY of:
+ *   - the VM reaching a STILL on it. A still is the picture STOPPING, which is
+ *     exactly what the board's own park rule measures, and it counts whether
+ *     the still is indefinite or FINITE: PAW_PATROL_MEET_EVEREST's VMGM PGC 14
+ *     is one button with fosl=1 behind a 10 s still -- a screen the viewer
+ *     really can press, which is why the tracer's blanket "auto-skip finite
+ *     stills" must not apply while buttons are up;
+ *   - the VM returning to the same (domain, vts, pgc, CELL) after a cell change
+ *     -- a loop, which is what a looping video menu is and what a clip's cells
+ *     never do (they ADVANCE, which is why the identity includes the cell: a
+ *     multi-cell intro would otherwise read as a loop on its own pgc number);
+ *   - or surviving PROBE_MAX_BLOCKS without leaving.
+ * An indefinite (0xff) still needs no candidate at all: it is a park by
+ * construction, so that path is unchanged.
+ *
+ * ⚠ Cheap in practice despite the cap, because the question is normally settled
+ * at the candidate cell's own END, not at the cap: PGC 26 resolves in its 211
+ * sectors and PGC 15 in its 88. The cap only bites on a long menu cell that
+ * neither stills nor loops. */
+#define PROBE_MAX_BLOCKS 16000
+
 int main(int argc, char **argv) {
   dvdnav_t *nav;
   uint8_t mem[DVD_VIDEO_LB_LEN];
   int finished = 0, parkno = 0, parked = 0, acted = 0;
   int wait_cells = 0, cells = 0;
+  int cand_on = 0, cand_dom = -1, cand_vts = -1, cand_pgc = -1, cand_cell = -1;
+  int cand_loops = 0;
+  long cand_blocks = 0;
   long blocks = 0, blocks_in_cell = 0;
 
   if (argc < 2) { printf("usage: %s <iso> [\"script\"] [rnd_seed]\n", argv[0]); return 1; }
@@ -152,11 +198,25 @@ int main(int argc, char **argv) {
       if (!parked && !acted && wait_cells == 0 && blocks_in_cell > 4) {
         pci_t *pci = dvdnav_get_current_nav_pci(nav);
         if (pci && pci->hli.hl_gi.hli_ss && (pci->hli.hl_gi.btn_ns & 0x3f)) {
-          dump_screen(nav, ++parkno); parked = 1;
-          int r = apply_action(nav);
-          if (r == 0) { printf("\n[script done -> stop]\n"); finished = 1; }
-          else if (r >= 2) { wait_cells = r - 2; parked = 0; }
-          else { acted = 1; }
+          dvd_state_t *st = &nav->vm->state;
+          if (!cand_on || st->domain != cand_dom || st->vtsN != cand_vts ||
+              st->pgcN != cand_pgc || st->cellN != cand_cell) {
+            cand_on = 1; cand_dom = st->domain; cand_vts = st->vtsN;
+            cand_pgc = st->pgcN; cand_cell = st->cellN;
+            cand_blocks = 0; cand_loops = 0;
+          } else {
+            cand_blocks++;
+          }
+          if (cand_loops > 0 || cand_blocks > PROBE_MAX_BLOCKS) {
+            printf("[park confirmed: pgc %d cell %d %s]\n", cand_pgc, cand_cell,
+                   cand_loops ? "looped" : "held past the probation cap");
+            cand_on = 0;
+            dump_screen(nav, ++parkno); parked = 1;
+            int r = apply_action(nav);
+            if (r == 0) { printf("\n[script done -> stop]\n"); finished = 1; }
+            else if (r >= 2) { wait_cells = r - 2; parked = 0; }
+            else { acted = 1; }
+          }
         }
       }
       if (blocks > 400000) { printf("[block cap]\n"); finished = 1; }
@@ -165,6 +225,7 @@ int main(int argc, char **argv) {
       dvdnav_still_event_t *s = (dvdnav_still_event_t *)buf;
       if (len == 0 && s->length == 0xff) { /* len field is in the event struct */ }
       if (s->length == 0xff) {                 /* indefinite still = a park */
+        cand_on = 0;   /* a still is a park by construction; no probation */
         if (!parked) {
           dump_screen(nav, ++parkno); parked = 1;
           int r = apply_action(nav);
@@ -175,6 +236,21 @@ int main(int argc, char **argv) {
           /* already acted on this still; if the VM didn't leave, force it */
           dvdnav_still_skip(nav);
         }
+      } else if (cand_on && !parked && nav->vm &&
+                 nav->vm->state.domain == cand_dom &&
+                 nav->vm->state.vtsN   == cand_vts &&
+                 nav->vm->state.pgcN   == cand_pgc) {
+        /* A FINITE still under a live candidate: the picture has stopped with
+         * buttons up, so this is an interactive screen on a timer, not a
+         * transition. Confirm it rather than skipping past it. */
+        printf("[park confirmed: pgc %d  %ds still with buttons up]\n",
+               cand_pgc, s->length);
+        cand_on = 0;
+        dump_screen(nav, ++parkno); parked = 1;
+        int r = apply_action(nav);
+        if (r == 0) { printf("\n[script done -> stop]\n"); finished = 1; }
+        else if (r >= 2) { wait_cells = r - 2; parked = 0; dvdnav_still_skip(nav); }
+        else acted = 1;
       } else {
         printf("[skip %ds still]\n", s->length);
         dvdnav_still_skip(nav);
@@ -186,6 +262,12 @@ int main(int argc, char **argv) {
       printf("[CELL #%d] title=%d part=%d  (blocks_in_prev_cell=%ld)\n",
              ++cells, tt, ptt, blocks_in_cell);
       dump_vm(nav, "cell");
+      if (cand_on) {
+        dvd_state_t *st = &nav->vm->state;
+        if (st->domain == cand_dom && st->vtsN == cand_vts &&
+            st->pgcN == cand_pgc && st->cellN == cand_cell)
+          cand_loops++;      /* came back to the same cell -> a real loop */
+      }
       blocks_in_cell = 0; parked = 0; acted = 0;
       if (wait_cells > 0) wait_cells--;
       if (cells > 4000) { printf("[cell cap]\n"); finished = 1; }

--- a/tools/dvd_trace/trace_nav.c
+++ b/tools/dvd_trace/trace_nav.c
@@ -154,15 +154,24 @@ static int apply_action(dvdnav_t *nav) {
  *     -- a loop, which is what a looping video menu is and what a clip's cells
  *     never do (they ADVANCE, which is why the identity includes the cell: a
  *     multi-cell intro would otherwise read as a loop on its own pgc number);
- *   - or surviving PROBE_MAX_BLOCKS without leaving.
+ * ⛔ AND *NOT* "it survived a block budget". That arm was tried and REMOVED:
+ * SHERLOCK_HOLMES VMGM PGC 13 is a 117 s clip (cells=1, still=0, pbtime=117s)
+ * whose POST is `HL_BTNN = button 1; LinkPGCN 27`, and 117 s of video is far
+ * more than any sane cap -- so the budget confirmed the clip as a park and the
+ * board, which plays it out and lands on 27, was reported as diverging. Same
+ * shape on SPEED RACER (title PGC 8 -> 13) and tomb_raider (1 -> 2).
+ * A screen that never stills AND never loops is not a screen: every genuine
+ * interactive park does one or the other, by construction. So a candidate that
+ * does neither is simply never confirmed, the trace ends at the global block
+ * cap with no park, and nav_diff reports the step as unreadable instead of
+ * inventing a landing. An honest "I could not tell" beats a confident wrong
+ * answer -- which is the whole reason this differential exists.
  * An indefinite (0xff) still needs no candidate at all: it is a park by
  * construction, so that path is unchanged.
  *
- * ⚠ Cheap in practice despite the cap, because the question is normally settled
- * at the candidate cell's own END, not at the cap: PGC 26 resolves in its 211
- * sectors and PGC 15 in its 88. The cap only bites on a long menu cell that
- * neither stills nor loops. */
-#define PROBE_MAX_BLOCKS 16000
+ * ⚠ Cheap in practice, because the question is normally settled at the
+ * candidate cell's own END: PGC 26 resolves in its 211 sectors, PGC 15 in
+ * its 88. */
 
 int main(int argc, char **argv) {
   dvdnav_t *nav;
@@ -205,11 +214,11 @@ int main(int argc, char **argv) {
             cand_pgc = st->pgcN; cand_cell = st->cellN;
             cand_blocks = 0; cand_loops = 0;
           } else {
-            cand_blocks++;
+            cand_blocks++;      /* diagnostic only -- never confirms a park */
           }
-          if (cand_loops > 0 || cand_blocks > PROBE_MAX_BLOCKS) {
-            printf("[park confirmed: pgc %d cell %d %s]\n", cand_pgc, cand_cell,
-                   cand_loops ? "looped" : "held past the probation cap");
+          if (cand_loops > 0) {
+            printf("[park confirmed: pgc %d cell %d looped]\n",
+                   cand_pgc, cand_cell);
             cand_on = 0;
             dump_screen(nav, ++parkno); parked = 1;
             int r = apply_action(nav);

--- a/tools/mister.py
+++ b/tools/mister.py
@@ -151,7 +151,11 @@ for f in /media/fat/MiSTer_DVDcss_hil_*; do
   [ $running = 0 ] && rm -f "$f"
 done
 echo "  harness files removed (core, mgl, agent, spare Mains)"
-echo "  NOTE: config/@CFG@ still holds whatever options the harness last set,"
+if [ -f /media/fat/config/@CFG@.hilbak ]; then
+  mv -f /media/fat/config/@CFG@.hilbak /media/fat/config/@CFG@
+  echo "  restored the saved settings the harness had overwritten"
+fi
+echo "  NOTE: config/@CFG@ is back to the user's own settings,"
 echo "        and the running Main stays until the next core load."
 """
 
@@ -546,7 +550,11 @@ def cmd_launch(args):
            f'  <file delay="{args.delay}" type="s" index="0" '
            f'path="{img}"/>\n'
            f'</mistergamedescription>\n')
+    # ⚠ This OVERWRITES the user's saved OSD settings for the core. Back them up
+    # once, so a harness session on someone's own rig is not destructive.
     ssh(f'''
+[ -f {CFG_DIR}/{CFG_NAME}.hilbak ] || [ ! -f {CFG_DIR}/{CFG_NAME} ] || \
+    cp {CFG_DIR}/{CFG_NAME} {CFG_DIR}/{CFG_NAME}.hilbak
 python3 -c "import sys;open('{CFG_DIR}/{CFG_NAME}','wb').write(bytes.fromhex('{blob.hex()}'))"
 cat > {CORE_DIR}/{HIL_MGL} <<'MGLEOF'
 {mgl}MGLEOF

--- a/tools/mister.py
+++ b/tools/mister.py
@@ -321,6 +321,60 @@ def build_status(opts):
 # ---------------------------------------------------------------------------
 # commands
 # ---------------------------------------------------------------------------
+def capture_devices():
+    """Resolve the capture card by NAME, not by index.
+
+    ⚠ ALSA card numbers and /dev/videoN are USB enumeration order and they MOVE.
+    The recorded default `hw:1,0` was correct when it was written and the card is
+    now hw:0 -- a stale index does not error, it records the WRONG DEVICE
+    (a webcam, or the motherboard's line-in) and hands back a confident silent
+    file. Same class as the hardcoded DVD_v2.CFG that stopped being read.
+
+    $MISTER_CAPTURE_NAME overrides the card name to match on.
+    """
+    want = os.environ.get('MISTER_CAPTURE_NAME', 'Hagibis')
+    adev = vdev = None
+    afmt = 'alsa'
+    # ⚠ PREFER THE SOUND SERVER. PipeWire/Pulse opens the USB capture card
+    # exclusively, so a raw `hw:N,0` fails with "Device or resource busy" -- and
+    # ffmpeg reports that as an input error, not as "something else has it".
+    # The server re-exposes the same card as a source; go through it.
+    try:
+        out = subprocess.run(['pactl', 'list', 'short', 'sources'],
+                             capture_output=True, text=True).stdout
+        for line in out.splitlines():
+            f = line.split('\t')
+            if len(f) > 1 and want.lower() in f[1].lower() and '.monitor' not in f[1]:
+                adev, afmt = f[1], 'pulse'
+                break
+    except Exception:
+        pass
+    if adev is None:
+        try:
+            out = subprocess.run(['arecord', '-l'], capture_output=True,
+                                 text=True).stdout
+            m = re.search(r'card (\d+): (\S*%s\S*)' % re.escape(want), out, re.I)
+            if m:
+                adev = 'hw:%s,0' % m.group(1)
+        except Exception:
+            pass
+    try:
+        out = subprocess.run(['v4l2-ctl', '--list-devices'], capture_output=True,
+                             text=True).stdout
+        block = None
+        for chunk in out.split('\n\n'):
+            if want.lower() in chunk.lower():
+                block = chunk
+                break
+        if block:
+            m = re.search(r'(/dev/video\d+)', block)
+            if m:
+                vdev = m.group(1)
+    except Exception:
+        pass
+    return vdev, adev, afmt
+
+
 def newest_rbf():
     rel = os.path.join(ROOT, 'releases')
     cands = [os.path.join(rel, f) for f in os.listdir(rel)] if os.path.isdir(rel) else []
@@ -654,8 +708,11 @@ def cmd_capture(args):
     cal = {}
     if os.path.exists(os.path.join(HERE, '.mister_capture.json')):
         cal = json.load(open(os.path.join(HERE, '.mister_capture.json')))
-    vdev = args.vdev or cal.get('video_device', '/dev/video0')
-    adev = args.adev or cal.get('audio_device', 'hw:1,0')
+    auto_v, auto_a, auto_fmt = capture_devices()
+    vdev = args.vdev or cal.get('video_device') or auto_v or '/dev/video0'
+    adev = args.adev or cal.get('audio_device') or auto_a or 'hw:0,0'
+    if not args.vdev and not cal.get('video_device') and auto_v:
+        print(f'  (resolved capture card by name: {auto_v} / {auto_a})')
     out = args.out or os.path.join(os.environ.get('TMPDIR', '/tmp'),
                                    f'hilcap_{time.strftime("%H%M%S")}.mkv')
     total = args.seconds + args.warmup
@@ -663,7 +720,8 @@ def cmd_capture(args):
            '-f', 'v4l2', '-input_format', args.pixfmt,
            '-video_size', args.video_size, '-framerate', str(args.fps),
            '-i', vdev,
-           '-f', 'alsa', '-ac', '2', '-ar', '48000', '-i', adev,
+           '-f', (args.afmt or auto_fmt), '-ac', '2', '-ar', '48000',
+           '-i', adev,
            '-t', str(total), '-c:v', 'copy', '-c:a', 'pcm_s16le', out]
     print(f'capture: {args.video_size}@{args.fps} {args.pixfmt} from {vdev} + {adev}')
     print(f'  {args.seconds}s (+{args.warmup}s warm-up) -> {out}')
@@ -898,6 +956,8 @@ def main():
     p.add_argument('--pixfmt', default='mjpeg')
     p.add_argument('--vdev')
     p.add_argument('--adev')
+    p.add_argument('--afmt', choices=('alsa', 'pulse'),
+                   help='ffmpeg audio input format (auto-detected)')
     p.set_defaults(fn=cmd_capture)
 
     p = sub.add_parser('log')

--- a/tools/nav_diff.py
+++ b/tools/nav_diff.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""
+nav_diff.py -- run the same button path through libdvdnav and the BOARD, and
+diff where each one landed. Track E phase 2 of the HIL harness.
+
+The soak test (tools/dvd_explore.py) can see a core that has CRASHED. It cannot
+see a core that navigated somewhere WRONG, because a wrong menu looks exactly
+like a right one. This closes that: it drives an independent implementation of
+the DVD virtual machine with the identical input and compares the landing.
+
+WHY libdvdnav AND NOT tools/dvd_vm_ref.py
+`dvd_vm_ref.py` is this project's golden VM model and it is NOT the oracle for
+this job. It was written from the RTL, so it holds the RTL's assumptions -- when
+the POST-only PGC dispatcher bug was found (CLAUDE.md, 70 of 505 discs), the
+model had the same wrong assumption and agreed with the hardware all the way
+through. libdvdnav is the independent implementation; it is what settled that
+bug, and it is what this diffs against. `dvd_vm_ref` is useful as a THIRD
+opinion when the two disagree, never as the reference.
+
+WHY THE BUTTON NUMBER IS THE UNIT
+libdvdnav's script token `<N>` is dvdnav_button_select_and_activate(N), and the
+core decodes a DIGIT KEY to exactly that (dvd/emu.sv: a digit press forces
+nav_pci's selection to that button AND activates it). So both sides take the
+SAME button number and there is no D-pad walk to reconcile -- a walk would make
+any disagreement ambiguous between "wrong landing" and "different route".
+
+WHAT THE BOARD CAN ACTUALLY TELL US
+With `Debug Overlay=On`, the transport HUD's "CH n/N" field is repurposed as
+{reader PGCN, VTS} (dvd/emu.sv). That is TWO of libdvdnav's five state fields --
+pgN and cellN are not observable, and the domain only indirectly. So the
+comparison is on PGCN (+ VTS where both sides are in a title domain), which is
+the headline nav question: "did it land in the right PGC?" Every nav bug this
+project has fixed would have shown up there.
+
+Usage:
+    nav_diff.py <disc> --script "w3 1 w2 2"      # explicit path
+    nav_diff.py <disc> --auto 4                  # walk buttons automatically
+    nav_diff.py --list                           # discs visible to both sides
+
+Script tokens (a subset of trace_nav's, chosen because the board can do them):
+    N     select+activate button N   (digit key)
+    mR    root menu                  (Menu key)
+    mT    title menu                 (Title key)
+    wN    wait N settle periods
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import mister as M              # noqa: E402
+import hud_read as H            # noqa: E402
+
+TRACE_NAV = os.path.join(HERE, 'bin', 'trace_nav')
+
+# The disc library is one SMB share mounted in two places. Both sides must open
+# the same bytes, so a run names one disc and each side resolves its own path.
+LOCAL_ROOT = os.environ.get('DVD_ISO_DIR', '/mnt/sattler/games/DVD')
+BOARD_ROOT = os.environ.get('MISTER_ISO_DIR', '/media/fat/cifs/games/DVD')
+
+# ⚠ DOCUMENTED DELIBERATE DEVIATION (CLAUDE.md, docs/dvd_vm.md "Boot-chain menu
+# shortcut"): before any menu-domain PGC has loaded, the core sends the Menu key
+# to best_menu_vts Root instead of the playing title's own VTSM Root, because on
+# a DVD-game disc the latter is a dispatcher that can start a random clip.
+# libdvdnav does the spec thing and lands elsewhere. A difference on the FIRST
+# menu call of a session is therefore EXPECTED and must not be reported as a
+# defect -- doing so would train the reader to ignore real ones.
+# Consecutive identical (PGCN,VTS) readings, WITH the highlight armed, before
+# the board is called settled. Measured: 1 was not enough (see board_park).
+SETTLE_REPEATS = 2
+
+BOOT_MENU_NOTE = ('first menu call of the session -- the core deliberately '
+                  'targets best_menu_vts Root (boot-chain shortcut)')
+
+
+# ---------------------------------------------------------------------------
+# the independent oracle
+# ---------------------------------------------------------------------------
+def trace_landings(iso, script, seed=None):
+    """Run libdvdnav over the script. -> [{'action', 'pgcn', 'vts', 'dom', ...}]
+
+    The landing for an action is the VM state at the NEXT park -- a park is
+    where libdvdnav waits for input, which is the same place the board's picture
+    goes still. Comparing anywhere else compares mid-transition states.
+    """
+    if not os.path.exists(TRACE_NAV):
+        sys.exit(f'nav_diff: {TRACE_NAV} not built')
+    cmd = [TRACE_NAV, iso, script] + ([str(seed)] if seed is not None else [])
+    p = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
+    out = p.stdout
+
+    vm_re = re.compile(r'VM\[\w+\]\s+dom=(-?\d+)\s+vtsN=(-?\d+)\s+pgcN=(-?\d+)'
+                       r'\s+pgN=(-?\d+)\s+cellN=(-?\d+)')
+    park_re = re.compile(r'^===== PARK #(\d+)\s+title=(-?\d+)\s+part=(-?\d+)\s+'
+                         r'buttons=(\d+)', re.M)
+    act_re = re.compile(r'^>> action: (.+)$', re.M)
+
+    events, last_vm = [], None
+    for line in out.splitlines():
+        m = vm_re.search(line)
+        if m:
+            last_vm = dict(dom=int(m.group(1)), vts=int(m.group(2)),
+                           pgcn=int(m.group(3)), pg=int(m.group(4)),
+                           cell=int(m.group(5)))
+            continue
+        m = park_re.match(line)
+        if m:
+            events.append(('park', dict(park=int(m.group(1)),
+                                        buttons=int(m.group(4)),
+                                        state=dict(last_vm or {}))))
+            continue
+        m = act_re.match(line)
+        if m:
+            events.append(('action', m.group(1).strip()))
+
+    # Pair each action with the state at the park that FOLLOWS it, and remember
+    # how many buttons existed at the park it was applied AT.
+    #
+    # ⚠ THAT SECOND NUMBER IS WHAT KEEPS THE COMPARISON HONEST. A run that
+    # pressed button 2 at a park with buttons=1 produced a reproducible,
+    # confident "difference" that was nothing of the kind: the board correctly
+    # ignores a digit for a button that does not exist, libdvdnav does something
+    # else with it, and neither is wrong because the input is undefined. Only
+    # well-defined inputs can be diffed.
+    out_rows, pending, at_park = [], None, None
+    for kind, val in events:
+        if kind == 'park':
+            if pending is not None:
+                out_rows.append(dict(action=pending, applied_buttons=at_park,
+                                     buttons=val['buttons'], **val['state']))
+                pending = None
+            at_park = val['buttons']
+        elif kind == 'action':
+            pending = val
+    if pending is not None:                      # script ended before a re-park
+        tail = [v for k, v in events if k == 'park']
+        st = tail[-1]['state'] if tail else {}
+        out_rows.append(dict(action=pending, applied_buttons=at_park,
+                             buttons=0, **st))
+    return out_rows, out
+
+
+# ---------------------------------------------------------------------------
+# the board
+# ---------------------------------------------------------------------------
+def board_landing(tmpdir, step):
+    """Screenshot the board and read {PGCN, VTS} off the HUD. -> dict or None."""
+    png = os.path.join(tmpdir, f'nav{step:03d}.png')
+    rc, _ = M.ssh('''
+rm -f /media/fat/screenshots/navd.png
+echo 'screenshot navd.png' > /dev/MiSTer_cmd
+for i in $(seq 1 20); do
+  sleep 0.25
+  if [ -f /media/fat/screenshots/navd.png ]; then
+    a=$(stat -c %s /media/fat/screenshots/navd.png); sleep 0.2
+    b=$(stat -c %s /media/fat/screenshots/navd.png)
+    [ "$a" = "$b" ] && [ "$a" != 0 ] && exit 0
+  fi
+done
+exit 1
+''', check=False)
+    if rc != 0:
+        return None
+    r = subprocess.run(['scp', *M.SSH_OPTS, '-q',
+                        f'{M.host()}:/media/fat/screenshots/navd.png', png],
+                       capture_output=True)
+    if r.returncode != 0:
+        return None
+    w, h, buf = H.load_image(png)
+    frame = H.Frame(w, h, buf)
+    res = H.decode(frame)
+    if not res['status']['present'] or res.get('dbg_pgcn') is None:
+        return None
+    # O[2] block 1 is hl_btns_armed -- the board's exact equivalent of
+    # libdvdnav's `buttons=N` at a park. Gated on menus_on, which the launch
+    # sets; `None` means the block was not drawn, not that it read false.
+    blk = H.read_blocks(frame)
+    return dict(pgcn=res['dbg_pgcn'], vts=res['dbg_vts'],
+                armed=blk['hl_btns_armed']['value'],
+                elapsed=res.get('elapsed'), png=png)
+
+
+def board_park(tmpdir, step, settle, timeout=45, want_armed=True):
+    """Wait until the board has PARKED, then read its landing.
+
+    ⚠ A FIXED SLEEP IS NOT A PARK, and using one produced two confident false
+    DIFFs on the first run: the board was still walking its boot chain (PGC
+    90 -> 2 -> 1) while the script was already pressing buttons, so the tool
+    compared the board's boot cells against libdvdnav's settled menu and called
+    it a navigation defect. libdvdnav applies every action AT a park; the board
+    must be at one too or the two are not comparable.
+
+    ⛔ NOT "the picture stopped moving" -- that is how dvd_explore detects a
+    still, and it is wrong here: a MOTION menu (MiB's root, Sherlock's) loops
+    video forever and never freezes, so a picture-based detector would time out
+    on exactly the discs with the most interesting navigation. The reader's
+    {PGCN, VTS} settling is the signal that works for both kinds.
+
+    ⚠ AND STABILITY ALONE IS NOT A PARK EITHER, which the second attempt
+    proved: a First Play LOGO cell holds one PGCN for many seconds, so
+    "same PGCN twice" declared a park at pgc=90 while the boot chain was still
+    walking to pgc=1. A park is where the disc WAITS FOR INPUT. libdvdnav says
+    so with `buttons=N`; the board says so with hl_btns_armed, which O[2]
+    block 1 exposes -- so the two are asking the same question.
+    ⚠ AND ONE REPEAT IS NOT SETTLED. A highlight stays armed from the PREVIOUS
+    menu while the reader walks to the next PGC, so `armed` plus one repeat
+    still fired mid-transition -- the board read the pass-through PGC while
+    libdvdnav reported the PGC it came to rest in, one step further on. The
+    trajectory is printed so this is visible rather than inferred.
+    """
+    deadline = time.time() + timeout
+    prev, stable, traj = None, 0, []
+    got = None
+    while time.time() < deadline:
+        got = board_landing(tmpdir, step)
+        if got is not None:
+            key = (got['pgcn'], got['vts'])
+            traj.append(f"{got['pgcn']}{'*' if got.get('armed') else ''}")
+            stable = stable + 1 if key == prev else 0
+            prev = key
+            if (got.get('armed') or not want_armed) and stable >= SETTLE_REPEATS:
+                got['traj'] = traj
+                return got
+        time.sleep(settle)
+    if got is not None:
+        got['traj'] = traj
+        got['unsettled'] = True
+    return got                               # best effort; caller reports it
+
+
+def board_apply(token, settle):
+    """Apply one script token on the board."""
+    if token.startswith('w'):
+        return 'wait'          # the park wait below IS the wait
+    if token.startswith('m'):
+        key = 'title' if token[1:2] == 'T' else 'menu'
+        M.cmd_key(argparse.Namespace(names=[key]))
+        return key
+    M.cmd_key(argparse.Namespace(names=[token]))
+    return f'button {token}'
+
+
+# ---------------------------------------------------------------------------
+def resolve(disc):
+    """One disc name -> (local path, board path). Both sides must see it."""
+    if os.path.isabs(disc) and os.path.exists(disc):
+        local = disc
+        rel = os.path.relpath(local, LOCAL_ROOT)
+    else:
+        rel = disc
+        local = os.path.join(LOCAL_ROOT, rel)
+    if not os.path.exists(local):
+        sys.exit(f'nav_diff: no such disc locally: {local}')
+    return local, os.path.join(BOARD_ROOT, rel)
+
+
+def cmd_list():
+    hits = []
+    for dirpath, _, files in os.walk(LOCAL_ROOT):
+        for f in files:
+            if f.lower().endswith(('.iso',)):
+                hits.append(os.path.relpath(os.path.join(dirpath, f), LOCAL_ROOT))
+    for h in sorted(hits)[:60]:
+        print('  ' + h)
+    print(f'  ... {len(hits)} ISOs under {LOCAL_ROOT}')
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('disc', nargs='?')
+    ap.add_argument('--script', default='w2 1',
+                    help='e.g. "w3 1 w2 2" (see the token table above)')
+    ap.add_argument('--settle', type=float, default=3.0,
+                    help='seconds the board is given to land after an action')
+    ap.add_argument('--seed', type=int, help='rnd seed for libdvdnav')
+    ap.add_argument('--boot-timeout', type=float, default=240.0,
+                    help='seconds to reach the first armed park')
+    ap.add_argument('--action-timeout', type=float, default=90.0,
+                    help='seconds to re-park after an action')
+    ap.add_argument('--out')
+    ap.add_argument('--list', action='store_true')
+    ap.add_argument('--red', type=int, metavar='N',
+                    help='drive the board with button N instead, to prove the comparison can fail')
+    ap.add_argument('--no-board', action='store_true',
+                    help='oracle only -- no hardware needed')
+    args = ap.parse_args()
+    if args.list:
+        return cmd_list()
+    if not args.disc:
+        ap.error('a disc is required (or --list)')
+
+    local, board = resolve(args.disc)
+    tmpdir = args.out or os.path.join(
+        os.environ.get('TMPDIR', '/tmp'), f'navdiff_{time.strftime("%H%M%S")}')
+    os.makedirs(tmpdir, exist_ok=True)
+    tokens = args.script.split()
+
+    print(f'nav_diff: {os.path.basename(local)}')
+    print(f'  script : {" ".join(tokens)}')
+    print(f'  oracle : libdvdnav (independent of our RTL and of dvd_vm_ref)')
+
+    oracle, raw = trace_landings(local, ' '.join(tokens), args.seed)
+    open(os.path.join(tmpdir, 'trace_nav.txt'), 'w').write(raw)
+    print(f'  libdvdnav produced {len(oracle)} landing(s)')
+    for r in oracle:
+        print(f'     {r["action"]:<34} -> dom={r.get("dom")} vts={r.get("vts")} '
+              f'pgc={r.get("pgcn")} pg={r.get("pg")} cell={r.get("cell")}')
+    if args.no_board:
+        return 0
+
+    print(f'\n  board  : launching {board}')
+    M.cmd_launch(argparse.Namespace(
+        image=board, opt=['Debug Overlay=On', 'Disc Menus=On',
+                          'Video Output=Progressive'],
+        delay=2, timeout=90, no_wait=False))
+    time.sleep(8)
+
+    # Reach the first park before touching anything, exactly as libdvdnav does.
+    # ⚠ GENEROUSLY: libdvdnav walks the nav graph at CPU speed while the board
+    # PLAYS every cell in real time, so a boot chain of logo cells that costs
+    # libdvdnav milliseconds costs the board minutes. A 45 s budget expired
+    # mid-chain and the run then compared the board's boot cells against
+    # libdvdnav's settled menu, reporting two confident differences that were
+    # entirely this tool's.
+    start = board_park(tmpdir, 0, args.settle, timeout=args.boot_timeout)
+    if start:
+        print(f'    booted to pgc={start["pgcn"]} vts={start["vts"]}'
+              f'   trajectory: {" ".join(start.get("traj", []))}'
+              + ('  [UNSETTLED]' if start.get('unsettled') else ''))
+    else:
+        print('    (no readable landing after boot)')
+
+    # ⛔ REFUSE to compare from an unknown starting state. Every landing after an
+    # unsettled boot is measured against a board that is somewhere else entirely,
+    # and the differences are the harness's, not the core's.
+    if start is None or start.get('unsettled') or not start.get('armed'):
+        print('\n  ABORT: the board never reached an armed park within '
+              f'{args.boot_timeout}s -- nothing to compare against.')
+        print('    Either the boot chain is longer than the budget (raise '
+              '--boot-timeout) or this disc does not present a button menu.')
+        print('    Comparing from here would report the harness, not the core.')
+        return 2
+
+    rows, menu_calls = [], 0
+    for i, tok in enumerate(tokens):
+        # ⚠ RED PROOF. A differential that reports "no differences" is worth
+        # nothing until it has been shown to report one. --red presses a
+        # DIFFERENT button on the board than the oracle was given, so the two
+        # must land apart; if this run comes back clean the comparison is broken
+        # and every green run before it meant nothing.
+        drive = tok
+        if args.red and tok.isdigit():
+            drive = str(args.red)
+            print(f'    [RED] oracle was given button {tok}; '
+                  f'pressing {drive} on the board instead')
+        did = board_apply(drive, args.settle)
+        got = board_park(tmpdir, i + 1, args.settle,
+                         timeout=args.action_timeout)
+        if tok.startswith('m'):
+            menu_calls += 1
+        rows.append(dict(token=tok, did=did, board=got))
+
+    # --- diff -------------------------------------------------------------
+    print('\n  landing comparison (PGCN is the headline; pg/cell are not '
+          'observable from the board)')
+    findings, expected, unknown, invalid = [], [], [], []
+    acted = [r for r in rows if not r['token'].startswith('w')]
+    for n, r in enumerate(acted):
+        o = oracle[n] if n < len(oracle) else None
+        b = r['board']
+        if o is None:
+            unknown.append(f'{r["did"]}: libdvdnav produced no landing')
+            continue
+        if b is None:
+            unknown.append(f'{r["did"]}: no readable HUD on the board')
+            continue
+        # An out-of-range button is not a comparable input.
+        nb = o.get('applied_buttons')
+        if r['token'].isdigit() and nb is not None and int(r['token']) > nb:
+            invalid.append(f'{r["did"]}: the park it was pressed at had only '
+                           f'{nb} button(s) -- undefined input, not compared')
+            print(f'    [skip] {r["did"]:<12} no such button at that park '
+                  f'(buttons={nb})')
+            continue
+        same = (o['pgcn'] == b['pgcn'])
+        first_menu = r['token'].startswith('m') and menu_calls == 1 and n == 0
+        mark = 'OK  ' if same else ('note' if first_menu else 'DIFF')
+        print(f'    [{mark}] {r["did"]:<12} libdvdnav pgc={o["pgcn"]:<4}'
+              f' vts={o["vts"]:<4} | board pgc={b["pgcn"]:<4} vts={b["vts"]:<4}'
+              f' traj: {" ".join(b.get("traj", []))}'
+              + ('  [UNSETTLED]' if b.get('unsettled') else ''))
+        if same:
+            continue
+        if first_menu:
+            expected.append(f'{r["did"]}: {BOOT_MENU_NOTE}')
+        else:
+            findings.append(f'{r["did"]}: libdvdnav landed in PGC {o["pgcn"]} '
+                            f'(VTS {o["vts"]}), the board in PGC {b["pgcn"]} '
+                            f'(VTS {b["vts"]})')
+
+    print()
+    for e in expected:
+        print(f'  note (documented deviation): {e}')
+    for iv in invalid:
+        print(f'  skipped: {iv}')
+    for u in unknown:
+        print(f'  unknown: {u}')
+    for f in findings:
+        print(f'  !! DIFFERENCE: {f}')
+    if not findings:
+        print('  no navigation differences' +
+              (' (some steps unreadable -- see above)' if unknown else ''))
+    if args.red:
+        ok = bool(findings)
+        print(f'\n  RED PROOF: {"PASS" if ok else "FAIL"} -- a deliberately '
+              f'mismatched input {"was" if ok else "was NOT"} reported as a '
+              'difference')
+        if not ok:
+            print('    The comparison cannot fail. Do not trust a green run.')
+        return 0 if ok else 3
+    json.dump(dict(disc=os.path.basename(local), script=tokens,
+                   oracle=oracle, board=[r['board'] for r in rows],
+                   findings=findings, expected=expected, unknown=unknown,
+                   invalid=invalid),
+              open(os.path.join(tmpdir, 'nav_diff.json'), 'w'), indent=2)
+    print(f'  artifacts: {tmpdir}')
+    return 1 if findings else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/nav_diff.py
+++ b/tools/nav_diff.py
@@ -128,20 +128,34 @@ def trace_landings(iso, script, seed=None):
     # ignores a digit for a button that does not exist, libdvdnav does something
     # else with it, and neither is wrong because the input is undefined. Only
     # well-defined inputs can be diffed.
-    out_rows, pending, at_park = [], None, None
+    #
+    # ⚠ THE **LAST** PARK BEFORE THE NEXT ACTION IS THE LANDING, NOT THE FIRST.
+    # For an intermediate action those are the same park (the next park spends
+    # the next script token, so exactly one sits between two actions). They
+    # differ only if the tracer emits more than one -- and then the later one is
+    # the settled screen, which is what the board's own SETTLE_REPEATS rule
+    # reports. Taking the first would compare a transient against a settled
+    # state, which is the shape of every false difference this tool has produced.
+    out_rows, pending, at_park, row_idx = [], None, None, None
     for kind, val in events:
         if kind == 'park':
             if pending is not None:
-                out_rows.append(dict(action=pending, applied_buttons=at_park,
-                                     buttons=val['buttons'], **val['state']))
-                pending = None
+                row = dict(action=pending, applied_buttons=applied_at,
+                           buttons=val['buttons'], **val['state'])
+                if row_idx is None:
+                    out_rows.append(row)
+                    row_idx = len(out_rows) - 1
+                else:
+                    out_rows[row_idx] = row
             at_park = val['buttons']
         elif kind == 'action':
             pending = val
-    if pending is not None:                      # script ended before a re-park
+            applied_at = at_park       # buttons at the park it is applied AT
+            row_idx = None
+    if pending is not None and row_idx is None:   # script ended before a re-park
         tail = [v for k, v in events if k == 'park']
         st = tail[-1]['state'] if tail else {}
-        out_rows.append(dict(action=pending, applied_buttons=at_park,
+        out_rows.append(dict(action=pending, applied_buttons=applied_at,
                              buttons=0, **st))
     return out_rows, out
 

--- a/tools/nav_diff.py
+++ b/tools/nav_diff.py
@@ -260,6 +260,22 @@ def resolve(disc):
     return local, os.path.join(BOARD_ROOT, rel)
 
 
+def is_nondeterministic(iso, script):
+    """Run the oracle twice under different RNG seeds. Different landings mean
+    the disc's navigation uses `rnd`, and a differential cannot be trusted on it.
+
+    ⚠ MEASURED, not parsed out of the command table: ATMOSFEAR's boot chain ends
+    in `rnd 6; JumpTT 1` (CLAUDE.md), so the core's LFSR and libdvdnav's RNG
+    disagree by design and every landing after that point is a coin flip. A
+    sweep that reports those as defects is worse than one that skips the disc.
+    """
+    a, _ = trace_landings(iso, script, seed=1)
+    b, _ = trace_landings(iso, script, seed=99)
+    pa = [r.get('pgcn') for r in a]
+    pb = [r.get('pgcn') for r in b]
+    return pa != pb, pa, pb
+
+
 def auto_script(iso, steps, seed):
     """Build a script of VALID button presses by asking the oracle, one step at
     a time.
@@ -340,6 +356,15 @@ def main():
     print(f'  script : {" ".join(tokens)}')
     print(f'  oracle : libdvdnav (independent of our RTL and of dvd_vm_ref)')
 
+    nd, pa, pb = is_nondeterministic(local, ' '.join(tokens))
+    if nd:
+        print(f'\n  ⚠ THIS DISC IS NON-DETERMINISTIC: the oracle lands '
+              f'{pa} under one RNG seed and {pb} under another.')
+        print('    Its navigation uses `rnd`, so the core\'s LFSR and '
+              "libdvdnav's RNG disagree BY DESIGN.")
+        print('    A differential cannot be trusted here; skipping the board.')
+        return 2
+
     oracle, raw = trace_landings(local, ' '.join(tokens), args.seed)
     open(os.path.join(tmpdir, 'trace_nav.txt'), 'w').write(raw)
     print(f'  libdvdnav produced {len(oracle)} landing(s)')
@@ -402,9 +427,16 @@ def main():
         rows.append(dict(token=tok, did=did, board=got))
 
     # --- diff -------------------------------------------------------------
-    print('\n  landing comparison (PGCN is the headline; pg/cell are not '
-          'observable from the board)')
-    findings, expected, unknown, invalid = [], [], [], []
+    print('\n  landing comparison -- PGCN is compared; VTS is shown for context '
+          'ONLY.')
+    # ⚠ The two VTS numbers do not mean the same thing and must not be diffed.
+    # libdvdnav reports vtsN relative to the DOMAIN (-1 in VMGM, the menu's own
+    # VTS in VTSM), while the board reports the reader's absolute VTS -- on a
+    # DVD board game with 70+ title sets that reads 72 where libdvdnav says 1,
+    # and neither is wrong. pg and cell are not observable from the board at all.
+    print('     (libdvdnav\'s VTS is domain-relative, the board\'s is absolute)')
+    findings, expected, unknown, invalid, downstream = [], [], [], [], []
+    diverged = False
     acted = [r for r in rows if not r['token'].startswith('w')]
     for n, r in enumerate(acted):
         o = oracle[n] if n < len(oracle) else None
@@ -414,6 +446,25 @@ def main():
             continue
         if b is None:
             unknown.append(f'{r["did"]}: no readable HUD on the board')
+            continue
+        if b.get('unsettled'):
+            # It never reached an armed park, so it was still in transit. The
+            # boot case already aborts; an ACTION that never settles was being
+            # compared anyway, which is the same error one step later.
+            unknown.append(f'{r["did"]}: never reached an armed park '
+                           f'(trajectory {" ".join(b.get("traj", []))})')
+            print(f'    [....] {r["did"]:<12} never parked -- not compared')
+            diverged = True
+            continue
+        if diverged:
+            # ⚠ ONCE THE TWO ARE IN DIFFERENT PLACES, NOTHING AFTER IS AN
+            # INDEPENDENT FINDING: the next button is pressed at two different
+            # menus, so a "difference" is guaranteed and says nothing. The
+            # Sherlock sweep reported two, of which only the first could
+            # possibly have meant anything.
+            downstream.append(f'{r["did"]}: after an earlier divergence')
+            print(f'    [----] {r["did"]:<12} downstream of a divergence '
+                  '-- not compared')
             continue
         # An out-of-range button is not a comparable input.
         nb = o.get('applied_buttons')
@@ -437,13 +488,17 @@ def main():
         else:
             findings.append(f'{r["did"]}: libdvdnav landed in PGC {o["pgcn"]} '
                             f'(VTS {o["vts"]}), the board in PGC {b["pgcn"]} '
-                            f'(VTS {b["vts"]})')
+                            f'(VTS {b["vts"]})  [board trajectory: '
+                            f'{" ".join(b.get("traj", []))}]')
+            diverged = True
 
     print()
     for e in expected:
         print(f'  note (documented deviation): {e}')
     for iv in invalid:
         print(f'  skipped: {iv}')
+    for d in downstream:
+        print(f'  not compared: {d}')
     for u in unknown:
         print(f'  unknown: {u}')
     for f in findings:
@@ -462,7 +517,7 @@ def main():
     json.dump(dict(disc=os.path.basename(local), script=tokens,
                    oracle=oracle, board=[r['board'] for r in rows],
                    findings=findings, expected=expected, unknown=unknown,
-                   invalid=invalid),
+                   invalid=invalid, downstream=downstream),
               open(os.path.join(tmpdir, 'nav_diff.json'), 'w'), indent=2)
     print(f'  artifacts: {tmpdir}')
     return 1 if findings else 0

--- a/tools/nav_diff.py
+++ b/tools/nav_diff.py
@@ -260,6 +260,31 @@ def resolve(disc):
     return local, os.path.join(BOARD_ROOT, rel)
 
 
+def auto_script(iso, steps, seed):
+    """Build a script of VALID button presses by asking the oracle, one step at
+    a time.
+
+    Which buttons exist depends on where you are, and where you are depends on
+    which buttons you pressed -- so the script cannot be written up front. Each
+    iteration runs libdvdnav over the script so far, reads how many buttons the
+    park it ended at offers, and appends one that exists. That is also what
+    keeps a sweep honest: a script generated this way never contains the
+    undefined input that produced a false difference by hand.
+    """
+    import random
+    rng = random.Random(seed)
+    script = []
+    for _ in range(steps):
+        rows, raw = trace_landings(iso, ' '.join(script) if script else 'w1', seed)
+        # buttons offered at the park we are sitting at now
+        parks = re.findall(r'^===== PARK #\d+.*?buttons=(\d+)', raw, re.M)
+        n = int(parks[-1]) if parks else 0
+        if n < 1:
+            break
+        script.append(str(rng.randint(1, n)))
+    return script
+
+
 def cmd_list():
     hits = []
     for dirpath, _, files in os.walk(LOCAL_ROOT):
@@ -276,6 +301,8 @@ def main():
     ap = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument('disc', nargs='?')
+    ap.add_argument('--auto', type=int, metavar='N',
+                    help='derive an N-step script of VALID buttons from the oracle')
     ap.add_argument('--script', default='w2 1',
                     help='e.g. "w3 1 w2 2" (see the token table above)')
     ap.add_argument('--settle', type=float, default=3.0,
@@ -301,7 +328,13 @@ def main():
     tmpdir = args.out or os.path.join(
         os.environ.get('TMPDIR', '/tmp'), f'navdiff_{time.strftime("%H%M%S")}')
     os.makedirs(tmpdir, exist_ok=True)
-    tokens = args.script.split()
+    if args.auto:
+        tokens = auto_script(local, args.auto, args.seed or 1)
+        if not tokens:
+            print('nav_diff: the oracle found no button menu on this disc')
+            return 2
+    else:
+        tokens = args.script.split()
 
     print(f'nav_diff: {os.path.basename(local)}')
     print(f'  script : {" ".join(tokens)}')

--- a/tools/nav_diff.py
+++ b/tools/nav_diff.py
@@ -61,7 +61,7 @@ TRACE_NAV = os.path.join(HERE, 'bin', 'trace_nav')
 
 # The disc library is one SMB share mounted in two places. Both sides must open
 # the same bytes, so a run names one disc and each side resolves its own path.
-LOCAL_ROOT = os.environ.get('DVD_ISO_DIR', '/mnt/sattler/games/DVD')
+LOCAL_ROOT = os.environ.get('DVD_ISO_DIR', os.path.expanduser('~/dvd-isos'))
 BOARD_ROOT = os.environ.get('MISTER_ISO_DIR', '/media/fat/cifs/games/DVD')
 
 # ⚠ DOCUMENTED DELIBERATE DEVIATION (CLAUDE.md, docs/dvd_vm.md "Boot-chain menu

--- a/tools/nav_diff.py
+++ b/tools/nav_diff.py
@@ -166,7 +166,8 @@ def trace_landings(iso, script, seed=None):
 def board_landing(tmpdir, step):
     """Screenshot the board and read {PGCN, VTS} off the HUD. -> dict or None."""
     png = os.path.join(tmpdir, f'nav{step:03d}.png')
-    rc, _ = M.ssh('''
+    try:
+        rc, _ = M.ssh('''
 rm -f /media/fat/screenshots/navd.png
 echo 'screenshot navd.png' > /dev/MiSTer_cmd
 for i in $(seq 1 20); do
@@ -179,6 +180,12 @@ for i in $(seq 1 20); do
 done
 exit 1
 ''', check=False)
+    except subprocess.TimeoutExpired:
+        # ⚠ A DROPPED SSH ROUND-TRIP IS NOT A NAVIGATION DIFFERENCE.
+        # One 120 s timeout during a 24-disc sweep aborted the whole run
+        # with a traceback, and the sweep driver scored that exit code as
+        # a FINDING. A lost screenshot is a retry, not evidence.
+        return None
     if rc != 0:
         return None
     r = subprocess.run(['scp', *M.SSH_OPTS, '-q',
@@ -197,7 +204,23 @@ exit 1
     blk = H.read_blocks(frame)
     return dict(pgcn=res['dbg_pgcn'], vts=res['dbg_vts'],
                 armed=blk['hl_btns_armed']['value'],
-                elapsed=res.get('elapsed'), png=png)
+                still=blk['still_active']['value'],
+                elapsed=res.get('elapsed'), total=res.get('total'),
+                png=png)
+
+
+def _secs(t):
+    """'0:01:33' -> 93. None or unparseable -> None."""
+    if not t:
+        return None
+    try:
+        parts = [int(x) for x in t.split(':')]
+    except ValueError:
+        return None
+    v = 0
+    for q in parts:
+        v = v * 60 + q
+    return v
 
 
 def board_park(tmpdir, step, settle, timeout=45, want_armed=True):
@@ -227,24 +250,69 @@ def board_park(tmpdir, step, settle, timeout=45, want_armed=True):
     still fired mid-transition -- the board read the pass-through PGC while
     libdvdnav reported the PGC it came to rest in, one step further on. The
     trajectory is printed so this is visible rather than inferred.
+
+    ★★ AND STABLE + ARMED IS STILL NOT A PARK -- THE FIFTH ATTEMPT, and it is
+    the exact mirror of the defect fixed in trace_nav. A disc may author a
+    TRANSIENT CLIP WITH A HIGHLIGHT UP: 24_DVD_BOARD_GAME boots into VMGM PGC 2,
+    a ~24 s intro whose POST is `JumpSS VTSM (vts 1, menu 4)`, and holds one
+    PGCN with buttons armed for the whole of it. Every rule above passes there,
+    so the sweep pressed its button during the intro and reported the resulting
+    mismatch as a navigation defect on SIX discs.
+
+    MEASURED on the board (screenshots, 8 s apart, `Debug Overlay=On`):
+
+        t= 8..32s   CH 2  0:04/0:24 -> 0:19/0:24, then 0:08/0:35 -> 0:22/0:35
+        t=40..96s   CH 3  0:00/0:29 0:13 0:26 | 0:10 0:24 | 0:08 0:21 0:04
+
+    PGC 3 is where it comes to rest, and the IFO says why: `cell_cmd=1 ->
+    LinkPGN 1`, a cell that replays itself. libdvdnav settles there too.
+
+    So a park is confirmed the same way the oracle confirms one -- BY A STILL OR
+    BY A LOOP:
+      - `still_active` (O[2] block 6) -- the reader parked on a still;
+      - or the HUD clock WRAPPED with the total unchanged -- the cell replayed.
+    ⚠ The total must be unchanged, or a multi-cell intro reads as a loop: PGC 2
+    above resets its clock too, but its total moves 0:24 -> 0:35 because a new
+    CELL started. A real loop replays the same cell, so the total holds.
+    ⚠ Neither can be required alone: a still-only rule times out on a looping
+    motion menu (the mistake in row 2 of this list), and a loop-only rule never
+    fires on a menu still, whose clock does not run at all.
+    A landing that reaches the timeout without either is returned FLAGGED
+    (`unconfirmed`) rather than silently trusted.
     """
     deadline = time.time() + timeout
     prev, stable, traj = None, 0, []
+    prev_el, prev_tot, looped = None, None, False
     got = None
     while time.time() < deadline:
         got = board_landing(tmpdir, step)
         if got is not None:
             key = (got['pgcn'], got['vts'])
             traj.append(f"{got['pgcn']}{'*' if got.get('armed') else ''}")
-            stable = stable + 1 if key == prev else 0
-            prev = key
-            if (got.get('armed') or not want_armed) and stable >= SETTLE_REPEATS:
+            el, tot = _secs(got.get('elapsed')), _secs(got.get('total'))
+            if key == prev:
+                stable += 1
+                # a LOOP: the same cell replayed -- clock went backwards while
+                # the cell's own length stayed put (see the docstring).
+                if (el is not None and prev_el is not None and el < prev_el
+                        and tot is not None and tot == prev_tot):
+                    looped = True
+            else:
+                stable, looped = 0, False
+            prev, prev_el, prev_tot = key, el, tot
+            settled = got.get('still') is True or looped
+            if ((got.get('armed') or not want_armed)
+                    and stable >= SETTLE_REPEATS and settled):
                 got['traj'] = traj
+                got['why'] = 'still' if got.get('still') else 'loop'
                 return got
         time.sleep(settle)
     if got is not None:
         got['traj'] = traj
-        got['unsettled'] = True
+        # Stable and armed but neither still nor looping: it may be a transient
+        # clip that simply outlasted the budget. Say so instead of trusting it.
+        got['unconfirmed'] = True
+        got['unsettled'] = not (stable >= SETTLE_REPEATS and got.get('armed'))
     return got                               # best effort; caller reports it
 
 
@@ -311,7 +379,11 @@ def auto_script(iso, steps, seed):
         n = int(parks[-1]) if parks else 0
         if n < 1:
             break
-        script.append(str(rng.randint(1, n)))
+        # ⚠ THE BOARD PRESSES BUTTONS WITH DIGIT KEYS, so only 1..9 exist:
+        # `emu.sv` decodes ONE digit per key. A menu with more buttons made
+        # auto_script emit `10`, which aborted the run on 4 of 24 discs in a
+        # sweep -- and the driver scored the exit code as a finding.
+        script.append(str(rng.randint(1, min(n, 9))))
     return script
 
 
@@ -405,6 +477,7 @@ def main():
     start = board_park(tmpdir, 0, args.settle, timeout=args.boot_timeout)
     if start:
         print(f'    booted to pgc={start["pgcn"]} vts={start["vts"]}'
+              f' ({start.get("why", "?")})'
               f'   trajectory: {" ".join(start.get("traj", []))}'
               + ('  [UNSETTLED]' if start.get('unsettled') else ''))
     else:
@@ -413,9 +486,12 @@ def main():
     # ⛔ REFUSE to compare from an unknown starting state. Every landing after an
     # unsettled boot is measured against a board that is somewhere else entirely,
     # and the differences are the harness's, not the core's.
-    if start is None or start.get('unsettled') or not start.get('armed'):
-        print('\n  ABORT: the board never reached an armed park within '
+    if (start is None or start.get('unsettled') or not start.get('armed')
+            or start.get('unconfirmed')):
+        print('\n  ABORT: the board never reached a CONFIRMED park within '
               f'{args.boot_timeout}s -- nothing to compare against.')
+        print('    A park is confirmed by a still or by the cell looping; '
+              'stable+armed alone is a transient clip with a highlight up.')
         print('    Either the boot chain is longer than the budget (raise '
               '--boot-timeout) or this disc does not present a button menu.')
         print('    Comparing from here would report the harness, not the core.')
@@ -460,6 +536,17 @@ def main():
             continue
         if b is None:
             unknown.append(f'{r["did"]}: no readable HUD on the board')
+            continue
+        if b.get('unconfirmed') and not b.get('unsettled'):
+            # Stable and armed, but neither still nor looping inside the
+            # budget -- i.e. possibly a transient clip that outlasted it. That
+            # is exactly the state that produced six false differences, so it
+            # is reported, never compared.
+            unknown.append(f'{r["did"]}: park not confirmed (no still, no '
+                           f'loop) within the budget '
+                           f'(trajectory {" ".join(b.get("traj", []))})')
+            print(f'    [....] {r["did"]:<12} park unconfirmed -- not compared')
+            diverged = True
             continue
         if b.get('unsettled'):
             # It never reached an armed park, so it was still in transit. The


### PR DESCRIPTION
Hardware-in-the-loop tooling only — no RTL, no Main, no user-visible change.

## What this is

The Track E phase-2 navigation differential (`tools/nav_diff.py`) drives
**libdvdnav** and the **board** down the same button path and diffs where each
lands. This branch makes it trustworthy, and then runs it.

## The defect, twice

A park was detected as *"a cell whose PCI carries buttons"*. That is true of a
looping menu and **false of a short authored clip that happens to carry an
HLI** — and the two are indistinguishable the instant the buttons appear.

Both sides had it, so the errors cancelled and the set read clean:

| disc | what it really is |
|---|---|
| SHERLOCK_HOLMES VMGM 26 | 9 s clip, `still=0`, POST `HL_BTNN=btn4; LinkPGCN 15` |
| SHERLOCK_HOLMES VMGM 13 | **117 s** clip, POST `HL_BTNN=btn1; LinkPGCN 27` |
| 24_DVD_BOARD_GAME VMGM 2 | 5-cell ~24 s intro, POST `JumpSS VTSM (vts 1, menu 4)` |
| 24_DVD_BOARD_GAME VTSM 3/78/79 | `cell_cmd=1` → `LinkPGN 1` — the cell replays itself |
| INCREDIBLE_HULK VTSM 11 | 39 s transition, POST `LinkPGCN 10` (10 self-loops) |
| PAW_PATROL VMGM 14 | one button, `fosl=1`, behind a **10 s finite still** |

It cost twice over: the clip was reported as the **landing**, and the next
button was applied **there** — a screen the board never sits on — so every step
after it compared two different walks.

A park is now confirmed **by a still or by a loop**, on both sides:

- oracle (`trace_nav`): a still (finite counts — PAW_PATROL is why), or the VM
  returning to the same `(domain, vts, pgc, cell)`. The old *"survived a block
  budget"* arm is **removed** — a 117 s clip outruns any sane cap.
- board (`nav_diff`): `still_active` (`O[2]` block 6), or the HUD clock
  **wrapping with the total unchanged**. Both signals were already being read.

Neither test works alone: still-only times out on a looping motion menu,
loop-only never fires on a menu still. A landing with neither is **flagged and
reported, never compared**.

## Validation

Every case where old and new disagree was checked against the disc's IFO or
against the board itself:

- **board-measured** (screenshots 8 s apart): 24_DVD_BOARD_GAME comes to rest
  looping on PGC 3 (clock wraps 0:26→0:10→0:24, total pinned 0:29);
  tomb_raider walks 25→26→24→PGC 1 VTS 3. Both where libdvdnav settles.
- **board-measured**, for the two discs the new tracer parks nowhere on:
  BATMAN_BEGINS and Beverly_Hills_Chihuahua_3 walk straight through to the
  feature and never park — so the old park was the false one.
- `--red` still proves the comparison can fail.

## Sweep result — 24 interactive discs, ~2.5 h of board time

| verdict | n |
|---|---|
| CLEAN | 16 |
| non-deterministic (disc uses `rnd`) | 3 |
| inconclusive — no confirmed park | 5 |
| **navigation differences** | **0** |

The five inconclusive discs are the deliberate trade and are named in
`docs/hil_harness.md`; each previously produced an answer that was not
trustworthy. Thayer's timed-still choice cells are flagged as worth revisiting.

⚠ The earlier "fully clean" verdicts on this set are **void**, not confirmed —
they were reached while both sides made the same mistake.

## Also here

- **`tools/acmod_scan.py`** (new) — reads the accepted AC-3 acmod set **out of
  `bsi_parse.sv`** rather than restating it, because the CLAUDE.md summary said
  "acmod 0/3/4/5/6 unsupported" long after the RTL grew 3–6, and that sent a
  session hunting a fixed defect. Sweep: 223 images / 1521 streams, **zero**
  acmod 0/3/4 — so the "absent from the measured library" premise the acmod-0
  rejection rests on is now measured. RED-proven by mutating the guard back.
- Confirmed on the rig with `tools/audio_check.py`: The Residents (the disc that
  reported the bug) plays at −29.5 dBFS on a genuinely acmod-6 VTS; a 6-track
  disc's mono track is audible.
- Two smaller harness fixes the sweep exposed, both of which had been scoring as
  findings: `auto_script` could emit **button 10** (the board has digit keys
  1–9) and an ssh timeout killed a run with a traceback.
- `nav_diff`'s ISO-library default was one workstation's NAS mount; it now uses
  the project's `${DVD_ISO_DIR:-~/dvd-isos}` like every other tool.

## Test plan

- [x] `trace_nav` old-vs-new over 28 disc/script pairs; every diff explained by IFO or board
- [x] board-measured ground truth on 4 discs
- [x] full 24-disc sweep, 0 differences
- [x] `--red` fails as designed
- [x] `acmod_scan` RED-proven against a mutated RTL guard
- [x] no RTL, Main or user-facing change — nothing to build or document

🤖 Generated with [Claude Code](https://claude.com/claude-code)
