### PR TITLE
HDMI passthru left the ADV7513 in non-PCM mode for the next core

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,59 @@ worse maintenance burden than targeted in-place edits. So:
 
 ## Hardware status (THIS fork, verified 2026-06-21)
 
+- 🔧 **HDMI PASSTHRU LEFT THE ADV7513 IN NON-PCM MODE FOR THE NEXT CORE (2026-09-11,
+  branch `fix/hdmi-audio-teardown`) — sim + host-proven RED/GREEN, mutation-checked
+  both sides, ⏳ HW-confirm pending.** Field report: *"enable passthru with the
+  modified Main installed, load another core, and you get no audio."* Reproduced in
+  code, and it needed **no disc** — selecting `Audio Out = Passthru` was enough.
+  ★★ **`docs/hdmi_bitstream.md` §2 PREDICTED THIS AND THE PREDICTION WAS FILED UNDER
+  THE ROUTE WE DIDN'T SHIP.** Its case for IEC958-direct was that route (i) *"can
+  only pin the flag high for a whole session, putting us straight back in the regime
+  the fj#110 fix exists to avoid"*. Route (ii) was then deleted after four failed HW
+  rounds and we shipped (i) — inheriting the exact property §2 had rejected it for,
+  with the warning still in the file describing the losing option. ⚠ **When a route
+  is abandoned, re-read what was written AGAINST the one that replaces it**; those
+  paragraphs become a defect list, not history.
+  **Three mechanisms, and only the third is ours alone:** (1) `0x12[7]` is the
+  non-PCM flag and **stock `init_data` has no `0x12` entry at all** — it rewrites
+  `0x0C`, so the *route* reverts while the flag stands, through a core load and
+  through a warm reboot (the HPS resets, the transmitter does not); a power cut
+  should clear it, which is the chip's reset value, not anything code here can
+  assert. (2) Nothing ran on the way out: other cores run **stock Main** via `main=`,
+  and our own re-exec cannot help either — `user_io_init()` hands off to the core's
+  `main=` binary at stock `user_io.cpp:~1484`, **before `video_init()` at 1514**.
+  (3) `want` was `passthru && sink_ok && !pcm_session`, and `pcm_session` reads 0
+  **both** when AC-3 is playing and when nothing is.
+  **Fix in three layers, because no single one survives a crash:** PCM is now the
+  RESTING state (new `aud_route.bs_session` = "a bitstream is what is playing right
+  now", so idle/menus/LPCM/ejected never claim the link); `dvd_hdmi_audio_teardown()`
+  at both orderly exits (integration steps 36/37 — `app_restart()`, which every core
+  load ends in, and `reboot()`); and `0x12` cleared in our own `hdmi_config_init()`
+  (step 38) so an unclean exit is recovered by loading this core again.
+  ★ **`bs_session`'s RESET DOMAIN is the whole design and is NOT `aud_rst_n`** — that
+  pulses on every seek, audio-track switch and `aud_flush`, so a verdict reset there
+  would release the transmitter and re-engage at every chapter skip, and the receiver
+  re-locks each time. It clears on `reset_n` and on an empty slot (`~media_seen`).
+  Without that distinction `bs_session` IS `pcm_session` inverted, which is why the
+  bench's seek arm is the load-bearing one.
+  ★ **Teardown keys on `chip_nonpcm`, NOT on `acked`:** they disagree for 50 ms at
+  every release (ack down, registers not yet restored), and a core load landing in
+  that window is exactly the case `acked` answers wrongly — the one host mutation
+  caught by a single arm.
+  ★ **CMD_AF needed a VERSION BIT (15), not just a data bit:** an old core and a new
+  IDLE one both answer `pcm_session = 0`, so without it Main cannot tell "AC-3 is
+  playing" from "this core cannot say", and either choice silently breaks one of
+  them. Old core ⇒ old rule, unchanged.
+  ⚠ **Found by my own test, not by review:** teardown first left `acked` set with the
+  chip in PCM — harmless at a terminal call site, a trap anywhere else. It now drops
+  the ack first, the same order a release uses.
+  Gates: `bench/dvd/run_passthru_pcm.sh --red` (`aud_route_tb` TEST 6 + 4 mutations)
+  and **`main/tests/run_tests.sh --red`**, which gains a RED arm (4 mutations, host
+  `g++`, no MiSTer/Docker). ⚠ **Residual by construction:** a crash, a panic, or the
+  board's reset button *while a DD/DTS track plays* still leaves the flag set for the
+  next stock-Main boot — recovery is a power cycle or reloading this core. ⚠ Accepted
+  trade: each title start is now one PCM→DD switch (the fj#110 shape) and may clip the
+  first moment of audio. Detail: **`docs/hdmi_bitstream.md` §5a**.
 - ✅ **LOGIC RECLAIM — three branches, ALL MERGED 2026-09-11 (PR #82 AC-3, PR #83 nav/VM/
   telemetry + `MISTER_DISABLE_ALSA`, PR #84 reader) and ✅ HW-CONFIRMED on the rig.** Together,
   against the v0.5.0 baseline fit on the same seed: ALUTs 60,642 → **57,465 (−3,177)**,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,8 +281,11 @@ worse maintenance burden than targeted in-place edits. So:
   register** — a game core has audio after it. ★ That second one had been written here
   three times as *"a power cut should clear it, which is the chip's reset value, not
   anything code here can assert"*; it is now MEASURED, and it is the only layer no
-  code can provide. ⏳ Still unreported: whether the PCM→DD switch clips the start of a
-  title — this rig's sink has no AC-3/DTS decoder, so nothing here can hear it.
+  code can provide. ✅ **And the accepted trade came back clean: the PCM→DD switch at a
+  title start does NOT clip audibly** (maintainer, 2026-09-12, on a real receiver —
+  this rig's sink has no AC-3/DTS decoder, so nothing here could hear it). That was the
+  one cost the design knowingly took on; it is now paid and measured, so the per-track
+  engage policy stands on its own rather than on the fj#110 precedent.
   ⚠ **Harness trap seen twice here: telemetry sampled across the launch transient is
   GARBAGE** (1003 refreshes/s, 65,524 drain-gate closures — counters read across the
   core's reset). Re-measure on settled playback; a second window read perfectly clean.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,11 +274,15 @@ worse maintenance burden than targeted in-place edits. So:
   engaged read `0x20`, with `teardown: restoring PCM mode` in the log** (layer 2 = the
   fix). Pacing unregressed: Decode 59.955 Hz / 24.01 fps / audio −12 ppm / 0 lates /
   0 drops; Passthru 59.953 Hz, 2.505 refreshes per frame.
-  ⚠ **NOT exercised: the `reboot()` arm (step 37).** Same one-line call, verified
-  present in the built binary, but the OSD Reboot row cannot be driven from the
-  harness and a reboot would wipe `/tmp` (and the log with it). Also untested: what a
-  real receiver does with the PCM→DD switch at a title start, since this sink has no
-  AC-3/DTS decoder at all.
+  ✅ **THE TWO ARMS THE HARNESS COULD NOT REACH WERE CLOSED BY THE MAINTAINER
+  2026-09-12:** rebooting while a DD track plays restores PCM for the next core (the
+  `reboot()` arm, step 37 — the OSD Reboot row cannot be driven from the harness, and
+  a reboot wipes `/tmp` and the log with it), **and a POWER CUT does not retain the
+  register** — a game core has audio after it. ★ That second one had been written here
+  three times as *"a power cut should clear it, which is the chip's reset value, not
+  anything code here can assert"*; it is now MEASURED, and it is the only layer no
+  code can provide. ⏳ Still unreported: whether the PCM→DD switch clips the start of a
+  title — this rig's sink has no AC-3/DTS decoder, so nothing here can hear it.
   ⚠ **Harness trap seen twice here: telemetry sampled across the launch transient is
   GARBAGE** (1003 refreshes/s, 65,524 drain-gate closures — counters read across the
   core's reset). Re-measure on settled playback; a second window read perfectly clean.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,9 +252,39 @@ worse maintenance burden than targeted in-place edits. So:
 
 ## Hardware status (THIS fork, verified 2026-06-21)
 
-- 🔧 **HDMI PASSTHRU LEFT THE ADV7513 IN NON-PCM MODE FOR THE NEXT CORE (2026-09-11,
+- ✅ **HDMI PASSTHRU LEFT THE ADV7513 IN NON-PCM MODE FOR THE NEXT CORE (2026-09-11,
   branch `fix/hdmi-audio-teardown`) — sim + host-proven RED/GREEN, mutation-checked
-  both sides, ⏳ HW-confirm pending.** Field report: *"enable passthru with the
+  both sides, and ✅ HW-CONFIRMED 2026-09-12 with the defect REPRODUCED FIRST** (build
+  `DVD_hdmiteardown_20260912_0320.rbf`, SEED 7 first roll, clk_dec 92.77/88.90).
+  ★★ **MEASURED AT THE CHIP, NOT BY EAR: `i2cget -y 1 0x39 0x12` on the rig** (the
+  ADV7513 is on **i2c bus 1**; `0x20` = PCM, `0xA0` = non-PCM). That turns "no audio on
+  the next core" — which sounds like a listening test needing a receiver — into a
+  one-byte read, and it is what let the RED arm run at all: **the rig's sink does not
+  advertise AC-3/DTS** (`sink_ok=0`), so nothing engages until `dvd_hdmi_bitstream=2`
+  is set in `MiSTer.ini` (restore it afterwards; `mister.py restore` does not).
+  **RED (pre-fix core + pre-fix Main): `0x12=0xA0` with the DVD core, and STILL `0xA0`
+  after loading the menu core** — the report, reproduced. **GREEN, in order:** the
+  stuck `0xA0` **self-healed to `0x20` at core load** (layer 3 — the RED arm left it
+  set, so the arm tested itself); `0x20` at t+3 s and t+6 s with nothing routed, then
+  `0xA0` from t+9 s when AC-3 started (layer 1); **3 chapter skips and 3 audio-track
+  switches produced EXACTLY ONE register write in total** (the reset-domain design,
+  confirmed — count `adv7513:` lines in `/tmp/dvd_hdmi_audio.log`, which records every
+  write and so catches blips a sampler would miss); an LPCM VOB in Passthru read
+  `0x20`; Decode PCM with AC-3 playing never engaged; and **loading another core while
+  engaged read `0x20`, with `teardown: restoring PCM mode` in the log** (layer 2 = the
+  fix). Pacing unregressed: Decode 59.955 Hz / 24.01 fps / audio −12 ppm / 0 lates /
+  0 drops; Passthru 59.953 Hz, 2.505 refreshes per frame.
+  ⚠ **NOT exercised: the `reboot()` arm (step 37).** Same one-line call, verified
+  present in the built binary, but the OSD Reboot row cannot be driven from the
+  harness and a reboot would wipe `/tmp` (and the log with it). Also untested: what a
+  real receiver does with the PCM→DD switch at a title start, since this sink has no
+  AC-3/DTS decoder at all.
+  ⚠ **Harness trap seen twice here: telemetry sampled across the launch transient is
+  GARBAGE** (1003 refreshes/s, 65,524 drain-gate closures — counters read across the
+  core's reset). Re-measure on settled playback; a second window read perfectly clean.
+  A short clip is the same trap in reverse — a 41 s window on a 66 s clip starting at
+  t+20 s spans the end of the file and reports the audio rate 15 % low.
+  Field report: *"enable passthru with the
   modified Main installed, load another core, and you get no audio."* Reproduced in
   code, and it needed **no disc** — selecting `Audio Out = Passthru` was enough.
   ★★ **`docs/hdmi_bitstream.md` §2 PREDICTED THIS AND THE PREDICTION WAS FILED UNDER

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -1111,4 +1111,12 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 #   bit_allocation -1,453, mantissa_dequant -484, bit_readers -366, dvd_iso_reader
 #   -251, dvd_vm -150, imdct -80, pgc_palette -55/-359 regs, pts_assoc -732 regs,
 #   dvd_telem -264 regs, alsa gone. Record: docs/logic_reclaim.md.
+# 2026-09-12 (fix/hdmi-audio-teardown, dev-hdmiteardown -- aud_route.bs_session +
+# the CMD_AF format word; the HDMI non-PCM flag was inherited by the next core):
+# SEED 7 held FIRST roll -- clk_dec 92.77 @100C / 88.9 @-40C (gate 86.0, PASS both
+# corners) at 87% ALM (36,632 needed), registers 50,565 (+68), RAM 501/553,
+# DSP 94/112. Build DVD_hdmiteardown_20260912_0320.rbf.
+# ⚠ The hot corner gives back 3.3 MHz against branch C's 96.06 for one flop and a
+# few wires -- netlist variance at this density, not a cost of the change; still
+# 6.8 MHz clear of the gate. Detail: docs/hdmi_bitstream.md §5a.
 set_global_assignment -name SEED 7

--- a/bench/dvd/aud_route_tb.sv
+++ b/bench/dvd/aud_route_tb.sv
@@ -21,13 +21,17 @@ module aud_route_tb;
     logic [1:0]  frame_type = 0;
     logic [15:0] frame_len = 0;
     logic        ring_ready = 0;
-    logic        dec_owns, wrap_owns, pcm_session;
+    logic        hard_rst_n = 0;
+    logic        sess_clr = 0;
+    logic        dec_owns, wrap_owns, pcm_session, bs_session;
 
     aud_route dut (
-        .clk(clk), .rst_n(rst_n), .split_en(split_en),
+        .clk(clk), .rst_n(rst_n),
+        .hard_rst_n(hard_rst_n), .sess_clr(sess_clr), .split_en(split_en),
         .frame_valid(frame_valid), .frame_type(frame_type), .frame_len(frame_len),
         .ring_ready(ring_ready),
-        .dec_owns(dec_owns), .wrap_owns(wrap_owns), .pcm_session(pcm_session)
+        .dec_owns(dec_owns), .wrap_owns(wrap_owns), .pcm_session(pcm_session),
+        .bs_session(bs_session)
     );
 
     integer errors = 0;
@@ -117,8 +121,15 @@ module aud_route_tb;
         end
     end endtask
 
+    logic boot_bs;      // bs_session as the core comes out of reset
+
     initial begin
-        repeat (4) @(posedge clk); rst_n = 1;
+        repeat (4) @(posedge clk); rst_n = 1; hard_rst_n = 1;
+        repeat (2) @(posedge clk);
+        // PCM is the RESTING state: nothing has played, so the HDMI link must not
+        // be claimed. This is the whole reported bug -- the core used to boot with
+        // the transmitter already in non-PCM mode and leave it there.
+        boot_bs = bs_session;
 
         // ---- TEST 1: a mixed stream routes by codec, byte-exactly -----------
         add(0, 32); add(0, 48); add(2, 40); add(2, 24); add(1, 64); add(3, 16);
@@ -162,6 +173,46 @@ module aud_route_tb;
         if (wrap_frames != 0 || dec_frames != 3) begin
             $display("  FAIL: Decode mode did not give every frame to the decoder");
             errors = errors + 1; end
+
+        // ---- TEST 6: bs_session, the HDMI link-format verdict ---------------
+        // Measured as a LEVEL the ADV7513 would be driven from, at the moments
+        // that actually happen on a disc: boot, a track, a seek, a track change,
+        // an eject. The reset domain is the point -- pcm_session already fails
+        // the seek arm by construction, which is why a second signal exists.
+        split_en = 1;
+        if (boot_bs !== 1'b0) begin
+            $display("  FAIL: bs_session set at boot -- the HDMI link is claimed with nothing playing");
+            errors = errors + 1; end
+
+        add(0, 32); drain_all(200000);          // an AC-3 track starts
+        if (bs_session !== 1'b1) begin
+            $display("  FAIL: bs_session did not follow an AC-3 frame"); errors = errors + 1; end
+
+        // A seek / audio-track switch / aud_flush pulses aud_rst_n. If the
+        // verdict resets there, every chapter skip releases the transmitter to
+        // PCM and re-engages, and the receiver re-locks on each one.
+        rst_n = 0; repeat (4) @(posedge clk); rst_n = 1; repeat (4) @(posedge clk);
+        if (bs_session !== 1'b1) begin
+            $display("  FAIL: an aud_rst_n pulse (seek) dropped bs_session");
+            errors = errors + 1; end
+
+        add(2, 24); drain_all(200000);          // switch to an LPCM track
+        if (bs_session !== 1'b0) begin
+            $display("  FAIL: bs_session stayed set on an LPCM track"); errors = errors + 1; end
+
+        add(0, 32); drain_all(200000);          // back to AC-3, then eject
+        if (bs_session !== 1'b1) begin
+            $display("  FAIL: bs_session did not re-arm on AC-3"); errors = errors + 1; end
+        sess_clr = 1; repeat (4) @(posedge clk); sess_clr = 0; @(posedge clk);
+        if (bs_session !== 1'b0) begin
+            $display("  FAIL: an empty slot left the HDMI link claimed"); errors = errors + 1; end
+
+        // Decode mode must never claim the link, whatever the codec is.
+        split_en = 0;
+        add(0, 16); add(1, 16); drain_all(200000);
+        if (bs_session !== 1'b0) begin
+            $display("  FAIL: bs_session set in Decode mode"); errors = errors + 1; end
+        $display("TEST 6: bs_session: boot 0, AC-3 1, survives a seek, LPCM 0, eject 0, Decode 0");
 
         if (errors == 0) $display("\naud_route: ALL TESTS PASSED");
         else             $display("\naud_route: %0d FAILURES", errors);

--- a/bench/dvd/dvd_telem_tb.sv
+++ b/bench/dvd/dvd_telem_tb.sv
@@ -33,7 +33,7 @@ module dvd_telem_tb;
 
     // CMD_AF inputs. Tied off explicitly: a new INPUT left unconnected floats Z
     // and quietly poisons whatever reads it (see CLAUDE.md's note on new ports).
-    reg af_pt = 0, af_pcm = 0;
+    reg af_pt = 0, af_pcm = 0, af_bs = 0;
 
     dvd_telem dut (
         .clk(clk), .io_enable(io_enable), .io_strobe(io_strobe),
@@ -42,7 +42,7 @@ module dvd_telem_tb;
         .drops(drops), .vid_err(vid_err), .drop_costs(drop_costs),
         .vbuf_fill(vbuf_fill), .aud_frames(aud_frames), .flags(flags),
         .aud_play(aud_play), .aud_gate(aud_gate),
-        .af_passthru(af_pt), .af_pcm_session(af_pcm));
+        .af_passthru(af_pt), .af_pcm_session(af_pcm), .af_bs_session(af_bs));
 
     task strobe(input [15:0] d);
         begin
@@ -134,20 +134,27 @@ module dvd_telem_tb;
         check("pickups",   got[2], 16'hBBBB);
 
         $display("[5] CMD_AF reports the audio link format, independently of 0x7A");
-        af_pt = 1; af_pcm = 0;                 // Passthru, bitstream content
+        // Bit 15 is the FORMAT VERSION and is set in every answer, content or
+        // not: Main uses it to tell a core that reports bs_session from one that
+        // predates it, and both answer bs=0 when nothing is playing.
+        af_pt = 1; af_pcm = 0; af_bs = 1;      // Passthru, an AC-3/DTS track
         repeat (64) @(negedge clk);   // sampler rotation is 57 cycles
         run_xact(16'h007B, 1'b0, drove);
         if (!drove) begin
             $display("  FAIL: CMD_AF did not drive the bus"); errors = errors + 1; end
-        check("afmt-bitstream", got[1], 16'h0001);
-        af_pcm = 1;                            // ...now an LPCM/MP2 track
+        check("afmt-bitstream", got[1], 16'h8005);
+        af_pcm = 1; af_bs = 0;                 // ...now an LPCM/MP2 track
         repeat (64) @(negedge clk);   // sampler rotation is 57 cycles
         run_xact(16'h007B, 1'b0, drove);
-        check("afmt-pcm", got[1], 16'h0003);
-        af_pt = 0; af_pcm = 0;                 // back to Decode
+        check("afmt-pcm", got[1], 16'h8003);
+        af_pt = 1; af_pcm = 0; af_bs = 0;      // Passthru, nothing playing yet
         repeat (64) @(negedge clk);   // sampler rotation is 57 cycles
         run_xact(16'h007B, 1'b0, drove);
-        check("afmt-decode", got[1], 16'h0000);
+        check("afmt-idle", got[1], 16'h8001);
+        af_pt = 0; af_pcm = 0; af_bs = 0;      // back to Decode
+        repeat (64) @(negedge clk);   // sampler rotation is 57 cycles
+        run_xact(16'h007B, 1'b0, drove);
+        check("afmt-decode", got[1], 16'h8000);
         // ...and the diagnostic snapshot is untouched by any of it.
         run_xact(16'h007A, 1'b0, drove);
         check("0x7A still reports counters", got[1], 16'hAAAA);

--- a/bench/dvd/run_passthru_pcm.sh
+++ b/bench/dvd/run_passthru_pcm.sh
@@ -81,6 +81,29 @@ if [ "$RED" -eq 1 ]; then
     #    and the NEXT frame's first byte goes to the wrong consumer.
     red_case take-byte-uncounted "payload taken by the other consumer" \
         "s/bytes_left <= take_rem;/bytes_left <= frame_len;/"
+
+    # 5. bs_session on the arbiter's own reset instead of its long-lived one.
+    #    This is the seek regression, and it is the ONLY thing separating
+    #    bs_session from pcm_session -- get it wrong and the two are the same
+    #    signal, so the HDMI link releases and re-engages at every chapter skip.
+    red_case bs-session-on-aud-reset "an aud_rst_n pulse (seek) dropped bs_session" \
+        "s/always_ff @(posedge clk or negedge hard_rst_n) begin/always_ff @(posedge clk or negedge rst_n) begin/;
+         s/if (!hard_rst_n)        bs_session <= 1'b0;/if (!rst_n)        bs_session <= 1'b0;/"
+
+    # 6. The verdict powers up SET: exactly the shipped behaviour this fixes --
+    #    the transmitter is put into non-PCM mode with nothing playing at all.
+    red_case bs-session-set-at-boot "bs_session set at boot" \
+        "s/if (!hard_rst_n)        bs_session <= 1'b0;/if (!hard_rst_n)        bs_session <= 1'b1;/"
+
+    # 7. An empty slot no longer forgets. An ejected disc would leave the link
+    #    claimed for as long as the core stayed loaded.
+    red_case bs-session-ignores-eject "an empty slot left the HDMI link claimed" \
+        "s/else if (sess_clr)      bs_session <= 1'b0;//"
+
+    # 8. Decode mode claims the link. The ack must never be raised for a path
+    #    whose audio leaves as PCM.
+    red_case bs-session-in-decode-mode "bs_session set in Decode mode" \
+        "s/else if (take \&\& split_en) bs_session <= is_bitstream;/else if (take) bs_session <= is_bitstream;/"
 fi
 
 if [ "$fail" -ne 0 ]; then echo; echo "SUITE FAILED"; exit 1; fi

--- a/docs/hdmi_bitstream.md
+++ b/docs/hdmi_bitstream.md
@@ -633,14 +633,34 @@ The §5a engage policy and teardown are covered off-hardware in two places:
    **silent, never noisy**, in Passthru. On **stock Main** the same `.rbf` is silent
    over HDMI and optical passthrough still works — i.e. the ack gate holds and a
    user who never installs MiSTer_DVDcss is unaffected.
-6. **§5a stickiness (⏳ pending).** Read the flag rather than listening where the
-   board has `i2cget` — bus 1 (2 on some boards), address `0x39`, register `0x12`:
-   `0x20` is PCM, `0xA0` non-PCM. (a) Passthru selected, nothing loaded → `0x20`.
-   (b) AC-3 title playing → `0xA0`; a chapter seek must NOT produce a
-   release/engage pair in `/tmp/dvd_hdmi_audio.log`. (c) an LPCM track → `0x20`.
-   (d) load another core while an AC-3 title plays → that core has HDMI audio and
-   `0x12` reads `0x20`. (e) OSD Reboot while engaged → the menu core has audio.
-   (f) listen at a title start for how much DD audio the PCM→DD switch clips.
+6. **§5a stickiness — ✅ HW-CONFIRMED 2026-09-12, defect reproduced first.** Read the
+   flag rather than listening: `i2cget -y 1 0x39 0x12` on the rig (**bus 1**, the
+   ADV7513 main map at `0x39`; chip revision reads `0x13` at register `0x00`, which is
+   how to find the bus). `0x20` = PCM, `0xA0` = non-PCM.
+   ⚠ **The rig's own sink does not advertise AC-3/DTS** (`sink_ok=0` in the log), so
+   nothing engages at all until `dvd_hdmi_bitstream=2` is set under `[DVD]` in
+   `MiSTer.ini` — **back it up and put it back by hand; `mister.py restore` does not
+   touch the ini.**
+
+   | arm | measured |
+   |---|---|
+   | RED: pre-fix core + Main, DVD core running | `0xA0` |
+   | RED: …then load the menu core | **`0xA0`** — the report, reproduced |
+   | GREEN: core load with the flag left stuck at `0xA0` | `0x20` — self-heal (step 38) |
+   | GREEN: Passthru, nothing routed yet (t+3 s, t+6 s) | `0x20` |
+   | GREEN: AC-3 playing (t+9 s onward) | `0xA0` |
+   | GREEN: 3 chapter skips + 3 audio-track switches | `0xA0`, **1 write in total** |
+   | GREEN: LPCM VOB in Passthru | `0x20` |
+   | GREEN: Decode PCM, AC-3 playing | `0x20` |
+   | GREEN: load another core while engaged | **`0x20`** + `teardown: restoring PCM mode` |
+
+   ★ **Count `adv7513:` lines in `/tmp/dvd_hdmi_audio.log` for the churn arms, not
+   register samples** — the log records every write, so it catches a release/engage
+   pair that a 0.5 s sampler would step over. Exactly 1 across six transport events.
+   ⏳ **Still unexercised: (e) the `reboot()` arm** — same one-line call, present in the
+   built binary, but the OSD Reboot row cannot be driven from the harness and a reboot
+   wipes `/tmp` along with the log. ⏳ And **(f)**, what a receiver does with the
+   PCM→DD switch at a title start: this sink has no AC-3/DTS decoder, so it cannot say.
 
 If (1) fails with the receiver naming nothing or mis-locking, try the §3
 preamble table before anything else.

--- a/docs/hdmi_bitstream.md
+++ b/docs/hdmi_bitstream.md
@@ -582,9 +582,10 @@ stock-Main boot will not clear it. **Recovery is a power cycle (measured: the
 register does not survive one) or loading this core again.** Layer 1 is what makes
 that window small instead of "any session in which Passthru was ever selected".
 
-⚠ **Accepted trade:** every title start is now one PCM→DD switch, which is the
-fj#110 shape (*"receiver sees PCM then one clean switch, like a real player"*) and
-may clip the first moment of audio while the receiver locks. HW check.
+✅ **The accepted trade, now paid:** every title start is one PCM→DD switch, the
+fj#110 shape (*"receiver sees PCM then one clean switch, like a real player"*). It
+was expected to cost the first moment of audio while the receiver locks; **on a real
+receiver it does not clip audibly** (2026-09-12, §6 gate (f)).
 
 ---
 
@@ -666,8 +667,10 @@ The §5a engage policy and teardown are covered off-hardware in two places:
    times in these notes as the chip's reset value *"not something any code here can
    assert"* — it is now measured, and it is the one layer no code can provide, which is
    why the residual below is bounded by it rather than by anything we wrote.
-   ⏳ **(f) remains unreported:** what a receiver makes of the PCM→DD switch at a title
-   start. This rig's sink has no AC-3/DTS decoder, so nothing here can hear it.
+   ✅ **(f) CONFIRMED 2026-09-12 (maintainer, on a real receiver): the PCM→DD switch at
+   a title start does not clip audibly.** This rig's sink has no AC-3/DTS decoder, so
+   nothing here could hear it — the whole per-track policy rested on the fj#110
+   precedent until someone listened.
 
 If (1) fails with the receiver naming nothing or mis-locking, try the §3
 preamble table before anything else.

--- a/docs/hdmi_bitstream.md
+++ b/docs/hdmi_bitstream.md
@@ -507,19 +507,83 @@ falls back to PCM in that case.
 
 Registers written for bitstream / PCM:
 
+Registers written for bitstream / PCM (**the shipping route (i) values**, corrected
+2026-09-11 — this table used to list the removed IEC958-direct route and was flagged
+as stale in §2's banner; the authority is `hdmi_config_set_audio()` in
+`main/integration/apply_integration.py`):
+
 | reg | bitstream | PCM | meaning |
 |---|---|---|---|
 | `0x0A` | `0x00` | `0x00` | audio select = I2S |
-| `0x0C` | `0x07` | `0x04` | I2S0 enable; `[1:0]` 3 = IEC958 direct, 0 = standard |
+| `0x0C` | `0x44` | `0x04` | I2S0 enable; `[6]` 1 = channel status from the register map; `[1:0]` 0 = standard I2S |
+| `0x12` | `0xA0` | `0x20` | channel status byte 0: `[7]` 1 = NOT linear PCM, `[5]` copyright not asserted |
 | `0x14` | `0x02` | `0x02` | word length 16 bit |
 | `0x15` | rate | rate | sampling rate (follows `hdmi_audio_96k`) |
-| `0x73` | `0x00` | `0x01` | InfoFrame CC: 0 = refer to stream header |
+| `0x73` | `0x01` | `0x01` | Channel Count = 1 (stereo) — Programming Guide §4.4.1.1 |
 
 **N and CTS are unchanged.** 61937 at 48 kHz *is* a 48 kHz stream — which is a
 large part of why this feature is small.
 
 MiSTer.ini: `dvd_hdmi_bitstream` — `0` auto (EDID-gated, default), `1` off,
 `2` force. Force exists because sinks do mis-report, especially over ARC.
+
+---
+
+## 5a. The non-PCM flag is STICKY (field report, 2026-09-11)
+
+Report: *"enable passthru with the modified main installed, then load another core
+— the register is still set and you get no audio."* Confirmed, and worse than it
+sounds, because it needed no disc: selecting Passthru was enough.
+
+★★ **§2 PREDICTED THIS AND THE PREDICTION WAS FILED UNDER A ROUTE WE DIDN'T
+SHIP.** Its argument for IEC958-direct was that route (i) *"can only pin the flag
+high for a whole session, putting us straight back in the regime the fj#110 fix
+exists to avoid"*. Route (ii) was then removed after four failed HW rounds and we
+shipped (i) — inheriting exactly the property §2 had rejected it for, with the
+warning still sitting in the file describing the losing option.
+
+Two mechanisms, and the second is the one that reaches other cores:
+
+1. **`0x12` is written by nobody else.** Stock `hdmi_config_init()` rewrites `0x0C`
+   — so the *route* reverts — but its `init_data` has **no `0x12` entry at all**.
+   Whatever we last wrote there stands, through a core load and through a warm
+   reboot (which resets the HPS, not the transmitter). A power cut should clear
+   it; that is the chip's reset value, not something any code here can assert.
+2. **Nothing ran on the way out.** Every other core runs **stock Main** via
+   `main=`, and our own re-exec cannot help either: `user_io_init()` hands off to
+   the core's `main=` binary at stock `user_io.cpp:~1484`, **before `video_init()`
+   at 1514**. So this process never touched the chip again.
+
+⚠ A third thing made it fire with nothing playing: `want` was
+`passthru && sink_ok && !pcm_session`, and `pcm_session` reads 0 **both** when
+AC-3 is playing and when nothing is. See `dvd/aud_route.sv`.
+
+**The fix is three-layered, because no single layer can cover a crash:**
+
+| layer | covers | mechanism |
+|---|---|---|
+| PCM is the resting state | idle, menus, LPCM/MP2, ejected, and everything after a crash *unless a DD/DTS track was playing at that instant* | `bs_session` (core) + `content_is_bitstream()` (Main) |
+| teardown at both exits | every core load and every reboot | steps 36/37: `dvd_hdmi_audio_teardown()` in `app_restart()` and `reboot()` |
+| clear at our own init | an unclean exit, recovered by loading this core again | step 38: `0x12 = 0x20` in `hdmi_config_init()` |
+
+★ **Teardown keys on `chip_nonpcm`, not on `acked`.** They disagree for 50 ms on
+every release — ack down, registers not yet restored — and a core load landing in
+that window is precisely the case `acked` answers wrongly. That is the one host
+mutation (`teardown-keyed-on-ack`) caught by a single arm.
+
+★ Both teardown sites sit immediately after their own function's
+`fpga_core_reset(1)`, so the core is silent before the registers move: the §4
+ordering invariant, applied to an exit.
+
+⚠ **Residual, by construction:** a Main crash, a kernel panic, or the board's
+reset button *while a DD/DTS track is playing* leaves the flag set, and the next
+stock-Main boot will not clear it. Recovery is a power cycle or loading this core
+again. Layer 1 is what makes that window small instead of "any session in which
+Passthru was ever selected".
+
+⚠ **Accepted trade:** every title start is now one PCM→DD switch, which is the
+fj#110 shape (*"receiver sees PCM then one clean switch, like a real player"*) and
+may clip the first moment of audio while the receiver locks. HW check.
 
 ---
 
@@ -543,6 +607,20 @@ demodulator was free-running a bit counter from reset instead of framing on
 that fail silently here are bit order and channel mapping, which is exactly why
 they have to be read back off the wire.
 
+⚠ **`i2s_iec958_tb` was DELETED with the IEC958-direct route** (§2's banner says so);
+the runner no longer builds it. The bullet stays because the *reason* it was written
+that way is the reusable part.
+
+The §5a engage policy and teardown are covered off-hardware in two places:
+
+- **`bench/dvd/run_passthru_pcm.sh --red`** — `aud_route_tb` TEST 6 measures
+  `bs_session` as a level at boot / AC-3 / a seek / LPCM / eject / Decode mode, with
+  four mutations each caught by its own assertion. The seek arm is the load-bearing
+  one: it is the only thing separating `bs_session` from `pcm_session`.
+- **`main/tests/run_tests.sh --red`** — the Main decision table, including teardown
+  inside the 50 ms release window and the version-flag fallback, with four mutations.
+  Ordinary host `g++`; no ARM toolchain, no MiSTer, no Docker.
+
 ### HW gate — nothing about the ADV7513 is simulable
 
 1. AVR shows "Dolby Digital" / "DTS" and plays 5.1.
@@ -555,6 +633,14 @@ they have to be read back off the wire.
    **silent, never noisy**, in Passthru. On **stock Main** the same `.rbf` is silent
    over HDMI and optical passthrough still works — i.e. the ack gate holds and a
    user who never installs MiSTer_DVDcss is unaffected.
+6. **§5a stickiness (⏳ pending).** Read the flag rather than listening where the
+   board has `i2cget` — bus 1 (2 on some boards), address `0x39`, register `0x12`:
+   `0x20` is PCM, `0xA0` non-PCM. (a) Passthru selected, nothing loaded → `0x20`.
+   (b) AC-3 title playing → `0xA0`; a chapter seek must NOT produce a
+   release/engage pair in `/tmp/dvd_hdmi_audio.log`. (c) an LPCM track → `0x20`.
+   (d) load another core while an AC-3 title plays → that core has HDMI audio and
+   `0x12` reads `0x20`. (e) OSD Reboot while engaged → the menu core has audio.
+   (f) listen at a title start for how much DD audio the PCM→DD switch clips.
 
 If (1) fails with the receiver naming nothing or mis-locking, try the §3
 preamble table before anything else.

--- a/docs/hdmi_bitstream.md
+++ b/docs/hdmi_bitstream.md
@@ -547,8 +547,9 @@ Two mechanisms, and the second is the one that reaches other cores:
 1. **`0x12` is written by nobody else.** Stock `hdmi_config_init()` rewrites `0x0C`
    — so the *route* reverts — but its `init_data` has **no `0x12` entry at all**.
    Whatever we last wrote there stands, through a core load and through a warm
-   reboot (which resets the HPS, not the transmitter). A power cut should clear
-   it; that is the chip's reset value, not something any code here can assert.
+   reboot (which resets the HPS, not the transmitter). **A power cut does clear it
+   — MEASURED 2026-09-12** (see §6 gate (e)), which was assumed from the chip's
+   reset value until someone pulled the plug and checked.
 2. **Nothing ran on the way out.** Every other core runs **stock Main** via
    `main=`, and our own re-exec cannot help either: `user_io_init()` hands off to
    the core's `main=` binary at stock `user_io.cpp:~1484`, **before `video_init()`
@@ -577,9 +578,9 @@ ordering invariant, applied to an exit.
 
 ⚠ **Residual, by construction:** a Main crash, a kernel panic, or the board's
 reset button *while a DD/DTS track is playing* leaves the flag set, and the next
-stock-Main boot will not clear it. Recovery is a power cycle or loading this core
-again. Layer 1 is what makes that window small instead of "any session in which
-Passthru was ever selected".
+stock-Main boot will not clear it. **Recovery is a power cycle (measured: the
+register does not survive one) or loading this core again.** Layer 1 is what makes
+that window small instead of "any session in which Passthru was ever selected".
 
 ⚠ **Accepted trade:** every title start is now one PCM→DD switch, which is the
 fj#110 shape (*"receiver sees PCM then one clean switch, like a real player"*) and
@@ -657,10 +658,16 @@ The §5a engage policy and teardown are covered off-hardware in two places:
    ★ **Count `adv7513:` lines in `/tmp/dvd_hdmi_audio.log` for the churn arms, not
    register samples** — the log records every write, so it catches a release/engage
    pair that a 0.5 s sampler would step over. Exactly 1 across six transport events.
-   ⏳ **Still unexercised: (e) the `reboot()` arm** — same one-line call, present in the
-   built binary, but the OSD Reboot row cannot be driven from the harness and a reboot
-   wipes `/tmp` along with the log. ⏳ And **(f)**, what a receiver does with the
-   PCM→DD switch at a title start: this sink has no AC-3/DTS decoder, so it cannot say.
+
+   ✅ **(e) the `reboot()` arm and the power-cut question — CONFIRMED BY THE MAINTAINER
+   2026-09-12**, both out of the harness's reach: rebooting while a DD track plays
+   restores PCM for the next core, and **a power cut does not retain the register** (a
+   game core has audio afterwards). ★ The power-cut behaviour had been asserted three
+   times in these notes as the chip's reset value *"not something any code here can
+   assert"* — it is now measured, and it is the one layer no code can provide, which is
+   why the residual below is bounded by it rather than by anything we wrote.
+   ⏳ **(f) remains unreported:** what a receiver makes of the PCM→DD switch at a title
+   start. This rig's sink has no AC-3/DTS decoder, so nothing here can hear it.
 
 If (1) fails with the receiver naming nothing or mis-locking, try the §3
 preamble table before anything else.

--- a/docs/hil_harness.md
+++ b/docs/hil_harness.md
@@ -134,6 +134,26 @@ primary reader: the numeric `DEBUG_OVERLAY` lattice it decodes is compiled out
 - `log_file_entry=0` in `MiSTer.ini`, so `/tmp/OSD_VISIBLE` is not written.
   Setting it to 1 would give the harness OSD state, which it otherwise cannot
   see at all.
+- **`i2cget`/`i2cdetect`/`i2cdump` are installed**, and the **ADV7513 main map is on
+  i2c bus 1 at `0x39`** (register `0x00` reads `0x13`, the chip revision — that is how
+  to find the bus; the other two buses error). This makes the HDMI audio path
+  *measurable* instead of a listening test: register `0x12` is `0x20` for PCM and
+  `0xA0` for non-PCM, and it settled the 2026-09-12 teardown bug end to end
+  (`docs/hdmi_bitstream.md` §5a). ⚠ **This rig's display does NOT advertise AC-3/DTS**,
+  so bitstream never engages here unless `dvd_hdmi_bitstream=2` is set under `[DVD]`;
+  **`mister.py restore` does not touch `MiSTer.ini`**, so back it up and put it back
+  by hand.
+
+### ⚠ Telemetry read across a launch is GARBAGE, and it looks like a finding
+
+A `telem --watch` window that starts too soon after `launch` spans the core's reset and
+reports impossibilities: **1003 refreshes/s, 1026 lates/s, 65,524 drain-gate closures**
+(counter deltas taken across the zeroing). A second window on settled playback read
+59.955 Hz, 24.01 fps, audio −12 ppm, 0 lates, 0 drops — the same build, seconds later.
+Settle ~20 s, and re-measure anything that looks catastrophic before believing it.
+
+⚠ The same trap in reverse: a 41 s window on a **66 s clip** starting 20 s in spans the
+end of the file and reports the audio rate 15 % low. Match the window to the material.
 
 ## Track C status (lip-sync)
 

--- a/docs/iec61937.md
+++ b/docs/iec61937.md
@@ -89,6 +89,11 @@
   set, and `emu.sv` leaves `bs_nonpcm_o` unconnected. PCM silence and a non-PCM hold
   put identical bits on the HDMI wire. Any future fill A/B must be run on optical.
   (The shipped fj#110 "PCM silence during holds" fix is therefore optical-only too.)
+  ⚠ **"While the ack is set" is now a PER-TRACK window, not a session** (2026-09-11):
+  Main raises the ack only while an AC-3/DTS track is actually being routed, so every
+  track change is a PCM↔non-PCM transition on HDMI where it used to be one at the
+  start of the session. That is the fj#110 shape by construction, and it is what
+  stops the flag being inherited by the next core — see `docs/hdmi_bitstream.md` §5a.
   ★★ **(2) AND IT WAS STILL NOT BUILT, because the premise was wrong.** A **PS5**
   playing a DVD was measured doing exactly the same thing: dropping the decoder on a
   pause and between menus. Leaving DD during a gap is what a shipping consumer

--- a/dvd/aud_route.sv
+++ b/dvd/aud_route.sv
@@ -30,6 +30,10 @@
 //  head refills from the descriptor RAM (audio_ring.sv:139-145). A grant must
 //  only ever be taken while frame_valid is high, or the type read is stale.
 //
+//  IT ALSO OWNS THE HDMI LINK-FORMAT VERDICT (bs_session), because this is the
+//  one place that knows which codec is on the wire. Its reset domain is
+//  deliberately NOT the arbiter's: see the hard_rst_n port comment.
+//
 //  ⚠ A held frame is NOT an idle one. iec61937_wrap holds a codec frame for A/V
 //  sync without popping it, sometimes for many burst periods. The grant stays
 //  with the wrapper throughout: the head really is its frame, and starving the
@@ -41,6 +45,14 @@
 module aud_route (
     input  logic       clk,
     input  logic       rst_n,          // audio-chain reset (aud_rst_n)
+
+    // ⚠ A SECOND, MUCH LONGER-LIVED reset domain, for bs_session ONLY. rst_n is
+    // aud_rst_n, which pulses on every seek, audio-track switch and aud_flush --
+    // fine for the arbiter's own state, fatal for a verdict the HDMI link format
+    // is derived from: a chapter skip would release the ADV7513 to PCM and
+    // re-engage a moment later, and the receiver re-locks on each one.
+    input  logic       hard_rst_n,     // core reset (reset_n)
+    input  logic       sess_clr,       // 1 = no media loaded; forget the verdict
 
     // 1 = Passthru: split by codec. 0 = Decode: the decoder takes everything,
     // which is the pre-existing behaviour, bit for bit.
@@ -60,7 +72,16 @@ module aud_route (
     // Content class of the frames being routed, latched at each grant so it
     // holds through gaps instead of flapping. 1 = LPCM/MP2 (this is a PCM
     // session), 0 = AC-3/DTS. Drives the HDMI link-format request.
-    output logic       pcm_session
+    output logic       pcm_session,
+
+    // 1 = the content being routed right now IS an IEC 61937 bitstream. NOT the
+    // inverse of pcm_session: that one resets to 0 (= "not PCM") and resets on
+    // every aud_rst_n, so "engage on !pcm_session" put the ADV7513 into non-PCM
+    // mode the moment the core booted with Passthru saved -- before any disc was
+    // loaded -- and left it there for the next core to inherit. This one is
+    // FALSE until a bitstream frame has actually been routed, so PCM is the
+    // resting state and the HDMI link is only claimed while DD/DTS is playing.
+    output logic       bs_session
 );
 
     // AC-3 and DTS are the IEC 61937 codecs; everything else is decoded to PCM.
@@ -118,6 +139,17 @@ module aud_route (
             end
             endcase
         end
+    end
+
+    // ---- the HDMI link-format verdict, in its own reset domain ---------------
+    // Same update event as pcm_session (a grant taken under split_en), so the two
+    // can never disagree about the frame they describe; only the reset differs.
+    // sess_clr is synchronous: it is a clk_sys level (~media_seen), and an eject
+    // is not urgent to the nanosecond -- what matters is that it is NOT aud_rst_n.
+    always_ff @(posedge clk or negedge hard_rst_n) begin
+        if (!hard_rst_n)        bs_session <= 1'b0;
+        else if (sess_clr)      bs_session <= 1'b0;
+        else if (take && split_en) bs_session <= is_bitstream;
     end
 
 endmodule

--- a/dvd/dvd_telem.sv
+++ b/dvd/dvd_telem.sv
@@ -107,8 +107,13 @@ module dvd_telem #(
     // What the wire is actually carrying, which is NOT what the OSD bit says: in
     // Passthru an LPCM or MP2 track leaves as linear PCM, and the ADV7513 has to
     // be taken out of non-PCM mode for it. Main polls this to decide.
+    // ⚠ Bit 15 is a FORMAT VERSION, not data. A core built before bs_session
+    // existed answers with it clear, and Main must then fall back to the old
+    // !pcm_session rule -- the two cannot be told apart otherwise, because an
+    // old core and a new idle one both answer "pcm_session = 0".
     input         af_passthru,            // Audio Out = Passthru
-    input         af_pcm_session          // ...and the current content is LPCM/MP2
+    input         af_pcm_session,         // ...and the current content is LPCM/MP2
+    input         af_bs_session           // ...and the current content IS AC-3/DTS
 );
 
     // ---- ONE round-robin two-consecutive-agree sampler (area pass 2026-09-10) --
@@ -140,7 +145,9 @@ module dvd_telem #(
     assign src[13] = av_drift;
     assign src[14] = sched_flags;
     assign src[15] = sched_dur;
-    assign src[16] = {14'd0, af_pcm_session, af_passthru};
+    // [15] = format v2 (this word carries bit 2), [2] bitstream session,
+    // [1] PCM session, [0] Passthru. See the port comments.
+    assign src[16] = {1'b1, 12'd0, af_bs_session, af_pcm_session, af_passthru};
     assign src[17] = 16'd0;                 // spare slots keep the walk a plain counter
     assign src[18] = 16'd0;
 

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -417,6 +417,10 @@ assign SPDIF_PASS_EN = pass_mode;
 // aud_route's grants + content class (driven by the instance further down; declared
 // here because pcm_mute and HDMI_BS_EN both need the class).
 wire rt_dec_owns, rt_wrap_owns, rt_pcm_session;
+// rt_bs_session: "a bitstream is what is playing right now". This, NOT
+// ~rt_pcm_session, is what Main engages the ADV7513's non-PCM mode on -- see the
+// port comment in dvd/aud_route.sv and docs/hdmi_bitstream.md.
+wire rt_bs_session;
 
 // ⚠ pass_mode alone no longer mutes: in Passthru with LPCM/MP2 content the sink
 // is in PCM mode and AUDIO_L/R is how HDMI carries it. hdmi_bs_ack stays in the
@@ -1030,7 +1034,8 @@ dvd_telem dvd_telem_inst (
     // CMD_AF: what the audio wire is really carrying, so Main can put the ADV7513
     // into PCM mode for an LPCM/MP2 track in Passthru.
     .af_passthru    (pass_mode),
-    .af_pcm_session (rt_pcm_session)
+    .af_pcm_session (rt_pcm_session),
+    .af_bs_session  (rt_bs_session)
 );
 
 
@@ -3208,6 +3213,10 @@ wire        pass_hold_active;                // wrapper A/V-sync hold level (wat
 aud_route aud_route_i (
     .clk         (clk_sys),
     .rst_n       (aud_rst_n),
+    // bs_session's own domain: it must survive every seek / track switch /
+    // aud_flush, and forget the verdict only when the slot is empty.
+    .hard_rst_n  (reset_n),
+    .sess_clr    (~media_seen),
     .split_en    (pass_mode),
     .frame_valid (aud_frame_valid),
     .frame_type  (aud_frame_type),
@@ -3215,7 +3224,8 @@ aud_route aud_route_i (
     .ring_ready  (aud_ring_ready),
     .dec_owns    (rt_dec_owns),
     .wrap_owns   (rt_wrap_owns),
-    .pcm_session (rt_pcm_session)
+    .pcm_session (rt_pcm_session),
+    .bs_session  (rt_bs_session)
 );
 
 wire dec_frame_valid  = aud_frame_valid & rt_dec_owns;

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -589,7 +589,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "dev-almreclaimrdr"
+`define CORE_VERSION "dev-hdmiteardown"
 
 parameter CONF_STR = {
     "DVD;;",

--- a/main/integration/INTEGRATION.md
+++ b/main/integration/INTEGRATION.md
@@ -152,8 +152,12 @@ sink expects PCM, and a bitstream would arrive as full-scale noise.
 | 19 | `video.cpp` | bump that counter in `hdmi_config_init()` |
 | 20 | `video.cpp` | `hdmi_config_set_audio()` — the audio-only register writer |
 | 21 | `cfg.h` / `cfg.cpp` | `dvd_hdmi_bitstream` ini key (0=auto, 1=off, 2=force) |
+| 35 | `fpga_io.cpp` | include `support/dvd/dvd_hdmi_audio.h` |
+| 36 | `fpga_io.cpp` | `dvd_hdmi_audio_teardown()` in `app_restart()` — every core load ends here |
+| 37 | `fpga_io.cpp` | `dvd_hdmi_audio_teardown()` in `reboot()` — a warm reboot resets the HPS, not the ADV7513 |
+| 38 | `video.cpp` | clear `0x12` (the non-PCM flag) in `hdmi_config_init()` — self-heal after an unclean exit |
 
-Three things here are easy to get subtly wrong:
+Four things here are easy to get subtly wrong:
 
 - **Step 19's anchor is the `for (uint i = 0; ...)` write-loop header, not
   `hdmi_config_set_csc();`.** That second string appears again later in
@@ -166,6 +170,16 @@ Three things here are easy to get subtly wrong:
 - **Bit 14 is nearly the last free `cfg[]` bit.** Stock defines up to
   `CONF_DIRECT_VIDEO2` (bit 13); only 14 and 15 remain. If a future stock version
   claims 14, this step must move rather than collide silently.
+- **Steps 36–38 exist because register `0x12` is STICKY and nobody else clears
+  it.** Stock `init_data` rewrites `0x0C` but has no `0x12` entry at all, so the
+  non-PCM flag we set survives into the next core — which runs stock Main, sends
+  ordinary PCM, and is rendered as a data burst: silent. This process is the only
+  one that can put it back, and it cannot do so on its own re-exec either, because
+  `user_io_init()` hands off to the core's `main=` binary **before** `video_init()`
+  runs. Hence teardown at both exits (36/37), plus 38 so an unclean exit is
+  recovered by loading this core again. Both teardown anchors sit immediately after
+  that function's own `fpga_core_reset(1)`, so the core is already silent when the
+  registers change.
 
 The core marks the option `OX6` rather than `O6`. `OX` means "also handled by the
 HPS": the bit still reaches the core exactly as before, but Main sees the

--- a/main/integration/apply_integration.py
+++ b/main/integration/apply_integration.py
@@ -517,4 +517,55 @@ m = replace_once(m,
 write(m_path, m)
 print("[integration] menu.cpp patched (MGL delay)")
 
+# ---------------------------------------------------------------- fpga_io.cpp
+# Teardown of the ADV7513's non-PCM mode. This process is the ONLY one that can
+# do it: every other core runs stock Main, whose hdmi_config_init() rewrites 0x0C
+# but has no 0x12 entry, so the non-PCM flag is never cleared by anybody else --
+# and our own re-exec cannot help, because user_io_init() hands off to the core's
+# `main=` binary BEFORE video_init() runs (stock user_io.cpp: the handoff at
+# ~1484, video_init() at 1514). See MiSTer_DVD/docs/hdmi_bitstream.md.
+fio_path = os.path.join(ROOT, "fpga_io.cpp")
+if not os.path.exists(fio_path):
+    fail(35, f"{fio_path} not found")
+fio = read(fio_path)
+
+# 35. include
+fio = insert_after(fio, '#include "fpga_io.h"',
+    '#include "support/dvd/dvd_hdmi_audio.h"   // dvd:hdmibs\n',
+    35, 'support/dvd/dvd_hdmi_audio.h')
+
+# 36. app_restart() — every core load reaches here (fpga_load_rbf() ends in it).
+# Placed after this function's fpga_core_reset(1), so the core is already silent
+# and PCM can never be presented into a link still expecting non-PCM.
+fio = insert_before(fio, '\tinput_switch(0);',
+    'dvd_hdmi_audio_teardown();   // dvd:hdmibs - never hand the next core a non-PCM link\n',
+    36, 'dvd_hdmi_audio_teardown')
+
+# 37. reboot() — the OSD Reboot row, `fpga_load_rbf(name, cfg)`, and app_restart's
+# own fallback. A warm reboot resets the HPS, NOT the transmitter, so without this
+# the flag survives into whatever core boots next. Also after fpga_core_reset(1).
+fio = insert_before(fio, '\tusleep(500000);',
+    'dvd_hdmi_audio_teardown();   // dvd:hdmibs - the HPS resets, the ADV7513 does not\n',
+    37, 'dvd:hdmibs - the HPS resets')
+
+write(fio_path, fio)
+print("[integration] fpga_io.cpp patched (hdmi bitstream teardown)")
+
+# ---------------------------------------------------------------- video.cpp
+# 38. Self-heal at our own init. Teardown covers every ORDERLY exit; a crash, a
+# kill, or the board's reset button does not run it. Clearing the flag here means
+# the DVD core itself always starts from PCM, so the machine recovers by loading
+# this core again. It also makes step 19's "the audio block is about to revert to
+# PCM" literally true: stock init_data has no 0x12 entry, which is the whole
+# reason the flag was sticky. The generation watcher re-applies non-PCM straight
+# afterwards if the ack is still held, so an engaged session is unaffected.
+vc = read(vc_path)
+vc = insert_before(vc, 'hdmi_cfg_generation++;',
+    '// dvd:hdmibs - 0x12[7] is the non-PCM flag and init_data does not carry it,\n'
+    '// so nothing else would ever clear it. 0x20 = linear PCM, copyright not asserted.\n'
+    'i2c_smbus_write_byte_data(hdmi_main_fd, 0x12, 0x20);\n',
+    38, 'dvd:hdmibs - 0x12[7] is the non-PCM flag')
+write(vc_path, vc)
+print("[integration] video.cpp patched (non-PCM flag cleared at init)")
+
 print("[integration] done")

--- a/main/support/dvd/dvd_hdmi_audio.cpp
+++ b/main/support/dvd/dvd_hdmi_audio.cpp
@@ -156,6 +156,8 @@ static void report_pump(void)
 #define DVD_TELEM_MAGIC  0xD7D1
 
 static int core_pcm_session = 0;   // 1 = Passthru is carrying PCM content
+static int core_bs_session  = 0;   // 1 = Passthru is carrying AC-3/DTS right now
+static int core_fmt_v2      = 0;   // the core reports bs_session at all
 
 static void poll_audio_format(void)
 {
@@ -169,14 +171,43 @@ static void poll_audio_format(void)
 
 	// An older core does not answer this command; leave the format unknown and
 	// behave exactly as before rather than guessing.
-	if (magic != DVD_TELEM_MAGIC) { core_pcm_session = 0; return; }
-	core_pcm_session = (fmt >> 1) & 1;   // bit0 = passthru, bit1 = pcm session
+	if (magic != DVD_TELEM_MAGIC) { core_pcm_session = 0; core_bs_session = 0;
+	                               core_fmt_v2 = 0; return; }
+	// bit0 = passthru, bit1 = pcm session, bit2 = bitstream session,
+	// bit15 = this word carries bit 2 at all.
+	core_pcm_session = (fmt >> 1) & 1;
+	core_bs_session  = (fmt >> 2) & 1;
+	core_fmt_v2      = (fmt >> 15) & 1;
+}
+
+// What the ADV7513 must be told to expect. ⚠ NOT the inverse of pcm_session:
+// that reads 0 both when AC-3 is playing and when NOTHING is, so engaging on it
+// put the transmitter into non-PCM mode the moment the core booted with Passthru
+// saved -- and the next core inherited it, because stock Main's hdmi_config_init()
+// rewrites 0x0C but has no 0x12 entry at all, and so never clears the flag.
+// A pre-bs_session core keeps the old rule; its word cannot express the
+// difference, and changing behaviour for it would be a guess.
+static int content_is_bitstream(void)
+{
+	return core_fmt_v2 ? core_bs_session : !core_pcm_session;
 }
 
 static int declared   = 0;   // the core declared OX6, so it has the HDMI tap
 static int acked      = 0;   // cfg[14] is currently set
 static int seen_gen   = -1;  // last hdmi_config_init() generation we applied over
 static unsigned long restore_at = 0;
+
+// What the CHIP is set to, which is NOT `acked`: between dropping the ack and the
+// 50 ms register restore the core is already silent while the transmitter is
+// still in non-PCM mode. Teardown has to act on the chip's state, not the ack's,
+// or a core load landing inside that window leaves the flag set.
+static int chip_nonpcm = 0;
+
+static void set_chip(int bitstream)
+{
+	chip_nonpcm = bitstream;
+	hdmi_config_set_audio(bitstream);
+}
 
 void dvd_hdmi_audio_declare(void)
 {
@@ -196,13 +227,34 @@ static void set_ack(int on)
 	user_io_send_buttons(1);        // pushes cfg[], incl. our bit, to the core
 }
 
+// Put the transmitter back before this process hands the machine to another core
+// (app_restart) or reboots. NOTHING ELSE WILL: other cores run stock Main, whose
+// hdmi_config_init() rewrites 0x0C but never writes 0x12, so the non-PCM flag
+// would otherwise survive into a core that is sending plain PCM -- which the sink
+// then renders as a data burst, i.e. silence or noise. Our own re-exec cannot do
+// it either: user_io_init() hands off to the core's `main=` binary BEFORE
+// video_init() runs, so this process never touches the chip again.
+void dvd_hdmi_audio_teardown(void)
+{
+	if (!chip_nonpcm) return;
+	printf("dvd_hdmi_audio: teardown - restoring PCM mode for the next core\n");
+	FILE *f = fopen(HDMI_LOG_PATH, "a");
+	if (f) { fprintf(f, "teardown: restoring PCM mode\n"); fclose(f); }
+	// Ack first, then the registers -- the same order as a release, for the same
+	// reason, and it leaves the module's state coherent rather than "acked but the
+	// chip is PCM". Both call sites have already reset the core, so this is belt
+	// and braces; it matters if teardown is ever called from a path that returns.
+	set_ack(0);
+	set_chip(0);
+}
+
 void dvd_hdmi_audio_tick(void)
 {
 	report_pump();
 
 	if (!declared || !is_dvd())
 	{
-		if (acked) { set_ack(0); hdmi_config_set_audio(0); }
+		if (acked) { set_ack(0); set_chip(0); }
 		// A core built before the HDMI tap never declares OX6. Say so, but only
 		// once the user actually selects passthru, so it cannot nag.
 		if (is_dvd() && !declared && user_io_status_get("6"))
@@ -223,27 +275,37 @@ void dvd_hdmi_audio_tick(void)
 	// audio to the framework's own I2S path, which is where the decoded samples
 	// already are. The existing release ordering (ack first, registers 50 ms
 	// later) is what keeps the gap silent rather than noisy.
+	//
+	// PCM IS THE RESTING STATE: content_is_bitstream() is false at idle, in menus
+	// before any audio, and once a disc is ejected, so the transmitter is only
+	// claimed while a DD/DTS track is actually playing. That bounds what a crash
+	// or a hardware reset (neither of which can run the teardown below) can leave
+	// behind for the next core.
 	poll_audio_format();
-	int want = (mode != 1) && passthru && sink_ok && !core_pcm_session;
+	int want = (mode != 1) && passthru && sink_ok && content_is_bitstream();
 
 	// Name the stage whenever the user has ASKED for passthru but we are not
 	// engaging - that is exactly the "no sound and the receiver says PCM" case.
 	static int last_dbg = -1;
 	int dbg = (passthru ? 1 : 0) | (sink_ok ? 2 : 0) | (declared ? 4 : 0) | (mode << 3)
-	        | (core_pcm_session ? 0x100 : 0);
+	        | (core_pcm_session ? 0x100 : 0) | (core_bs_session ? 0x200 : 0)
+	        | (core_fmt_v2 ? 0x400 : 0);
 	if (dbg != last_dbg)
 	{
 		last_dbg = dbg;
 		FILE *f = fopen(HDMI_LOG_PATH, "a");
 		if (f)
 		{
-			fprintf(f, "state: passthru=%d sink_ok=%d declared=%d ini_mode=%d acked=%d pcm_session=%d\n",
-			        passthru, sink_ok, declared, mode, acked, core_pcm_session);
+			fprintf(f, "state: passthru=%d sink_ok=%d declared=%d ini_mode=%d acked=%d pcm_session=%d bs_session=%d fmt_v2=%d\n",
+			        passthru, sink_ok, declared, mode, acked, core_pcm_session,
+			        core_bs_session, core_fmt_v2);
 			fclose(f);
 		}
 	}
 
-	if (passthru && !want && !core_pcm_session)
+	// Only when the CONTENT wants a bitstream: "we are not engaging because an
+	// LPCM track is playing" is the feature working, not a stage to report.
+	if (passthru && !want && content_is_bitstream())
 	{
 		if (mode == 1)      report("Bitstream disabled\n\ndvd_hdmi_bitstream=1 in MiSTer.ini");
 		else if (!sink_ok)  report("Sink does not list AC-3/DTS\n\nSet dvd_hdmi_bitstream=2 to force");
@@ -258,7 +320,7 @@ void dvd_hdmi_audio_tick(void)
 	{
 		printf("dvd_hdmi_audio: ADV7513 re-initialised, re-applying non-PCM\n");
 		set_ack(0);
-		hdmi_config_set_audio(1);
+		set_chip(1);
 		seen_gen = gen;
 		set_ack(1);
 		return;
@@ -268,7 +330,7 @@ void dvd_hdmi_audio_tick(void)
 	if (want && !acked)
 	{
 		// ORDER MATTERS: configure the chip FIRST, then let the core start.
-		hdmi_config_set_audio(1);
+		set_chip(1);
 		set_ack(1);
 		// ⚠ NO ON-SCREEN NOTICE HERE, deliberately. Engaging used to be a
 		// once-per-session event worth confirming, so it raised one. It is now a
@@ -301,6 +363,6 @@ void dvd_hdmi_audio_tick(void)
 	if (restore_at && CheckTimer(restore_at))
 	{
 		restore_at = 0;
-		if (!acked) hdmi_config_set_audio(0);
+		if (!acked) set_chip(0);
 	}
 }

--- a/main/support/dvd/dvd_hdmi_audio.h
+++ b/main/support/dvd/dvd_hdmi_audio.h
@@ -27,4 +27,11 @@ void dvd_hdmi_audio_tick(void);
 // The cfg[14] ack, read by user_io_send_buttons().
 int  dvd_hdmi_audio_ack(void);
 
+// Restore the ADV7513 to PCM before this process gives up the machine — called
+// from app_restart() and reboot(). Stock Main, which every other core runs,
+// rewrites 0x0C at startup but never writes 0x12, so the non-PCM flag would
+// otherwise be inherited by a core sending ordinary PCM: silence, or noise.
+// A no-op unless we actually put the chip into non-PCM mode.
+void dvd_hdmi_audio_teardown(void);
+
 #endif

--- a/main/tests/dvd_hdmi_audio_test.cpp
+++ b/main/tests/dvd_hdmi_audio_test.cpp
@@ -222,6 +222,103 @@ int main(void)
     } else printf("  ok   explanatory notice still queued: \"%s\"\n", stage_msg);
     cfg.dvd_hdmi_bitstream = 0;
 
+    // -----------------------------------------------------------------------
+    // The reported bug: Passthru left the transmitter in non-PCM mode, and the
+    // next core -- running stock Main, which never writes 0x12 -- inherited it
+    // and played silently. Two halves: PCM is now the resting state, and an
+    // orderly exit restores it. `fake_afmt` bit 15 marks a core that reports
+    // which codec is actually routed; bit 2 is that report.
+    // -----------------------------------------------------------------------
+    printf("[9] v2 core, Passthru selected, nothing playing: the link is NOT claimed\n");
+    // ⚠ Set the word BEFORE reset_world(): its tick runs the real decision, so a
+    // leftover word from the previous arm would engage during the setup and the
+    // preconditions would describe that instead of this test.
+    fake_passthru = 1;
+    fake_afmt = 0x8001;                 // v2 | passthru; no content routed yet
+    reset_world();
+    settle();
+    check("acked", dvd_hdmi_audio_ack(), 0);
+    check("chip left in PCM", cfg_audio_state, 0);
+
+    // ...and it RELEASES when the content stops, which is what an eject looks
+    // like from here: the core forgets the verdict, so this is the state the next
+    // core would otherwise inherit.
+    fake_afmt = 0x8005; settle();
+    check("engaged while a track plays", cfg_audio_state, 1);
+    fake_afmt = 0x8001; settle();
+    check("released once it stops", cfg_audio_state, 0);
+    check("acked after it stops", dvd_hdmi_audio_ack(), 0);
+
+    printf("[10] v2: engage on a bitstream track, release on a PCM one\n");
+    reset_world();
+    fake_afmt = 0x8005;                 // v2 | passthru | bitstream session
+    settle();
+    check("acked", dvd_hdmi_audio_ack(), 1);
+    check("chip in non-PCM", cfg_audio_state, 1);
+    if (trace_index("chip=nonpcm") < 0 || trace_index("ack=1") < 0 ||
+        trace_index("chip=nonpcm") > trace_index("ack=1")) {
+        printf("  FAIL: engage raised the ack before configuring the chip\n"); errors++;
+    } else printf("  ok   engage order: chip then ack\n");
+    reset_world();
+    fake_afmt = 0x8003;                 // v2 | passthru | PCM session
+    settle();
+    check("acked after an LPCM track", dvd_hdmi_audio_ack(), 0);
+    check("chip back in PCM", cfg_audio_state, 0);
+    if (trace_index("ack=0") < 0 || trace_index("chip=pcm") < 0 ||
+        trace_index("ack=0") > trace_index("chip=pcm")) {
+        printf("  FAIL: release restored PCM registers before dropping the ack\n");
+        errors++;
+    } else printf("  ok   release order: ack then chip\n");
+
+    printf("[11] teardown restores PCM for the next core\n");
+    reset_world();
+    fake_afmt = 0x8005; settle();
+    check("engaged first", cfg_audio_state, 1);
+    n_trace = 0;
+    dvd_hdmi_audio_teardown();
+    check("chip after teardown", cfg_audio_state, 0);
+    if (trace_index("chip=pcm") < 0) {
+        printf("  FAIL: teardown did not write the PCM registers\n"); errors++;
+    } else printf("  ok   teardown wrote the PCM registers\n");
+
+    // ...including INSIDE the 50 ms release window, where the ack is already
+    // down but the chip is still non-PCM. A core load landing there is exactly
+    // the case `acked` cannot answer and `chip_nonpcm` can.
+    reset_world();
+    fake_afmt = 0x8005; settle();
+    fake_afmt = 0x8003;                 // switch to PCM content...
+    fake_ms += 20; dvd_hdmi_audio_tick();   // ...ack drops, restore is pending
+    check("ack already down", dvd_hdmi_audio_ack(), 0);
+    check("chip still non-PCM", cfg_audio_state, 1);
+    n_trace = 0;
+    dvd_hdmi_audio_teardown();
+    check("chip after teardown in the window", cfg_audio_state, 0);
+
+    printf("[12] teardown on an untouched chip writes nothing\n");
+    reset_world();
+    fake_passthru = 0; fake_afmt = 0x8000;
+    settle();
+    check("chip in PCM", cfg_audio_state, 0);
+    n_trace = 0;
+    dvd_hdmi_audio_teardown();
+    if (n_trace != 0) {
+        printf("  FAIL: teardown wrote %d time(s) with the chip already in PCM\n", n_trace);
+        errors++;
+    } else printf("  ok   no I2C traffic\n");
+
+    printf("[13] the SAME content word without the v2 flag keeps the old rule\n");
+    // The discriminating pair for [9]: an old core and a new idle one both report
+    // pcm_session = 0, so only the version flag separates "AC-3 is playing" from
+    // "nothing is playing". Without it, engaging is the old, correct guess.
+    reset_world();
+    fake_passthru = 1;
+    fake_afmt = 0x0001;                 // no v2 | passthru, pcm_session = 0
+    settle();
+    check("acked (old core still engages)", dvd_hdmi_audio_ack(), 1);
+    reset_world();
+    fake_passthru = 0; fake_afmt = 0;
+    settle();
+
     if (errors) { printf("dvd_hdmi_audio_test: FAILURES\n"); return 1; }
     printf("dvd_hdmi_audio_test: ALL GREEN\n");
     return 0;

--- a/main/tests/run_tests.sh
+++ b/main/tests/run_tests.sh
@@ -6,8 +6,14 @@
 # test #includes the module under test and stubs the rest of Main at link time,
 # so it exercises the real logic rather than a paraphrase of it.
 #
+#   ./run_tests.sh          GREEN only
+#   ./run_tests.sh --red    + mutations, each caught by the test written for it
+#
 set -e
 cd "$(dirname "$0")"
+
+RED=0
+[ "${1:-}" = "--red" ] && RED=1
 
 CXX="${CXX:-g++}"
 OUT="$(mktemp -d)"
@@ -35,6 +41,65 @@ for t in *_test.cpp; do
     "$OUT/$n" || fail=1
     echo
 done
+
+# ---------------------------------------------------------------------------
+# RED arm. A decision table is exactly the shape that passes without proving
+# anything, so each mutation must be caught BY ITS OWN test -- one caught only by
+# some unrelated assertion leaves the intended arm vacuous. A mutation that fails
+# to COMPILE is a harness failure, not a pass: it proves nothing about the test.
+red_case() {
+    local mod="$1" test="$2" expect="$3" sedexpr="$4" name="$5"
+    local dir="$OUT/red_$name"
+    cp -r "$TREE" "$dir"
+    sed "$sedexpr" "$TREE/support/dvd/$mod" > "$dir/support/dvd/$mod"
+    if cmp -s "$TREE/support/dvd/$mod" "$dir/support/dvd/$mod"; then
+        echo "  !! RED $name: mutation matched nothing (the anchor moved)"; fail=1; return
+    fi
+    if ! "$CXX" -std=c++11 -Wall -Wno-unused-function -O0 -g \
+            -I "$dir/support/dvd" -o "$dir/bin" "$test" 2>"$dir/build.log"; then
+        echo "  !! RED $name: mutant did not compile"; sed -n '1,4p' "$dir/build.log"
+        fail=1; return
+    fi
+    local log="$dir/log"
+    "$dir/bin" > "$log" 2>&1 && { echo "  !! RED $name: test PASSED against broken code"; fail=1; return; }
+    if ! grep -q "$expect" "$log"; then
+        echo "  !! RED $name: caught, but not by \"$expect\""
+        grep "FAIL" "$log" | head -3; fail=1
+    else
+        echo "  RED $name -> caught by \"$expect\""
+    fi
+}
+
+if [ "$RED" -eq 1 ]; then
+    echo "### RED arm"
+
+    # The reported bug itself: nothing restores the transmitter, so the next core
+    # inherits a non-PCM link and plays silently.
+    red_case dvd_hdmi_audio.cpp dvd_hdmi_audio_test.cpp \
+        "teardown did not write the PCM registers" \
+        "s/\tif (!chip_nonpcm) return;/\treturn;/" teardown-noop
+
+    # Teardown keyed on the ack instead of the chip. Correct everywhere EXCEPT the
+    # 50 ms release window, where the ack is already down and the chip is not --
+    # which is the whole reason chip_nonpcm exists as a separate flag.
+    red_case dvd_hdmi_audio.cpp dvd_hdmi_audio_test.cpp \
+        "chip after teardown in the window" \
+        "s/\tif (!chip_nonpcm) return;/\tif (!acked) return;/" teardown-keyed-on-ack
+
+    # Ignore the version flag: an idle v2 core reads as "not PCM" and the link is
+    # claimed with nothing playing -- the shipped behaviour this fixes.
+    red_case dvd_hdmi_audio.cpp dvd_hdmi_audio_test.cpp \
+        "chip left in PCM" \
+        "s/return core_fmt_v2 ? core_bs_session : !core_pcm_session;/return !core_pcm_session;/" \
+        ignores-fmt-version
+
+    # ...and the other way: assume every core reports bs_session, and a core built
+    # before it can never engage at all.
+    red_case dvd_hdmi_audio.cpp dvd_hdmi_audio_test.cpp \
+        "acked (old core still engages)" \
+        "s/core_fmt_v2      = (fmt >> 15) \& 1;/core_fmt_v2      = 1;/" assumes-fmt-version
+    echo
+fi
 
 if [ "$fail" != 0 ]; then echo "main/tests: FAILURES"; exit 1; fi
 echo "main/tests: ALL GREEN"

--- a/site/content/audio/passthrough.md
+++ b/site/content/audio/passthrough.md
@@ -35,6 +35,19 @@ advertises AC-3/DTS support in its EDID.
     the stock Main does not parse at all. The safety is structural rather than a
     convention.
 
+Over HDMI the transmitter is switched out of PCM mode **only while a Dolby Digital or DTS
+track is actually playing**, and switched back when the track changes, when you load
+another core, and when you reboot. You do not need to leave Passthru before loading
+something else.
+
+!!! warning "If another core loses HDMI audio, update both halves and power-cycle"
+    Earlier versions switched the transmitter as soon as Passthru was selected and never
+    switched it back, so the next core was silent — and nothing but removing power cleared
+    it. Update the core and `MiSTer_DVDcss` together: a current Main with an older core
+    falls back to the older behaviour, because an older core cannot tell it which format is
+    playing. See
+    [Troubleshooting](../reference/troubleshooting.md#another-core-has-no-hdmi-audio-after-i-used-the-dvd-core).
+
 ## What passes through and what does not
 
 | Format | In Passthru | Notes |

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -204,6 +204,25 @@ dvd_hdmi_bitstream=2      ; 0=auto (default), 1=off, 2=force
 Read `/tmp/dvd_hdmi_audio.log` to see what it decided and why — it records the EDID result
 and each stage of the handoff.
 
+### Another core has no HDMI audio after I used the DVD core
+
+Update `MiSTer_DVDcss` to the version that shipped with your `.rbf`, and power-cycle the
+MiSTer once to clear the state you are seeing now.
+
+To send a bitstream, the custom Main switches the HDMI transmitter out of PCM mode. Older
+versions did that as soon as you selected `Audio Out` = `Passthru`, even with nothing
+playing, and never switched it back — so the next core, which sends ordinary PCM, was
+played into a link still expecting compressed audio, and you got silence. Nothing else
+resets that setting: it survives loading another core and it survives a reboot from the
+menu. Only removing power clears it.
+
+Current versions switch the transmitter only while a Dolby Digital or DTS track is actually
+playing, and switch it back when you load another core or reboot.
+
+!!! warning "Update the core and `MiSTer_DVDcss` together"
+    This fix is in both halves. A current Main with an older core still falls back to the
+    older behaviour, because an older core cannot tell it which format is playing.
+
 ## Picture problems
 
 ### 16:9 content looks tall and thin on a CRT


### PR DESCRIPTION
Field report: *"enable passthru with the modified Main installed, load another core, and
you get no audio."*

Confirmed, and it needed **no disc** — selecting `Audio Out = Passthru` was enough.

## Why

1. **Register `0x12` is written by nobody else.** Its bit 7 is the non-PCM flag. Stock
   `hdmi_config_init()` rewrites `0x0C`, so the *route* reverts, but its `init_data` has
   no `0x12` entry at all — nothing clears the flag, through a core load or a warm reboot.
2. **Nothing of ours ran on the way out.** Every other core runs stock Main via `main=`,
   and our own re-exec cannot help either: `user_io_init()` hands off to the core's
   `main=` binary *before* `video_init()` runs.
3. **`want` was `passthru && sink_ok && !pcm_session`**, and `pcm_session` reads 0 both
   when AC-3 is playing and when nothing is — hence "no disc needed".

★ `docs/hdmi_bitstream.md` §2 predicted exactly this, as its argument *against* the route
we ended up shipping. When a route is abandoned, the case written against its replacement
becomes a defect list.

## The fix, three layers

| Layer | Covers |
|---|---|
| PCM is the resting state (`aud_route.bs_session`) | idle, menus, LPCM/MP2, ejected |
| Teardown at both exits (steps 36/37) | every core load, every reboot |
| Clear `0x12` at our own init (step 38) | an unclean exit — recovered by reloading this core |

- **`bs_session`'s reset domain is the design** and is deliberately *not* `aud_rst_n`,
  which pulses at every seek and track switch — a verdict reset there would release and
  re-engage the receiver at every chapter skip. It clears on the core reset and an empty
  slot.
- **Teardown keys on the chip's state, not the ack**: they disagree for 50 ms at every
  release, and a core load landing there is exactly the case the ack answers wrongly.
- **CMD_AF gains a version bit**, because an old core and a new idle one both report
  `pcm_session = 0`. Old core ⇒ old rule, unchanged.

## Test plan

- [x] `bench/dvd/run_passthru_pcm.sh --red` — `aud_route_tb` TEST 6 (boot / AC-3 / seek /
      LPCM / eject / Decode) + 4 mutations, each caught by its own assertion
- [x] `main/tests/run_tests.sh --red` — new RED arm, 4 mutations including teardown keyed
      on the ack (caught only by the release-window case)
- [x] `bench/dvd/run_telem.sh`, `run_hdmi_bitstream.sh`, `run_stc_freerun.sh` — green
- [x] `tools/lint_undriven.sh`, netlist canary, `docs_check.py`, `mkdocs --strict`
- [x] Custom Main builds against a pristine stock tree; all four anchors land correctly
- [x] Core compiles: SEED 7 first roll, clk_dec 92.77 @100C / 88.90 @-40C, 87 % ALM
- [x] **HW, defect reproduced first**: pre-fix build reads `0xA0` after switching cores
- [x] **HW, fixed**: `0x20` at idle, `0xA0` only while AC-3 plays, **1 register write**
      across 3 chapter skips + 3 track switches, LPCM → `0x20`, Decode → never engages,
      **load another core while engaged → `0x20`** with the teardown logged
- [x] HW pacing unregressed: 59.955 Hz, 24.01 fps, audio −12 ppm, 0 lates, 0 drops
- [x] HW (maintainer): reboot while a DD track plays restores PCM for the next core
- [x] HW (maintainer): a power cut does not retain the register — measured, not assumed
- [x] HW (maintainer): the PCM→DD switch at a title start does not clip audibly

Detail: `docs/hdmi_bitstream.md` §5a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
