### PR TITLE
Logic reclaim A: AC-3 decoder duplicated arithmetic (-2,544 ALUTs, zero value changes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,34 @@ worse maintenance burden than targeted in-place edits. So:
 
 ## Hardware status (THIS fork, verified 2026-06-21)
 
+- 🔧 **LOGIC RECLAIM, BRANCH A — AC-3 duplicated arithmetic (2026-09-11, branch
+  `feature/alm-reclaim-ac3`, unpushed) — sim-proven bit-exact, ⏳ HW-confirm pending**
+  (build `DVD_almreclaim_20260911_0138.rbf`, SEED 7 first roll, clk_dec 93.66/90.86).
+  Zero value changes: **−2,544 ALUTs** (60,642 → 58,098), "ALMs needed" 93 % → 89 %.
+  ★★ **THE HEADLINE PERCENTAGE WAS LYING IN BOTH DIRECTIONS.** A same-seed fit of
+  v0.5.0 `main` PLACED 40,821 ALMs (97 %) in 4,188/4,191 LABs — its "93 %" was the
+  fitter's dense-packing estimate subtracted from a full device — and the two
+  speculative branches that "hit 98 %" placed only ~400 more; the estimate collapsed and
+  the percentage jumped. **Measure reclaim in synthesis ALUTs (`DVD.map.rpt` per entity)
+  and placed ALMs, never the headline.** Cutting the CD player would have recovered
+  ~300 ALMs; declined.
+  ★ **Where the AC-3 area actually was: not memory (M19 finished that) but Quartus
+  muxing RESULTS across mutually exclusive FSM states, so every inlined function call
+  was its own datapath.** `bit_allocation` had `compute_mask` at five states and
+  `UPDATE_LEAK` at four (2,491 → 1,348 ALUTs with ONE shared path, then a 20-bit width
+  with the range proof in the file); `mantissa_dequant` had `scale_coeff` at 19 sites
+  (1,594 → 1,110); both `bit_reader`s carried 64-bit barrel shifters for a stated
+  40/24-bit bound (−366). The IMDCT operand-mux/butterfly rewrite was worth only −81:
+  Quartus already shared it — but that module swung **+786 ALUTs between two netlists
+  with identical RTL**, a mapping cliff the regular form should remove.
+  ⚠ **`bench/ac3/run_balloc.sh` had been failing silently since M19d** (it modelled
+  delta-BA combinationally after the read became registered; 17 bap mismatches inside
+  the delta-BA bands, vvp exit 0). RTL was right, bench was stale; fixed and `$fatal`ed
+  BEFORE the refactor so it could gate it. Gate at every commit: `run_front_cosim.sh`
+  bap bit-exact on 13 streams **and PCM dumps of blocks 0–5 byte-identical** to a
+  pre-change baseline, plus each unit suite. Detail: `docs/ac3_decoder_architecture.md`
+  §4.12, `DVD.qsf` ledger. Plan for the remaining branches (nav/VM/glue, reader,
+  block-RAM packing) is in the audit record there.
 - 🔧 **SINGLE-RASTER ANALOG OUTPUT — the second raster (`re_interlace`/VGA2) is
   RETIRED; the interlaced MAIN raster carries the N64 half-line and drives the CRT
   directly (2026-09-03, branch `feature/single-raster-analog`). ✅ HW-CONFIRMED on the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,10 @@ worse maintenance burden than targeted in-place edits. So:
 ## Hardware status (THIS fork, verified 2026-06-21)
 
 - 🔧 **LOGIC RECLAIM, BRANCH A — AC-3 duplicated arithmetic (2026-09-11, branch
-  `feature/alm-reclaim-ac3`, unpushed) — sim-proven bit-exact, ⏳ HW-confirm pending**
+  `feature/alm-reclaim-ac3`, unpushed) — sim-proven bit-exact and ✅ HW-CONFIRMED 2026-09-11**
+  (maintainer's rig: all four MiB AC-3 tracks audible on the capture card, −26 to −42 dBFS;
+  LPCM VOB −52 dBFS; MP2 VCD −44 dBFS at 44.1 kHz; Passthru telemetry steady; video pacing
+  2.4996 refreshes/frame, 48 kHz −51 ppm, 0 lates/drops over 46 s)
   (build `DVD_almreclaim_20260911_0138.rbf`, SEED 7 first roll, clk_dec 93.66/90.86).
   Zero value changes: **−2,544 ALUTs** (60,642 → 58,098), "ALMs needed" 93 % → 89 %.
   ★★ **THE HEADLINE PERCENTAGE WAS LYING IN BOTH DIRECTIONS.** A same-seed fit of

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -1020,4 +1020,29 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # #79 HW-confirmed SEED 7 on the passthru netlist, but this is a different
 # netlist. The release smoke-test is what discharges it.
 
+# 2026-09-11 (feature/alm-reclaim-ac3, dev-almreclaim -- LOGIC RECLAIM BRANCH A:
+# AC-3 duplicated-arithmetic pass, zero value changes; docs/ac3_decoder_architecture.md
+# §4.12): SEED 7 held FIRST roll -- clk_dec 93.66 @100C / 90.86 @-40C (gate 86.0,
+# PASS both corners) at 89% ALM (37,358 needed; 40,231 PLACED = 96%), registers
+# 52,404, RAM 498/553, DSP 94/112. Build DVD_almreclaim_20260911_0138.rbf.
+# ★★ MEASURE THIS BRANCH IN ALUTs, NOT THE HEADLINE PERCENTAGE. A baseline fit of
+# main (v0.5.0, same seed) reproduces 38,802 "needed" exactly -- but that build
+# PLACED 40,821 ALMs (97%) in 4,188/4,191 LABs; the "93%" was the fitter's
+# dense-packing estimate ([B] 2,703) subtracted from a device that was already
+# full. The two speculative branches then placed only ~400 more ALMs and the
+# estimate collapsed to 637, which is the whole 93->98% story.
+#   v0.5.0 main :  60,642 ALUTs / 52,238 regs / 40,821 placed / 38,802 needed
+#   this branch :  58,098 ALUTs / 52,404 regs / 40,231 placed / 37,358 needed
+# = -2,544 ALUTs (-4.2%), attributed at synthesis (DVD.map.rpt) per module:
+# bit_allocation 2,491->1,348 (one compute_mask/UPDATE_LEAK datapath, then a
+# 20-bit width), mantissa_dequant 1,594->1,110 (one scale_coeff shifter for 19
+# call sites), the two bit_readers -366 (ACC_W 64->MAXW+8), imdct_512 -81 (the
+# (x,y,w1,w2) operand mux -- Quartus was already sharing most of it), audblk
+# -14. Gate at every commit: run_front_cosim.sh bap bit-exact on 13 streams AND
+# PCM dumps of blocks 0-5 byte-identical to a pre-change baseline.
+# ⚠ imdct_512 measured 3,228 ALUTs on v0.5.0 main and 4,014 on the cdda branch
+# with IDENTICAL RTL, memories, regs and DSPs -- a Quartus 17 mapping cliff on
+# that operand mux. The regular (x,y,w1,w2) form should hold at ~3,147; if a
+# later unrelated netlist shows it near 4,000 again, that is the cliff, not
+# the branch.
 set_global_assignment -name SEED 7

--- a/bench/ac3/bit_allocation_tb.sv
+++ b/bench/ac3/bit_allocation_tb.sv
@@ -52,11 +52,15 @@ module bit_allocation_tb;
     wire [10:0] ba_exp_rd_addr;
     // exp now comes from exponent_decode's M10K (registered, 1-cycle latency);
     // model that here so the prefetch pipeline (C_COPY/C_CCOPY) is exercised as
-    // it is in hardware.  deltba stays combinational (audblk_parse.deltba_mem).
+    // it is in hardware.  deltba is ALSO a registered read since M19d
+    // (audblk_parse.deltba_mem, 1-cycle latency) -- this bench modelled it
+    // combinationally after that change and had been failing silently
+    // (17 bap mismatches, all inside the delta-BA bands, vvp exit 0).
     reg  [4:0]  ba_exp_rd_data;
     always @(posedge clk) ba_exp_rd_data <= exp_prov[ba_exp_rd_addr[8:0]];
     wire [8:0]  deltba_rd_addr;
-    wire signed [3:0] deltba_rd_data = dba_prov[deltba_rd_addr];
+    reg  signed [3:0] deltba_rd_data;
+    always @(posedge clk) deltba_rd_data <= dba_prov[deltba_rd_addr];
 
     logic [10:0] bap_rd_addr = 11'd0;
     wire  signed [7:0] bap_rd_data;
@@ -128,7 +132,7 @@ module bit_allocation_tb;
             $display("bit_allocation_tb: PASS (bap bit-exact vs liba52, endmant=%0d,%0d)",
                      endmant0, endmant1);
         else
-            $display("bit_allocation_tb: FAIL (%0d mismatches)", errors);
+            $fatal(1, "bit_allocation_tb: FAIL (%0d mismatches)", errors);
         $finish;
     end
 endmodule

--- a/docs/ac3_decoder_architecture.md
+++ b/docs/ac3_decoder_architecture.md
@@ -825,8 +825,12 @@ netlist roll); the `S_POST256` register set aliasing onto `S_POST`'s (~150–250
 ALMs, touches the M16 short-block path, deferred until the cheaper levers are
 spent).
 
-Fit result: _(filled in from the branch build — see the `DVD.qsf` seed ledger
-entry for `dev-almreclaim`)_.
+**Fit result (SEED 7, first roll):** clk_dec 93.66 / 90.86 MHz (gate 86.0),
+ALUTs 60,642 → **58,098 (−2,544)**, "ALMs needed" 38,802 → 37,358 (93 % → 89 %),
+placed ALMs 40,821 → 40,231, RAM 498 and DSP 94 unchanged, `lint_undriven` and
+`netlist_canary` PASS. Build `DVD_almreclaim_20260911_0138.rbf`. ⏳ HW gate: an
+AC-3 5.1 disc, a mono/2-2 disc, an MP2 VCD and an LPCM disc through both decode
+and Passthru (the cosim proves the numbers; the board proves the netlist).
 
 ## 5. Fixed-point convention (pin BEFORE datapath RTL)
 

--- a/docs/ac3_decoder_architecture.md
+++ b/docs/ac3_decoder_architecture.md
@@ -828,9 +828,12 @@ spent).
 **Fit result (SEED 7, first roll):** clk_dec 93.66 / 90.86 MHz (gate 86.0),
 ALUTs 60,642 → **58,098 (−2,544)**, "ALMs needed" 38,802 → 37,358 (93 % → 89 %),
 placed ALMs 40,821 → 40,231, RAM 498 and DSP 94 unchanged, `lint_undriven` and
-`netlist_canary` PASS. Build `DVD_almreclaim_20260911_0138.rbf`. ⏳ HW gate: an
-AC-3 5.1 disc, a mono/2-2 disc, an MP2 VCD and an LPCM disc through both decode
-and Passthru (the cosim proves the numbers; the board proves the netlist).
+`netlist_canary` PASS. Build `DVD_almreclaim_20260911_0138.rbf`. ✅ HW-CONFIRMED
+2026-09-11 on the maintainer's rig: all four MiB AC-3 tracks audible on the capture card,
+an LPCM VOB and an MP2 VCD audible, Passthru telemetry steady, video pacing and A/V
+unchanged (`docs/logic_reclaim.md` §3 has the numbers). Mono / 2-2 discs were not
+re-run on hardware — the cosim decodes both bit-exactly and nothing in this pass is
+acmod-specific.
 
 ## 5. Fixed-point convention (pin BEFORE datapath RTL)
 

--- a/docs/ac3_decoder_architecture.md
+++ b/docs/ac3_decoder_architecture.md
@@ -779,6 +779,55 @@ landed exactly on the documented 1648 LSB once the convention was fixed).
 
 ---
 
+### 4.12 Logic-reclaim area pass (2026-09-10, branch `feature/alm-reclaim-ac3`)
+
+**Motivation:** the design reached 98 % ALM on two consecutive feature branches
+(`feature/wav-audio`, `feature/cdda-physical`) and a fresh fit of `main`
+showed v0.5.0 itself already PLACED 40,821 ALMs (97 %) — its reported "93 %"
+was the fitter's dense-packing estimate, not free space. A per-entity audit
+found the AC-3 subtree's remaining fat was no longer memory (M19 finished
+that) but **duplicated arithmetic**: Quartus muxes RESULTS across mutually
+exclusive FSM states, never the operators, so every inlined function call is
+its own datapath. **Zero value changes — every commit gated by
+`run_front_cosim.sh` (bap bit-exact vs liba52 on all 13 streams) AND by the
+PCM dumps of blocks 0–5 of every stream being BYTE-IDENTICAL to a pre-change
+baseline**, plus each module's unit suite.
+
+| commit | what | ALUTs (synthesis, vs v0.5.0) |
+|---|---|---|
+| `bit_allocation` shared datapath | `compute_mask` was inlined at 5 states, `upd_fast/slow` at 4; now ONE combinational path (`nlc_w / cm_psd / fl_w / sl_w / cm_pre / cm_mask`) with state-selected operands | 2,491 → 1,348 (**−1,143**) |
+| `bit_allocation` 20-bit datapath | literal 32-bit transcription of liba52 `int`; bounds proven in the file header (largest intermediate < 70 k) | see fit table below |
+| `mantissa_dequant` one `scale_coeff` | called at 19 sites over 4 states, each a 32-bit shifter; one state-selected operand mux + a 25-bit shifter. Dither path 41 → 32 bits (|dith_prod| < 2^30, so shifts ≥ 31 are exactly 0). `m16_direct` 16-bit shifter | 1,594 → 1,110 (**−484**) |
+| `bit_reader` ×2 `ACC_W = MAXW+8` | the header already stated the bound; 64 bits bought nothing but three 64-bit barrel shifters per instance | 536 → 360 and 450 → 260 (**−366**) |
+| `imdct_512` (x, y, w1, w2) operand mux + one butterfly core | 19-case × 208-bit mux → 104-bit mux with fixed lanes; five per-op adder trees (58 adders) → one `A±T / B±U` core. Max-error figures IDENTICAL (1648 / 879 / 1116) | 3,228 → 3,147 (**−81**) — Quartus was already sharing most of it; the module's bulk is the 34×18 products spilling past a 27×27 DSP, which precision rules out |
+| `audblk_parse` group counts + `cplco` | `x/(3<<k) == (x/3)>>k`; one 22-bit right shifter for the Q5.18 placement | −14 (already cheap) |
+| `subpic_blend` (outside AC-3) | `in*16 + wt*(c-in)`: one multiply per channel, not two | flattened into `emu` |
+
+**Two findings worth more than their ALMs:**
+
+1. **`bench/ac3/run_balloc.sh` had been failing silently since M19d** — it still
+   presented delta-BA combinationally after `audblk_parse.deltba_mem` became a
+   registered read, so the DUT's `C_COPY` prefetch stored every delta-BA band
+   one slot early: 17 bap mismatches, all in the delta-BA bands, masked by
+   vvp's exit 0. The RTL was right (the cosim is bap bit-exact); the bench was
+   stale. Fixed (registered provider, `$fatal` on mismatch) BEFORE the refactor
+   so it could gate it. Same class as the M17 `run_imdct/imdct256/drc` masking.
+2. **The IMDCT's ALUT count swung +786 between two netlists with identical
+   RTL** (v0.5.0 `main` 3,228 vs the cdda branch 4,014; same M10Ks, regs,
+   DSPs). Quartus 17's mapping of that operand mux sat on a heuristic cliff.
+   The (x, y, w1, w2) form is smaller by only 81 ALUTs but is a regular
+   structure, so the cliff should be gone — check the next unrelated
+   branch's imdct row against 3,147.
+
+**Kept, deliberately:** the 4-mult DSP bank (M19e: never serialise it);
+`exponent_decode` / `pcm_out` / `bsi_parse` (120 / 120 / 45 ALMs — not worth a
+netlist roll); the `S_POST256` register set aliasing onto `S_POST`'s (~150–250
+ALMs, touches the M16 short-block path, deferred until the cheaper levers are
+spent).
+
+Fit result: _(filled in from the branch build — see the `DVD.qsf` seed ledger
+entry for `dev-almreclaim`)_.
+
 ## 5. Fixed-point convention (pin BEFORE datapath RTL)
 
 > ### ★ OUTPUT LEVEL CONVENTION (added 2026-09-07 — this was MISSING, and its

--- a/docs/logic_reclaim.md
+++ b/docs/logic_reclaim.md
@@ -1,0 +1,104 @@
+# Logic reclaim — the 2026-09-10 area audit and its branches
+
+**Status:** Branch A (AC-3) built and sim-gated, ⏳ HW-confirm pending; Branch B
+(nav/VM/glue) in progress; Branch C (reader) and the block-RAM packing pass planned.
+
+## 0. Why
+
+Two consecutive speculative branches (`feature/wav-audio`, `feature/cdda-physical`) each
+landed the core at **98 % ALM**, the regime where the DVD.qsf seed ledger measures the
+fitter seed as worth more than 18 MHz on clk_dec. The question was where the ALMs go and
+what could be reclaimed with zero behaviour change.
+
+## 1. What the numbers actually said
+
+Ground truth came from the fit report's per-entity table (`output_files/DVD.fit.rpt`
+§20), a map-vs-fit per-entity diff, the RAM summary, and a **fresh fit of v0.5.0 `main`**
+in a worktree (same seed).
+
+| | v0.5.0 `main` | cdda branch | 
+|---|---|---|
+| ALMs needed (headline %) | 38,802 (93 %) | 41,273 (98 %) |
+| **[A] ALMs used in final placement** | **40,821 (97 %)** | 41,207 (98 %) |
+| [B] "recoverable by dense packing" | 2,703 | 637 |
+| LABs used | 4,188 / 4,191 | 4,191 / 4,191 |
+| combinational ALUTs | 60,642 | 62,227 |
+| registers | 52,238 | 52,785 |
+
+Three conclusions, each of which changed the plan:
+
+1. **The release build was already physically full.** The headline "93 %" was the
+   fitter's dense-packing estimate subtracted from a device with three LABs free. The two
+   branches placed ~400 more ALMs and the estimate collapsed; that is the whole 93→98 %
+   story. **Measure reclaim in synthesis ALUTs (`DVD.map.rpt` per entity) and placed
+   ALMs, never the headline percentage.**
+2. **The fitter adds only ~418 ALUTs over synthesis.** The 62k ALUTs are real RTL logic,
+   not congestion duplication, so reclaim has to come from the RTL.
+3. **Cutting the CD player would have recovered ~300 ALMs.** The WAV + CD-DA branches
+   are ~660 ALUTs of their own logic; the largest per-entity delta between the two
+   netlists (+786) was inside the AC-3 IMDCT, which neither branch touched — a Quartus
+   17 mapping cliff on identical RTL (same memories, registers, DSPs). Declined.
+
+Block RAM: 131 memories on 508 blocks hold 71 % of the bit capacity. The M10K's ×1 and
+×2 modes store only 8 Kbit per block, so the subpicture bitmap (414,720 × 2-bit, 102
+blocks) would fit in 82 if pixels were packed five to a 10-bit word.
+
+## 2. Where the area is (own ALMs, cdda fit)
+
+`dvd_iso_reader` 4,340 (FSM next-state muxes and duplicated adders — its tables are ALL
+already in M10K, the "tables in flops" theory was false there) · `imdct_512` 2,610 ·
+`ascal` 2,255 · `dvd_vm` 2,078 · `bit_allocation` 1,307 · `mem_shim_burst` 1,291 (already
+reclaimed once) · emu glue 1,077 · `vld` 986 · `mantissa_dequant` 963 · `audblk_parse` 653 ·
+`spu_decode` 616 · `pts_assoc` 563 (912 flops of shift-FIFO) · transport cluster ≈ 2,370 ·
+`pgc_palette` 340 (a 384-flop raw shadow) · `dvd_telem` 306 (19 × 3-flop filters).
+
+The recurring pattern this time was not memory but **Quartus muxing RESULTS across
+mutually exclusive FSM states**: every inlined function call, every per-state copy of an
+adder, is its own datapath.
+
+## 3. Branch A — `feature/alm-reclaim-ac3` (✅ built, ⏳ HW gate)
+
+Detail in `docs/ac3_decoder_architecture.md` §4.12 and the DVD.qsf ledger. Every commit
+gated by `bench/ac3/run_front_cosim.sh` (bap bit-exact vs liba52 on 13 streams) **and PCM
+dumps of blocks 0–5 byte-identical** to a pre-change baseline, plus each unit suite.
+Synthesis result **−2,544 ALUTs**; fit SEED 7 first roll, clk_dec 93.66 / 90.86.
+
+Found en route: `bench/ac3/run_balloc.sh` had been failing silently since M19d (stale
+combinational delta-BA model, vvp exit 0). Fixed and `$fatal`ed before the refactor.
+
+## 4. Branch B — `feature/alm-reclaim-nav` (in progress)
+
+| item | change | gate |
+|---|---|---|
+| `pts_assoc` | 16×57-bit shift FIFO → sync-read ring + 2-entry registered window with a same-cycle write bypass (back-to-back pops stay legal) | `run_pts_assoc.sh` (+RED arm); `tools/netlist_canary.sh` row moved from `pts_q` to `head_pts` in the same commit |
+| `pgc_palette` | convert-on-write; the 384-flop raw YCbCr shadow and its three 16:1 muxes deleted; reset defaults pre-converted (literal table) | `pgc_palette_tb`, `run_subpic.sh` |
+| `dvd_vm` | 1 Hz counter tick: 16 parallel incrementers → one-GPRM-per-cycle walk, dispatch held during the walk | `dvd_vm_tb` (do_ticks widened to >16 cycles), `dvd_vm_atmos_tb`, `iso_reader_vm/vmgm/zerocell_tb` |
+| `emu` O[2] | 52 window comparators → 5 x-windows × 3 y-bands; 24-bit colour chain → 2-bit code expanded at the output mux | no bench (eyeball O[2] On on HW) |
+| `dvd_telem` | 19 × `telem_sync` (s1/s2/q) → one round-robin two-agree sampler, 57-cycle rotation | `run_telem.sh` (waits widened to 64 cycles) |
+| `nav_pci` | `f_eptm` (32 b, only ever tested for all-ones) → 1-bit `f_forever`; write-only `h_sptm` deleted | `nav_pci_tb` |
+| `emu` | `entropy_ctr` 32 → 16 bits | — |
+
+Considered and skipped after reading: `spu_decode`'s "per-line multiplier" is a constant
+STRIDE (already shift-adds); `nav_pci`'s duplicate subtracts are CSE'd by Quartus; the
+SetSTN triple read (~60 ALMs, needs a latched condition) and the seek_time/seek_bar table
+sharing (~4 M10K, cross-module ports) are deferred.
+
+## 5. Branch C — reader (planned)
+
+Low-risk first: gate/serialise the VCD/WAV-only seek math, delete the unreachable
+`S_IFO_MAT/_PARSE/_TSRPT` states, factor the 4× flat-fallback init, remove dead ports;
+then share the 7 PGC-window adder pairs and the `sd_lba` generation; then drop the BCD
+prefix sum (also fixes the `cell_start_mem[cell_i[6:0]]` index-width bug). The
+34-source `sec_lba` mux factoring is the big one and the riskiest.
+
+## 6. Block RAM (planned)
+
+spu bitmap 5 px / 10-bit word (−20 M10K); seek_time + seek_bar share one
+pmap/cellf/clast set (−3…−4); `lpcm_unpack` FIFO_AW 12 → 11 (−11) only with an LPCM disc
+on the HW gate.
+
+## 7. Framework macros (user decision 2026-09-10)
+
+`MISTER_DISABLE_ALSA` — yes (unused HPS→core audio, ~290 ALMs). `MISTER_DISABLE_ADAPTIVE`
+and `MISTER_DOWNSCALE_NN` — declined (scaler filters vanish from the OSD; NN downscale
+would alias a 720×576 source on 640×480 / 480-line-PAL outputs, the CRT users).

--- a/docs/logic_reclaim.md
+++ b/docs/logic_reclaim.md
@@ -56,7 +56,16 @@ The recurring pattern this time was not memory but **Quartus muxing RESULTS acro
 mutually exclusive FSM states**: every inlined function call, every per-state copy of an
 adder, is its own datapath.
 
-## 3. Branch A — `feature/alm-reclaim-ac3` (✅ built, ⏳ HW gate)
+## 3. Branch A — `feature/alm-reclaim-ac3` (✅ built, ✅ HW-CONFIRMED 2026-09-11)
+
+**HW round (maintainer's rig, `DVD_almreclaim_20260911_0138.rbf`):** `audio_check` on Men
+in Black — all four AC-3 tracks audible (5.1 main −26.2 dBFS RMS, the others −31 to −42,
+gate −80, digital silence reads −999); a controlled single capture of an LPCM VOB
+(−51.9 dBFS RMS, −35 peak) and of an MP2 VCD (−44.3 / −20.3 at 44.1 kHz); Passthru with
+steady telemetry (ring parked at 34 frames, video 2.497 refreshes/frame, no drain-gate
+closures — no AC-3 receiver on the rig, so the bitstream itself is not decodable there, as
+always); video pacing on the feature 2.49955 refreshes per picked-up frame, 23.973 fps,
+audio 47,997.6 Hz, zero lates, zero drops over 46 s.
 
 Detail in `docs/ac3_decoder_architecture.md` §4.12 and the DVD.qsf ledger. Every commit
 gated by `bench/ac3/run_front_cosim.sh` (bap bit-exact vs liba52 on 13 streams) **and PCM

--- a/dvd/ac3/audblk_parse.sv
+++ b/dvd/ac3/audblk_parse.sv
@@ -264,33 +264,44 @@ module audblk_parse (
 
     // fbw endmant/nchgrps from chbwcod (the chbwcod read is on data_in).
     wire [8:0]  endmant_w     = ({3'd0, data_in[5:0]} * 9'd3) + 9'd73;
-    wire [4:0]  grpsz_w       = 5'd3 << (cur_chexpstr - 2'd1);
+    // grpsz is 3 << (expstr-1) with the 2-bit wrap (expstr==0 / REUSE gives
+    // 3<<3 = 24; that quotient is never consumed but is reproduced exactly).
+    // The group count is x / (3 << k) == (x / 3) >> k for non-negative
+    // integers (nested floor division), so the three variable 9-by-5-bit
+    // restoring dividers this used to build (~100-130 ALUTs each) are now one
+    // constant divide-by-3 plus a shift apiece -- area pass 2026-09-10.
+    wire [1:0]  grp_sh        = cur_chexpstr - 2'd1;
+    wire [4:0]  grpsz_w       = 5'd3 << grp_sh;
     wire [8:0]  ngnum_w       = endmant_w + {4'd0, grpsz_w} - 9'd4;
-    wire [8:0]  nchgrps_full  = ngnum_w / {4'd0, grpsz_w};
+    wire [8:0]  nchgrps_full  = (ngnum_w / 9'd3) >> grp_sh;
     wire [6:0]  nchgrps_w     = nchgrps_full[6:0];
 
     // coupled fbw channel: endmant = cplstrtmant, nchgrps from that.
     wire [8:0]  ngnum_cpl     = cplstrtmant + {4'd0, grpsz_w} - 9'd4;
-    wire [8:0]  nchgrps_cplf  = ngnum_cpl / {4'd0, grpsz_w};
+    wire [8:0]  nchgrps_cplf  = (ngnum_cpl / 9'd3) >> grp_sh;
     wire [6:0]  nchgrps_cpl   = nchgrps_cplf[6:0];
 
     // coupling-channel exponent geometry: ncplgrps = (cplendmant - cplstrtmant)
     //  / (3 << (cplexpstr - 1)).
-    wire [4:0]  cpl_grpsz     = 5'd3 << (cplexpstr - 2'd1);
+    wire [1:0]  cpl_sh        = cplexpstr - 2'd1;
     wire [8:0]  cpl_nmant     = cplendmant - cplstrtmant;
-    wire [8:0]  ncplgrps_full = cpl_nmant / {4'd0, cpl_grpsz};
+    wire [8:0]  ncplgrps_full = (cpl_nmant / 9'd3) >> cpl_sh;
     wire [6:0]  ncplgrps      = ncplgrps_full[6:0];
 
     // cplco compute (A/52 §5.4.3.5): cplcomant magnitude then * scale_factor.
     // scale_factor[i] = 2^-(15+i); store cplco as Q5.18 -> shift = 3 - exp_idx.
-    wire [31:0] cplcomant_full = (cplcoexp_r == 4'd15)
-                                   ? ({28'd0, data_in[3:0]} << 14)
-                                   : (({28'd0, data_in[3:0]} | 32'h10) << 13);
+    // cplcomant_full is a 5-bit mantissa placed at bit 13 or 14 (<= 2^19), and
+    // the Q5.18 placement is "<< (3 - exp_idx)" for exp_idx in 0..24.  Written
+    // as ((v << 3) >> exp_idx) it is one right shifter on a 22-bit value; the
+    // old sign-split form instantiated a 32-bit left AND a 32-bit right barrel
+    // shifter plus a mux.  Identical: v<<3 cannot overflow 22 bits, and for
+    // exp_idx > 3 the three zero low bits shift out first -- area pass
+    // 2026-09-10.  Consumed as cplco_val[23:0] (cplco_mem write below).
+    wire [21:0] cplcomant_full = (cplcoexp_r == 4'd15)
+                                   ? ({18'd0, data_in[3:0]} << 14)
+                                   : (({18'd0, data_in[3:0]} | 22'h10) << 13);
     wire [5:0]  cpl_exp_idx    = {1'b0, cplcoexp_r} + {2'd0, mstrcplco_r};   // 0..24
-    wire signed [6:0] cpl_shift = 7'sd3 - $signed({1'b0, cpl_exp_idx});
-    wire [31:0] cplco_val      = cpl_shift[6]
-                                   ? (cplcomant_full >> (-cpl_shift))
-                                   : (cplcomant_full << cpl_shift[4:0]);
+    wire [24:0] cplco_val      = {cplcomant_full, 3'b000} >> cpl_exp_idx;
 
     // rematrixing band edges + this-block end (do-while termination).
     wire [8:0]  remat_end      = (chincpl != 5'b0) ? cplstrtmant : 9'd253;

--- a/dvd/ac3/bit_allocation.sv
+++ b/dvd/ac3/bit_allocation.sv
@@ -356,29 +356,64 @@ module bit_allocation (
     // (M19b: the old bap_lookup() function — (baptab+156)[mask+4*exp] with the
     //  clamp — is now the bl_addr wire + sync baptab_q read + p2_* stage above.)
 
-    // UPDATE_LEAK (liba52 macro), split per leak.
-    function automatic signed [31:0] upd_fast
-        (input signed [31:0] fl, input signed [31:0] psd_in);
-        logic signed [31:0] x;
-        begin
-            x = fl + fdecay;
-            if (x > psd_in + fgain) x = psd_in + fgain;
-            upd_fast = x;
-        end
-    endfunction
-    function automatic signed [31:0] upd_slow
-        (input signed [31:0] sl, input signed [31:0] psd_in);
-        logic signed [31:0] x;
-        begin
-            x = sl + sdecay;
-            if (x > psd_in + sgain) x = psd_in + sgain;
-            upd_slow = x;
-        end
-    endfunction
+    // ---- SHARED MASK DATAPATH (area pass, 2026-09-10) -------------------------
+    // compute_mask() used to be instantiated at FIVE call sites (C_P1..C_P4,
+    // C_P5MASK) and UPDATE_LEAK (upd_fast/upd_slow) at four -- the states are
+    // mutually exclusive, but Quartus muxes RESULTS, never arithmetic, so the
+    // fitter built ~2,000 ALUTs of duplicated 32-bit add/compare trees
+    // (bit_allocation measured 2,482 ALUTs against 390 registers).  Every
+    // operand is a register that is stable for the whole ph1 cycle (st, i,
+    // jcap, ex_qa/ex_qb, lowcomp, psd_r, the leaks, hth_q, db_q, cpl), so the
+    // five bodies are the SAME expression with state-selected inputs.  Build
+    // it once, combinationally, and let each state consume the wires.
+    //
+    //   cm_psd  : 128*expc[i]            (C_P1..C_P4)   | psd_r  (C_P5MASK)
+    //   nlc_w   : the per-phase lowcomp term (phase 1/2 jcap-guarded, phase 3
+    //             seed 320 unguarded, phase 4 lowcomp-128, phase 5 none)
+    //   fl_w/sl_w: UPDATE_LEAK on cm_psd (unused by C_P1, which seeds instead)
+    //   cm_pre  : C_P1 = psd+fgain+nlc; C_P2..4 = min(fl+nlc, sl);
+    //             C_P5MASK = min(fl, sl)   (nlc_w == 0 there)
+    //   cm_mask : compute_mask(cm_psd, cm_pre, hth_q, db)  with the coupling
+    //             channel's delta-BA forced to 0 exactly as before.
+    // Values are IDENTICAL to the per-state copies (same 32-bit modular
+    // arithmetic, same operation order); only the sharing changed.  Gate:
+    // bench/ac3/run_balloc.sh (bap bit-exact) + run_front_cosim.sh.
+    // The leak update is written as plain ternaries, not a function: Quartus
+    // 17 has miscompiled small scalar-argument functions in this decoder
+    // before (the acmod helpers, 2026-08-31).
+    logic signed [31:0] cm_psd, cm_pre, cm_mask, fl_w, sl_w, psd_fg, psd_sg;
+    logic signed [31:0] fl_dec, sl_dec, a_nlc;
+    logic signed [15:0] nlc_w;
+    logic signed [3:0]  db_sel;
+    always_comb begin
+        nlc_w = lowcomp;
+        case (st)
+            C_P1, C_P2:
+                if ({1'b0, i} < jcap) begin
+                    if (ex_qb == ex_qa - 5'd2)                 nlc_w = 16'sd384;
+                    else if (lowcomp != 0 && ex_qb > ex_qa)    nlc_w = lowcomp - 16'sd64;
+                end
+            C_P3: begin
+                if (ex_qb == ex_qa - 5'd2)                     nlc_w = 16'sd320;
+                else if (lowcomp != 0 && ex_qb > ex_qa)        nlc_w = lowcomp - 16'sd64;
+            end
+            C_P4:    nlc_w = lowcomp - 16'sd128;
+            default: nlc_w = 16'sd0;
+        endcase
+        cm_psd = (st == C_P5MASK) ? psd_r : 32'sd128 * $signed({27'd0, ex_qa});
+        psd_fg = cm_psd + fgain;
+        psd_sg = cm_psd + sgain;
+        fl_dec = fastleak_r + fdecay;
+        sl_dec = slowleak_r + sdecay;
+        fl_w   = (fl_dec > psd_fg) ? psd_fg : fl_dec;      // UPDATE_LEAK fast
+        sl_w   = (sl_dec > psd_sg) ? psd_sg : sl_dec;      // UPDATE_LEAK slow
+        a_nlc  = ((st == C_P1) ? psd_fg : fl_w) + $signed(nlc_w);
+        cm_pre = (st == C_P1) ? a_nlc : ((a_nlc < sl_w) ? a_nlc : sl_w);
+        db_sel = ((st == C_P5MASK) && cpl) ? 4'sd0 : db_q;
+        cm_mask = compute_mask(cm_psd, cm_pre, $signed({16'd0, hth_q}), db_sel);
+    end
 
-    // scratch (combinational temporaries inside the FF; written before read)
-    logic signed [31:0] vpsd, vmaskpre, vmask, vfl, vsl;
-    logic signed [15:0] vnlc;
+    // scratch (combinational temporary inside the FF; written before read)
     logic        [8:0]  veb;
 
     always_ff @(posedge clk) begin
@@ -464,27 +499,19 @@ module bit_allocation (
                 // ---- phase 1: do { bin i } while (i<3 || (i<7 && exp rising)) ----
                 // (M19: ph0 fetches ex_qa=expc[i], ex_qb=expc[i+1], db_q=dbc[i];
                 //  ph1 is the original body with those substitutions.)
+                // (Shared datapath: nlc_w / cm_psd / cm_mask, see above.)
                 C_P1: if (!ph) ph <= 1'b1; else begin
                     ph <= 1'b0;
-                    vnlc = lowcomp;
-                    if ({1'b0, i} < jcap) begin
-                        if (ex_qb == ex_qa - 5'd2)                 vnlc = 16'sd384;
-                        else if (lowcomp != 0 && ex_qb > ex_qa)
-                                                                   vnlc = lowcomp - 16'sd64;
-                    end
-                    vpsd     = 32'sd128 * $signed({27'd0, ex_qa});
-                    vmaskpre = vpsd + fgain + $signed(vnlc);
-                    vmask    = compute_mask(vpsd, vmaskpre, $signed({16'd0, hth_q}), db_q);
                     pend_we <= 1'b1; pend_waddr <= {cur_slot, i};
-                    pend_lookup <= 1'b1; pend_mask <= vmask; pend_e <= ex_qa;
+                    pend_lookup <= 1'b1; pend_mask <= cm_mask; pend_e <= ex_qa;
 
-                    lowcomp <= vnlc;
-                    psd_r   <= vpsd;
+                    lowcomp <= nlc_w;
+                    psd_r   <= cm_psd;
                     i       <= i + 8'd1;
                     if (!(((i + 8'd1) < 8'd3) ||
                           (((i + 8'd1) < 8'd7) && (ex_qb > ex_qa)))) begin
-                        fastleak_r <= vpsd + fgain;
-                        slowleak_r <= vpsd + sgain;
+                        fastleak_r <= psd_fg;
+                        slowleak_r <= psd_sg;
                         st         <= C_P2;
                     end
                 end
@@ -498,23 +525,11 @@ module bit_allocation (
                         if (lfe) begin st <= C_FLUSH; flush_cnt <= 2'd0; end
                         else st <= C_P3;
                     end else begin
-                        vnlc = lowcomp;
-                        if ({1'b0, i} < jcap) begin
-                            if (ex_qb == ex_qa - 5'd2)             vnlc = 16'sd384;
-                            else if (lowcomp != 0 && ex_qb > ex_qa)
-                                                                   vnlc = lowcomp - 16'sd64;
-                        end
-                        vpsd     = 32'sd128 * $signed({27'd0, ex_qa});
-                        vfl      = upd_fast(fastleak_r, vpsd);
-                        vsl      = upd_slow(slowleak_r, vpsd);
-                        vmaskpre = ((vfl + $signed(vnlc)) < vsl) ?
-                                   (vfl + $signed(vnlc)) : vsl;
-                        vmask    = compute_mask(vpsd, vmaskpre, $signed({16'd0, hth_q}), db_q);
                         pend_we <= 1'b1; pend_waddr <= {cur_slot, i};
-                        pend_lookup <= 1'b1; pend_mask <= vmask; pend_e <= ex_qa;
+                        pend_lookup <= 1'b1; pend_mask <= cm_mask; pend_e <= ex_qa;
 
-                        fastleak_r <= vfl; slowleak_r <= vsl;
-                        lowcomp <= vnlc; psd_r <= vpsd;
+                        fastleak_r <= fl_w; slowleak_r <= sl_w;
+                        lowcomp <= nlc_w; psd_r <= cm_psd;
                         i <= i + 8'd1;
                     end
                 end
@@ -524,21 +539,11 @@ module bit_allocation (
                     ph <= 1'b0;
                     if (i >= 8'd20) st <= C_P4;
                     else begin
-                        vnlc = lowcomp;
-                        if (ex_qb == ex_qa - 5'd2)                 vnlc = 16'sd320;
-                        else if (lowcomp != 0 && ex_qb > ex_qa)
-                                                                   vnlc = lowcomp - 16'sd64;
-                        vpsd     = 32'sd128 * $signed({27'd0, ex_qa});
-                        vfl      = upd_fast(fastleak_r, vpsd);
-                        vsl      = upd_slow(slowleak_r, vpsd);
-                        vmaskpre = ((vfl + $signed(vnlc)) < vsl) ?
-                                   (vfl + $signed(vnlc)) : vsl;
-                        vmask    = compute_mask(vpsd, vmaskpre, $signed({16'd0, hth_q}), db_q);
                         pend_we <= 1'b1; pend_waddr <= {cur_slot, i};
-                        pend_lookup <= 1'b1; pend_mask <= vmask; pend_e <= ex_qa;
+                        pend_lookup <= 1'b1; pend_mask <= cm_mask; pend_e <= ex_qa;
 
-                        fastleak_r <= vfl; slowleak_r <= vsl;
-                        lowcomp <= vnlc; psd_r <= vpsd;
+                        fastleak_r <= fl_w; slowleak_r <= sl_w;
+                        lowcomp <= nlc_w; psd_r <= cm_psd;
                         i <= i + 8'd1;
                     end
                 end
@@ -550,18 +555,11 @@ module bit_allocation (
                         j  <= {1'b0, i};
                         st <= C_P5SETUP;
                     end else begin
-                        vnlc     = lowcomp - 16'sd128;
-                        vpsd     = 32'sd128 * $signed({27'd0, ex_qa});
-                        vfl      = upd_fast(fastleak_r, vpsd);
-                        vsl      = upd_slow(slowleak_r, vpsd);
-                        vmaskpre = ((vfl + $signed(vnlc)) < vsl) ?
-                                   (vfl + $signed(vnlc)) : vsl;
-                        vmask    = compute_mask(vpsd, vmaskpre, $signed({16'd0, hth_q}), db_q);
                         pend_we <= 1'b1; pend_waddr <= {cur_slot, i};
-                        pend_lookup <= 1'b1; pend_mask <= vmask; pend_e <= ex_qa;
+                        pend_lookup <= 1'b1; pend_mask <= cm_mask; pend_e <= ex_qa;
 
-                        fastleak_r <= vfl; slowleak_r <= vsl;
-                        lowcomp <= vnlc;
+                        fastleak_r <= fl_w; slowleak_r <= sl_w;
+                        lowcomp <= nlc_w;
                         i <= i + 8'd1;
                     end
                 end
@@ -609,15 +607,10 @@ module bit_allocation (
 
                 C_P5MASK: if (!ph) ph <= 1'b1; else begin
                     ph <= 1'b0;
-                    vfl      = upd_fast(fastleak_r, psd_r);
-                    vsl      = upd_slow(slowleak_r, psd_r);
-                    vmaskpre = (vfl < vsl) ? vfl : vsl;
                     // coupling channel has no delta-BA in scope (cpl deltbae NEW
-                    // fails loud upstream), so its deltba term is 0.
-                    mask_r   <= compute_mask(psd_r, vmaskpre,
-                                             $signed({16'd0, hth_q}),
-                                             cpl ? 4'sd0 : db_q);
-                    fastleak_r <= vfl; slowleak_r <= vsl;
+                    // fails loud upstream), so its deltba term is 0 (db_sel).
+                    mask_r   <= cm_mask;
+                    fastleak_r <= fl_w; slowleak_r <= sl_w;
                     i  <= i + 8'd1;
                     jw <= sb;
                     st <= C_P5WRITE;

--- a/dvd/ac3/bit_allocation.sv
+++ b/dvd/ac3/bit_allocation.sv
@@ -108,6 +108,23 @@ module bit_allocation (
     output logic        done          // 1-cycle pulse: all channels allocated
 );
 
+    // ---- datapath width (area pass 2026-09-10) ----
+    // liba52 computes bit allocation in C `int`, and this file was a literal
+    // 32-bit transcription.  The values are small.  Bounds, from the tables
+    // and codes: psd = 128*exp <= 3968; lowcomp <= 384 (16-bit reg);
+    // fgain <= 1024, fdecay <= 123, sgain < 4096, sdecay <= 21, so the leaks
+    // are <= ~8100; dbknee < 8192; snroffset in [-3132, 9151]; floor_s <= 255;
+    // 128*deltba in [-1024, 896]; the hearing threshold hth_q is a 16-bit ROM
+    // word (<= 65535).  compute_mask's largest intermediate is therefore the
+    // hth-capped mask minus snroffset, |m| < 70,000, before it is clamped to
+    // <= 0 and shifted; bl_idx <= 156 + 344 + 124 before its own clamp; the
+    // phase-5 log-add psd stays below 8k.  20-bit signed (+/-524,287) holds
+    // every one with 7x margin.  Literals stay 32-bit: Verilog evaluates the
+    // expression at 32 bits and truncates on assignment, which is identical
+    // whenever the value fits -- and the bap cosim is bit-exact.
+    localparam int BW = 20;
+
+
     localparam logic [2:0] CPL = AC3_CH_CPL[2:0];   // 5
     localparam logic [2:0] LFE = AC3_CH_LFE[2:0];   // 6
     wire [2:0] nfm1 = nfchans - 3'd1;
@@ -152,7 +169,7 @@ module bit_allocation (
     logic               pend_we;
     logic [10:0]        pend_waddr;
     logic               pend_lookup;     // 1: bap_lookup(pend_mask,pend_e); 0: pend_lit
-    logic signed [31:0] pend_mask;
+    logic signed [BW-1:0] pend_mask;
     logic        [4:0]  pend_e;
     logic signed [7:0]  pend_lit;
     logic        [1:0]  flush_cnt;
@@ -194,8 +211,9 @@ module bit_allocation (
     logic [4:0]        ex_qa, ex_qb;   // sync reads: expc[raddr_a/b]
     logic signed [3:0] db_q;           // sync read: dbc[i]
 
+
     // ---- per-channel constants (latched at channel start) ----
-    logic signed [31:0] fdecay, fgain, sdecay, sgain, dbknee, floor_s, snroffset;
+    logic signed [BW-1:0] fdecay, fgain, sdecay, sgain, dbknee, floor_s, snroffset;
     logic        [8:0]  end_r;
 
     // ---- FSM ----
@@ -220,12 +238,12 @@ module bit_allocation (
     logic [7:0]  i;                    // band/bin index (<=49; 8b for clean idx)
     logic [8:0]  jcap;                 // end-1 (phase 1/2 lowcomp guard)
     logic signed [15:0] lowcomp;
-    logic signed [31:0] psd_r, fastleak_r, slowleak_r, mask_r;
+    logic signed [BW-1:0] psd_r, fastleak_r, slowleak_r, mask_r;
     logic [8:0]  j, jw, sb, eb;        // phase-5 read / write / band bounds
     logic [1:0]  ph;                   // M19 micro-phase: 0=fetch RAM operands,
                                        // 1=execute the original state body
                                        // (2 = C_P5ACC log-add apply, M19b)
-    logic signed [31:0] vnext_r, vdelta_r;  // M19b: C_P5ACC ph1->ph2 operands
+    logic signed [BW-1:0] vnext_r, vdelta_r;  // M19b: C_P5ACC ph1->ph2 operands
 
     // destination channel slot for bap writes (fbw / coupling / LFE).
     wire [2:0] cur_slot = lfe ? LFE : cpl ? CPL : cur_ch;
@@ -237,23 +255,23 @@ module bit_allocation (
     wire [3:0] sel_fsnroffst= lfe ? lfeba_bai[6:3] : fsnroffst[cur_ch*4 +: 4];
     wire [1:0] sel_deltbae  = lfe ? 2'd2 : deltbae[cur_ch*2 +: 2];  // lfe: no delta-BA
 
-    wire signed [31:0] w_fdecay = 32'sd63 + 32'sd20 * $signed({30'd0, fdcycod});
-    wire signed [31:0] w_sdecay = 32'sd15 + 32'sd2  * $signed({30'd0, sdcycod});
-    wire signed [31:0] w_sgain  = $signed({20'd0, slowgain_t[sgaincod]});
-    wire signed [31:0] w_dbknee = $signed({19'd0, dbpbtab_t[dbpbcod]});
-    wire signed [31:0] w_fgain  = 32'sd128 + 32'sd128 * $signed({29'd0, sel_fgaincod});
-    wire signed [31:0] w_floorf = $signed({19'd0, floortab_t[floorcod]});
-    wire signed [31:0] w_snr    = 32'sd960 - 32'sd64 * $signed({26'd0, csnroffst})
+    wire signed [BW-1:0] w_fdecay = 32'sd63 + 32'sd20 * $signed({30'd0, fdcycod});
+    wire signed [BW-1:0] w_sdecay = 32'sd15 + 32'sd2  * $signed({30'd0, sdcycod});
+    wire signed [BW-1:0] w_sgain  = $signed({20'd0, slowgain_t[sgaincod]});
+    wire signed [BW-1:0] w_dbknee = $signed({19'd0, dbpbtab_t[dbpbcod]});
+    wire signed [BW-1:0] w_fgain  = 32'sd128 + 32'sd128 * $signed({29'd0, sel_fgaincod});
+    wire signed [BW-1:0] w_floorf = $signed({19'd0, floortab_t[floorcod]});
+    wire signed [BW-1:0] w_snr    = 32'sd960 - 32'sd64 * $signed({26'd0, csnroffst})
                                           - 32'sd4  * $signed({28'd0, sel_fsnroffst})
                                           + w_floorf;
-    wire signed [31:0] w_floors = w_floorf >>> 5;
+    wire signed [BW-1:0] w_floors = w_floorf >>> 5;
 
     // coupling-channel constants (M12 Stage B): fgain/snroffset use cplba.bai's
     // sub-codes; fdecay/sdecay/sgain/dbknee/floor are channel-independent.
     wire [2:0] cpl_fgaincod  = cplba_bai[2:0];
     wire [3:0] cpl_fsnroffst = cplba_bai[6:3];
-    wire signed [31:0] w_fgain_cpl = 32'sd128 + 32'sd128 * $signed({29'd0, cpl_fgaincod});
-    wire signed [31:0] w_snr_cpl   = 32'sd960 - 32'sd64 * $signed({26'd0, csnroffst})
+    wire signed [BW-1:0] w_fgain_cpl = 32'sd128 + 32'sd128 * $signed({29'd0, cpl_fgaincod});
+    wire signed [BW-1:0] w_snr_cpl   = 32'sd960 - 32'sd64 * $signed({26'd0, csnroffst})
                                               - 32'sd4  * $signed({28'd0, cpl_fsnroffst})
                                               + w_floorf;
 
@@ -309,7 +327,7 @@ module bit_allocation (
     // baptab: address formed combinationally from the pend_* stage (valid the
     // cycle after a state stages a lookup); baptab_q registers alongside p2_*.
     // This is the old bap_lookup() clamp, relocated ahead of the ROM.
-    wire signed [31:0] bl_idx  = 32'sd156 + pend_mask
+    wire signed [BW-1:0] bl_idx  = 32'sd156 + pend_mask
                                + (32'sd4 * $signed({27'd0, pend_e}));
     wire        [8:0]  bl_addr = (bl_idx < 0)         ? 9'd0
                                : (bl_idx > 32'sd304)  ? 9'd304
@@ -320,9 +338,9 @@ module bit_allocation (
     // latab: the C_P5ACC log-add operand.  Address is the old vid clamp,
     // computed from ex_qb (expc[j], valid at C_P5ACC ph1) and the accumulated
     // psd_r; la_q registers at the ph1 edge and is applied at ph2.
-    wire signed [31:0] la_vnext  = 32'sd128 * $signed({27'd0, ex_qb});
-    wire signed [31:0] la_vdelta = la_vnext - psd_r;
-    wire signed [31:0] la_vid    = ((la_vdelta >>> 9) == -32'sd1)
+    wire signed [BW-1:0] la_vnext  = 32'sd128 * $signed({27'd0, ex_qb});
+    wire signed [BW-1:0] la_vdelta = la_vnext - psd_r;
+    wire signed [BW-1:0] la_vid    = ((la_vdelta >>> 9) == -32'sd1)
                                  ? ((-la_vdelta) >>> 1) : (la_vdelta >>> 1);
     wire        [7:0]  la_addr   = (la_vid > 32'sd255) ? 8'd255 : la_vid[7:0];
     logic signed [7:0] la_q;
@@ -338,10 +356,10 @@ module bit_allocation (
     // per-channel constants).  M19b: the hearing-threshold value is passed in
     // (hth_q sync-ROM read, band == i at every call site) instead of read from
     // the ROM inside the function.
-    function automatic signed [31:0] compute_mask
-        (input signed [31:0] psd_in, input signed [31:0] mask_in,
-         input signed [31:0] hthv, input signed [3:0] db);
-        logic signed [31:0] m;
+    function automatic signed [BW-1:0] compute_mask
+        (input signed [BW-1:0] psd_in, input signed [BW-1:0] mask_in,
+         input signed [BW-1:0] hthv, input signed [3:0] db);
+        logic signed [BW-1:0] m;
         begin
             m    = mask_in;
             if (psd_in > dbknee) m = m - ((psd_in - dbknee) >>> 2);
@@ -381,8 +399,8 @@ module bit_allocation (
     // The leak update is written as plain ternaries, not a function: Quartus
     // 17 has miscompiled small scalar-argument functions in this decoder
     // before (the acmod helpers, 2026-08-31).
-    logic signed [31:0] cm_psd, cm_pre, cm_mask, fl_w, sl_w, psd_fg, psd_sg;
-    logic signed [31:0] fl_dec, sl_dec, a_nlc;
+    logic signed [BW-1:0] cm_psd, cm_pre, cm_mask, fl_w, sl_w, psd_fg, psd_sg;
+    logic signed [BW-1:0] fl_dec, sl_dec, a_nlc;
     logic signed [15:0] nlc_w;
     logic signed [3:0]  db_sel;
     always_comb begin

--- a/dvd/ac3/bit_reader.sv
+++ b/dvd/ac3/bit_reader.sv
@@ -48,10 +48,13 @@ module bit_reader #(
 );
 
     // Bit accumulator, LEFT-justified: acc[ACC_W-1] is the next bit out.
-    // Must hold up to (MAXW-1) leftover bits plus a freshly appended byte, so
-    // 64 bits is comfortable for MAXW<=32 (worst case need<=32, cnt can reach
-    // need+7 = 39 < 64).
-    localparam int ACC_W = 64;
+    // Must hold up to (MAXW-1) leftover bits plus a freshly appended byte:
+    // a byte is only appended while cnt < need <= MAXW, so cnt <= MAXW-1 and
+    // after the append cnt <= MAXW+7.  ACC_W = MAXW+8 is therefore exact
+    // (40 for the AC-3 instance, 24 for MP2).  It was 64 "for comfort", which
+    // bought nothing and cost three 64-bit barrel shifters per instance
+    // (~500 ALUTs each at MAXW=32, ~450 at MAXW=16) -- area pass 2026-09-10.
+    localparam int ACC_W = MAXW + 8;
 
     logic [ACC_W-1:0] acc;     // valid bits are the top `cnt`, MSB-first
     logic [6:0]       cnt;     // number of valid bits in acc (0..ACC_W)

--- a/dvd/ac3/imdct_512.sv
+++ b/dvd/ac3/imdct_512.sv
@@ -471,179 +471,113 @@ module imdct_512 (
     wire signed [31:0] dly1 = dly1_r;       // delay[2i+1]
 
     // ---- multiplier-operand mux (combinational) ----
+    // Area pass 2026-09-10.  This used to select all eight multiplier inputs
+    // (4 x 34-bit ma, 4 x 18-bit mb = 208 bits) independently across 19
+    // (state, phase) cases.  Sixteen of those cases are the same complex-
+    // multiply shape: pick a sample pair (x, y) and a twiddle pair (w1, w2)
+    // and form x*w1, y*w2, x*w2, y*w1 -- OP_BFULL is the one variant with
+    // lanes 2/3 swapped (y*w1, x*w2), selected by `sw`.  So the wide mux is
+    // now on (x, y, w1, w2) = 104 bits, and the lane assignment is fixed.
+    // Two forms fall outside it and are overlaid on the lanes explicitly:
+    // OP_BHALF's a-operands are the four pre-added sums (all b = swr), and the
+    // M19e downmix puts a third sample (dmx_rs) on lane 2.  Every (ma, mb)
+    // pair is bit-identical to the old table in every cycle a product is
+    // consumed; cycles with no case still drive zeros as before.
+    logic signed [33:0] mx, my;
+    logic signed [17:0] mw1, mw2;
+    logic               sw, bh, dm;
     always_comb begin
-        ma0 = '0; ma1 = '0; ma2 = '0; ma3 = '0;
-        mb0 = '0; mb1 = '0; mb2 = '0; mb3 = '0;
+        mx = '0; my = '0; mw1 = '0; mw2 = '0; sw = 1'b0; bh = 1'b0; dm = 1'b0;
         unique case (st)
             S_PRE: if (ph == 3'd5) begin
                 // buf.re = d255k*pre_im + dk*pre_re ; buf.im = d255k*pre_re - dk*pre_im
-                ma0 = 34'(d255k); mb0 = pre_im;
-                ma1 = 34'(dk);    mb1 = pre_re;
-                ma2 = 34'(d255k); mb2 = pre_re;
-                ma3 = 34'(dk);    mb3 = pre_im;
+                mx = 34'(d255k); my = 34'(dk); mw1 = pre_im; mw2 = pre_re;
             end
             S_IFFT: begin
                 if (op == OP_BHALF) begin
-                    ma0 = 34'(c2r) + 34'(c2i); mb0 = swr;   // (a2.r+a2.i)*w
-                    ma1 = 34'(c2i) - 34'(c2r); mb1 = swr;
-                    ma2 = 34'(c3r) - 34'(c3i); mb2 = swr;
-                    ma3 = 34'(c3i) + 34'(c3r); mb3 = swr;
+                    bh = 1'b1; mw1 = swr; mw2 = swr;          // (a.r+/-a.i)*w
                 end else if (op == OP_BFULL) begin
-                    if (ph == 3'd3) begin       // c2 products -> tt5/tt6
-                        ma0 = 34'(c2r); mb0 = swr;  // a2.r*wr
-                        ma1 = 34'(c2i); mb1 = swi;  // a2.i*wi
-                        ma2 = 34'(c2i); mb2 = swr;  // a2.i*wr
-                        ma3 = 34'(c2r); mb3 = swi;  // a2.r*wi
-                    end else begin              // c3 products (write cycles)
-                        ma0 = 34'(c3r); mb0 = swr;  // a3.r*wr
-                        ma1 = 34'(c3i); mb1 = swi;  // a3.i*wi
-                        ma2 = 34'(c3i); mb2 = swr;  // a3.i*wr
-                        ma3 = 34'(c3r); mb3 = swi;  // a3.r*wi
-                    end
+                    sw = 1'b1; mw1 = swr; mw2 = swi;
+                    if (ph == 3'd3) begin mx = 34'(c2r); my = 34'(c2i); end // c2 -> tt5/tt6
+                    else            begin mx = 34'(c3r); my = 34'(c3i); end // c3 (write cycles)
                 end
             end
             S_POST: case (ph)
-                3'd2: begin                       // a_r,a_i from buf[i]
-                    ma0 = 34'(bir); mb0 = po_re;
-                    ma1 = 34'(bii); mb1 = po_im;
-                    ma2 = 34'(bir); mb2 = po_im;
-                    ma3 = 34'(bii); mb3 = po_re;
-                end
-                3'd3: begin                       // b_r,b_i from buf[127-i]
-                    ma0 = 34'(b1r); mb0 = po_im;
-                    ma1 = 34'(b1i); mb1 = po_re;
-                    ma2 = 34'(b1r); mb2 = po_re;
-                    ma3 = 34'(b1i); mb3 = po_im;
-                end
-                3'd4: begin                       // a-pair window (wa=w[2i], wb=w[255-2i])
-                    ma0 = 34'(dly0); mb0 = wb_q;  // delay*window[255-2i]
-                    ma1 = 34'(ar);   mb1 = wa_q;  // a_r*window[2i]
-                    ma2 = 34'(dly0); mb2 = wa_q;
-                    ma3 = 34'(ar);   mb3 = wb_q;
-                end
-                3'd5: begin                       // b-pair window (wa=w[2i+1], wb=w[254-2i])
-                    ma0 = 34'(dly1); mb0 = wb_q;  // delay*window[254-2i]
-                    ma1 = 34'(br);   mb1 = wa_q;  // b_r*window[2i+1]
-                    ma2 = 34'(dly1); mb2 = wa_q;
-                    ma3 = 34'(br);   mb3 = wb_q;
-                end
+                3'd2: begin mx = 34'(bir);  my = 34'(bii); mw1 = po_re; mw2 = po_im; end // a from buf[i]
+                3'd3: begin mx = 34'(b1r);  my = 34'(b1i); mw1 = po_im; mw2 = po_re; end // b from buf[127-i]
+                3'd4: begin mx = 34'(dly0); my = 34'(ar);  mw1 = wb_q;  mw2 = wa_q;  end // a-pair window
+                3'd5: begin mx = 34'(dly1); my = 34'(br);  mw1 = wb_q;  mw2 = wa_q;  end // b-pair window
                 default: ;
             endcase
             // ---- M16 short-block POST (a52_imdct_256) ----
-            // post2 products (a/b from buf1, c/d from buf2), each _r = p0+p1,
-            // _i = p2-p3; then four windowed output pairs.  See the FF block.
             S_POST256: case (ph)
-                5'd3: begin                       // a_r,a_i from buf1[i]
-                    ma0 = 34'(q1ir); mb0 = po_re;
-                    ma1 = 34'(q1ii); mb1 = po_im;
-                    ma2 = 34'(q1ir); mb2 = po_im;
-                    ma3 = 34'(q1ii); mb3 = po_re;
-                end
-                5'd4: begin                       // b_r,b_i from buf1[63-i]
-                    ma0 = 34'(q1mr); mb0 = po_im;
-                    ma1 = 34'(q1mi); mb1 = po_re;
-                    ma2 = 34'(q1mr); mb2 = po_re;
-                    ma3 = 34'(q1mi); mb3 = po_im;
-                end
-                5'd5: begin                       // c_r,c_i from buf2[i]
-                    ma0 = 34'(q2ir); mb0 = po_re;
-                    ma1 = 34'(q2ii); mb1 = po_im;
-                    ma2 = 34'(q2ir); mb2 = po_im;
-                    ma3 = 34'(q2ii); mb3 = po_re;
-                end
-                5'd6: begin                       // d_r,d_i from buf2[63-i]
-                    ma0 = 34'(q2mr); mb0 = po_im;
-                    ma1 = 34'(q2mi); mb1 = po_re;
-                    ma2 = 34'(q2mr); mb2 = po_re;
-                    ma3 = 34'(q2mi); mb3 = po_im;
-                end
-                5'd7: begin                       // window a-pair (wa=w[2i], wb=w[255-2i])
-                    ma0 = 34'(s_dly2i); mb0 = wb_q; // delay[2i]*window[255-2i]
-                    ma1 = 34'(s_ar);    mb1 = wa_q; // a_r*window[2i]
-                    ma2 = 34'(s_dly2i); mb2 = wa_q;
-                    ma3 = 34'(s_ar);    mb3 = wb_q;
-                end
-                5'd8: begin                       // a_i-pair (wa=w[127-2i], wb=w[128+2i])
-                    ma0 = 34'(s_dly127); mb0 = wa_q;
-                    ma1 = 34'(s_ai);     mb1 = wb_q;
-                    ma2 = 34'(s_dly127); mb2 = wb_q;
-                    ma3 = 34'(s_ai);     mb3 = wa_q;
-                end
-                5'd9: begin                       // b_i-pair (wa=w[2i+1], wb=w[254-2i])
-                    ma0 = 34'(s_dly2i1); mb0 = wb_q; // delay[2i+1]*window[254-2i]
-                    ma1 = 34'(s_bi);     mb1 = wa_q; // b_i*window[2i+1]
-                    ma2 = 34'(s_dly2i1); mb2 = wa_q;
-                    ma3 = 34'(s_bi);     mb3 = wb_q;
-                end
-                5'd10: begin                      // b_r-pair (wa=w[126-2i], wb=w[129+2i])
-                    ma0 = 34'(s_dly126); mb0 = wa_q;
-                    ma1 = 34'(s_br);     mb1 = wb_q;
-                    ma2 = 34'(s_dly126); mb2 = wb_q;
-                    ma3 = 34'(s_br);     mb3 = wa_q;
-                end
+                5'd3:  begin mx = 34'(q1ir);     my = 34'(q1ii); mw1 = po_re; mw2 = po_im; end
+                5'd4:  begin mx = 34'(q1mr);     my = 34'(q1mi); mw1 = po_im; mw2 = po_re; end
+                5'd5:  begin mx = 34'(q2ir);     my = 34'(q2ii); mw1 = po_re; mw2 = po_im; end
+                5'd6:  begin mx = 34'(q2mr);     my = 34'(q2mi); mw1 = po_im; mw2 = po_re; end
+                5'd7:  begin mx = 34'(s_dly2i);  my = 34'(s_ar); mw1 = wb_q;  mw2 = wa_q;  end
+                5'd8:  begin mx = 34'(s_dly127); my = 34'(s_ai); mw1 = wa_q;  mw2 = wb_q;  end
+                5'd9:  begin mx = 34'(s_dly2i1); my = 34'(s_bi); mw1 = wb_q;  mw2 = wa_q;  end
+                5'd10: begin mx = 34'(s_dly126); my = 34'(s_br); mw1 = wa_q;  mw2 = wb_q;  end
                 default: ;
             endcase
             // M19e: 5.1->stereo fold on the shared bank (Lo written ph6, Ro ph7;
-            // hold the operands through both cycles)
+            // hold the operands through both cycles).  Lane 3 is unused here.
             S_DMX: if (ph == 4'd6 || ph == 4'd7) begin
-                ma0 = 34'(dmx_c);  mb0 = clev;
-                ma1 = 34'(dmx_ls); mb1 = slev;
-                ma2 = 34'(dmx_rs); mb2 = slev;
+                dm = 1'b1; mx = 34'(dmx_c); my = 34'(dmx_ls); mw1 = clev; mw2 = slev;
             end
             default: ;
         endcase
+        // Fixed lane assignment (see above).
+        ma0 = bh ? (34'(c2r) + 34'(c2i)) : mx;                          mb0 = mw1;
+        ma1 = bh ? (34'(c2i) - 34'(c2r)) : my;                          mb1 = mw2;
+        ma2 = bh ? (34'(c3r) - 34'(c3i)) : dm ? 34'(dmx_rs) : sw ? my : mx;
+        mb2 = sw ? mw1 : mw2;
+        ma3 = bh ? (34'(c3i) + 34'(c3r)) : sw ? mx : my;
+        mb3 = sw ? mw2 : mw1;
     end
 
     // ---- butterfly result words (combinational, from registered operands) ----
     // Identical arithmetic to M8; produced combinationally so the two write
     // micro-cycles (ph4 -> a,b ; ph5 -> c,d) just drive the RAM ports.
+    // Area pass 2026-09-10: the five ops used to spell out their own adder
+    // trees (58 x 34-bit add/sub, results muxed).  They are one structure:
+    //   A = c0 (+ c1 for the IFFT ops), B = c1 (c0 - c1 for the IFFT ops),
+    //   T/U = the op's two complex terms, then a = A+T, c = A-T, b = B+U,
+    //   d = B-U.  Two's-complement addition is associative and commutative
+    //   modulo 2^34, and each result is truncated to 32 bits, so regrouping
+    //   the terms is bit-identical.  OP_IFFT2 sets T = U = 0; its c/d words
+    //   are never written (ph5 is gated on op != OP_IFFT2).
     logic [63:0] res_a, res_b, res_c, res_d;
     always_comb begin
-        logic signed [33:0] t1,t2,t3,t4,t5,t6,t7,t8;
-        t1='0;t2='0;t3='0;t4='0;t5='0;t6='0;t7='0;t8='0;
-        res_a = '0; res_b = '0; res_c = '0; res_d = '0;
+        logic signed [33:0] Ar, Ai, Br, Bi, Tr, Ti, Ur, Ui, f7, f8;
+        if (op == OP_IFFT2 || op == OP_IFFT4) begin
+            Ar = 34'(c0r) + 34'(c1r); Ai = 34'(c0i) + 34'(c1i);
+            Br = 34'(c0r) - 34'(c1r); Bi = 34'(c0i) - 34'(c1i);
+        end else begin
+            Ar = 34'(c0r); Ai = 34'(c0i); Br = 34'(c1r); Bi = 34'(c1i);
+        end
+        f7 = p0 - p1;     // OP_BFULL: a3.r*wr - a3.i*wi
+        f8 = p2 + p3;     //           a3.i*wr + a3.r*wi
         unique case (op)
-            OP_IFFT2: begin
-                res_a = {32'(34'(c0r) + 34'(c1r)), 32'(34'(c0i) + 34'(c1i))};
-                res_b = {32'(34'(c0r) - 34'(c1r)), 32'(34'(c0i) - 34'(c1i))};
-            end
-            OP_IFFT4: begin
-                t1 = 34'(c0r)+34'(c1r); t2 = 34'(c3r)+34'(c2r);
-                t3 = 34'(c0i)+34'(c1i); t4 = 34'(c2i)+34'(c3i);
-                t5 = 34'(c0r)-34'(c1r); t6 = 34'(c0i)-34'(c1i);
-                t7 = 34'(c2i)-34'(c3i); t8 = 34'(c3r)-34'(c2r);
-                res_a = {32'(t1+t2), 32'(t3+t4)};
-                res_c = {32'(t1-t2), 32'(t3-t4)};
-                res_b = {32'(t5+t7), 32'(t6+t8)};
-                res_d = {32'(t5-t7), 32'(t6-t8)};
-            end
-            OP_BZERO: begin
-                t1 = 34'(c2r)+34'(c3r); t2 = 34'(c2i)+34'(c3i);
-                t3 = 34'(c2i)-34'(c3i); t4 = 34'(c3r)-34'(c2r);
-                res_c = {32'(34'(c0r)-t1), 32'(34'(c0i)-t2)};
-                res_d = {32'(34'(c1r)-t3), 32'(34'(c1i)-t4)};
-                res_a = {32'(34'(c0r)+t1), 32'(34'(c0i)+t2)};
-                res_b = {32'(34'(c1r)+t3), 32'(34'(c1i)+t4)};
+            OP_IFFT4, OP_BZERO: begin
+                Tr = 34'(c2r) + 34'(c3r); Ti = 34'(c2i) + 34'(c3i);
+                Ur = 34'(c2i) - 34'(c3i); Ui = 34'(c3r) - 34'(c2r);
             end
             OP_BHALF: begin
-                t5 = p0; t6 = p1; t7 = p2; t8 = p3;
-                t1 = t5+t7; t2 = t6+t8; t3 = t6-t8; t4 = t7-t5;
-                res_c = {32'(34'(c0r)-t1), 32'(34'(c0i)-t2)};
-                res_d = {32'(34'(c1r)-t3), 32'(34'(c1i)-t4)};
-                res_a = {32'(34'(c0r)+t1), 32'(34'(c0i)+t2)};
-                res_b = {32'(34'(c1r)+t3), 32'(34'(c1i)+t4)};
+                Tr = p0 + p2; Ti = p1 + p3; Ur = p1 - p3; Ui = p2 - p0;
             end
-            default: begin   // OP_BFULL: t5/t6 latched (tt5/tt6), t7/t8 from c3
-                t5 = tt5; t6 = tt6;
-                t7 = p0 - p1;     // a3.r*wr - a3.i*wi
-                t8 = p2 + p3;     // a3.i*wr + a3.r*wi
-                t1 = t5+t7; t2 = t6+t8; t3 = t6-t8; t4 = t7-t5;
-                res_c = {32'(34'(c0r)-t1), 32'(34'(c0i)-t2)};
-                res_d = {32'(34'(c1r)-t3), 32'(34'(c1i)-t4)};
-                res_a = {32'(34'(c0r)+t1), 32'(34'(c0i)+t2)};
-                res_b = {32'(34'(c1r)+t3), 32'(34'(c1i)+t4)};
+            OP_BFULL: begin   // t5/t6 latched (tt5/tt6), t7/t8 from c3
+                Tr = tt5 + f7; Ti = tt6 + f8; Ur = tt6 - f8; Ui = f7 - tt5;
+            end
+            default: begin    // OP_IFFT2
+                Tr = '0; Ti = '0; Ur = '0; Ui = '0;
             end
         endcase
+        res_a = {32'(Ar + Tr), 32'(Ai + Ti)};
+        res_c = {32'(Ar - Tr), 32'(Ai - Ti)};
+        res_b = {32'(Br + Ur), 32'(Bi + Ui)};
+        res_d = {32'(Br - Ur), 32'(Bi - Ui)};
     end
 
     // ---- buffer RAM port drive (combinational) ----

--- a/dvd/ac3/mantissa_dequant.sv
+++ b/dvd/ac3/mantissa_dequant.sv
@@ -191,14 +191,17 @@ module mantissa_dequant (
     wire signed [31:0] dith_prod = $signed(dith_next) * 32'sd23170;
 
     // ---- coefficient scaler: coeff = (m16 << 8) >> exp, Q1.23 (truncating) ----
+    // (Area pass 2026-09-10: the shifted value is 17+8 = 25 bits, so a 25-bit
+    //  arithmetic shift yields the same low 24 bits as the old 32-bit one.)
     function automatic signed [23:0] scale_coeff
         (input signed [16:0] m16v, input [4:0] e);
-        logic signed [31:0] s;
+        logic signed [24:0] s;
         begin
-            s = ($signed({{15{m16v[16]}}, m16v}) <<< 8) >>> e;
+            s = ($signed({{8{m16v[16]}}, m16v}) <<< 8) >>> e;
             scale_coeff = s[23:0];
         end
     endfunction
+
 
     // ---- full-precision dither coefficient (Q1.23) -----------------------------
     // The old path computed a 17-bit m16 = (ns*23170)>>15 (truncating) and then
@@ -212,13 +215,21 @@ module mantissa_dequant (
     // (m16<<8>>e == (ns*23170)/2^(7+e) algebraically, but without the early
     //  17-bit clamp/floor).  Max |coeff| at e=0 ≈ 32768*181 ≈ 5.9e6 < 2^23, so no
     // saturation is possible (liba52 dither can't clip either).
+    // Area pass 2026-09-10: |dith_prod| <= 32768*23170 < 2^30, so for
+    // sh >= 31 the rounded quotient (x + 2^(sh-1)) >> sh is exactly 0 (the sum
+    // lies in (0, 2^sh)), and for sh <= 30 the sum fits 32 bits without
+    // overflow.  A 32-bit adder + shifter therefore reproduces the old 41-bit
+    // computation bit for bit; the wide form existed only to hold 2^(sh-1) for
+    // shifts that can never contribute.
     function automatic signed [23:0] dither_coeff(input [4:0] e);
         logic [5:0]         sh;
-        logic signed [40:0] s;
+        logic signed [31:0] s;
         begin
             sh = 6'd7 + {1'b0, e};                       // shift = 7 + exp
-            s  = ($signed({{9{dith_prod[31]}}, dith_prod})
-                  + (41'sd1 <<< (sh - 6'd1))) >>> sh;     // round-to-nearest
+            if (sh > 6'd30)
+                s = 32'sd0;
+            else
+                s = (dith_prod + (32'sd1 <<< (sh - 6'd1))) >>> sh;  // round-to-nearest
             dither_coeff = s[23:0];
         end
     endfunction
@@ -264,8 +275,13 @@ module mantissa_dequant (
     wire [3:0]  i4b = code % 7'd11;
     // direct (signed) mantissa for bap 5..16: sext(bits)<<(16-bap).
     wire [5:0]  bw  = bap[5:0];                     // bit width == bap value
-    wire signed [16:0] m16_direct =
-        17'($signed(data_in << (6'd32 - bw)) >>> 6'd16);
+    // The old form shifted all 32 bits of data_in left by (32-bw) and back
+    // right by 16; the value that survives is data_in[bw-1:0] left-aligned in
+    // a 16-bit field (direct baps are 5..15 bits, so 16-bw >= 1), sign-
+    // extended to 17.  A 16-bit shifter is the same number -- area pass
+    // 2026-09-10.
+    wire [15:0] m16_sh = data_in[15:0] << (6'd16 - bw);
+    wire signed [16:0] m16_direct = {m16_sh[15], m16_sh};
 
     // ---- FSM ----
     typedef enum logic [4:0] {
@@ -326,6 +342,38 @@ module mantissa_dequant (
             M_REMRDR: cm_raddr = {3'd1, rem_j[7:0]};   // present R (slot 1)
             default:  cm_raddr = coeff_rd2_addr;       // IMDCT
         endcase
+    end
+
+    // ---- ONE scale_coeff for the whole module (area pass 2026-09-10) ----------
+    // sc_out was called at 14 sites across M_EXAM / M_WAIT / M_CPLEXAM /
+    // M_CPLWAIT, each an inlined 32-bit barrel shifter (Quartus muxes results,
+    // not arithmetic).  The states are mutually exclusive and every operand is
+    // stable for the cycle, so the mantissa and exponent are selected here by
+    // the SAME conditions the call sites test, and each site latches sc_out.
+    // In any state/branch that does not latch it the value is don't-care.
+    logic signed [16:0] sc_m16;
+    logic        [4:0]  sc_exp;
+    logic signed [23:0] sc_out;
+    wire sc_wait = (st == M_WAIT) || (st == M_CPLWAIT);
+    always_comb begin
+        sc_exp = sc_wait ? pend_exp : exp;
+        if (sc_wait) begin
+            case (bap)
+                -8'sd1:  sc_m16 = q1lev[i1a];
+                -8'sd2:  sc_m16 = q2lev[i2a];
+                -8'sd3:  sc_m16 = q4lev[i4a];
+                8'sd3:   sc_m16 = q3lev[code3];
+                8'sd4:   sc_m16 = q5lev[code4];
+                default: sc_m16 = m16_direct;
+            endcase
+        end else begin
+            case (bap)
+                -8'sd2:  sc_m16 = q2_cache[q2_ptr[0]];
+                -8'sd3:  sc_m16 = q4_cache;
+                default: sc_m16 = q1_cache[q1_ptr[0]];   // bap1 (-1)
+            endcase
+        end
+        sc_out = scale_coeff(sc_m16, sc_exp);
     end
 
     always_ff @(posedge clk) begin
@@ -442,7 +490,7 @@ module mantissa_dequant (
                             -8'sd1: begin   // bap1, 3-level
                                 if (q1_ptr >= 0) begin
                                     cm_we <= 1'b1; cm_waddr <= {ch, idx[7:0]};
-                                    cm_wdata <= scale_coeff(q1_cache[q1_ptr[0]], exp);
+                                    cm_wdata <= sc_out;
                                     q1_ptr <= q1_ptr - 2'sd1;
                                     idx <= idx + 9'd1;
                                 end else begin
@@ -455,7 +503,7 @@ module mantissa_dequant (
                             -8'sd2: begin   // bap2, 5-level
                                 if (q2_ptr >= 0) begin
                                     cm_we <= 1'b1; cm_waddr <= {ch, idx[7:0]};
-                                    cm_wdata <= scale_coeff(q2_cache[q2_ptr[0]], exp);
+                                    cm_wdata <= sc_out;
                                     q2_ptr <= q2_ptr - 2'sd1;
                                     idx <= idx + 9'd1;
                                 end else begin
@@ -468,7 +516,7 @@ module mantissa_dequant (
                             -8'sd3: begin   // bap4, 11-level
                                 if (q4_ptr == 0) begin
                                     cm_we <= 1'b1; cm_waddr <= {ch, idx[7:0]};
-                                    cm_wdata <= scale_coeff(q4_cache, exp);
+                                    cm_wdata <= sc_out;
                                     q4_ptr <= -2'sd1;
                                     idx <= idx + 9'd1;
                                 end else begin
@@ -500,25 +548,25 @@ module mantissa_dequant (
                     cm_we <= 1'b1; cm_waddr <= {pend_ch, pend_idx};
                     case (bap)
                         -8'sd1: begin   // bap1 group of 3
-                            cm_wdata <= scale_coeff(q1lev[i1a], pend_exp);
+                            cm_wdata <= sc_out;
                             q1_cache[1] <= q1lev[i1b];
                             q1_cache[0] <= q1lev[i1c];
                             q1_ptr <= 2'sd1;
                         end
                         -8'sd2: begin   // bap2 group of 3
-                            cm_wdata <= scale_coeff(q2lev[i2a], pend_exp);
+                            cm_wdata <= sc_out;
                             q2_cache[1] <= q2lev[i2b];
                             q2_cache[0] <= q2lev[i2c];
                             q2_ptr <= 2'sd1;
                         end
                         -8'sd3: begin   // bap4 group of 2
-                            cm_wdata <= scale_coeff(q4lev[i4a], pend_exp);
+                            cm_wdata <= sc_out;
                             q4_cache <= q4lev[i4b];
                             q4_ptr <= 2'sd0;
                         end
-                        8'sd3:  cm_wdata <= scale_coeff(q3lev[code3], pend_exp);
-                        8'sd4:  cm_wdata <= scale_coeff(q5lev[code4], pend_exp);
-                        default:cm_wdata <= scale_coeff(m16_direct, pend_exp);
+                        8'sd3:  cm_wdata <= sc_out;
+                        8'sd4:  cm_wdata <= sc_out;
+                        default:cm_wdata <= sc_out;
                     endcase
                     idx <= idx + 9'd1;
                     st  <= M_FETCH;
@@ -572,7 +620,7 @@ module mantissa_dequant (
 
                         -8'sd1: begin   // bap1, 3-level grouped
                             if (q1_ptr >= 0) begin
-                                cc_r   <= scale_coeff(q1_cache[q1_ptr[0]], exp);
+                                cc_r   <= sc_out;
                                 q1_ptr <= q1_ptr - 2'sd1;
                                 st     <= M_CPLWR;
                             end else begin
@@ -581,7 +629,7 @@ module mantissa_dequant (
                         end
                         -8'sd2: begin   // bap2, 5-level grouped
                             if (q2_ptr >= 0) begin
-                                cc_r   <= scale_coeff(q2_cache[q2_ptr[0]], exp);
+                                cc_r   <= sc_out;
                                 q2_ptr <= q2_ptr - 2'sd1;
                                 st     <= M_CPLWR;
                             end else begin
@@ -590,7 +638,7 @@ module mantissa_dequant (
                         end
                         -8'sd3: begin   // bap4, 11-level grouped
                             if (q4_ptr == 0) begin
-                                cc_r   <= scale_coeff(q4_cache, exp);
+                                cc_r   <= sc_out;
                                 q4_ptr <= -2'sd1;
                                 st     <= M_CPLWR;
                             end else begin
@@ -610,22 +658,22 @@ module mantissa_dequant (
                 M_CPLWAIT: if (ack) begin
                     case (bap)
                         -8'sd1: begin
-                            cc_r <= scale_coeff(q1lev[i1a], pend_exp);
+                            cc_r <= sc_out;
                             q1_cache[1] <= q1lev[i1b]; q1_cache[0] <= q1lev[i1c];
                             q1_ptr <= 2'sd1;
                         end
                         -8'sd2: begin
-                            cc_r <= scale_coeff(q2lev[i2a], pend_exp);
+                            cc_r <= sc_out;
                             q2_cache[1] <= q2lev[i2b]; q2_cache[0] <= q2lev[i2c];
                             q2_ptr <= 2'sd1;
                         end
                         -8'sd3: begin
-                            cc_r <= scale_coeff(q4lev[i4a], pend_exp);
+                            cc_r <= sc_out;
                             q4_cache <= q4lev[i4b]; q4_ptr <= 2'sd0;
                         end
-                        8'sd3:  cc_r <= scale_coeff(q3lev[code3], pend_exp);
-                        8'sd4:  cc_r <= scale_coeff(q5lev[code4], pend_exp);
-                        default:cc_r <= scale_coeff(m16_direct, pend_exp);
+                        8'sd3:  cc_r <= sc_out;
+                        8'sd4:  cc_r <= sc_out;
+                        default:cc_r <= sc_out;
                     endcase
                     st <= M_CPLWR;
                 end

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -589,7 +589,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "v0.5.0"
+`define CORE_VERSION "dev-almreclaim"
 
 parameter CONF_STR = {
     "DVD;;",

--- a/dvd/subpic_blend.sv
+++ b/dvd/subpic_blend.sv
@@ -48,12 +48,20 @@ module subpic_blend (
 
     // out = (c*wt + in*(16-wt)) / 16   (unsigned linear interp; wt in [0..16], so the
     // sum never exceeds max(c,in)*16 = 4080 -> fits 13 bits, >>4 back to 8 bits).
+    // Computed as in*16 + wt*(c - in), which is the same integer (expand the
+    // product), so ONE multiply per channel instead of two -- area pass
+    // 2026-09-10.  (c - in) is a signed 9-bit difference; the sum is provably
+    // in [0, 4080] because it equals the original non-negative expression.
     // c/wt are explicit args so the continuous assigns below stay sensitive to them.
     function automatic [7:0] mix(input [7:0] v_in, input [7:0] c, input [4:0] wt);
-        logic [12:0] acc;
+        logic signed [9:0]  d;
+        logic signed [15:0] prod;
+        logic signed [13:0] acc;
         begin
-            acc = c * wt + v_in * (5'd16 - wt);
-            mix = acc[11:4];
+            d    = $signed({2'b00, c}) - $signed({2'b00, v_in});   // -255..255
+            prod = d * $signed({1'b0, wt});                          // x 0..16
+            acc  = $signed({1'b0, v_in, 4'b0000}) + prod;            // in*16 + wt*(c-in)
+            mix  = acc[11:4];
         end
     endfunction
 


### PR DESCRIPTION
## Summary

Logic-reclaim branch A: a zero-behaviour-change area pass on the in-fabric AC-3 decoder. The design had reached 98 % ALM on two consecutive branches; a fresh same-seed fit of `main` showed v0.5.0 already **placed** 40,821 ALMs (97 %), so the headline percentage was the fitter's packing estimate on a full device. The reclaim is measured in synthesis ALUTs.

**−2,544 ALUTs** (60,642 → 58,098) against v0.5.0, fit SEED 7 first roll, clk_dec 93.66 / 90.86 MHz (gate 86.0):

- `bit_allocation` 2,491 → 1,348 ALUTs: `compute_mask` was inlined at five mutually exclusive FSM states and `UPDATE_LEAK` at four; now one shared datapath with state-selected operands, then a 20-bit width with the range proof in the file.
- `mantissa_dequant` 1,594 → 1,110: one `scale_coeff` shifter for 19 call sites; dither and `m16_direct` paths narrowed.
- both `bit_reader`s: accumulator `MAXW+8` instead of 64 (−366).
- `imdct_512`: `(x, y, w1, w2)` operand mux with fixed lanes and one butterfly adder core (−81, and it regularises a Quartus mapping cliff that swung this module +786 ALUTs between netlists with identical RTL).
- `audblk_parse`: `x/(3<<k) == (x/3)>>k`; one shifter for `cplco`.
- `subpic_blend`: `in*16 + wt*(c-in)`, one multiply per channel.

Found en route: `bench/ac3/run_balloc.sh` had been failing silently since M19d (stale combinational delta-BA model, vvp exit 0). Fixed and `$fatal`ed before the refactor so it could gate it.

Records: `docs/logic_reclaim.md` (the audit and the three-branch plan), `docs/ac3_decoder_architecture.md` §4.12, the `DVD.qsf` seed ledger, CLAUDE.md status bullet.

## Test plan

- [x] Every commit: `bench/ac3/run_front_cosim.sh` bap bit-exact vs liba52 on all 13 streams AND PCM dumps of blocks 0–5 byte-identical to a pre-change baseline
- [x] Unit suites: `run_balloc`, `run_bit_reader`, `run_audblk`, `run_mantissa`, `run_imdct` / `imdct256` / `drc` (max-error figures identical: 1648 / 879 / 1116), `bench/dvd/run_mp2.sh`, `subpic_blend_tb` + `run_subpic.sh`
- [x] Full compile: fmax gate PASS both corners, `lint_undriven` PASS, `netlist_canary` PASS
- [x] HW (maintainer's rig, `DVD_almreclaim_20260911_0138.rbf`): all four MiB AC-3 tracks audible on the capture card, LPCM VOB and MP2 VCD audible, Passthru telemetry steady, video pacing 2.4996 refreshes/frame, 48 kHz, 0 lates/drops; maintainer's own look: good

🤖 Generated with [Claude Code](https://claude.com/claude-code)
