### PR TITLE
README + manual home page: bring up to date with v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@
 A **DVD player core for the MiSTer FPGA platform** (DE10-Nano / Intel Cyclone V).
 
 Put a decrypted DVD image on the SD card and it plays — with the disc's own menus,
-button highlights, chapters, subtitles, and multi-channel audio. Everything runs in
-FPGA fabric: there is no HPS-side daemon and no Linux helper process. The ARM only
-serves SD blocks through the standard framework interface, exactly like any other core.
+button highlights, chapters, subtitles, and multi-channel audio. Decoding and navigation
+run entirely in FPGA fabric, with no HPS-side daemon. On the bare core the ARM only serves
+SD blocks through the standard framework interface, exactly like any other core; the
+optional `MiSTer_DVDcss` Main adds physical discs, CSS decryption and HDMI bitstream audio
+on the ARM side.
 
 Built as a fork of [`mrchrisster/MiSTer_MPEG2`](https://github.com/mrchrisster/MiSTer_MPEG2),
 itself a MiSTer port of **Koen De Vleeschauwer's `mpeg2fpga`** hardware MPEG-2 decoder
 (2007). The video decode datapath is theirs and is largely unmodified; this project adds
 everything needed to turn a decoder into a player.
 
-> **Status: pre-release alpha.** Film and TV playback is the supported path and is
-> exercised across a library of ~34 commercial discs. Interactive DVD *games* are
+> **Status: alpha.** Film and TV playback is the supported path and is exercised across a
+> library of hundreds of commercial discs. Interactive DVD *games* are
 > known-incomplete — see [Known limitations](#known-limitations).
 
 
@@ -28,7 +30,7 @@ DVD-Video specification and libdvdnav's source to establish correct behaviour, d
 what to build and in what order, and then running each build on real hardware, finding
 what broke, and narrowing it down to a root cause.
 
-That last part is the bulk of the work: roughly 890 commits and 280 hardware builds since
+That last part is the bulk of the work, and there has been a great deal of it since
 development began in June 2026. The `docs/` directory records the reasoning behind most
 non-trivial decisions, including the long diagnostic hunts (A/V drift, film cadence,
 field-coded discs) where the root cause turned out to be several layers away from the
@@ -47,11 +49,13 @@ know. It is not an endorsement of the approach — draw your own conclusions.
   [`MiSTer_DVDcss`](https://owenb321.github.io/MiSTer_DVD/formats/physical-discs/) add-on — no PC decrypt step, and
   encrypted images need no optical drive at all.
 - **Video** — MPEG-2 and MPEG-1, NTSC and PAL auto-detected, progressive or native
-  480i/576i, [3:2 pulldown for film](https://owenb321.github.io/MiSTer_DVD/video/film-24p/), PTS-driven A/V sync.
+  480i/576i, [3:2 pulldown for film](https://owenb321.github.io/MiSTer_DVD/video/film-24p/), and one clock for
+  picture, sound, subtitles and captions — so lip sync holds across seeks, menus and mode changes.
 - **Audio** — AC-3 (every channel mode) and MP2 and LPCM decoded
   [entirely in fabric](https://owenb321.github.io/MiSTer_DVD/audio/formats/); AC-3 and DTS as
   [IEC 61937 bitstream](https://owenb321.github.io/MiSTer_DVD/audio/passthrough/) to a receiver — over optical S/PDIF,
-  or over HDMI with the custom Main, so 5.1 needs no add-on board.
+  or over HDMI with the custom Main, so 5.1 needs no add-on board. Tracks with no bitstream
+  format still play as PCM in that mode.
 - **Analog / CRT** — a native 15 kHz 480i/576i raster built from the disc's
   [authored fields](https://owenb321.github.io/MiSTer_DVD/video/analog-crt/), with broadcast-standard composite
   sync: the presentation a set-top player feeds a TV. Engages from `MiSTer.ini` like any
@@ -62,9 +66,6 @@ know. It is not an endorsement of the approach — draw your own conclusions.
 - **Gamepad, keyboard or infrared remote** — every transport action has a
   [built-in key](https://owenb321.github.io/MiSTer_DVD/playback/controls/), so a USB IR receiver
   turns any remote you already own into a DVD remote with nothing to configure.
-
-Everything runs in FPGA fabric: no HPS-side daemon, no Linux helper process. The ARM only
-serves SD blocks through the standard framework interface.
 
 ## Known limitations
 
@@ -144,6 +145,7 @@ That falls out of what it is built from rather than being a preference:
 | `sys/` — MiSTer framework | GPL, mixed "v2 or later" and "v3 or later" |
 | `rtl/` — MPEG-2 decoder, © 2007 Koen De Vleeschauwer | **BSD** ([`mpeg2fpga`](https://opencores.org/projects/mpeg2fpga)) |
 | `dvd/`, `bench/dvd/`, `tools/`, `docs/`, `site/` | Original to this project — GPL-3.0-or-later |
+| `dvd/ac3/` — the AC-3 decoder | Original RTL, but a **derivative work of liba52** (GPL-2.0-or-later) — see [NOTICE](NOTICE) |
 
 The `sys/` files that are "v2 or later" can be taken to v3, but the "v3 or later" ones
 cannot go down to v2, so the combination resolves to GPLv3-or-later. BSD is
@@ -170,6 +172,8 @@ This core is built on **Koen De Vleeschauwer's** [`mpeg2fpga`](https://opencores
 MPEG-2 decoder (2007), ported to MiSTer by **mrchrisster** as
 [`MiSTer_MPEG2`](https://github.com/mrchrisster/MiSTer_MPEG2), on the **MiSTer-devel**
 framework. Much of what looks like original engineering here is the result of having good
-references — libdvdnav, libdvdread, liba52 and others — to check against.
+references — libdvdnav, libdvdread and others — to check against. The AC-3 decoder goes
+further than checking: it follows **liba52** closely enough to be a derivative work of it,
+as [NOTICE](NOTICE) records.
 
 [Full credits, specs and verification oracles →](https://owenb321.github.io/MiSTer_DVD/about/acknowledgements/)

--- a/site/content/index.md
+++ b/site/content/index.md
@@ -3,11 +3,13 @@
 A **DVD player core for the MiSTer FPGA platform** (DE10-Nano / Intel Cyclone V).
 
 Put a decrypted DVD image on the SD card and it plays — with the disc's own menus, button
-highlights, chapters, subtitles, and multi-channel audio. Everything runs in FPGA fabric:
-there is no HPS-side daemon and no Linux helper process. The ARM only serves SD blocks
-through the standard framework interface, exactly like any other core.
+highlights, chapters, subtitles, and multi-channel audio. Decoding and navigation run
+entirely in FPGA fabric, with no HPS-side daemon. On the bare core the ARM only serves SD
+blocks through the standard framework interface, exactly like any other core; the optional
+[`MiSTer_DVDcss`](formats/physical-discs.md) Main adds physical discs, CSS decryption and
+HDMI bitstream audio on the ARM side.
 
-!!! warning "Status: pre-release alpha"
+!!! warning "Status: alpha"
     Film and TV playback is the supported path and is exercised across a library of
     hundreds of commercial discs. Interactive DVD *games* are known-incomplete — see
     [Compatibility](reference/compatibility.md).
@@ -38,8 +40,9 @@ honest list of what works and what does not.
 
 **Video** — MPEG-2 decode at full rate, plus MPEG-1 (the DVD spec's other permitted video
 format, 352×240 / 352×288). NTSC and PAL are auto-detected from the stream. Progressive
-and native 480i/576i output, 3:2 pulldown handling for film, and PTS-driven A/V sync with
-a display-refresh-locked frame-rate governor.
+and native 480i/576i output, and 3:2 pulldown handling for film. Picture, sound,
+subtitles and captions are all presented against one clock, so lip sync holds across
+seeks, menus and mode changes.
 
 **DVD navigation** — the core reads an ISO directly, parses the IFOs, and runs a real
 **DVD virtual machine** validated command-by-command against libdvdnav's behaviour. The
@@ -52,7 +55,8 @@ infrared remote, with an on-screen HUD and seek bar.
 **Audio** — AC-3 and MPEG-1 Layer II decoded entirely in fabric (every AC-3 channel mode,
 downmixed to stereo) to HDMI; 48 kHz LPCM; AC-3 and DTS as
 [IEC 61937 bitstream](audio/passthrough.md) to a receiver — over optical S/PDIF, or over
-HDMI itself with the custom Main, so 5.1 needs no add-on board.
+HDMI itself with the custom Main, so 5.1 needs no add-on board. Tracks with no bitstream
+format — LPCM and MP2 — still play as PCM in that mode.
 
 **Physical discs and encrypted ISOs** — with the optional
 [`MiSTer_DVDcss`](formats/physical-discs.md) add-on, the core plays a **physical DVD**
@@ -66,8 +70,9 @@ the data-track `.bin` and the core strips the raw CD sectors in fabric, demuxes 
 pause.
 
 **Analog / CRT** — a native 15 kHz 480i/576i raster on the analog pins, built from the
-disc's [authored fields](video/analog-crt.md), re-timed 1:1 — the presentation a set-top
-player feeds a TV. It engages from `MiSTer.ini` alone, like any other core.
+disc's [authored fields](video/analog-crt.md), with broadcast-standard composite sync — the
+presentation a set-top player feeds a TV. It engages from `MiSTer.ini` alone, like any
+other core.
 
 **Closed captions** — NTSC discs carry EIA-608 captions hidden in the MPEG-2 video stream,
 separately from subtitles. The core extracts them and re-modulates them onto
@@ -82,7 +87,7 @@ specification and libdvdnav's source to establish correct behaviour, deciding wh
 and in what order, and then running each build on real hardware, finding what broke, and
 narrowing it down to a root cause.
 
-That last part is the bulk of the work: roughly 890 commits and 280 hardware builds since
+That last part is the bulk of the work, and there has been a great deal of it since
 development began in June 2026. The
 [`docs/` directory](https://github.com/owenb321/MiSTer_DVD/tree/main/docs) records the
 reasoning behind most non-trivial decisions, including the long diagnostic hunts (A/V

--- a/site/content/video/interlaced.md
+++ b/site/content/video/interlaced.md
@@ -44,7 +44,7 @@ what a CRT is built to show.
 
 While it is active:
 
-- The **CRT** gets the fields re-timed 1:1 on a native 15 kHz raster — the smoothest
+- The **CRT** gets each authored field directly on a native 15 kHz raster — the smoothest
   presentation for video-sourced discs, and the same thing a set-top player outputs.
 - **HDMI** drops to 480i for the session, deinterlaced by the framework scaler.
   `480i Deint` picks Bob (smooth motion, half vertical resolution) or Weave (full


### PR DESCRIPTION
## Summary

Brings the README and the manual's home page up to date with v0.5.0. Several statements had gone stale, and two paragraphs on the home page described architecture that no longer exists.

**Stale facts (README and `site/content/index.md`)**
- "The ARM only serves SD blocks" stopped being true when `MiSTer_DVDcss` shipped. It now applies to the bare core, and says what the custom Main adds (physical discs, CSS decryption, HDMI bitstream audio).
- Status "pre-release alpha" → "alpha": five releases are published.
- "~34 commercial discs" was an old census figure; now "hundreds", matching what the home page already said.
- The commit and hardware-build counts are dropped in favour of "a great deal of work". They were pre-migration figures.

**Retired architecture (home page)**
- *Video:* "a display-refresh-locked frame-rate governor". PR #63 removed the refresh-counted timing; picture, sound, subtitles and captions now run on one clock.
- *Analog / CRT:* "re-timed 1:1" described the separate re-interlacing raster deleted in v0.4.0 (`analog-crt.md` already says so). Replaced with the broadcast-standard composite sync this release is named for. `video/interlaced.md` had the same phrase and is corrected too.

**v0.5.0 headlines added:** the single-clock lip sync, and LPCM/MP2 still playing as PCM in Passthru.

**Licensing (README only):** the table called all of `dvd/` original and the acknowledgements listed liba52 as a reference. `NOTICE` records `dvd/ac3/` as a derivative work of liba52 and explicitly withdrew the clean-room claim. Both README spots now say what `NOTICE` says. No new licensing position is taken.

Deliberately out of scope: licensing gaps in `NOTICE` itself (`main/` and `site/` coverage) and the acknowledgements page's liba52 wording.

## When it reaches users
- **README:** on merge.
- **Manual home page:** with the next release, since the manual only deploys from release tags (or sooner via `docs-v0.5.0` if wanted).

## Test plan
- [x] `python3 tools/docs_check.py`
- [x] `mkdocs build --strict`
- [x] README's `#known-limitations` self-anchor still resolves
- [x] No remaining instances of the stale phrases in the README or `site/content/`
- [ ] README renders correctly on GitHub
- [ ] Home page reads correctly in the next manual deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
