### PR TITLE
Logic reclaim C: dvd_iso_reader shared adders, dead states, explicit ext_mem write port

### DIFF
--- a/DVD.qsf
+++ b/DVD.qsf
@@ -1084,4 +1084,19 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # with branch A's operand-mux form underneath, so the two branches now simply add:
 # bit_allocation 2,497 -> 1,044, mantissa_dequant 1,861 -> 1,377, dvd_vm -150,
 # pgc_palette -55/-359 regs, pts_assoc -732 regs, dvd_telem -264 regs, alsa gone.
+# 2026-09-11 (feature/alm-reclaim-reader, dev-almreclaimrdr -- LOGIC RECLAIM BRANCH C:
+# dvd_iso_reader shared PGC-window adder, unreachable IFO states deleted, one
+# flat-init state, one sd_lba adder, explicit ext_mem write port): SEED 7 held
+# FIRST roll -- clk_dec 88.75 @100C / 88.62 @-40C (gate 86.0, PASS both corners) at
+# 92% ALM (38,765 needed; 40,706 PLACED = 97%), registers 52,378, RAM 498/553,
+# DSP 94/112. Build DVD_almreclaimrdr_20260911_0335.rbf. Synthesis vs v0.5.0 main:
+# reader 6,680 -> 6,421 ALUTs (-259), design ALUTs 60,224 -> 60,151.
+# ★★ THE FIRST BUILD OF THIS BRANCH DID NOT FIT (4,261 LABs against 4,191) AND
+# QUARTUS SAID NOTHING: consolidating the reader's ext_mem write sites made it stop
+# inferring the 100x64 extent table as RAM -- +5,373 registers, four M10Ks gone,
+# no warning; the map report merely listed ext_mem[n][b] as registers. An explicit
+# registered write port with one address expression restored the altsyncram
+# (verified by a synthesis-only run before re-fitting). The parse_buf lesson in a
+# new form: after ANY edit near a memory's write sites, grep DVD.map.rpt for its
+# "Inferred altsyncram" line before spending a fit on it.
 set_global_assignment -name SEED 7

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -1099,4 +1099,16 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # (verified by a synthesis-only run before re-fitting). The parse_buf lesson in a
 # new form: after ANY edit near a memory's write sites, grep DVD.map.rpt for its
 # "Inferred altsyncram" line before spending a fit on it.
+# 2026-09-11d (feature/alm-reclaim-reader REBASED ONTO main after branches A (#82)
+# and B (#83) merged): SEED 7 held FIRST roll -- clk_dec 96.06 @100C / 91.84 @-40C
+# (gate 86.0, PASS both corners) at 87% ALM (36,636 needed; 39,890 PLACED = 95%),
+# registers 50,497, RAM 501/553, DSP 94/112. Build DVD_almreclaimrdr_20260911_2046.rbf.
+# ext_mem inferred as altsyncram (2 instances) -- the explicit write port holds.
+# ★ THE THREE RECLAIM BRANCHES TOGETHER, vs the v0.5.0 baseline fit on this seed:
+#   ALUTs 60,642 -> 57,465 (-3,177, -5.2%), registers 52,238 -> 50,497 (-1,741),
+#   placed ALMs 40,821 -> 39,890 (-931), "needed" 38,802 -> 36,636 (93% -> 87%),
+#   clk_dec hot corner 89.94 (v0.5.0 release) -> 96.06. Synthesis per module:
+#   bit_allocation -1,453, mantissa_dequant -484, bit_readers -366, dvd_iso_reader
+#   -251, dvd_vm -150, imdct -80, pgc_palette -55/-359 regs, pts_assoc -732 regs,
+#   dvd_telem -264 regs, alsa gone. Record: docs/logic_reclaim.md.
 set_global_assignment -name SEED 7

--- a/docs/logic_reclaim.md
+++ b/docs/logic_reclaim.md
@@ -56,7 +56,16 @@ The recurring pattern this time was not memory but **Quartus muxing RESULTS acro
 mutually exclusive FSM states**: every inlined function call, every per-state copy of an
 adder, is its own datapath.
 
-## 3. Branch A — `feature/alm-reclaim-ac3` (✅ built, ⏳ HW gate)
+## 3. Branch A — `feature/alm-reclaim-ac3` (✅ built, ✅ HW-CONFIRMED 2026-09-11)
+
+**HW round (maintainer's rig, `DVD_almreclaim_20260911_0138.rbf`):** `audio_check` on Men
+in Black — all four AC-3 tracks audible (5.1 main −26.2 dBFS RMS, the others −31 to −42,
+gate −80, digital silence reads −999); a controlled single capture of an LPCM VOB
+(−51.9 dBFS RMS, −35 peak) and of an MP2 VCD (−44.3 / −20.3 at 44.1 kHz); Passthru with
+steady telemetry (ring parked at 34 frames, video 2.497 refreshes/frame, no drain-gate
+closures — no AC-3 receiver on the rig, so the bitstream itself is not decodable there, as
+always); video pacing on the feature 2.49955 refreshes per picked-up frame, 23.973 fps,
+audio 47,997.6 Hz, zero lates, zero drops over 46 s.
 
 Detail in `docs/ac3_decoder_architecture.md` §4.12 and the DVD.qsf ledger. Every commit
 gated by `bench/ac3/run_front_cosim.sh` (bap bit-exact vs liba52 on 13 streams) **and PCM
@@ -66,7 +75,41 @@ Synthesis result **−2,544 ALUTs**; fit SEED 7 first roll, clk_dec 93.66 / 90.8
 Found en route: `bench/ac3/run_balloc.sh` had been failing silently since M19d (stale
 combinational delta-BA model, vvp exit 0). Fixed and `$fatal`ed before the refactor.
 
-## 4. Branch B — `feature/alm-reclaim-nav` (in progress)
+## 4. Branch B — `feature/alm-reclaim-nav` (✅ built, ✅ HW-CONFIRMED 2026-09-11, rebased onto A)
+
+**Re-fit on top of Branch A (SEED 7, first roll):** clk_dec **96.76 / 92.13**, "needed"
+36,833 (88 %), placed 40,059, ALUTs 60,642 → **57,723** and registers 52,238 → **50,328**
+against v0.5.0 — the IMDCT cliff is gone (3,148 ALUTs) and the two branches' savings add.
+Build `DVD_almreclaimnav_20260911_2010.rbf`. The two paragraphs below record the earlier
+`main`-based fits and remain true of them.
+
+**HW round (maintainer's rig, `DVD_almreclaimnav_20260911_0244.rbf`):** Men in Black
+navigation diffed against libdvdnav (FP → 1 → 2, no differences); the `O[2]` blocks decode
+exactly as before (highlight armed, subpicture shown, recolour fired — the 2-bit colour code
+expands to the same four colours); the palette convert-on-write renders the MiB menu's
+button/text colours correctly by eye; the rewritten telemetry sampler reads 47,999.5 Hz
+audio (−11 ppm) and 2.496 refreshes per frame on the feature — identical to Branch A —
+and a direct three-sample delta of `aud_play` gave exactly 3,000 counts/s; Scene It boots
+to its main menu (PGC 14, armed) with the serialised counter tick and button 1 starts the
+game. ⚠ A 30 s `telem --watch` over the MiB MENU read 69.5 kHz: that is the harness's
+16-bit unwrap being fooled by the counter reset at a menu-loop restart, not the sampler
+(the same window on the feature reads 48 kHz).
+⚠ **Pre-existing, NOT this branch:** `nav_diff` on ULTIMATE_T2 (`--script "1 2"`) reports
+button 1 landing in PGC 5 / VTS 4 on the board where libdvdnav lands in VTSM PGC 1 — the
+v0.5.0 build on the same rig gives the identical result. libdvdnav presses 1 at a
+two-button VTSM menu; the board parks on a title-domain still first (trajectory 3 3 1 1 1*),
+so the same digit is pressed at different menus. Worth its own issue.
+
+**Fit (SEED 7, first roll, cut from `main`):** clk_dec 89.73 / 89.42, "needed" 38,768,
+placed 40,823 (unchanged), registers 51,954 → 50,578 (**−1,376**), ALUTs +774 — **of
+which +799 is the IMDCT mapping cliff on RTL this branch does not touch** (3,228 on
+`main`, 4,027 here). Own modules: pts_assoc −732 regs, pgc_palette −359 regs / −55
+ALUTs, dvd_telem −264 regs, dvd_vm −148 ALUTs. ⚠ Read no ALM figure off this fit until
+the branch is re-fit on top of Branch A, whose regular operand-mux form held the IMDCT
+at 3,147–3,254 across two netlists. Build `DVD_almreclaimnav_20260911_0214.rbf`.
+**Rebuilt with `MISTER_DISABLE_ALSA` (SEED 7, first roll):** clk_dec 92.64 / 91.97,
+registers **52,238 → 50,167**, placed ALMs 40,821 → 40,615, the `alsa` entity gone; ALUTs
++551 of which the IMDCT cliff is +782. Build `DVD_almreclaimnav_20260911_0244.rbf`.
 
 | item | change | gate |
 |---|---|---|

--- a/docs/logic_reclaim.md
+++ b/docs/logic_reclaim.md
@@ -83,7 +83,15 @@ STRIDE (already shift-adds); `nav_pci`'s duplicate subtracts are CSE'd by Quartu
 SetSTN triple read (~60 ALMs, needs a latched condition) and the seek_time/seek_bar table
 sharing (~4 M10K, cross-module ports) are deferred.
 
-## 5. Branch C — `feature/alm-reclaim-reader` (✅ built, ⏳ HW gate)
+## 5. Branch C — `feature/alm-reclaim-reader` (✅ built, ✅ HW-CONFIRMED 2026-09-11)
+
+**HW round (maintainer's rig, `DVD_almreclaimrdr_20260911_0335.rbf`):** Men in Black
+navigation diffed against libdvdnav (FP → button 1 → button 2: no differences); the feature
+with chapter skips 1→3, a D-pad +10 s seek and prev-chapter restarting the chapter, all read
+off the pinned HUD; a flat `.VOB` mount through the consolidated `S_FLAT_INIT` (HUD clock
+live, D-pad seek advancing it); a VCD `.bin` mount and seek (44.1 kHz, 2.00 refreshes per
+frame). Telemetry after every seek: 2.496–2.498 refreshes per picked-up frame, 48 kHz,
+zero lates, zero drops, zero drain-gate closures.
 
 Shipped: shared PGC-window walk adder (7 sites → 1 mux + 1 adder pair), the unreachable
 `S_IFO_MAT/_PARSE/_TSRPT` states deleted, one `S_FLAT_INIT` state for the three flat

--- a/docs/logic_reclaim.md
+++ b/docs/logic_reclaim.md
@@ -126,7 +126,16 @@ STRIDE (already shift-adds); `nav_pci`'s duplicate subtracts are CSE'd by Quartu
 SetSTN triple read (~60 ALMs, needs a latched condition) and the seek_time/seek_bar table
 sharing (~4 M10K, cross-module ports) are deferred.
 
-## 5. Branch C — `feature/alm-reclaim-reader` (✅ built, ✅ HW-CONFIRMED 2026-09-11)
+## 5. Branch C — `feature/alm-reclaim-reader` (✅ built, ✅ HW-CONFIRMED 2026-09-11, rebased onto A+B)
+
+**Re-fit on top of A and B (SEED 7, first roll):** clk_dec **96.06 / 91.84**, "needed"
+36,636 (87 %), placed 39,890 (95 %), ALUTs 57,465, registers 50,497; the extent table
+infers as two `altsyncram`s. Build `DVD_almreclaimrdr_20260911_2046.rbf`.
+
+**All three branches together against the v0.5.0 baseline fit on the same seed:** ALUTs
+60,642 → **57,465 (−3,177, −5.2 %)**, registers 52,238 → **50,497 (−1,741)**, placed ALMs
+40,821 → 39,890, "ALMs needed" 38,802 → 36,636 (93 % → 87 %), clk_dec hot corner 89.94
+(the v0.5.0 release fit) → 96.06.
 
 **HW round (maintainer's rig, `DVD_almreclaimrdr_20260911_0335.rbf`):** Men in Black
 navigation diffed against libdvdnav (FP → button 1 → button 2: no differences); the feature

--- a/docs/logic_reclaim.md
+++ b/docs/logic_reclaim.md
@@ -56,16 +56,7 @@ The recurring pattern this time was not memory but **Quartus muxing RESULTS acro
 mutually exclusive FSM states**: every inlined function call, every per-state copy of an
 adder, is its own datapath.
 
-## 3. Branch A — `feature/alm-reclaim-ac3` (✅ built, ✅ HW-CONFIRMED 2026-09-11)
-
-**HW round (maintainer's rig, `DVD_almreclaim_20260911_0138.rbf`):** `audio_check` on Men
-in Black — all four AC-3 tracks audible (5.1 main −26.2 dBFS RMS, the others −31 to −42,
-gate −80, digital silence reads −999); a controlled single capture of an LPCM VOB
-(−51.9 dBFS RMS, −35 peak) and of an MP2 VCD (−44.3 / −20.3 at 44.1 kHz); Passthru with
-steady telemetry (ring parked at 34 frames, video 2.497 refreshes/frame, no drain-gate
-closures — no AC-3 receiver on the rig, so the bitstream itself is not decodable there, as
-always); video pacing on the feature 2.49955 refreshes per picked-up frame, 23.973 fps,
-audio 47,997.6 Hz, zero lates, zero drops over 46 s.
+## 3. Branch A — `feature/alm-reclaim-ac3` (✅ built, ⏳ HW gate)
 
 Detail in `docs/ac3_decoder_architecture.md` §4.12 and the DVD.qsf ledger. Every commit
 gated by `bench/ac3/run_front_cosim.sh` (bap bit-exact vs liba52 on 13 streams) **and PCM
@@ -75,41 +66,7 @@ Synthesis result **−2,544 ALUTs**; fit SEED 7 first roll, clk_dec 93.66 / 90.8
 Found en route: `bench/ac3/run_balloc.sh` had been failing silently since M19d (stale
 combinational delta-BA model, vvp exit 0). Fixed and `$fatal`ed before the refactor.
 
-## 4. Branch B — `feature/alm-reclaim-nav` (✅ built, ✅ HW-CONFIRMED 2026-09-11, rebased onto A)
-
-**Re-fit on top of Branch A (SEED 7, first roll):** clk_dec **96.76 / 92.13**, "needed"
-36,833 (88 %), placed 40,059, ALUTs 60,642 → **57,723** and registers 52,238 → **50,328**
-against v0.5.0 — the IMDCT cliff is gone (3,148 ALUTs) and the two branches' savings add.
-Build `DVD_almreclaimnav_20260911_2010.rbf`. The two paragraphs below record the earlier
-`main`-based fits and remain true of them.
-
-**HW round (maintainer's rig, `DVD_almreclaimnav_20260911_0244.rbf`):** Men in Black
-navigation diffed against libdvdnav (FP → 1 → 2, no differences); the `O[2]` blocks decode
-exactly as before (highlight armed, subpicture shown, recolour fired — the 2-bit colour code
-expands to the same four colours); the palette convert-on-write renders the MiB menu's
-button/text colours correctly by eye; the rewritten telemetry sampler reads 47,999.5 Hz
-audio (−11 ppm) and 2.496 refreshes per frame on the feature — identical to Branch A —
-and a direct three-sample delta of `aud_play` gave exactly 3,000 counts/s; Scene It boots
-to its main menu (PGC 14, armed) with the serialised counter tick and button 1 starts the
-game. ⚠ A 30 s `telem --watch` over the MiB MENU read 69.5 kHz: that is the harness's
-16-bit unwrap being fooled by the counter reset at a menu-loop restart, not the sampler
-(the same window on the feature reads 48 kHz).
-⚠ **Pre-existing, NOT this branch:** `nav_diff` on ULTIMATE_T2 (`--script "1 2"`) reports
-button 1 landing in PGC 5 / VTS 4 on the board where libdvdnav lands in VTSM PGC 1 — the
-v0.5.0 build on the same rig gives the identical result. libdvdnav presses 1 at a
-two-button VTSM menu; the board parks on a title-domain still first (trajectory 3 3 1 1 1*),
-so the same digit is pressed at different menus. Worth its own issue.
-
-**Fit (SEED 7, first roll, cut from `main`):** clk_dec 89.73 / 89.42, "needed" 38,768,
-placed 40,823 (unchanged), registers 51,954 → 50,578 (**−1,376**), ALUTs +774 — **of
-which +799 is the IMDCT mapping cliff on RTL this branch does not touch** (3,228 on
-`main`, 4,027 here). Own modules: pts_assoc −732 regs, pgc_palette −359 regs / −55
-ALUTs, dvd_telem −264 regs, dvd_vm −148 ALUTs. ⚠ Read no ALM figure off this fit until
-the branch is re-fit on top of Branch A, whose regular operand-mux form held the IMDCT
-at 3,147–3,254 across two netlists. Build `DVD_almreclaimnav_20260911_0214.rbf`.
-**Rebuilt with `MISTER_DISABLE_ALSA` (SEED 7, first roll):** clk_dec 92.64 / 91.97,
-registers **52,238 → 50,167**, placed ALMs 40,821 → 40,615, the `alsa` entity gone; ALUTs
-+551 of which the IMDCT cliff is +782. Build `DVD_almreclaimnav_20260911_0244.rbf`.
+## 4. Branch B — `feature/alm-reclaim-nav` (in progress)
 
 | item | change | gate |
 |---|---|---|
@@ -126,7 +83,27 @@ STRIDE (already shift-adds); `nav_pci`'s duplicate subtracts are CSE'd by Quartu
 SetSTN triple read (~60 ALMs, needs a latched condition) and the seek_time/seek_bar table
 sharing (~4 M10K, cross-module ports) are deferred.
 
-## 5. Branch C — reader (planned)
+## 5. Branch C — `feature/alm-reclaim-reader` (✅ built, ⏳ HW gate)
+
+Shipped: shared PGC-window walk adder (7 sites → 1 mux + 1 adder pair), the unreachable
+`S_IFO_MAT/_PARSE/_TSRPT` states deleted, one `S_FLAT_INIT` state for the three flat
+fallbacks, one base+offset adder for `sd_lba`. Reader 6,680 → **6,421 ALUTs**; fit SEED 7
+first roll, clk_dec 88.75 / 88.62. Gate: every `iso_reader_*_tb` (verdict set identical to
+`main`, which has four pre-existing non-passes: `atmos`/`attr` fixtures absent,
+`tpsw_boot` fails on `main`, `mount_tb` only trips a grep), plus `run_vcd`, `run_mgl`,
+`run_mode_realign`, `run_dpad_seek`, `run_seamless_audio`. Build
+`DVD_almreclaimrdr_20260911_0335.rbf`.
+
+⚠ **The first build did not fit and Quartus said nothing:** consolidating the `ext_mem`
+write sites made it stop inferring the extent table as RAM (+5,373 registers, four M10Ks
+gone, `ext_mem[n][b]` listed as plain registers). An explicit registered write port with
+one address expression restored the `altsyncram`. After any edit near a memory's write
+sites, check `DVD.map.rpt` for its "Inferred altsyncram" line before spending a fit.
+
+Not done (deferred, medium risk): serialising the VCD seek arithmetic, dropping the BCD
+prefix sum, the 34-source `sec_lba` mux factoring.
+
+### Originally planned
 
 Low-risk first: gate/serialise the VCD/WAV-only seek math, delete the unreachable
 `S_IFO_MAT/_PARSE/_TSRPT` states, factor the 4× flat-fallback init, remove dead ports;

--- a/dvd/dvd_iso_reader.sv
+++ b/dvd/dvd_iso_reader.sv
@@ -1257,6 +1257,11 @@ reg        raw_m2;         // this sector's mode byte (@15) == 2
 reg        raw_sec_pass;   // Form-2 sector: pass payload window [24, 2348)
 reg [11:0] raw_wcnt;       // compact cache write index within the current block
 
+// ---- S_STREAM request address (area pass 2026-09-10) ---------------------------
+wire [31:0] sd_base_w = cell_mode ? (menu_dom ? menu_base_blk : (ext_start_q - ext_cum))
+                                  : ext_start_q;
+wire [31:0] sd_off_w  = cell_mode ? play_blk : strm_blk;
+
 // ---- PGC-window walk address (area pass 2026-09-10) ----------------------------
 // Seven walk starts computed `pgc_sec + ((pgc_off + OFF) >> 11)` and
 // `(pgc_off + OFF) & 0x7FF` each with their own 17-bit and 32-bit adders, OFF
@@ -3866,9 +3871,13 @@ always @(posedge clk or negedge rst_n) begin
                     // ext_start_q = ext_mem[strm_idx][start]; valid because every
                     // strm_idx change detours through S_EXT_LOAD before returning
                     // here. Menu domain bypasses the extent table (single VOB).
-                    sd_lba       <= cell_mode ? (menu_dom ? (menu_base_blk + play_blk)
-                                                          : (ext_start_q + (play_blk - ext_cum)))
-                                              : (ext_start_q + strm_blk);
+                    // One adder: base + offset, where the menu-domain base is
+                    // menu_base_blk, the title-domain base is the extent's
+                    // start rebased by ext_cum (modulo 2^32 the same as the
+                    // old ext_start_q + (play_blk - ext_cum)), and the linear
+                    // base is the extent start -- area pass 2026-09-10 (this
+                    // was three adders, a subtract and a 3-way 32-bit mux).
+                    sd_lba       <= sd_base_w + sd_off_w;
                     sd_rd        <= 1'b1;
                     blk_inflight <= 1'b1;
                 end else if (blk_inflight) begin

--- a/dvd/dvd_iso_reader.sv
+++ b/dvd/dvd_iso_reader.sv
@@ -1118,9 +1118,8 @@ localparam S_DONE      = 6'd11;
 localparam S_ERROR     = 6'd12;
 // IFO title-selection states (appended at the end so S_STREAM/DONE/ERROR keep
 // their numbers and existing testbenches' magic numbers stay valid)
-localparam S_IFO_MAT      = 6'd13;   // setup: read VMGI sector, shadow @196
-localparam S_IFO_MAT_PARSE= 6'd14;   // tt_srpt ptr -> read TT_SRPT sector
-localparam S_IFO_TSRPT    = 6'd15;   // nr_of_srpts + title 1 title_set_nr
+localparam S_FLAT_INIT    = 6'd13;   // whole-file single-extent setup -> S_EXT_LOAD (area pass 2026-09-10)
+// (6'd14, 6'd15 were S_IFO_MAT_PARSE / S_IFO_TSRPT, unreachable, deleted 2026-09-10)
 localparam S_SELECT       = 6'd16;   // scan group table for target VTS
 // PGC / cell-timeline states (Phase 7; appended)
 localparam S_PGC_BEGIN    = 6'd17;   // decide PGC-parse vs linear fallback; read VTSI_MAT
@@ -1257,6 +1256,26 @@ reg [11:0] raw_pos;        // sector byte position (mod 2352) of the next byte
 reg        raw_m2;         // this sector's mode byte (@15) == 2
 reg        raw_sec_pass;   // Form-2 sector: pass payload window [24, 2348)
 reg [11:0] raw_wcnt;       // compact cache write index within the current block
+
+// ---- PGC-window walk address (area pass 2026-09-10) ----------------------------
+// Seven walk starts computed `pgc_sec + ((pgc_off + OFF) >> 11)` and
+// `(pgc_off + OFF) & 0x7FF` each with their own 17-bit and 32-bit adders, OFF
+// being one of six offsets. Quartus muxes results across FSM states, never
+// the operators, so this was seven adder pairs. The offset is a function of
+// the state / walker phase the site sits in, so select it once and share the
+// pair. Every site latches the wires in the same cycle it used to compute the
+// expression, from the same registers, so the values are identical (the two
+// 12-bit-wide originals cannot exceed 2^12 either: pgc_off < 2048 and
+// OFF <= 156).
+wire [15:0] pgc_woff   = (state == S_PGC_HDR)     ? 16'd12 :
+                         (state == S_PGC_CELLCHK) ? cell_pb_off16 :
+                         (wphase == P_SUBP)       ? 16'd156 :    // ACTL+SUBP walk done -> header
+                         (wphase == P_HDR)        ? ((cmd_tbl_off != 16'd0) ? cmd_tbl_off
+                                                                            : prog_map_off16) :
+                                                    prog_map_off16;      // P_CMDH / P_CMD
+wire [16:0] pgc_wsum   = {6'b0, pgc_off} + {1'b0, pgc_woff};
+wire [31:0] walk_sec_w = pgc_sec + {15'b0, pgc_wsum[16:11]};
+wire [10:0] walk_off_w = pgc_wsum[10:0];
 
 // Linear-transport seek math (combinational off the latched target; consumed
 // by the !cell_mode seek_jump branch). Raw mode: a target file block r maps to
@@ -2499,12 +2518,7 @@ always @(posedge clk or negedge rst_n) begin
                 if (total_blocks == 32'd0) begin
                     state <= S_DONE;
                 end else if (total_blocks < 32'd17) begin
-                    ext_mem[0] <= {32'd0, total_blocks};
-                    best_base <= 7'd0; best_cnt <= 7'd1;
-                    strm_idx  <= 7'd0; strm_left <= 7'd1;
-                    strm_blk  <= 32'd0; strm_done <= 1'b0;
-                    wr_ptr    <= 0;
-                    state     <= S_EXT_LOAD;   // let ext_start_q/ext_blocks_q refresh first
+                    state     <= S_FLAT_INIT;             // shared whole-file extent setup
                 end else begin
                     // Probe file byte 0 first: a raw MODE2/2352 image (VCD/SVCD
                     // .bin) starts with the 12-byte CD sync there, block-aligned.
@@ -2529,12 +2543,7 @@ always @(posedge clk or negedge rst_n) begin
                     raw_m2       <= 1'b0;
                     raw_sec_pass <= 1'b0;
                     raw_wcnt     <= 12'd0;
-                    ext_mem[0] <= {32'd0, total_blocks};
-                    best_base <= 7'd0; best_cnt <= 7'd1;
-                    strm_idx  <= 7'd0; strm_left <= 7'd1;
-                    strm_blk  <= 32'd0; strm_done <= 1'b0;
-                    wr_ptr    <= 0;
-                    state     <= S_EXT_LOAD;
+                    state     <= S_FLAT_INIT;             // shared whole-file extent setup
                 end else begin
                     sec_lba   <= 32'd16;
                     fetch_base<= 11'd0;      // CD001 / type at sector start
@@ -2610,12 +2619,7 @@ always @(posedge clk or negedge rst_n) begin
             S_CHK_VD0: begin
                 if (!cd001) begin
                     // Not ISO9660 -> flat-file fallback (whole file linear)
-                    ext_mem[0] <= {32'd0, total_blocks};
-                    best_base <= 7'd0; best_cnt <= 7'd1;
-                    strm_idx  <= 7'd0; strm_left <= 7'd1;
-                    strm_blk  <= 32'd0; strm_done <= 1'b0;
-                    wr_ptr    <= 0;
-                    state     <= S_EXT_LOAD;   // let ext_start_q/ext_blocks_q refresh first
+                    state     <= S_FLAT_INIT;             // shared whole-file extent setup
                 end else if (vd_type == 8'd1) begin
                     // PVD present in parse_buf; shadow its root record @156
                     iso_mode   <= 1'b1;
@@ -2836,45 +2840,21 @@ always @(posedge clk or negedge rst_n) begin
                 end
             end
 
-            // ------------------------------------------------------------
-            // IFO title selection: read the VMGI (VIDEO_TS.IFO) sector and
-            // shadow bytes @196.. to get the TT_SRPT sector pointer.
-            S_IFO_MAT: begin
-                sec_lba    <= vmgi_lba;
-                fetch_base <= 11'd196;
-                fetch_ret  <= S_IFO_MAT_PARSE;
-                fi         <= 6'd0;
-                fi_cap_v   <= 1'b0;
-                state      <= S_SECREAD;
-            end
+            // (S_IFO_MAT / S_IFO_MAT_PARSE / S_IFO_TSRPT -- the pre-VM "title 1"
+            //  selection -- were unreachable and are deleted; area pass 2026-09-10.)
 
             // ------------------------------------------------------------
-            // tt_srpt is a sector ptr relative to the IFO start (BE). Read the
-            // TT_SRPT sector; bail to the largest-VTS fallback if it's absent.
-            S_IFO_MAT_PARSE: begin
-                if (tt_srpt_ptr == 32'd0 || tt_srpt_ptr > 32'd65535) begin
-                    state <= S_PGC_BEGIN;              // malformed -> largest-VTS
-                end else begin
-                    sec_lba    <= vmgi_lba + tt_srpt_ptr;
-                    fetch_base <= 11'd0;
-                    fetch_ret  <= S_IFO_TSRPT;
-                    fi         <= 6'd0;
-                    fi_cap_v   <= 1'b0;
-                    state      <= S_SECREAD;
-                end
-            end
-
-            // ------------------------------------------------------------
-            // TT_SRPT: nr_of_srpts@0 (BE) + TT_SRP[0].title_set_nr@14 = the VTS
-            // that holds title 1 (the conventional main feature).
-            S_IFO_TSRPT: begin
-                target_vtsn <= ttsrp0_vtsn;
-                if (nr_of_srpts == 16'd0 || ttsrp0_vtsn == 8'd0) begin
-                    state <= S_PGC_BEGIN;              // no titles -> largest-VTS
-                end else begin
-                    sel_i <= 7'd0;
-                    state <= S_SELECT2;   // wait for gmem_q to refresh, then scan
-                end
+            // Whole-file single-extent setup, shared by the three flat
+            // fallbacks (tiny image, raw MODE2/2352, not-ISO9660). One extra
+            // cycle at mount; the three copies were three sources on each of
+            // seven register muxes (area pass 2026-09-10).
+            S_FLAT_INIT: begin
+                ext_mem[0] <= {32'd0, total_blocks};
+                best_base <= 7'd0; best_cnt <= 7'd1;
+                strm_idx  <= 7'd0; strm_left <= 7'd1;
+                strm_blk  <= 32'd0; strm_done <= 1'b0;
+                wr_ptr    <= 0;
+                state     <= S_EXT_LOAD;   // let ext_start_q/ext_blocks_q refresh first
             end
 
             // ------------------------------------------------------------
@@ -3342,8 +3322,8 @@ always @(posedge clk or negedge rst_n) begin
                     // gates aud_switch on it so the streaming words can't glitch
                     // a track resync).
                     pgc_ctl_valid <= 1'b0;
-                    walk_sec  <= pgc_sec + (({1'b0,pgc_off} + 12'd12) >> 11);
-                    walk_off  <= ({1'b0,pgc_off} + 12'd12) & 12'h7FF;
+                    walk_sec  <= walk_sec_w;              // pgc + 12 (shared adder, see pgc_woff)
+                    walk_off  <= walk_off_w;
                     walk_left <= 13'd16;               // 8 streams x 2 bytes
                     walk_idx  <= 13'd0;
                     wphase    <= P_ACTL;
@@ -3414,8 +3394,8 @@ always @(posedge clk or negedge rst_n) begin
                     end
                     if (walk_left == 13'd1) begin
                         // subp_control done -> the @156 PGC header window (P_HDR).
-                        walk_sec  <= pgc_sec + (({1'b0,pgc_off} + 12'd156) >> 11);
-                        walk_off  <= ({1'b0,pgc_off} + 12'd156) & 12'h7FF;
+                        walk_sec  <= walk_sec_w;          // pgc + 156 (shared adder)
+                        walk_off  <= walk_off_w;
                         walk_left <= 13'd78;
                         walk_idx  <= 13'd0;
                         wphase    <= P_HDR;
@@ -3453,8 +3433,8 @@ always @(posedge clk or negedge rst_n) begin
                         // (if any) -> cell check. cell_pb_off16 is being written
                         // THIS cycle; later states read the registered value.
                         if (cmd_tbl_off != 16'd0) begin
-                            walk_sec  <= pgc_sec + (({6'b0,pgc_off} + {1'b0,cmd_tbl_off}) >> 11);
-                            walk_off  <= (({6'b0,pgc_off} + {1'b0,cmd_tbl_off})) & 17'h07FF;
+                            walk_sec  <= walk_sec_w;      // pgc + cmd_tbl_off (shared adder)
+                            walk_off  <= walk_off_w;
                             walk_left <= 13'd8;        // counts@0-5 + last_byte@6-7
                             walk_idx  <= 13'd0;
                             wphase    <= P_CMDH;
@@ -3464,8 +3444,8 @@ always @(posedge clk or negedge rst_n) begin
                             cmd_nr_cell <= 8'd0;
                             if (prog_map_off16 != 16'd0 && cmd_nr_pgm != 8'd0 &&
                                 dom != DOM_FP) begin
-                                walk_sec  <= pgc_sec + (({6'b0,pgc_off} + {1'b0,prog_map_off16}) >> 11);
-                                walk_off  <= (({6'b0,pgc_off} + {1'b0,prog_map_off16})) & 17'h07FF;
+                                walk_sec  <= walk_sec_w;  // pgc + prog_map_off (shared adder)
+                                walk_off  <= walk_off_w;
                                 walk_left <= {5'd0, cmd_nr_pgm};
                                 walk_idx  <= 13'd0;
                                 wphase    <= P_PMAP;
@@ -3493,8 +3473,8 @@ always @(posedge clk or negedge rst_n) begin
                             // empty or absurd -> skip to the program map / cells
                             if (prog_map_off16 != 16'd0 && cmd_nr_pgm != 8'd0 &&
                                 dom != DOM_FP) begin
-                                walk_sec  <= pgc_sec + (({6'b0,pgc_off} + {1'b0,prog_map_off16}) >> 11);
-                                walk_off  <= (({6'b0,pgc_off} + {1'b0,prog_map_off16})) & 17'h07FF;
+                                walk_sec  <= walk_sec_w;  // pgc + prog_map_off (shared adder)
+                                walk_off  <= walk_off_w;
                                 walk_left <= {5'd0, cmd_nr_pgm};
                                 walk_idx  <= 13'd0;
                                 wphase    <= P_PMAP;
@@ -3533,8 +3513,8 @@ always @(posedge clk or negedge rst_n) begin
                     if (walk_left == 13'd1) begin
                         if (prog_map_off16 != 16'd0 && cmd_nr_pgm != 8'd0 &&
                             dom != DOM_FP) begin
-                            walk_sec  <= pgc_sec + (({6'b0,pgc_off} + {1'b0,prog_map_off16}) >> 11);
-                            walk_off  <= (({6'b0,pgc_off} + {1'b0,prog_map_off16})) & 17'h07FF;
+                            walk_sec  <= walk_sec_w;      // pgc + prog_map_off (shared adder)
+                            walk_off  <= walk_off_w;
                             walk_left <= {5'd0, cmd_nr_pgm};
                             walk_idx  <= 13'd0;
                             wphase    <= P_PMAP;
@@ -3665,8 +3645,8 @@ always @(posedge clk or negedge rst_n) begin
                         state <= S_FINAL2;             // title linear fallback (palette kept)
                 end else begin
                     // start the P_CELL walk at pgc + cell_playback_offset
-                    walk_sec  <= pgc_sec + (({6'b0,pgc_off} + {1'b0,cell_pb_off16}) >> 11);
-                    walk_off  <= (({6'b0,pgc_off} + {1'b0,cell_pb_off16})) & 17'h07FF;
+                    walk_sec  <= walk_sec_w;              // pgc + cell_pb_off (shared adder)
+                    walk_off  <= walk_off_w;
                     walk_left <= {nr_cells, 5'd0} - {2'd0, nr_cells, 3'd0};  // nr_cells*24
                     walk_idx  <= 13'd0;
                     wphase    <= P_CELL;

--- a/dvd/dvd_iso_reader.sv
+++ b/dvd/dvd_iso_reader.sv
@@ -572,6 +572,19 @@ localparam MAXEXT = 100;
 // fresh before use. sd reads are ~ms apart, so the extra idle cycle is free.
 reg [63:0] ext_mem [0:MAXEXT-1];       // {start[63:32], blocks[31:0]}
 reg [31:0] ext_start_q, ext_blocks_q;  // registered read of ext_mem[strm_idx]
+// ONE registered write port (area pass 2026-09-10). The FSM used to write
+// ext_mem at several sites (three constant-address `ext_mem[0] <=` and the
+// directory scan's `ext_mem[all_n] <=`); after those were consolidated Quartus
+// 17 stopped inferring the M10K and built the 100x64 table from flops
+// (+5,373 registers, the design no longer fit). An explicit port with one
+// address expression is the form it always infers. Writes land one cycle
+// after the site sets ext_w_*: the scan's writes are consumed many cycles
+// later, and the flat-init path waits one extra state (S_FLAT_INIT2) before
+// S_EXT_LOAD refreshes the read.
+reg        ext_w_en;
+reg [6:0]  ext_w_addr;
+reg [63:0] ext_w_data;
+always @(posedge clk) if (ext_w_en) ext_mem[ext_w_addr] <= ext_w_data;
 reg [6:0]  all_n;
 
 reg [6:0]  best_base;
@@ -1119,7 +1132,8 @@ localparam S_ERROR     = 6'd12;
 // IFO title-selection states (appended at the end so S_STREAM/DONE/ERROR keep
 // their numbers and existing testbenches' magic numbers stay valid)
 localparam S_FLAT_INIT    = 6'd13;   // whole-file single-extent setup -> S_EXT_LOAD (area pass 2026-09-10)
-// (6'd14, 6'd15 were S_IFO_MAT_PARSE / S_IFO_TSRPT, unreachable, deleted 2026-09-10)
+localparam S_FLAT_INIT2   = 6'd14;   // one-cycle wait for the ext_mem write port
+// (6'd15 was S_IFO_TSRPT, unreachable, deleted 2026-09-10)
 localparam S_SELECT       = 6'd16;   // scan group table for target VTS
 // PGC / cell-timeline states (Phase 7; appended)
 localparam S_PGC_BEGIN    = 6'd17;   // decide PGC-parse vs linear fallback; read VTSI_MAT
@@ -1864,6 +1878,7 @@ always @(posedge clk or negedge rst_n) begin
         pgc_loaded   <= 1'b0;
         pgc_error    <= 1'b0;
         cmd_we       <= 1'b0;
+        ext_w_en     <= 1'b0;
         cell_end_pulse <= 1'b0;
         pgc_end_pulse  <= 1'b0;
         still_timed  <= 1'b0;
@@ -1945,6 +1960,7 @@ always @(posedge clk or negedge rst_n) begin
         cmd_we   <= 1'b0;
         pm_we    <= 1'b0;
         ptt_we   <= 1'b0;
+        ext_w_en <= 1'b0;                   // one-cycle write strobe (see ext_mem)
         jump_ack <= 1'b0;
         pgc_loaded <= 1'b0;
         pgc_error  <= 1'b0;
@@ -2753,7 +2769,8 @@ always @(posedge clk or negedge rst_n) begin
                         end else begin
                             grp_total <= grp_total + rec_datalen;
                         end
-                        ext_mem[all_n] <= {rec_startblk, rec_blocks};
+                        ext_w_en <= 1'b1; ext_w_addr <= all_n;
+                        ext_w_data <= {rec_startblk, rec_blocks};
                         all_n          <= all_n + 7'd1;
                     end
                     p          <= p + rec_len_b;
@@ -2854,13 +2871,15 @@ always @(posedge clk or negedge rst_n) begin
             // cycle at mount; the three copies were three sources on each of
             // seven register muxes (area pass 2026-09-10).
             S_FLAT_INIT: begin
-                ext_mem[0] <= {32'd0, total_blocks};
+                ext_w_en <= 1'b1; ext_w_addr <= 7'd0;
+                ext_w_data <= {32'd0, total_blocks};
                 best_base <= 7'd0; best_cnt <= 7'd1;
                 strm_idx  <= 7'd0; strm_left <= 7'd1;
                 strm_blk  <= 32'd0; strm_done <= 1'b0;
                 wr_ptr    <= 0;
-                state     <= S_EXT_LOAD;   // let ext_start_q/ext_blocks_q refresh first
+                state     <= S_FLAT_INIT2;
             end
+            S_FLAT_INIT2: state <= S_EXT_LOAD;   // the write lands; S_EXT_LOAD then refreshes ext_*_q
 
             // ------------------------------------------------------------
             // Scan the group table for a target VTS (sync-read M10K: gmem_q

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -589,7 +589,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "dev-almreclaimnav"
+`define CORE_VERSION "dev-almreclaimrdr"
 
 parameter CONF_STR = {
     "DVD;;",
@@ -1985,11 +1985,11 @@ wire pause_aud = pause_q | hold_freeze;
 // instant does not. Falls back to the counter alone if the framework never
 // sends it (TIMESTAMP stays 0). See docs/dvd_vm.md "DVD-game entropy".
 wire [32:0] hps_timestamp;
-reg  [15:0] entropy_ctr = 16'd0;   // 16 bits: every consumer reads [15:0] or less (area pass 2026-09-10)
+reg  [31:0] entropy_ctr = 32'd0;
 reg  [24:0] sec_div     = 25'd0;
 reg         sec_tick    = 1'b0;
 always @(posedge clk_sys) begin
-    entropy_ctr <= entropy_ctr + 16'd1;
+    entropy_ctr <= entropy_ctr + 32'd1;
     if (sec_div == 25'd26_999_999) begin   // clk_sys = 27 MHz -> 1 Hz
         sec_div  <= 25'd0;
         sec_tick <= 1'b1;
@@ -5566,7 +5566,7 @@ idle_logo #(.LOGO_QX_LEAD(12'd12)) idle_logo_inst (
     .il_mode        (il_eff),
     .frame_tick     (av_refresh_tick),
     .vis            (logo_vis),
-    .entropy        ({16'd0, entropy_ctr}),
+    .entropy        (entropy_ctr),
     .ioctl_download (ioctl_download),
     .ioctl_wr       (ioctl_wr),
     .ioctl_addr     (ioctl_addr),
@@ -5642,24 +5642,17 @@ subpic_blend subpic_blend_inst (
 //     coli + subpicture): its PRESENCE = armed, its POSITION = the rect coords.
 // Registered => hotspot-safe; zero effect with O[2] Off.
 wire        dbg_hl_en = status[2] && menus_on;
-// Area pass 2026-09-10: the 13 blocks used to carry FOUR independent 12-bit
-// magnitude compares each (52 comparators) for what is 5 X-windows x 3 Y-bands;
-// factor the windows once and AND them. Bit-identical.
-wire        dbg_x0 = (ov_h_gen >= 12'd8)  && (ov_h_gen < 12'd24);
-wire        dbg_x1 = (ov_h_gen >= 12'd28) && (ov_h_gen < 12'd44);
-wire        dbg_x2 = (ov_h_gen >= 12'd48) && (ov_h_gen < 12'd64);
-wire        dbg_x3 = (ov_h_gen >= 12'd68) && (ov_h_gen < 12'd84);
-wire        dbg_x4 = (ov_h_gen >= 12'd88) && (ov_h_gen < 12'd104);
-wire        dbg_y0 = (core_v_pos >= 12'd8)  && (core_v_pos < 12'd24);
-wire        dbg_y1 = (core_v_pos >= 12'd30) && (core_v_pos < 12'd46);
-wire        dbg_y2 = (core_v_pos >= 12'd62) && (core_v_pos < 12'd78);
-wire        dbg_blk1  = dbg_x0 && dbg_y0;
-wire        dbg_blk2  = dbg_x1 && dbg_y0;
-wire        dbg_blk3  = dbg_x2 && dbg_y0;
+wire        dbg_blk1  = (ov_h_gen >= 12'd8)  && (ov_h_gen < 12'd24) &&
+                        (core_v_pos >= 12'd8)  && (core_v_pos < 12'd24);
+wire        dbg_blk2  = (ov_h_gen >= 12'd28) && (ov_h_gen < 12'd44) &&
+                        (core_v_pos >= 12'd8)  && (core_v_pos < 12'd24);
+wire        dbg_blk3  = (ov_h_gen >= 12'd48) && (ov_h_gen < 12'd64) &&
+                        (core_v_pos >= 12'd8)  && (core_v_pos < 12'd24);
 // block 4: SPU bytes reached spu_decode this frame (ps_demux routed the substream).
 // GREEN + block3 RED = SPU arrives but spu_decode won't commit/show (decode/PTS);
 // RED = ps_demux filtered it out (sp_track) or it isn't in the stream.
-wire        dbg_blk4  = dbg_x3 && dbg_y0;
+wire        dbg_blk4  = (ov_h_gen >= 12'd68) && (ov_h_gen < 12'd84) &&
+                        (core_v_pos >= 12'd8)  && (core_v_pos < 12'd24);
 // VBUF-LAG DIAGNOSIS (docs/dvd_menu_refinements.md §5) — second row + a bar.
 //   blk5 (v30..46, x8..24)  = vbuf_deep: GREEN = the fast-drain threshold tripped
 //                             (menu_ff engaged), RED = VBUF below 0x40 (menu_ff never
@@ -5670,8 +5663,10 @@ wire        dbg_blk4  = dbg_x3 && dbg_y0;
 //     ~x72 (0x40) vbuf_deep should be set. HIGH bar at the blank frame => cell 0 IS
 //     buffered but not displayed (pickup/decode issue); LOW => cell 0 never reached the
 //     VBUF (keep_vbuf LinkPGCN junction dropped it).
-wire        dbg_blk5  = dbg_x0 && dbg_y1;
-wire        dbg_blk6  = dbg_x1 && dbg_y1;
+wire        dbg_blk5  = (ov_h_gen >= 12'd8)  && (ov_h_gen < 12'd24) &&
+                        (core_v_pos >= 12'd30) && (core_v_pos < 12'd46);
+wire        dbg_blk6  = (ov_h_gen >= 12'd28) && (ov_h_gen < 12'd44) &&
+                        (core_v_pos >= 12'd30) && (core_v_pos < 12'd46);
 // §7 return-highlight probes (2nd row): blk7 = hl_on_w (nav_pci armed AND fetched -
 // the render gate needs BOTH; block1 green + blk7 RED => the FETCH isn't completing).
 // blk8 = a highlight RECOLOUR pixel fired this frame (hl_use = inside the rect, class
@@ -5679,8 +5674,10 @@ wire        dbg_blk6  = dbg_x1 && dbg_y1;
 // blk7 GREEN + blk8 RED => armed+fetched but no
 // class-1/2 subpicture pixel is landing in the button rect on the displayed frame
 // (the keep_vbuf display/parse skew), NOT a promotion/fetch fault.
-wire        dbg_blk7  = dbg_x2 && dbg_y1;
-wire        dbg_blk8  = dbg_x3 && dbg_y1;
+wire        dbg_blk7  = (ov_h_gen >= 12'd48) && (ov_h_gen < 12'd64) &&
+                        (core_v_pos >= 12'd30) && (core_v_pos < 12'd46);
+wire        dbg_blk8  = (ov_h_gen >= 12'd68) && (ov_h_gen < 12'd84) &&
+                        (core_v_pos >= 12'd30) && (core_v_pos < 12'd46);
 wire        dbg_vbar  = (core_v_pos >= 12'd50) && (core_v_pos < 12'd58) &&
                         (ov_h_gen >= 12'd8)  && (ov_h_gen < (12'd8 + {4'd0, vbuf_fill_s1}));
 // RASTER-TRIGGER ROW (single-raster analog, 2026-09-03; the RGBS/YPbPr "shake every
@@ -5696,11 +5693,16 @@ wire        dbg_vbar  = (core_v_pos >= 12'd50) && (core_v_pos < 12'd58) &&
 //   blk13 (x 88..104) Main re-wrote the cfg word AFTER its first write (OSD leave,
 //                     video_mode_adjust, [video=] section re-parse — informational)
 wire        dbg_r3_en = status[2] && interlaced_eff;
-wire        dbg_blk9  = dbg_x0 && dbg_y2;
-wire        dbg_blk10 = dbg_x1 && dbg_y2;
-wire        dbg_blk11 = dbg_x2 && dbg_y2;
-wire        dbg_blk12 = dbg_x3 && dbg_y2;
-wire        dbg_blk13 = dbg_x4 && dbg_y2;
+wire        dbg_blk9  = (ov_h_gen >= 12'd8)  && (ov_h_gen < 12'd24) &&
+                        (core_v_pos >= 12'd62) && (core_v_pos < 12'd78);
+wire        dbg_blk10 = (ov_h_gen >= 12'd28) && (ov_h_gen < 12'd44) &&
+                        (core_v_pos >= 12'd62) && (core_v_pos < 12'd78);
+wire        dbg_blk11 = (ov_h_gen >= 12'd48) && (ov_h_gen < 12'd64) &&
+                        (core_v_pos >= 12'd62) && (core_v_pos < 12'd78);
+wire        dbg_blk12 = (ov_h_gen >= 12'd68) && (ov_h_gen < 12'd84) &&
+                        (core_v_pos >= 12'd62) && (core_v_pos < 12'd78);
+wire        dbg_blk13 = (ov_h_gen >= 12'd88) && (ov_h_gen < 12'd104) &&
+                        (core_v_pos >= 12'd62) && (core_v_pos < 12'd78);
 // clk_dec events -> toggles (one flip per event), 2-FF synced, edge-detected in clk_sys
 reg         wd_rst_q, wd_tgl, vs0_q, vs0_tgl;
 always @(posedge clk_dec) begin
@@ -5762,35 +5764,57 @@ always @(posedge clk_sys) begin
     if (~core_vs_prev_sys & core_v_sync) begin hlvis_seen_l <= hlvis_seen; hlvis_seen <= 1'b0; end
     else if (hl_use_q)                   hlvis_seen <= 1'b1;
 end
-// Area pass 2026-09-10: the blocks only ever show four colours, so the
-// priority chain below resolves to a 2-bit code and the output mux expands it
-// (was three 8-bit registers fed by a 14-way 24-bit chain).
-localparam [1:0] DBG_RED = 2'd0, DBG_GREEN = 2'd1, DBG_CYAN = 2'd2, DBG_MAGENTA = 2'd3;
-reg  [1:0]  dbg_col_q;
+reg  [7:0]  dbg_r_q, dbg_g_q, dbg_b_q;
 reg         dbg_px_q;
-wire [7:0]  dbg_r_q = (dbg_col_q == DBG_RED   || dbg_col_q == DBG_MAGENTA) ? 8'hFF : 8'h00;
-wire [7:0]  dbg_g_q = (dbg_col_q == DBG_GREEN || dbg_col_q == DBG_CYAN)    ? 8'hFF : 8'h00;
-wire [7:0]  dbg_b_q = (dbg_col_q == DBG_CYAN  || dbg_col_q == DBG_MAGENTA) ? 8'hFF : 8'h00;
 always @(posedge clk_sys) begin
     dbg_px_q <= (dbg_hl_en && (dbg_blk1 || dbg_blk2 || dbg_blk3 || dbg_blk4 ||
                                dbg_blk5 || dbg_blk6 || dbg_blk7 || dbg_blk8 || dbg_vbar ||
                                (hl_btns_armed && dbg_rectb)))
              || (dbg_r3_en && (dbg_blk9 || dbg_blk10 || dbg_blk11 || dbg_blk12 || dbg_blk13));
-    if (dbg_blk1) dbg_col_q <= hl_btns_armed ? DBG_GREEN : DBG_RED;
-    else if (dbg_blk2) dbg_col_q <= video_live_s2 ? DBG_GREEN : DBG_RED;
-    else if (dbg_blk3) dbg_col_q <= sp_seen_l ? DBG_GREEN : DBG_RED;
-    else if (dbg_blk4) dbg_col_q <= spb_seen_l ? DBG_GREEN : DBG_RED;
-    else if (dbg_blk5) dbg_col_q <= vbuf_deep ? DBG_GREEN : DBG_RED;   // vbuf_deep (menu_ff engaged)
-    else if (dbg_blk6) dbg_col_q <= still_active ? DBG_GREEN : DBG_RED; // still_active (reader parked)
-    else if (dbg_blk7) dbg_col_q <= hl_on_w ? DBG_GREEN : DBG_RED;     // hl_on_w = armed AND fetched
-    else if (dbg_blk8) dbg_col_q <= hlvis_seen_l ? DBG_GREEN : DBG_RED; // recolour fired this frame
-    else if (dbg_blk9) dbg_col_q <= wd_seen_l ? DBG_GREEN : DBG_RED;   // raster row: watchdog expired
-    else if (dbg_blk10) dbg_col_q <= ils_seen_l ? DBG_GREEN : DBG_RED; // raster row: il_switch fired
-    else if (dbg_blk11) dbg_col_q <= pal_seen_l ? DBG_GREEN : DBG_RED; // raster row: pal_eff changed
-    else if (dbg_blk12) dbg_col_q <= vs0_seen_l ? DBG_GREEN : DBG_RED; // raster row: vertical_size hit 0
-    else if (dbg_blk13) dbg_col_q <= cfg_seen_l ? DBG_GREEN : DBG_RED; // raster row: cfg re-written
-    else if (dbg_vbar) dbg_col_q <= DBG_CYAN;                            // VBUF occupancy bar
-    else               dbg_col_q <= DBG_MAGENTA;                         // rect border
+    if (dbg_blk1) begin
+        dbg_r_q <= hl_btns_armed ? 8'h00 : 8'hFF;
+        dbg_g_q <= hl_btns_armed ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
+    end else if (dbg_blk2) begin
+        dbg_r_q <= video_live_s2 ? 8'h00 : 8'hFF;
+        dbg_g_q <= video_live_s2 ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
+    end else if (dbg_blk3) begin
+        dbg_r_q <= sp_seen_l ? 8'h00 : 8'hFF;
+        dbg_g_q <= sp_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
+    end else if (dbg_blk4) begin
+        dbg_r_q <= spb_seen_l ? 8'h00 : 8'hFF;
+        dbg_g_q <= spb_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
+    end else if (dbg_blk5) begin                                 // vbuf_deep (menu_ff engaged)
+        dbg_r_q <= vbuf_deep ? 8'h00 : 8'hFF;
+        dbg_g_q <= vbuf_deep ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
+    end else if (dbg_blk6) begin                                 // still_active (reader parked)
+        dbg_r_q <= still_active ? 8'h00 : 8'hFF;
+        dbg_g_q <= still_active ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
+    end else if (dbg_blk7) begin                                 // hl_on_w = armed AND fetched
+        dbg_r_q <= hl_on_w ? 8'h00 : 8'hFF;
+        dbg_g_q <= hl_on_w ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
+    end else if (dbg_blk8) begin                                 // recolour fired this frame
+        dbg_r_q <= hlvis_seen_l ? 8'h00 : 8'hFF;
+        dbg_g_q <= hlvis_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
+    end else if (dbg_blk9) begin                                 // raster row: watchdog expired
+        dbg_r_q <= wd_seen_l ? 8'h00 : 8'hFF;
+        dbg_g_q <= wd_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
+    end else if (dbg_blk10) begin                                // raster row: il_switch fired
+        dbg_r_q <= ils_seen_l ? 8'h00 : 8'hFF;
+        dbg_g_q <= ils_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
+    end else if (dbg_blk11) begin                                // raster row: pal_eff changed
+        dbg_r_q <= pal_seen_l ? 8'h00 : 8'hFF;
+        dbg_g_q <= pal_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
+    end else if (dbg_blk12) begin                                // raster row: vertical_size hit 0
+        dbg_r_q <= vs0_seen_l ? 8'h00 : 8'hFF;
+        dbg_g_q <= vs0_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
+    end else if (dbg_blk13) begin                                // raster row: cfg re-written
+        dbg_r_q <= cfg_seen_l ? 8'h00 : 8'hFF;
+        dbg_g_q <= cfg_seen_l ? 8'hFF : 8'h00; dbg_b_q <= 8'h00;
+    end else if (dbg_vbar) begin                                 // VBUF occupancy bar (cyan)
+        dbg_r_q <= 8'h00; dbg_g_q <= 8'hFF; dbg_b_q <= 8'hFF;
+    end else begin
+        dbg_r_q <= 8'hFF; dbg_g_q <= 8'h00; dbg_b_q <= 8'hFF;   // magenta rect border
+    end
 end
 
 // =========================================================================


### PR DESCRIPTION
## Summary

Logic-reclaim branch C: zero-behaviour-change area pass on `dvd/dvd_iso_reader.sv`. Rebased onto A (#82) and B (#83).

- One PGC-window walk adder: seven sites computed `pgc_sec + ((pgc_off + OFF) >> 11)` with their own adders; the offset is a function of the state / walker phase, so one mux selects it and one adder pair serves all seven.
- The unreachable `S_IFO_MAT / S_IFO_MAT_PARSE / S_IFO_TSRPT` states deleted; the three verbatim flat-fallback inits are one `S_FLAT_INIT` state.
- `sd_lba` is one base + one offset instead of three adders, a subtract and a 3-way mux.
- An explicit registered write port for `ext_mem`: the first fit of this branch **did not fit** (4,261 LABs against 4,191) because consolidating the write sites made Quartus 17 stop inferring the 100×64 extent table as RAM — +5,373 registers, no warning. The explicit port is the form it always infers; recorded in the ledger as a trap.

Reader 6,750 → 6,499 ALUTs. Re-fit on top of A and B, SEED 7 first roll: clk_dec **96.06 / 91.84 MHz**, the extent table inferring as two `altsyncram`s.

**All three reclaim branches against the v0.5.0 baseline fit on the same seed:** ALUTs 60,642 → **57,465 (−3,177)**, registers 52,238 → **50,497**, placed ALMs 40,821 → 39,890, "ALMs needed" 93 % → 87 %, clk_dec hot corner 89.94 → 96.06. Full record: `docs/logic_reclaim.md`.

## Test plan

- [x] Every `bench/dvd/iso_reader_*_tb.sv`: verdict set identical to `main` (27 pass; the four remaining are pre-existing — `atmos`/`attr` fixtures absent, `tpsw_boot` fails on `main`, `mount_tb` only trips the runner's grep); re-run on the rebased tree
- [x] `run_vcd.sh`, `run_mgl.sh`, `run_mode_realign.sh`, `run_dpad_seek.sh`, `run_seamless_audio.sh` green
- [x] Full compile: fmax gate PASS both corners, `lint_undriven` PASS, `netlist_canary` PASS; `ext_mem` altsyncram inference confirmed in the map report
- [x] HW (maintainer's rig, `DVD_almreclaimrdr_20260911_0335.rbf`): MiB navigation diffed against libdvdnav (no differences); chapter skips 1→3, a D-pad +10 s seek and prev-chapter read off the pinned HUD; a flat `.VOB` mount and seek; a VCD `.bin` mount and seek; pacing after every seek 2.496–2.498 refreshes/frame, 48 kHz, 0 lates/drops; maintainer's own look: good

🤖 Generated with [Claude Code](https://claude.com/claude-code)
