### PR TITLE
Logic reclaim B: nav / VM / glue / telemetry + MISTER_DISABLE_ALSA (-2,919 ALUTs, -1,910 registers vs v0.5.0)

### DIFF
--- a/DVD.qsf
+++ b/DVD.qsf
@@ -387,6 +387,13 @@ set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
 
 # Verilog define for PLL instantiation
 set_global_assignment -name VERILOG_MACRO "QUARTUS=1"
+# MISTER_DISABLE_ALSA (2026-09-11, user decision, logic reclaim branch B): drops
+# sys/alsa.sv + its ddr_svc channel (~290 ALMs, 544 regs). It is the HPS->core audio
+# path (Linux-side players mixed into the core output); this core decodes every codec in
+# fabric and the HPS audio daemon is retired, so nothing here feeds it. Consequence: a
+# Linux-side audio player (a BGM script, say) is silent while the DVD core is loaded --
+# documented in site/content/reference/compatibility.md.
+set_global_assignment -name VERILOG_MACRO "MISTER_DISABLE_ALSA=1"
 # DVD-FORK DEBUG: to bring back the Atmosfear wrong-title diagnosis overlay
 # (dvd/debug_overlay.sv rows 21..26; O[2] + Disc Menus On to view), uncomment the
 # next line and rebuild (--compile). It re-tightens the congested fit and may

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -1045,4 +1045,20 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # that operand mux. The regular (x,y,w1,w2) form should hold at ~3,147; if a
 # later unrelated netlist shows it near 4,000 again, that is the cliff, not
 # the branch.
+# 2026-09-11 (feature/alm-reclaim-nav, dev-almreclaimnav -- LOGIC RECLAIM BRANCH B:
+# pts_assoc ring, pgc_palette convert-on-write, dvd_vm serial tick, O[2] block
+# factoring, dvd_telem round-robin sampler, nav_pci f_forever; cut from main, NOT
+# on top of branch A): SEED 7 held FIRST roll -- clk_dec 89.73 @100C / 89.42 @-40C
+# (gate 86.0, PASS both corners) at 93% ALM (38,768 needed; 40,823 PLACED = 97%),
+# registers 50,926, RAM 500/553, DSP 94/112. Build DVD_almreclaimnav_20260911_0214.rbf.
+# Synthesis vs v0.5.0 main: registers 51,954 -> 50,578 (-1,376: pts_assoc -732,
+# pgc_palette -359, dvd_telem -264, nav_pci -31); ALUTs 60,224 -> 60,998 (+774), of
+# which imdct_512 is +799 ON UNCHANGED RTL -- the same Quartus 17 mapping cliff the
+# branch-A ledger entry describes (3,228 on main, 4,014 on the cdda branch, 4,027
+# here; same memories/regs/DSPs). Without it the branch is ~ -25 ALUTs (dvd_vm
+# -148, pgc_palette -55, pts_assoc +29, dvd_telem +5, the rest noise).
+# ⚠ So this fit does NOT show the branch's ALM effect: placed ALMs are unchanged
+# (40,821 -> 40,823) because the reclaimed flops were paid straight back into the
+# imdct cliff. Re-fit after branch A merges (its (x,y,w1,w2) form held at
+# 3,147-3,254 on two netlists) before reading any ALM number off this branch.
 set_global_assignment -name SEED 7

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -1074,4 +1074,14 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # vs main), RAM 501/553, DSP 94/112. Build DVD_almreclaimnav_20260911_0244.rbf.
 # Synthesis vs v0.5.0 main: regs 51,954 -> 49,890 (-2,064), ALUTs +551 with the
 # imdct cliff at +782 again (same RTL). The alsa entity is gone from the netlist.
+# 2026-09-11c (feature/alm-reclaim-nav REBASED ONTO main after branch A merged as
+# PR #82): SEED 7 held FIRST roll -- clk_dec 96.76 @100C / 92.13 @-40C (gate 86.0,
+# PASS both corners; the widest hot-corner margin this ledger records) at 88% ALM
+# (36,833 needed; 40,059 PLACED = 96%), registers 50,328, RAM 501/553, DSP 94/112.
+# Build DVD_almreclaimnav_20260911_2010.rbf.
+# Synthesis vs v0.5.0 main: ALUTs 60,224 -> 57,342 (-2,882), regs 51,954 -> 49,736
+# (-2,218). imdct_512 is 3,148 -- the cliff the two entries above describe is GONE
+# with branch A's operand-mux form underneath, so the two branches now simply add:
+# bit_allocation 2,497 -> 1,044, mantissa_dequant 1,861 -> 1,377, dvd_vm -150,
+# pgc_palette -55/-359 regs, pts_assoc -732 regs, dvd_telem -264 regs, alsa gone.
 set_global_assignment -name SEED 7

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -1068,4 +1068,10 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # (40,821 -> 40,823) because the reclaimed flops were paid straight back into the
 # imdct cliff. Re-fit after branch A merges (its (x,y,w1,w2) form held at
 # 3,147-3,254 on two netlists) before reading any ALM number off this branch.
+# 2026-09-11b (feature/alm-reclaim-nav + MISTER_DISABLE_ALSA): SEED 7 held FIRST
+# roll -- clk_dec 92.64 @100C / 91.97 @-40C (gate 86.0, PASS both corners) at 92%
+# ALM (38,601 needed; 40,615 PLACED = 97%, -206 vs main), registers 50,167 (-2,071
+# vs main), RAM 501/553, DSP 94/112. Build DVD_almreclaimnav_20260911_0244.rbf.
+# Synthesis vs v0.5.0 main: regs 51,954 -> 49,890 (-2,064), ALUTs +551 with the
+# imdct cliff at +782 again (same RTL). The alsa entity is gone from the netlist.
 set_global_assignment -name SEED 7

--- a/bench/dvd/dvd_telem_tb.sv
+++ b/bench/dvd/dvd_telem_tb.sv
@@ -65,7 +65,7 @@ module dvd_telem_tb;
             if (disturb) begin
                 refreshes = 16'hAAAA; pickups = 16'hBBBB; lates = 16'hCCCC;
                 drops = 16'hDDDD; vid_err = 16'hEEEE;
-                repeat (8) @(negedge clk);     // let the syncs settle too
+                repeat (64) @(negedge clk);    // let the sampler walk all 19 sources (57 cycles since the 2026-09-10 area pass)
             end
             for (i = 1; i <= 10; i = i + 1) begin
                 strobe(16'd0);
@@ -89,7 +89,7 @@ module dvd_telem_tb;
 
     reg drove;
     initial begin
-        repeat (20) @(negedge clk);
+        repeat (64) @(negedge clk);   // sampler rotation is 57 cycles (2026-09-10 area pass)
 
         $display("[1] matching command returns MAGIC then the counters");
         run_xact(16'h007A, 1'b0, drove);
@@ -120,7 +120,7 @@ module dvd_telem_tb;
         $display("[3] snapshot is atomic across a disturbed transaction");
         refreshes = 16'h1111; pickups = 16'h2222; lates = 16'h3333;
         drops = 16'h4444; vid_err = 16'h5555;
-        repeat (8) @(negedge clk);
+        repeat (64) @(negedge clk);   // sampler rotation is 57 cycles
         run_xact(16'h007A, 1'b1, drove);       // counters change mid-readout
         check("refreshes", got[1], 16'h1111);
         check("pickups",   got[2], 16'h2222);
@@ -135,17 +135,17 @@ module dvd_telem_tb;
 
         $display("[5] CMD_AF reports the audio link format, independently of 0x7A");
         af_pt = 1; af_pcm = 0;                 // Passthru, bitstream content
-        repeat (8) @(negedge clk);
+        repeat (64) @(negedge clk);   // sampler rotation is 57 cycles
         run_xact(16'h007B, 1'b0, drove);
         if (!drove) begin
             $display("  FAIL: CMD_AF did not drive the bus"); errors = errors + 1; end
         check("afmt-bitstream", got[1], 16'h0001);
         af_pcm = 1;                            // ...now an LPCM/MP2 track
-        repeat (8) @(negedge clk);
+        repeat (64) @(negedge clk);   // sampler rotation is 57 cycles
         run_xact(16'h007B, 1'b0, drove);
         check("afmt-pcm", got[1], 16'h0003);
         af_pt = 0; af_pcm = 0;                 // back to Decode
-        repeat (8) @(negedge clk);
+        repeat (64) @(negedge clk);   // sampler rotation is 57 cycles
         run_xact(16'h007B, 1'b0, drove);
         check("afmt-decode", got[1], 16'h0000);
         // ...and the diagnostic snapshot is untouched by any of it.

--- a/bench/dvd/dvd_vm_tb.sv
+++ b/bench/dvd/dvd_vm_tb.sv
@@ -1437,7 +1437,11 @@ module dvd_vm_tb;
         for (k = 0; k < n; k = k + 1) begin
             @(negedge clk); sec_tick = 1;
             @(negedge clk); sec_tick = 0;
-            repeat (4) @(negedge clk);   // let V_IDLE apply tick_pending
+            // let V_IDLE apply tick_pending: since the 2026-09-10 area pass
+            // the tick is a 16-cycle walk (one GPRM per cycle), not a single
+            // cycle, so consecutive ticks need > 16 idle cycles between them
+            // to each be applied -- real ticks are 27 million cycles apart.
+            repeat (20) @(negedge clk);
         end
     end
     endtask

--- a/docs/logic_reclaim.md
+++ b/docs/logic_reclaim.md
@@ -56,7 +56,16 @@ The recurring pattern this time was not memory but **Quartus muxing RESULTS acro
 mutually exclusive FSM states**: every inlined function call, every per-state copy of an
 adder, is its own datapath.
 
-## 3. Branch A — `feature/alm-reclaim-ac3` (✅ built, ⏳ HW gate)
+## 3. Branch A — `feature/alm-reclaim-ac3` (✅ built, ✅ HW-CONFIRMED 2026-09-11)
+
+**HW round (maintainer's rig, `DVD_almreclaim_20260911_0138.rbf`):** `audio_check` on Men
+in Black — all four AC-3 tracks audible (5.1 main −26.2 dBFS RMS, the others −31 to −42,
+gate −80, digital silence reads −999); a controlled single capture of an LPCM VOB
+(−51.9 dBFS RMS, −35 peak) and of an MP2 VCD (−44.3 / −20.3 at 44.1 kHz); Passthru with
+steady telemetry (ring parked at 34 frames, video 2.497 refreshes/frame, no drain-gate
+closures — no AC-3 receiver on the rig, so the bitstream itself is not decodable there, as
+always); video pacing on the feature 2.49955 refreshes per picked-up frame, 23.973 fps,
+audio 47,997.6 Hz, zero lates, zero drops over 46 s.
 
 Detail in `docs/ac3_decoder_architecture.md` §4.12 and the DVD.qsf ledger. Every commit
 gated by `bench/ac3/run_front_cosim.sh` (bap bit-exact vs liba52 on 13 streams) **and PCM

--- a/docs/logic_reclaim.md
+++ b/docs/logic_reclaim.md
@@ -66,7 +66,24 @@ Synthesis result **−2,544 ALUTs**; fit SEED 7 first roll, clk_dec 93.66 / 90.8
 Found en route: `bench/ac3/run_balloc.sh` had been failing silently since M19d (stale
 combinational delta-BA model, vvp exit 0). Fixed and `$fatal`ed before the refactor.
 
-## 4. Branch B — `feature/alm-reclaim-nav` (✅ built, ⏳ HW gate)
+## 4. Branch B — `feature/alm-reclaim-nav` (✅ built, ✅ HW-CONFIRMED 2026-09-11)
+
+**HW round (maintainer's rig, `DVD_almreclaimnav_20260911_0244.rbf`):** Men in Black
+navigation diffed against libdvdnav (FP → 1 → 2, no differences); the `O[2]` blocks decode
+exactly as before (highlight armed, subpicture shown, recolour fired — the 2-bit colour code
+expands to the same four colours); the palette convert-on-write renders the MiB menu's
+button/text colours correctly by eye; the rewritten telemetry sampler reads 47,999.5 Hz
+audio (−11 ppm) and 2.496 refreshes per frame on the feature — identical to Branch A —
+and a direct three-sample delta of `aud_play` gave exactly 3,000 counts/s; Scene It boots
+to its main menu (PGC 14, armed) with the serialised counter tick and button 1 starts the
+game. ⚠ A 30 s `telem --watch` over the MiB MENU read 69.5 kHz: that is the harness's
+16-bit unwrap being fooled by the counter reset at a menu-loop restart, not the sampler
+(the same window on the feature reads 48 kHz).
+⚠ **Pre-existing, NOT this branch:** `nav_diff` on ULTIMATE_T2 (`--script "1 2"`) reports
+button 1 landing in PGC 5 / VTS 4 on the board where libdvdnav lands in VTSM PGC 1 — the
+v0.5.0 build on the same rig gives the identical result. libdvdnav presses 1 at a
+two-button VTSM menu; the board parks on a title-domain still first (trajectory 3 3 1 1 1*),
+so the same digit is pressed at different menus. Worth its own issue.
 
 **Fit (SEED 7, first roll, cut from `main`):** clk_dec 89.73 / 89.42, "needed" 38,768,
 placed 40,823 (unchanged), registers 51,954 → 50,578 (**−1,376**), ALUTs +774 — **of

--- a/docs/logic_reclaim.md
+++ b/docs/logic_reclaim.md
@@ -56,16 +56,7 @@ The recurring pattern this time was not memory but **Quartus muxing RESULTS acro
 mutually exclusive FSM states**: every inlined function call, every per-state copy of an
 adder, is its own datapath.
 
-## 3. Branch A — `feature/alm-reclaim-ac3` (✅ built, ✅ HW-CONFIRMED 2026-09-11)
-
-**HW round (maintainer's rig, `DVD_almreclaim_20260911_0138.rbf`):** `audio_check` on Men
-in Black — all four AC-3 tracks audible (5.1 main −26.2 dBFS RMS, the others −31 to −42,
-gate −80, digital silence reads −999); a controlled single capture of an LPCM VOB
-(−51.9 dBFS RMS, −35 peak) and of an MP2 VCD (−44.3 / −20.3 at 44.1 kHz); Passthru with
-steady telemetry (ring parked at 34 frames, video 2.497 refreshes/frame, no drain-gate
-closures — no AC-3 receiver on the rig, so the bitstream itself is not decodable there, as
-always); video pacing on the feature 2.49955 refreshes per picked-up frame, 23.973 fps,
-audio 47,997.6 Hz, zero lates, zero drops over 46 s.
+## 3. Branch A — `feature/alm-reclaim-ac3` (✅ built, ⏳ HW gate)
 
 Detail in `docs/ac3_decoder_architecture.md` §4.12 and the DVD.qsf ledger. Every commit
 gated by `bench/ac3/run_front_cosim.sh` (bap bit-exact vs liba52 on 13 streams) **and PCM
@@ -75,7 +66,15 @@ Synthesis result **−2,544 ALUTs**; fit SEED 7 first roll, clk_dec 93.66 / 90.8
 Found en route: `bench/ac3/run_balloc.sh` had been failing silently since M19d (stale
 combinational delta-BA model, vvp exit 0). Fixed and `$fatal`ed before the refactor.
 
-## 4. Branch B — `feature/alm-reclaim-nav` (in progress)
+## 4. Branch B — `feature/alm-reclaim-nav` (✅ built, ⏳ HW gate)
+
+**Fit (SEED 7, first roll, cut from `main`):** clk_dec 89.73 / 89.42, "needed" 38,768,
+placed 40,823 (unchanged), registers 51,954 → 50,578 (**−1,376**), ALUTs +774 — **of
+which +799 is the IMDCT mapping cliff on RTL this branch does not touch** (3,228 on
+`main`, 4,027 here). Own modules: pts_assoc −732 regs, pgc_palette −359 regs / −55
+ALUTs, dvd_telem −264 regs, dvd_vm −148 ALUTs. ⚠ Read no ALM figure off this fit until
+the branch is re-fit on top of Branch A, whose regular operand-mux form held the IMDCT
+at 3,147–3,254 across two netlists. Build `DVD_almreclaimnav_20260911_0214.rbf`.
 
 | item | change | gate |
 |---|---|---|

--- a/docs/logic_reclaim.md
+++ b/docs/logic_reclaim.md
@@ -75,6 +75,9 @@ which +799 is the IMDCT mapping cliff on RTL this branch does not touch** (3,228
 ALUTs, dvd_telem −264 regs, dvd_vm −148 ALUTs. ⚠ Read no ALM figure off this fit until
 the branch is re-fit on top of Branch A, whose regular operand-mux form held the IMDCT
 at 3,147–3,254 across two netlists. Build `DVD_almreclaimnav_20260911_0214.rbf`.
+**Rebuilt with `MISTER_DISABLE_ALSA` (SEED 7, first roll):** clk_dec 92.64 / 91.97,
+registers **52,238 → 50,167**, placed ALMs 40,821 → 40,615, the `alsa` entity gone; ALUTs
++551 of which the IMDCT cliff is +782. Build `DVD_almreclaimnav_20260911_0244.rbf`.
 
 | item | change | gate |
 |---|---|---|

--- a/docs/logic_reclaim.md
+++ b/docs/logic_reclaim.md
@@ -75,7 +75,13 @@ Synthesis result **−2,544 ALUTs**; fit SEED 7 first roll, clk_dec 93.66 / 90.8
 Found en route: `bench/ac3/run_balloc.sh` had been failing silently since M19d (stale
 combinational delta-BA model, vvp exit 0). Fixed and `$fatal`ed before the refactor.
 
-## 4. Branch B — `feature/alm-reclaim-nav` (✅ built, ✅ HW-CONFIRMED 2026-09-11)
+## 4. Branch B — `feature/alm-reclaim-nav` (✅ built, ✅ HW-CONFIRMED 2026-09-11, rebased onto A)
+
+**Re-fit on top of Branch A (SEED 7, first roll):** clk_dec **96.76 / 92.13**, "needed"
+36,833 (88 %), placed 40,059, ALUTs 60,642 → **57,723** and registers 52,238 → **50,328**
+against v0.5.0 — the IMDCT cliff is gone (3,148 ALUTs) and the two branches' savings add.
+Build `DVD_almreclaimnav_20260911_2010.rbf`. The two paragraphs below record the earlier
+`main`-based fits and remain true of them.
 
 **HW round (maintainer's rig, `DVD_almreclaimnav_20260911_0244.rbf`):** Men in Black
 navigation diffed against libdvdnav (FP → 1 → 2, no differences); the `O[2]` blocks decode

--- a/dvd/dvd_telem.sv
+++ b/dvd/dvd_telem.sv
@@ -54,23 +54,13 @@
 // ⚠ CDC IS A STABILITY FILTER, NOT A PLAIN 2-FF SYNC. These are multi-bit
 // BINARY counters from clk_dec/clk_mem: catching one mid-increment can read
 // 0x00FF as 0x01FF -- not a small error, a wild one, and a single bad sample
-// corrupts a rate measurement. telem_sync commits a value only when two
+// corrupts a rate measurement. The sampler commits a value only when two
 // consecutive samples agree, which is cheap and sufficient because nothing here
 // advances faster than ~60 Hz against a 27 MHz clock.
 //============================================================================
 
-module telem_sync #(parameter W = 16) (
-    input              clk,
-    input      [W-1:0] d,
-    output reg [W-1:0] q
-);
-    reg [W-1:0] s1, s2;
-    always @(posedge clk) begin
-        s1 <= d;
-        s2 <= s1;
-        if (s1 == s2) q <= s2;      // commit only a value seen twice running
-    end
-endmodule
+// (telem_sync, the per-source 3-register filter, was retired by the 2026-09-10
+//  area pass in favour of the shared round-robin sampler inside dvd_telem.)
 
 
 module dvd_telem #(
@@ -121,32 +111,69 @@ module dvd_telem #(
     input         af_pcm_session          // ...and the current content is LPCM/MP2
 );
 
-    wire [15:0] s_refresh, s_pickup, s_late, s_drop, s_viderr, s_costs, s_aud;
-    wire  [7:0] s_vbuf, s_flags;
-    telem_sync #(16) u_ref (clk, refreshes,  s_refresh);
-    telem_sync #(16) u_pck (clk, pickups,    s_pickup);
-    telem_sync #(16) u_lat (clk, lates,      s_late);
-    telem_sync #(16) u_drp (clk, drops,      s_drop);
-    telem_sync #(16) u_err (clk, vid_err,    s_viderr);
-    telem_sync #(16) u_cst (clk, drop_costs, s_costs);
-    telem_sync #(16) u_aud (clk, aud_frames, s_aud);
-    telem_sync #(8)  u_vbf (clk, vbuf_fill,  s_vbuf);
-    telem_sync #(8)  u_flg (clk, flags,      s_flags);
-    wire [15:0] s_play, s_gate;
-    telem_sync #(16) u_ply (clk, aud_play,   s_play);
-    telem_sync #(16) u_gat (clk, aud_gate,   s_gate);
-    wire [15:0] s_dlag, s_perr, s_drift;
-    telem_sync #(16) u_dlg (clk, disp_lag,   s_dlag);
-    telem_sync #(16) u_per (clk, play_err,   s_perr);
-    telem_sync #(16) u_dft (clk, av_drift,   s_drift);
-    wire [15:0] s_sfl, s_sdu;
-    telem_sync #(16) u_sfl (clk, sched_flags, s_sfl);
-    telem_sync #(16) u_sdu (clk, sched_dur,   s_sdu);
+    // ---- ONE round-robin two-consecutive-agree sampler (area pass 2026-09-10) --
+    // This used to be 19 telem_sync instances, each holding s1/s2/q = three
+    // copies of its word (864 flops for 288 bits of data). The filter needs
+    // two consecutive samples of ONE source to agree; nothing here changes
+    // faster than ~60 Hz, so one sampler can walk the 19 sources in turn --
+    // sample source n at cycle A, sample it again at cycle B, commit q[n] at
+    // C if the two registered samples agree -- and every q is refreshed every
+    // 57 cycles (2.1 us at 27 MHz) instead of every cycle. Same filter, same
+    // registered-sample commit (never the raw asynchronous input), 1/3 the
+    // flops. The atomic snapshot below is untouched: q[] is latched together
+    // on the command strobe exactly as the 19 outputs were.
+    localparam int NSRC = 19;
+    wire [15:0] src [0:NSRC-1];
+    assign src[0]  = refreshes;
+    assign src[1]  = pickups;
+    assign src[2]  = lates;
+    assign src[3]  = drops;
+    assign src[4]  = vid_err;
+    assign src[5]  = drop_costs;
+    assign src[6]  = aud_frames;
+    assign src[7]  = {8'd0, vbuf_fill};
+    assign src[8]  = {8'd0, flags};
+    assign src[9]  = aud_play;
+    assign src[10] = aud_gate;
+    assign src[11] = disp_lag;
+    assign src[12] = play_err;
+    assign src[13] = av_drift;
+    assign src[14] = sched_flags;
+    assign src[15] = sched_dur;
+    assign src[16] = {14'd0, af_pcm_session, af_passthru};
+    assign src[17] = 16'd0;                 // spare slots keep the walk a plain counter
+    assign src[18] = 16'd0;
 
-    // Two-consecutive-agree filter, same as the counters: these cross from clk_sys
-    // and Main reads them asynchronously.
-    wire [15:0] s_afmt;
-    telem_sync #(16) u_afm (clk, {14'd0, af_pcm_session, af_passthru}, s_afmt);
+    reg  [4:0]  cur;                        // source being sampled
+    reg  [1:0]  sph;                        // 0: sample A, 1: sample B, 2: compare+commit
+    reg  [15:0] s1, s2;
+    reg  [15:0] q [0:NSRC-1];
+    integer qi;
+    // Power-up state (this module has no reset; telem_sync never needed one
+    // because its samplers free-ran, but a walk needs a defined cursor).
+    initial begin
+        cur = 5'd0; sph = 2'd0;
+        for (qi = 0; qi < NSRC; qi = qi + 1) q[qi] = 16'd0;
+    end
+    always @(posedge clk) begin
+        case (sph)
+            2'd0: begin s1 <= src[cur]; sph <= 2'd1; end
+            2'd1: begin s2 <= src[cur]; sph <= 2'd2; end
+            default: begin
+                if (s1 == s2) q[cur] <= s2;   // commit only a value seen twice running
+                cur <= (cur == NSRC - 1) ? 5'd0 : cur + 5'd1;
+                sph <= 2'd0;
+            end
+        endcase
+    end
+
+    wire [15:0] s_refresh = q[0],  s_pickup = q[1],  s_late  = q[2],  s_drop  = q[3];
+    wire [15:0] s_viderr  = q[4],  s_costs  = q[5],  s_aud   = q[6];
+    wire  [7:0] s_vbuf    = q[7][7:0], s_flags = q[8][7:0];
+    wire [15:0] s_play    = q[9],  s_gate   = q[10];
+    wire [15:0] s_dlag    = q[11], s_perr   = q[12], s_drift = q[13];
+    wire [15:0] s_sfl     = q[14], s_sdu    = q[15];
+    wire [15:0] s_afmt    = q[16];
 
     reg  [3:0] wcnt;
     reg        active;

--- a/dvd/dvd_vm.sv
+++ b/dvd/dvd_vm.sv
@@ -257,6 +257,7 @@ wire [15:0] lfsr_seed = (|rnd_seed) ? rnd_seed : 16'hACE1;
 // 1 Hz counter-mode GPRM tick, idle-gated: a sec_tick sets tick_pending, which
 // is applied in V_IDLE (never during a command, so it can't race a GPRM write).
 reg tick_pending;
+reg [3:0] tick_i;              // serial walk cursor (area pass 2026-09-10)
 
 // SPRM read mux (eval_reg, system half). Constants per libdvdnav vm_reset.
 function [15:0] sprm_read(input [4:0] r);
@@ -662,6 +663,7 @@ always @(posedge clk or negedge rst_n) begin
         sprm9 <= 16'd0;  sprm10 <= 16'd0; sprm13 <= 16'd15;
         lfsr  <= lfsr_seed;
         tick_pending <= 1'b0;
+        tick_i <= 4'd0;
         ins   <= 64'd0;
         blk   <= BLK_PRE;
         nat_src <= 1'b0;
@@ -786,6 +788,7 @@ always @(posedge clk or negedge rst_n) begin
             sprm9 <= 16'd0;  sprm10 <= 16'd0; sprm13 <= 16'd15;
             lfsr  <= lfsr_seed;         // re-seed rnd from the mount-time entropy
             tick_pending <= 1'b0;
+            tick_i <= 4'd0;
             rsm_vts <= 8'd0;
             vm_dom <= DOM_TT; vm_vts <= 8'd0;
             skip_pre <= 1'b0;
@@ -815,10 +818,20 @@ always @(posedge clk or negedge rst_n) begin
                 //  - fold user-input timing into the rnd LFSR so rnd varies
                 //    per play even for discs (e.g. Scene It HP) that seed only
                 //    from rnd. See docs/dvd_vm.md "DVD-game entropy".
+                // Area pass 2026-09-10: the tick used to increment all 16
+                // GPRMs in one cycle -- 16 parallel 16-bit incrementers plus a
+                // unique data source on every GPRM write mux -- for a 1 Hz
+                // event. It now walks one GPRM per V_IDLE cycle (tick_i) and
+                // holds event dispatch below until the walk completes, so no
+                // command can observe a half-applied tick; the walk takes 16
+                // cycles at 27 MHz, invisible against a 1 s tick. A sec_tick
+                // arriving mid-walk re-arms tick_pending exactly as before
+                // (one flag, merged), and the NBA ordering with the set at the
+                // end of this block is unchanged.
                 if (tick_pending) begin
-                    for (gi = 0; gi < 16; gi = gi + 1)
-                        if (gprm_mode[gi]) gprm[gi] <= gprm[gi] + 16'd1;
-                    tick_pending <= 1'b0;
+                    if (gprm_mode[tick_i]) gprm[tick_i] <= gprm[tick_i] + 16'd1;
+                    tick_i <= tick_i + 4'd1;
+                    if (tick_i == 4'd15) tick_pending <= 1'b0;
                 end
                 // Zero-guard: an all-zero LFSR is a LOCKUP (lfsr_next of 0 is
                 // 0, so every later rnd returns 1 forever). The XOR can land
@@ -827,7 +840,9 @@ always @(posedge clk or negedge rst_n) begin
                 if (entropy_stir)
                     lfsr <= (|(lfsr ^ entropy_val)) ? (lfsr ^ entropy_val)
                                                     : 16'hACE1;
-                if (!enable) begin
+                if (tick_pending) begin
+                    // counter-mode walk in progress: hold dispatch (see above)
+                end else if (!enable) begin
                     ev_boot <= 1'b0; ev_loaded <= 1'b0; ev_error <= 1'b0;
                     ev_btn  <= 1'b0; ev_menu <= 1'b0; ev_resume <= 1'b0;
                     ev_title <= 1'b0; ev_return <= 1'b0;

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -1985,11 +1985,11 @@ wire pause_aud = pause_q | hold_freeze;
 // instant does not. Falls back to the counter alone if the framework never
 // sends it (TIMESTAMP stays 0). See docs/dvd_vm.md "DVD-game entropy".
 wire [32:0] hps_timestamp;
-reg  [31:0] entropy_ctr = 32'd0;
+reg  [15:0] entropy_ctr = 16'd0;   // 16 bits: every consumer reads [15:0] or less (area pass 2026-09-10)
 reg  [24:0] sec_div     = 25'd0;
 reg         sec_tick    = 1'b0;
 always @(posedge clk_sys) begin
-    entropy_ctr <= entropy_ctr + 32'd1;
+    entropy_ctr <= entropy_ctr + 16'd1;
     if (sec_div == 25'd26_999_999) begin   // clk_sys = 27 MHz -> 1 Hz
         sec_div  <= 25'd0;
         sec_tick <= 1'b1;
@@ -5566,7 +5566,7 @@ idle_logo #(.LOGO_QX_LEAD(12'd12)) idle_logo_inst (
     .il_mode        (il_eff),
     .frame_tick     (av_refresh_tick),
     .vis            (logo_vis),
-    .entropy        (entropy_ctr),
+    .entropy        ({16'd0, entropy_ctr}),
     .ioctl_download (ioctl_download),
     .ioctl_wr       (ioctl_wr),
     .ioctl_addr     (ioctl_addr),
@@ -5642,17 +5642,24 @@ subpic_blend subpic_blend_inst (
 //     coli + subpicture): its PRESENCE = armed, its POSITION = the rect coords.
 // Registered => hotspot-safe; zero effect with O[2] Off.
 wire        dbg_hl_en = status[2] && menus_on;
-wire        dbg_blk1  = (ov_h_gen >= 12'd8)  && (ov_h_gen < 12'd24) &&
-                        (core_v_pos >= 12'd8)  && (core_v_pos < 12'd24);
-wire        dbg_blk2  = (ov_h_gen >= 12'd28) && (ov_h_gen < 12'd44) &&
-                        (core_v_pos >= 12'd8)  && (core_v_pos < 12'd24);
-wire        dbg_blk3  = (ov_h_gen >= 12'd48) && (ov_h_gen < 12'd64) &&
-                        (core_v_pos >= 12'd8)  && (core_v_pos < 12'd24);
+// Area pass 2026-09-10: the 13 blocks used to carry FOUR independent 12-bit
+// magnitude compares each (52 comparators) for what is 5 X-windows x 3 Y-bands;
+// factor the windows once and AND them. Bit-identical.
+wire        dbg_x0 = (ov_h_gen >= 12'd8)  && (ov_h_gen < 12'd24);
+wire        dbg_x1 = (ov_h_gen >= 12'd28) && (ov_h_gen < 12'd44);
+wire        dbg_x2 = (ov_h_gen >= 12'd48) && (ov_h_gen < 12'd64);
+wire        dbg_x3 = (ov_h_gen >= 12'd68) && (ov_h_gen < 12'd84);
+wire        dbg_x4 = (ov_h_gen >= 12'd88) && (ov_h_gen < 12'd104);
+wire        dbg_y0 = (core_v_pos >= 12'd8)  && (core_v_pos < 12'd24);
+wire        dbg_y1 = (core_v_pos >= 12'd30) && (core_v_pos < 12'd46);
+wire        dbg_y2 = (core_v_pos >= 12'd62) && (core_v_pos < 12'd78);
+wire        dbg_blk1  = dbg_x0 && dbg_y0;
+wire        dbg_blk2  = dbg_x1 && dbg_y0;
+wire        dbg_blk3  = dbg_x2 && dbg_y0;
 // block 4: SPU bytes reached spu_decode this frame (ps_demux routed the substream).
 // GREEN + block3 RED = SPU arrives but spu_decode won't commit/show (decode/PTS);
 // RED = ps_demux filtered it out (sp_track) or it isn't in the stream.
-wire        dbg_blk4  = (ov_h_gen >= 12'd68) && (ov_h_gen < 12'd84) &&
-                        (core_v_pos >= 12'd8)  && (core_v_pos < 12'd24);
+wire        dbg_blk4  = dbg_x3 && dbg_y0;
 // VBUF-LAG DIAGNOSIS (docs/dvd_menu_refinements.md §5) — second row + a bar.
 //   blk5 (v30..46, x8..24)  = vbuf_deep: GREEN = the fast-drain threshold tripped
 //                             (menu_ff engaged), RED = VBUF below 0x40 (menu_ff never
@@ -5663,10 +5670,8 @@ wire        dbg_blk4  = (ov_h_gen >= 12'd68) && (ov_h_gen < 12'd84) &&
 //     ~x72 (0x40) vbuf_deep should be set. HIGH bar at the blank frame => cell 0 IS
 //     buffered but not displayed (pickup/decode issue); LOW => cell 0 never reached the
 //     VBUF (keep_vbuf LinkPGCN junction dropped it).
-wire        dbg_blk5  = (ov_h_gen >= 12'd8)  && (ov_h_gen < 12'd24) &&
-                        (core_v_pos >= 12'd30) && (core_v_pos < 12'd46);
-wire        dbg_blk6  = (ov_h_gen >= 12'd28) && (ov_h_gen < 12'd44) &&
-                        (core_v_pos >= 12'd30) && (core_v_pos < 12'd46);
+wire        dbg_blk5  = dbg_x0 && dbg_y1;
+wire        dbg_blk6  = dbg_x1 && dbg_y1;
 // §7 return-highlight probes (2nd row): blk7 = hl_on_w (nav_pci armed AND fetched -
 // the render gate needs BOTH; block1 green + blk7 RED => the FETCH isn't completing).
 // blk8 = a highlight RECOLOUR pixel fired this frame (hl_use = inside the rect, class
@@ -5674,10 +5679,8 @@ wire        dbg_blk6  = (ov_h_gen >= 12'd28) && (ov_h_gen < 12'd44) &&
 // blk7 GREEN + blk8 RED => armed+fetched but no
 // class-1/2 subpicture pixel is landing in the button rect on the displayed frame
 // (the keep_vbuf display/parse skew), NOT a promotion/fetch fault.
-wire        dbg_blk7  = (ov_h_gen >= 12'd48) && (ov_h_gen < 12'd64) &&
-                        (core_v_pos >= 12'd30) && (core_v_pos < 12'd46);
-wire        dbg_blk8  = (ov_h_gen >= 12'd68) && (ov_h_gen < 12'd84) &&
-                        (core_v_pos >= 12'd30) && (core_v_pos < 12'd46);
+wire        dbg_blk7  = dbg_x2 && dbg_y1;
+wire        dbg_blk8  = dbg_x3 && dbg_y1;
 wire        dbg_vbar  = (core_v_pos >= 12'd50) && (core_v_pos < 12'd58) &&
                         (ov_h_gen >= 12'd8)  && (ov_h_gen < (12'd8 + {4'd0, vbuf_fill_s1}));
 // RASTER-TRIGGER ROW (single-raster analog, 2026-09-03; the RGBS/YPbPr "shake every
@@ -5693,16 +5696,11 @@ wire        dbg_vbar  = (core_v_pos >= 12'd50) && (core_v_pos < 12'd58) &&
 //   blk13 (x 88..104) Main re-wrote the cfg word AFTER its first write (OSD leave,
 //                     video_mode_adjust, [video=] section re-parse — informational)
 wire        dbg_r3_en = status[2] && interlaced_eff;
-wire        dbg_blk9  = (ov_h_gen >= 12'd8)  && (ov_h_gen < 12'd24) &&
-                        (core_v_pos >= 12'd62) && (core_v_pos < 12'd78);
-wire        dbg_blk10 = (ov_h_gen >= 12'd28) && (ov_h_gen < 12'd44) &&
-                        (core_v_pos >= 12'd62) && (core_v_pos < 12'd78);
-wire        dbg_blk11 = (ov_h_gen >= 12'd48) && (ov_h_gen < 12'd64) &&
-                        (core_v_pos >= 12'd62) && (core_v_pos < 12'd78);
-wire        dbg_blk12 = (ov_h_gen >= 12'd68) && (ov_h_gen < 12'd84) &&
-                        (core_v_pos >= 12'd62) && (core_v_pos < 12'd78);
-wire        dbg_blk13 = (ov_h_gen >= 12'd88) && (ov_h_gen < 12'd104) &&
-                        (core_v_pos >= 12'd62) && (core_v_pos < 12'd78);
+wire        dbg_blk9  = dbg_x0 && dbg_y2;
+wire        dbg_blk10 = dbg_x1 && dbg_y2;
+wire        dbg_blk11 = dbg_x2 && dbg_y2;
+wire        dbg_blk12 = dbg_x3 && dbg_y2;
+wire        dbg_blk13 = dbg_x4 && dbg_y2;
 // clk_dec events -> toggles (one flip per event), 2-FF synced, edge-detected in clk_sys
 reg         wd_rst_q, wd_tgl, vs0_q, vs0_tgl;
 always @(posedge clk_dec) begin
@@ -5764,57 +5762,35 @@ always @(posedge clk_sys) begin
     if (~core_vs_prev_sys & core_v_sync) begin hlvis_seen_l <= hlvis_seen; hlvis_seen <= 1'b0; end
     else if (hl_use_q)                   hlvis_seen <= 1'b1;
 end
-reg  [7:0]  dbg_r_q, dbg_g_q, dbg_b_q;
+// Area pass 2026-09-10: the blocks only ever show four colours, so the
+// priority chain below resolves to a 2-bit code and the output mux expands it
+// (was three 8-bit registers fed by a 14-way 24-bit chain).
+localparam [1:0] DBG_RED = 2'd0, DBG_GREEN = 2'd1, DBG_CYAN = 2'd2, DBG_MAGENTA = 2'd3;
+reg  [1:0]  dbg_col_q;
 reg         dbg_px_q;
+wire [7:0]  dbg_r_q = (dbg_col_q == DBG_RED   || dbg_col_q == DBG_MAGENTA) ? 8'hFF : 8'h00;
+wire [7:0]  dbg_g_q = (dbg_col_q == DBG_GREEN || dbg_col_q == DBG_CYAN)    ? 8'hFF : 8'h00;
+wire [7:0]  dbg_b_q = (dbg_col_q == DBG_CYAN  || dbg_col_q == DBG_MAGENTA) ? 8'hFF : 8'h00;
 always @(posedge clk_sys) begin
     dbg_px_q <= (dbg_hl_en && (dbg_blk1 || dbg_blk2 || dbg_blk3 || dbg_blk4 ||
                                dbg_blk5 || dbg_blk6 || dbg_blk7 || dbg_blk8 || dbg_vbar ||
                                (hl_btns_armed && dbg_rectb)))
              || (dbg_r3_en && (dbg_blk9 || dbg_blk10 || dbg_blk11 || dbg_blk12 || dbg_blk13));
-    if (dbg_blk1) begin
-        dbg_r_q <= hl_btns_armed ? 8'h00 : 8'hFF;
-        dbg_g_q <= hl_btns_armed ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
-    end else if (dbg_blk2) begin
-        dbg_r_q <= video_live_s2 ? 8'h00 : 8'hFF;
-        dbg_g_q <= video_live_s2 ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
-    end else if (dbg_blk3) begin
-        dbg_r_q <= sp_seen_l ? 8'h00 : 8'hFF;
-        dbg_g_q <= sp_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
-    end else if (dbg_blk4) begin
-        dbg_r_q <= spb_seen_l ? 8'h00 : 8'hFF;
-        dbg_g_q <= spb_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
-    end else if (dbg_blk5) begin                                 // vbuf_deep (menu_ff engaged)
-        dbg_r_q <= vbuf_deep ? 8'h00 : 8'hFF;
-        dbg_g_q <= vbuf_deep ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
-    end else if (dbg_blk6) begin                                 // still_active (reader parked)
-        dbg_r_q <= still_active ? 8'h00 : 8'hFF;
-        dbg_g_q <= still_active ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
-    end else if (dbg_blk7) begin                                 // hl_on_w = armed AND fetched
-        dbg_r_q <= hl_on_w ? 8'h00 : 8'hFF;
-        dbg_g_q <= hl_on_w ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
-    end else if (dbg_blk8) begin                                 // recolour fired this frame
-        dbg_r_q <= hlvis_seen_l ? 8'h00 : 8'hFF;
-        dbg_g_q <= hlvis_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
-    end else if (dbg_blk9) begin                                 // raster row: watchdog expired
-        dbg_r_q <= wd_seen_l ? 8'h00 : 8'hFF;
-        dbg_g_q <= wd_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
-    end else if (dbg_blk10) begin                                // raster row: il_switch fired
-        dbg_r_q <= ils_seen_l ? 8'h00 : 8'hFF;
-        dbg_g_q <= ils_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
-    end else if (dbg_blk11) begin                                // raster row: pal_eff changed
-        dbg_r_q <= pal_seen_l ? 8'h00 : 8'hFF;
-        dbg_g_q <= pal_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
-    end else if (dbg_blk12) begin                                // raster row: vertical_size hit 0
-        dbg_r_q <= vs0_seen_l ? 8'h00 : 8'hFF;
-        dbg_g_q <= vs0_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
-    end else if (dbg_blk13) begin                                // raster row: cfg re-written
-        dbg_r_q <= cfg_seen_l ? 8'h00 : 8'hFF;
-        dbg_g_q <= cfg_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
-    end else if (dbg_vbar) begin                                 // VBUF occupancy bar (cyan)
-        dbg_r_q <= 8'h00; dbg_g_q <= 8'hFF; dbg_b_q <= 8'hFF;
-    end else begin
-        dbg_r_q <= 8'hFF; dbg_g_q <= 8'h00; dbg_b_q <= 8'hFF;   // magenta rect border
-    end
+    if (dbg_blk1) dbg_col_q <= hl_btns_armed ? DBG_GREEN : DBG_RED;
+    else if (dbg_blk2) dbg_col_q <= video_live_s2 ? DBG_GREEN : DBG_RED;
+    else if (dbg_blk3) dbg_col_q <= sp_seen_l ? DBG_GREEN : DBG_RED;
+    else if (dbg_blk4) dbg_col_q <= spb_seen_l ? DBG_GREEN : DBG_RED;
+    else if (dbg_blk5) dbg_col_q <= vbuf_deep ? DBG_GREEN : DBG_RED;   // vbuf_deep (menu_ff engaged)
+    else if (dbg_blk6) dbg_col_q <= still_active ? DBG_GREEN : DBG_RED; // still_active (reader parked)
+    else if (dbg_blk7) dbg_col_q <= hl_on_w ? DBG_GREEN : DBG_RED;     // hl_on_w = armed AND fetched
+    else if (dbg_blk8) dbg_col_q <= hlvis_seen_l ? DBG_GREEN : DBG_RED; // recolour fired this frame
+    else if (dbg_blk9) dbg_col_q <= wd_seen_l ? DBG_GREEN : DBG_RED;   // raster row: watchdog expired
+    else if (dbg_blk10) dbg_col_q <= ils_seen_l ? DBG_GREEN : DBG_RED; // raster row: il_switch fired
+    else if (dbg_blk11) dbg_col_q <= pal_seen_l ? DBG_GREEN : DBG_RED; // raster row: pal_eff changed
+    else if (dbg_blk12) dbg_col_q <= vs0_seen_l ? DBG_GREEN : DBG_RED; // raster row: vertical_size hit 0
+    else if (dbg_blk13) dbg_col_q <= cfg_seen_l ? DBG_GREEN : DBG_RED; // raster row: cfg re-written
+    else if (dbg_vbar) dbg_col_q <= DBG_CYAN;                            // VBUF occupancy bar
+    else               dbg_col_q <= DBG_MAGENTA;                         // rect border
 end
 
 // =========================================================================

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -589,7 +589,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "dev-almreclaim"
+`define CORE_VERSION "dev-almreclaimnav"
 
 parameter CONF_STR = {
     "DVD;;",

--- a/dvd/nav_pci.sv
+++ b/dvd/nav_pci.sv
@@ -213,7 +213,9 @@ wire [9:0] cur = pci_frame_start ? 10'd0 : fidx;
 reg [23:0] facc;               // rolling accumulator (BE u32 assembly)
 reg [1:0]  f_ss;
 reg [31:0] f_vptm;             // pci_gi.vobu_s_ptm (schedules ss=0 disarms)
-reg [31:0] f_sptm, f_eptm;
+reg [31:0] f_sptm;
+reg        f_forever;          // hli_e_ptm == 0xFFFFFFFF (area pass 2026-09-10: the only
+                               // use of the 32-bit e_ptm was this all-ones test)
 reg [5:0]  f_btn_ns, f_fosl, f_foac;
 reg [1:0]  f_grns;             // hl_gi.btngr_ns (1..3; 0 treated as 1)
 reg [2:0]  f_g1ty, f_g2ty, f_g3ty;   // btngrX_dsp_ty (bit0 wide, bit1 LB, bit2 P&S)
@@ -261,7 +263,7 @@ endfunction
 // Committed (display) HLI state
 // =========================================================================
 reg        armed;
-reg [31:0] h_sptm;
+// (h_sptm, the committed HLI's s_ptm, was write-only and is gone -- area pass 2026-09-10)
 reg [5:0]  h_btn_ns, h_foac;
 reg [1:0]  h_grns;             // committed btngr_ns + per-group display types
 reg [2:0]  h_g1ty, h_g2ty, h_g3ty;
@@ -424,7 +426,6 @@ always @(posedge clk or negedge rst_n) begin
         armed     <= 1'b0;
         h_btn_ns  <= 6'd0;
         h_foac    <= 6'd0;
-        h_sptm    <= 32'd0;
         h_forever <= 1'b0;
         btn_sel   <= 6'd1;
         fstate    <= F_IDLE;
@@ -447,7 +448,7 @@ always @(posedge clk or negedge rst_n) begin
         coli_act  <= 32'd0;
         bsh       <= 56'd0;
         f_sptm    <= 32'd0;
-        f_eptm    <= 32'd0;
+        f_forever <= 1'b0;
         f_btn_ns  <= 6'd0;
         f_fosl    <= 6'd0;
         f_foac    <= 6'd0;
@@ -486,7 +487,7 @@ always @(posedge clk or negedge rst_n) begin
             10'h00F: f_vptm   <= {facc, pci_byte};   // pci_gi.vobu_s_ptm
             10'h061: f_ss     <= pci_byte[1:0];      // hli_ss (low 2 of u16)
             10'h065: f_sptm   <= {facc, pci_byte};   // hli_s_ptm
-            10'h069: f_eptm   <= {facc, pci_byte};   // hli_e_ptm
+            10'h069: f_forever<= (&facc) && (&pci_byte); // hli_e_ptm == 0xFFFFFFFF
             10'h06E: begin                           // btn_md hi: btngr_ns + gr1_dsp_ty
                 f_grns <= pci_byte[5:4];
                 f_g1ty <= pci_byte[2:0];
@@ -534,7 +535,7 @@ always @(posedge clk or negedge rst_n) begin
                     nxt_btn_ns<= f_btn_ns;
                     nxt_fosl  <= f_fosl;
                     nxt_foac  <= (f_ss == 2'd1) ? f_foac : 6'd0;
-                    nxt_forever<= (f_eptm == 32'hFFFF_FFFF);
+                    nxt_forever<= f_forever;
                     nxt_grns  <= f_grns;
                     nxt_g1ty  <= f_g1ty;
                     nxt_g2ty  <= f_g2ty;
@@ -566,7 +567,6 @@ always @(posedge clk or negedge rst_n) begin
             end else begin
                 disp_bank <= nxt_bank;
                 armed     <= 1'b1;
-                h_sptm    <= nxt_sptm;
                 h_btn_ns  <= nxt_btn_ns;
                 h_foac    <= nxt_foac;
                 h_forever <= nxt_forever;

--- a/dvd/pgc_palette.sv
+++ b/dvd/pgc_palette.sv
@@ -8,13 +8,16 @@
 // captures the 16 raw entries and converts them to 24-bit RGB so the display path
 // only does a flat 16:1 lookup.
 //
-// AREA/HOTSPOT NOTE: the conversion is NOT done per-pixel. A single round-robin
-// converter walks one entry per clk_sys cycle (cvt_i 0..15), so the whole table
-// re-derives within 16 cycles of a palette load — long before any pixel query that
-// matters — using ONE small constant-coefficient multiply datapath (shared across
-// all 16 entries). The per-pixel side is just `rgb[idx]`, 16 registers -> a 16:1
-// mux the caller pipelines. This keeps the display-path (X33_Y11..X44_Y22) cost to
-// a plain mux, not a colour-space converter.
+// AREA/HOTSPOT NOTE: the conversion is NOT done per-pixel. Each entry is
+// converted ONCE, the cycle after the reader writes it (convert-on-write), by
+// ONE small constant-coefficient multiply datapath. The per-pixel side is just
+// `rgb[idx]`, 16 registers -> a 16:1 mux the caller pipelines. This keeps the
+// display-path (X33_Y11..X44_Y22) cost to a plain mux, not a colour-space
+// converter. (Area pass 2026-09-10: this used to be a free-running round-robin
+// over a raw {Y,Cr,Cb} shadow of the table -- 384 flops plus three 16:1 read
+// muxes whose only purpose was to feed that walk. Converting the entry being
+// written removes the shadow outright; the reset defaults are now written
+// pre-converted.)
 //
 // Conversion: BT.601 studio-swing (DVD is limited-range Y in [16,235]):
 //   R = 1.164(Y-16) + 1.596(Cr-128)
@@ -39,11 +42,6 @@ module pgc_palette (
     output wire [7:0]  rgb_g,
     output wire [7:0]  rgb_b
 );
-    // Raw {Y, Cr, Cb} store (written 1 entry/cycle by the reader).
-    reg [7:0] raw_y  [0:15];
-    reg [7:0] raw_cr [0:15];
-    reg [7:0] raw_cb [0:15];
-
     // Converted RGB (the display-path lookup table).
     reg [7:0] r_mem [0:15];
     reg [7:0] g_mem [0:15];
@@ -53,14 +51,16 @@ module pgc_palette (
     assign rgb_g = g_mem[idx];
     assign rgb_b = b_mem[idx];
 
-    // Round-robin converter cursor.
-    reg [3:0] cvt_i;
+    // Convert-on-write pipeline: the entry the reader wrote last cycle.
+    reg        cv_we;
+    reg [3:0]  cv_addr;
+    reg [7:0]  cv_y, cv_cr, cv_cb;
 
-    // Signed differences for the current entry.
-    wire signed [9:0] yt  = $signed({2'b00, raw_y [cvt_i]}) - 10'sd16;   // Y-16  (>=0 clamp below)
-    wire signed [9:0] crm = $signed({2'b00, raw_cr[cvt_i]}) - 10'sd128;  // Cr-128
-    wire signed [9:0] cbm = $signed({2'b00, raw_cb[cvt_i]}) - 10'sd128;  // Cb-128
-    wire signed [9:0] ycl = (yt < 0) ? 10'sd0 : yt;                      // clamp Y-16 at 0
+    // Signed differences for the entry being converted.
+    wire signed [9:0] yt  = $signed({2'b00, cv_y })  - 10'sd16;   // Y-16  (>=0 clamp below)
+    wire signed [9:0] crm = $signed({2'b00, cv_cr})  - 10'sd128;  // Cr-128
+    wire signed [9:0] cbm = $signed({2'b00, cv_cb})  - 10'sd128;  // Cb-128
+    wire signed [9:0] ycl = (yt < 0) ? 10'sd0 : yt;               // clamp Y-16 at 0
 
     wire signed [31:0] r_acc = 298*ycl + 409*crm;
     wire signed [31:0] g_acc = 298*ycl - 100*cbm - 208*crm;
@@ -77,31 +77,42 @@ module pgc_palette (
         end
     endfunction
 
+    // Reset default, PRE-CONVERTED: entry 0 black, then the chroma-neutral
+    // grayscale ramp Y = 16 + 15k that the old raw defaults converted to --
+    // R = G = B = clip8(298 * 15k) (crm = cbm = 0), i.e. entries 1..15 =
+    // 17 34 52 69 87 104 122 139 157 174 192 209 226 244 255. Same table the
+    // round-robin used to produce, just present from the first cycle instead
+    // of the 16th. A literal, not a function: Quartus 17 has miscompiled small
+    // functions in this project before.
+    localparam [127:0] RAMP_TBL = {8'd255, 8'd244, 8'd226, 8'd209, 8'd192, 8'd174, 8'd157, 8'd139, 8'd122, 8'd104, 8'd87, 8'd69, 8'd52, 8'd34, 8'd17, 8'd0};   // entry 15 .. entry 0
+
     integer k;
     always @(posedge clk or negedge rst_n) begin
         if (!rst_n) begin
-            cvt_i <= 4'd0;
-            // Default: entry 0 black, entry 1 white, 2..15 a neutral grayscale ramp
-            // (all chroma-neutral). So a SPU shown before/without a PGC palette load
-            // (rare: palette straddles the PGC sector) still renders legibly with the
-            // spu_decode identity col map, rather than black-on-black. Round-robin
-            // conversion below keeps r/g/b in sync with these raws.
+            cv_we   <= 1'b0;
+            cv_addr <= 4'd0;
+            cv_y    <= 8'd0; cv_cr <= 8'd128; cv_cb <= 8'd128;
+            // Default (see RAMP_TBL): a SPU shown before/without a PGC palette load
+            // (rare: palette straddles the PGC sector) still renders legibly
+            // with the spu_decode identity col map, rather than black-on-black.
             for (k = 0; k < 16; k = k + 1) begin
-                raw_cr[k] <= 8'd128; raw_cb[k] <= 8'd128;   // neutral chroma
-                raw_y [k] <= (k == 0) ? 8'd16 : (8'd16 + k[3:0] * 8'd15);
-                r_mem [k] <= 8'd0;  g_mem [k] <= 8'd0;   b_mem [k] <= 8'd0;
+                r_mem[k] <= RAMP_TBL[k*8 +: 8];
+                g_mem[k] <= RAMP_TBL[k*8 +: 8];
+                b_mem[k] <= RAMP_TBL[k*8 +: 8];
             end
         end else begin
-            if (pal_we) begin
-                raw_y [pal_waddr] <= pal_wdata[23:16];
-                raw_cr[pal_waddr] <= pal_wdata[15:8];
-                raw_cb[pal_waddr] <= pal_wdata[7:0];
+            // Stage 1: capture the written entry.
+            cv_we   <= pal_we;
+            cv_addr <= pal_waddr;
+            cv_y    <= pal_wdata[23:16];
+            cv_cr   <= pal_wdata[15:8];
+            cv_cb   <= pal_wdata[7:0];
+            // Stage 2: convert it into the lookup table.
+            if (cv_we) begin
+                r_mem[cv_addr] <= clip8(r_acc);
+                g_mem[cv_addr] <= clip8(g_acc);
+                b_mem[cv_addr] <= clip8(b_acc);
             end
-            // Convert one entry per cycle (round-robin, continuous).
-            r_mem[cvt_i] <= clip8(r_acc);
-            g_mem[cvt_i] <= clip8(g_acc);
-            b_mem[cvt_i] <= clip8(b_acc);
-            cvt_i        <= cvt_i + 4'd1;
         end
     end
 

--- a/dvd/pts_assoc.sv
+++ b/dvd/pts_assoc.sv
@@ -13,19 +13,15 @@
 //    header the byte position of the picture start code the vld just parsed
 //           (getbits_fifo.bitpos - 32, same origin -- pinned by pts_assoc_tb)
 //
-//  A shift-register FIFO of {pts, stamp} (head always in slot 0, so the
-//  compare is a register read, never an async array read -- the LUT-RAM
-//  pattern this project keeps paying for). At every picture header ONE
+//  A FIFO of {pts, stamp}. The HEAD (and the entry behind it) live in
+//  registers so the compare below is a register read, never an async array
+//  read -- the LUT-RAM pattern this project keeps paying for; the rest of the
+//  queue is a sync-read circular buffer (area pass 2026-09-10: this was a
+//  16-deep shift register of 57-bit entries = 912 flops that packed at under
+//  two per ALM, 563 ALMs for a queue that is rarely more than 3 deep). At
+//  every picture header ONE
 //  decision, in one cycle: if the head stamp lies at or before the start code,
 //  pop it and it is this picture's tag; otherwise this picture has none.
-//  Entries that are still at or before the LAST header while the vld is
-//  parsing the picture body belong to no picture (a PES carrying a PTS but no
-//  access-unit start -- illegal, but seen) and are popped and discarded, so
-//  they can never be attached to a later picture. A stamp pushed after the
-//  vld already passed it (the PTS value arriving late through its CDC while
-//  the VBUF ran nearly empty) is discarded the same way: a lost tag, never a
-//  wrong one.
-//
 //  The tag is REGISTERED and held until the next header. motcomp_picbuf reads
 //  it at its STATE_UPDATE for the picture, which is >= 3 cycles after the
 //  header (update_picture_buffers -> mvec fifo -> picbuf) and can be no later
@@ -76,10 +72,26 @@ module pts_assoc #(
 );
 
     localparam int CW = $clog2(DEPTH + 1);
+    localparam int AW = $clog2(DEPTH);
+    localparam int EW = 33 + PW;               // one entry: {pts, pos}
 
-    logic [32:0]   pts_q   [DEPTH];
-    logic [PW-1:0] pos_q   [DEPTH];
+    // ---- entry store ----------------------------------------------------------
+    // Every accepted stamp is written to the ring at wr_ptr; the two entries at
+    // the read side (head = rd_ptr, nxt = rd_ptr+1) are ALSO held in registers
+    // so a pop needs no RAM latency: head <= nxt, nxt <= the entry at rd_ptr+2,
+    // which the ring read port fetched the cycle before. The read address is
+    // computed from the POST-pop pointer, so back-to-back pops (a pop_tag at a
+    // header followed by a pop_drop the next cycle) each find their third entry
+    // ready. A same-cycle write to the address being read is bypassed
+    // (byp_*), the one read-during-write case a sync RAM cannot serve itself.
+    // No init, no reset of the ring: entries beyond cnt are unreachable.
+    (* ramstyle = "no_rw_check" *) logic [EW-1:0] mem [DEPTH];
+    logic [AW-1:0] rd_ptr, wr_ptr;
     logic [CW-1:0] cnt;
+    logic [32:0]   head_pts, nxt_pts;
+    logic [PW-1:0] head_pos, nxt_pos;
+    logic [EW-1:0] ram_q, byp_q;
+    logic          byp_v;
     logic [PW-1:0] last_hdr;             // position of the last header parsed
     logic          hdr_seen;
 
@@ -87,8 +99,8 @@ module pts_assoc #(
     wire empty = (cnt == '0);
 
     // head stamp at or before a position: (pos - head) has its MSB clear
-    wire [PW-1:0] d_hdr  = hdr_pos  - pos_q[0];
-    wire [PW-1:0] d_last = last_hdr - pos_q[0];
+    wire [PW-1:0] d_hdr  = hdr_pos  - head_pos;
+    wire [PW-1:0] d_last = last_hdr - head_pos;
     wire head_le_hdr  = !empty && !d_hdr[PW-1];
     wire head_le_last = !empty && hdr_seen && !d_last[PW-1];
 
@@ -104,11 +116,25 @@ module pts_assoc #(
     wire gap_ok  = !gap_armed || (gap_d >= MIN_GAP);
     wire do_push = stamp_valid && !full && gap_ok;
 
-    integer i;
+    wire [EW-1:0] push_d  = {stamp_pts, stamp_pos};
+    wire [CW-1:0] cnt_pp  = do_pop ? (cnt - 1'b1) : cnt;        // count after this pop
+    wire [AW-1:0] rd_nxt  = do_pop ? (rd_ptr + 1'b1) : rd_ptr;  // rd_ptr after this pop
+    wire [AW-1:0] rd_addr = rd_nxt + 2'd2;                       // entry that becomes `third`
+    wire [EW-1:0] third   = byp_v ? byp_q : ram_q;               // entry at rd_ptr+2 (valid when cnt >= 3)
+
+    always_ff @(posedge clk) begin
+        if (do_push) mem[wr_ptr] <= push_d;
+        ram_q <= mem[rd_addr];
+        byp_v <= do_push && (wr_ptr == rd_addr);
+        byp_q <= push_d;
+    end
+
     always_ff @(posedge clk) begin
         tag_commit <= 1'b0;
         if (!rst_n || flush) begin
             cnt        <= '0;
+            rd_ptr     <= '0;
+            wr_ptr     <= '0;
             gap_armed  <= 1'b0;
             hdr_seen   <= 1'b0;
             last_hdr   <= '0;
@@ -116,42 +142,36 @@ module pts_assoc #(
             tag_valid  <= 1'b0;
             tag_pts    <= '0;
             tag_second <= 1'b0;
+            head_pts   <= '0;
+            head_pos   <= '0;
+            nxt_pts    <= '0;
+            nxt_pos    <= '0;
             if (!rst_n) dbg_ovf <= '0;
-            for (i = 0; i < DEPTH; i = i + 1) begin
-                pts_q[i] <= '0;
-                pos_q[i] <= '0;
-            end
         end else begin
             if (hdr_pulse) begin
                 last_hdr   <= hdr_pos;
                 hdr_seen   <= 1'b1;
                 tag_valid  <= head_le_hdr;
-                tag_pts    <= pts_q[0];
+                tag_pts    <= head_pts;
                 tag_second <= hdr_second;
                 tag_commit <= 1'b1;
             end
             if (do_push) begin
                 last_stamp <= stamp_pos;
                 gap_armed  <= 1'b1;
-            end
-            if (do_pop)
-                for (i = 0; i < DEPTH - 1; i = i + 1) begin
-                    pts_q[i] <= pts_q[i+1];
-                    pos_q[i] <= pos_q[i+1];
-                end
-            if (do_push) begin
-                for (i = 0; i < DEPTH; i = i + 1)
-                    if (i == (do_pop ? cnt - 1 : cnt)) begin
-                        pts_q[i] <= stamp_pts;
-                        pos_q[i] <= stamp_pos;
-                    end
+                wr_ptr     <= wr_ptr + 1'b1;
             end else if (stamp_valid && full && gap_ok && ~&dbg_ovf)
                 dbg_ovf <= dbg_ovf + 1'b1;
-            case ({do_push, do_pop})
-                2'b10:   cnt <= cnt + 1'b1;
-                2'b01:   cnt <= cnt - 1'b1;
-                default: cnt <= cnt;
-            endcase
+            if (do_pop) rd_ptr <= rd_ptr + 1'b1;
+            cnt <= cnt_pp + (do_push ? 1'b1 : 1'b0);
+            // the registered window
+            if (do_pop) begin
+                {head_pts, head_pos} <= (cnt_pp >= 1) ? {nxt_pts, nxt_pos} : push_d;
+                {nxt_pts,  nxt_pos}  <= (cnt_pp >= 2) ? third              : push_d;
+            end else begin
+                if (do_push && (cnt == 0)) {head_pts, head_pos} <= push_d;
+                if (do_push && (cnt == 1)) {nxt_pts,  nxt_pos}  <= push_d;
+            end
         end
     end
 

--- a/site/content/reference/compatibility.md
+++ b/site/content/reference/compatibility.md
@@ -73,6 +73,12 @@ button will not produce subtitles. This matches a set-top player.
     that was never meant for it — the text came out as flat grey with no black outline and
     was very hard to read. It is now simply not shown.
 
+**Audio played by the MiSTer's Linux side is not heard while this core is loaded.** The
+framework path that mixes Linux-side audio (a background-music script, for example) into
+a core's output is left out of this core to free logic for the player itself. Every
+disc, file and audio CD the core plays is decoded in the FPGA, so nothing the player does
+depends on it.
+
 **Seeking on a seamless-branch disc is unreliable.** Some special editions store two cuts
 of the film — theatrical and extended — woven together in the same part of the disc, and
 the player chooses between them as it goes. Seeking into a woven stretch can drop you into

--- a/tools/netlist_canary.sh
+++ b/tools/netlist_canary.sh
@@ -37,7 +37,7 @@ RPT=${1:-output_files/DVD.map.rpt}
 # name-in-report                            what it means if it collapsed
 CANARIES=(
   "pts_assoc:pts_assoc|tag_pts|the picture PTS tag is constant -- no video PTS reaches the decoder"
-  "pts_assoc:pts_assoc|pts_q|the PTS association queue is constant -- ps_demux PTS never crosses to clk_dec"
+  "pts_assoc:pts_assoc|head_pts|the PTS association queue head is constant -- ps_demux PTS never crosses to clk_dec"
 )
 
 fail=0


### PR DESCRIPTION
## Summary

Logic-reclaim branch B: zero-behaviour-change area pass on the navigation, VM, glue and telemetry modules, plus the framework `MISTER_DISABLE_ALSA` macro (user decision). Rebased onto branch A (#82).

Re-fit on top of A, SEED 7 first roll: clk_dec **96.76 / 92.13 MHz** (gate 86.0). Against v0.5.0: **57,723 ALUTs (−2,919) and 50,328 registers (−1,910)**, "ALMs needed" 36,833 (88 %). With A underneath the IMDCT mapping cliff is gone (3,148 ALUTs) and the two branches' savings add.

- `pts_assoc`: 16×57-bit shift FIFO → sync-read ring + 2-entry registered window with a same-cycle write bypass (−732 registers); the netlist canary row moved from `pts_q` to `head_pts` in the same commit so it cannot pass vacuously.
- `pgc_palette`: convert-on-write; the 384-flop raw YCbCr shadow and its three 16:1 muxes deleted; reset defaults pre-converted from a literal table.
- `dvd_vm`: the 1 Hz counter-mode tick walks one GPRM per idle cycle instead of 16 parallel incrementers; dispatch held during the walk (−150 ALUTs).
- `emu`: the release-visible `O[2]` diagnostic blocks share 5 x-window × 3 y-band terms instead of 52 comparators; the colour chain is a 2-bit code expanded at the output mux; `entropy_ctr` 32 → 16 bits.
- `dvd_telem`: one round-robin two-consecutive-agree sampler instead of 19 three-register filters (−264 registers); same filter, same atomic snapshot.
- `nav_pci`: `hli_e_ptm` kept as the one bit it is ever tested for; write-only `h_sptm` removed.
- `DVD.qsf`: `MISTER_DISABLE_ALSA=1` — the unused HPS→core audio bridge (~290 ALMs). Manual: Known limitations notes that Linux-side audio is not heard while the core is loaded.

Records: `docs/logic_reclaim.md` §4, the `DVD.qsf` seed ledger (three entries: the `main`-based fit, the ALSA rebuild, the re-fit on A).

## Test plan

- [x] `bench/dvd/run_pts_assoc.sh` (both fixtures, chain GREEN, RED arm fails as it must), `pgc_palette_tb` + `run_subpic.sh`, `dvd_vm_tb` (do_ticks widened past the 16-cycle walk) + `dvd_vm_atmos_tb` + `iso_reader_vm/vmgm/zerocell_tb`, `nav_pci_tb`, `run_telem.sh` (waits widened past the 57-cycle rotation), `bench/ac3/run_balloc.sh`; all re-run on the rebased tree
- [x] Full compile: fmax gate PASS both corners, `lint_undriven` PASS, `netlist_canary` PASS; `tools/docs_check.py` + `mkdocs build --strict`
- [x] HW (maintainer's rig, `DVD_almreclaimnav_20260911_0244.rbf`): MiB navigation diffed against libdvdnav (no differences); `O[2]` blocks decode as before; palette colours right by eye; telemetry sampler reads 47,999.5 Hz / 2.496 refreshes per frame, identical to A, with a direct `aud_play` delta of exactly 3,000 counts/s; Scene It boots to its menu with the serialised tick; maintainer's own look: good
- [ ] Pre-existing, not from this branch: `nav_diff` on ULTIMATE_T2 buttons "1 2" diverges from libdvdnav on button 1 — identical on the v0.5.0 build (the two sides park at different menus after the boot chain); wants its own issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
