### PR TITLE
Fix #81: a menu context is not a menu domain, and support bundles carry button data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1309,13 +1309,30 @@ worse maintenance burden than targeted in-place edits. So:
   move are exactly: available bit SET **and** a non-zero id for the presented aspect
   **and** an in-title HLI menu. ⚠ The reporter did not pass `--nav-packs`, so the
   HLI itself is not in evidence and the diagnosis is structural.
-  ⚠ **NEXT SUSPECT IF THE HW ROUND FAILS: `wide`.** An in-title menu takes it from
-  `ar_wide_auto` (the DECODED sequence header) while a menu-domain menu uses the IFO's
-  `VTSM_V_ATR` precisely because "DVD menus are routinely authored 16:9 anamorphic with a
-  4:3 sequence-header code". A 4:3 code here would take the `[28:24]` field (0) and the
-  symptom survives. `VTS_V_ATTR@0x200` is already resident in `parse_buf` during the
-  Phase-10 `S_ATTR` sweep, so exporting it is one extra `attr_addr` step — NOT done, one
-  behavioural delta per round. Gate: `subp_stream_map_tb` arms [7]–[10] + 6 new vectors.
+  ★★ **AND libdvdnav — THE INDEPENDENT ORACLE — EXPOSED A SECOND WRONG FACT ON THE SAME
+  LOOKUP, WHICH IS WHY IT GOT FIXED RATHER THAN DEFERRED.** `vm_get_subp_stream`
+  (`vmget.c:138`) has **NO domain condition on the map at all** (the domain only forces
+  `subpN=0` and turns a `-1` into 0), so it applies `subp_control` in
+  `DVD_DOMAIN_VTSTitle` too and resolves this disc to `0x21` — our fix agrees with it.
+  But the aspect it feeds the lookup is `vm_get_video_attr()` =
+  **`vtsi_mat->vts_video_attr` in the title domain (`vmget.c:313`) — the IFO, not the
+  sequence header**, while we used `ar_wide_auto` there. A menu-domain menu already reads
+  the IFO *precisely because* "DVD menus are routinely authored 16:9 anamorphic with a 4:3
+  sequence-header code", and a title-domain menu is the same authoring — so a 4:3 code
+  would take the `[28:24]` field (0) and **the symptom would have survived the domain fix
+  entirely.** New reader output `title_ar_wide` from `VTS_V_ATTR@0x200`, costing ONE extra
+  `attr_addr` step (the Phase-10 `S_ATTR` sweep already has that sector resident), consumed
+  by ONE mux arm: `sp_map_wide = sp_menu_early && !menu_dom_live ? title_ar_wide_w :
+  ar_wide_auto_eff`.
+  ⚠ **Scoped to the in-title MENU only** — the white-rabbit `SetSTN` path, the user
+  subtitle path and `ar_wide_eff`/`VIDEO_ARX` keep the HW-proven sequence-header value.
+  The asymmetry is deliberate: one of those has a working precedent to preserve, the other
+  does not. And it is NOT a second delta in the "one per HW round" sense — its blast radius
+  is the SAME single case as the domain fix.
+  Gates: `subp_stream_map_tb` arms [7]–[10] + 6 vectors; `iso_reader_attr_tb`'s
+  `title_ar_wide` arm, which reads `VTS_V_ATTR` **out of the fixture** rather than
+  restating 1 (MiB VTS_21 = `0x4E80`) and refuses to be vacuous, **3/3 reader mutations
+  caught**; `check_subp_map_wiring.py` on both ports, RED on 3 re-regressions.
   Detail: **`docs/track_selection.md`** "The domain gate asked the wrong question",
   `docs/dvd_nav.md` (Scene It section).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2939,12 +2939,12 @@ either route. That is structural, not a tuning matter.
 `dvd_report.py --nav-window SECTORS` (with `--lba`) captures every NAV pack in one
 SEQUENTIAL run forward from the sector being served, and `dvd_report.cpp` passes
 `--nav-window 2048` whenever it has a playhead.
-★ **Measured, which is what chose it over "just pass `--nav-packs` too":** the
-window costs **0.28 s and a 38 KB bundle** and yields 16 NAV packs of which 13–20
-of ~20 carry multi-button HLI on Scene It's game VTSes, against **4.9 s and 5.6 MB**
-for `--nav-packs` on MEN_IN_BLACK (its 680 MB of menu VOBs hit the 512 MB cap) —
-minutes of seeking on an optical disc the core is streaming from, for data that
-still misses the in-title case. Proven end to end: a window bundle reconstructs to
+★ **Measured ON THE MISTER, which is what chose it over "just pass `--nav-packs`
+too": the window costs 1.38 s against 0.86 s for no capture at all (SCENEIT_HP,
+16 NAV packs, a 37 KB bundle), while `--nav-packs` on MEN_IN_BLACK costs 37.7 s —
+19× the window's 1.98 s on the same disc**, from local storage with the core not
+even running. It yields 13–20 of ~20 packs carrying multi-button HLI on Scene It's
+game VTSes, which `--nav-packs` cannot reach at all. Proven end to end: a window bundle reconstructs to
 an ISO whose `nav_extract.py` walk decodes a complete 7-button in-title menu.
 ⚠ A VOBU is ≤1 s, so 2048 sectors spans several, and an HLI is re-sent every VOBU
 while a menu is up — forward-only is enough. ⚠ The content guarantee is unchanged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1263,6 +1263,55 @@ worse maintenance burden than targeted in-place edits. So:
     `phys_streamN` golden contract is untouched.
     Detail: **`docs/stc_freerun.md` §12**, `docs/subpicture.md`, `docs/dvd_nav.md`.
 
+- 🔧 **A MENU CONTEXT IS NOT A MENU DOMAIN — the subpicture map's domain gate asked the
+  wrong question (2026-09-12, issue #81); sim-proven + mutation-checked, ⏳ HW-confirm
+  pending.** Field report on v0.5.0: *Aniki, mon Frère* (**BROTHER**) PAL FR Z2, physical
+  disc, `Disc Menus` On — *"No visible selection on the main menus."*
+  ★★ **THAT IS WORD-FOR-WORD THE #60/#61 SYMPTOM ON A DISC THE #60/#61 FIX COULD NOT
+  REACH, AND THE SENTENCE CLAIMING IT COULD WAS IN `emu.sv` THE WHOLE TIME.** Measured
+  from the repro bundle: the disc's FP is `g[3]=1; JumpTT 3`, so its menus are
+  **TITLE-domain PGCs** (VTS_02, 22 titles of 30–41 s, `PGCN 4` post
+  `if (g[0]==0) JumpVTS_PTT 4:1` = a looping motion menu, and `HL_BTNN = 0x400/0x800` in
+  five PGCs' POSTs = it expects highlights), VTS_02 `V_ATTR = 0x5E00` (PAL 16:9), and
+  `subp_control[0] = 0x80010200` on **every** PGC — **the exact word both #60/#61 discs
+  author**, so the highlight SPU rides `0x21` while the core filtered `0x20`. A highlight
+  is a RECOLOUR of subpicture pixels, so nothing was drawn.
+  ★ **The mechanism: `subp_stream_map`'s gate was `ctx_menu ? ~dom_tt : dom_tt`, driven
+  from `emu.sv`'s `menu_sp_ctx` — and `menu_sp_ctx` is DELIBERATELY WIDER than the menu
+  domain** (it includes `sp_menu_early`, the in-title multi-button HLI menu: Scene It's
+  game menus, and this disc's motion menus). So a menu context in the TITLE domain
+  demanded a menu-domain table, found the title's, and fell back to the logical index.
+  Fix: the input is now `menu_dom` (`menus_on && menu_active` — a fact about the PLAYER)
+  and the test is `dom_ok = (dom_tt != menu_dom)` = "the table belongs to the domain we
+  are in".
+  ⚠⚠ **THE MODULE'S TRUTH TABLE DID NOT CHANGE** (`ctx_menu ? ~dom_tt : dom_tt` is the
+  same function of that bit; verified over 200,000 input points), so
+  `subp_stream_map_tb` **cannot go RED for this defect** — only emu's choice of what to
+  put on the wire changed, and there is no emu-level bench.
+  ★★ **THAT IS THE DURABLE LESSON, AND THE DOC HAD ALREADY TALKED ITSELF OUT OF THE
+  GATE:** `docs/track_selection.md` said a chain bench "would have to *replicate* emu's
+  glue, which is a bench agreeing with a copy of the thing it is meant to check" — true,
+  and it was then read as covering the glue. It did not: a single port connection
+  carrying the wrong FACT is invisible to every module-level test. New
+  **`tools/check_subp_map_wiring.py`** gates that one connection by **reading it out of
+  `dvd/emu.sv`** (the `tools/acmod_scan.py` / `csync_pipe_tb` pattern — a table that
+  cannot go stale beats a correct one), runs from `run_subpic.sh` in milliseconds, and is
+  RED on the pre-#81 file and on 2 targeted re-regressions.
+  ⚠ **No local repro, quantified: 958 ISOs → 7 discs have a title-domain PGC resolving
+  logical 0 non-zero, and NONE of the 7 carries an in-title HLI** (`nav_extract.py
+  --title-vob`), so they are untouched either way — the same standing as #60/#61, which
+  also could not be reproduced locally. ⚠ The reporter did not pass `--nav-packs`, so the
+  HLI itself is not in evidence and the diagnosis is structural.
+  ⚠ **NEXT SUSPECT IF THE HW ROUND FAILS: `wide`.** An in-title menu takes it from
+  `ar_wide_auto` (the DECODED sequence header) while a menu-domain menu uses the IFO's
+  `VTSM_V_ATR` precisely because "DVD menus are routinely authored 16:9 anamorphic with a
+  4:3 sequence-header code". A 4:3 code here would take the `[28:24]` field (0) and the
+  symptom survives. `VTS_V_ATTR@0x200` is already resident in `parse_buf` during the
+  Phase-10 `S_ATTR` sweep, so exporting it is one extra `attr_addr` step — NOT done, one
+  behavioural delta per round. Gate: `subp_stream_map_tb` arms [7]–[10] + 6 new vectors.
+  Detail: **`docs/track_selection.md`** "The domain gate asked the wrong question",
+  `docs/dvd_nav.md` (Scene It section).
+
 - ✅ **MEM_SHIM_BURST TAG/LRU STORE → M10K — the ALM congestion reclaim (2026-08-27,
   PR #18) — ✅ HW-CONFIRMED 2026-08-28 (user soak: full-length MiB + menu/seek stress,
   no shear/artifacting; build `DVD_shimreclaim_20260828_0259.rbf`).**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2951,13 +2951,22 @@ while a menu is up — forward-only is enough. ⚠ The content guarantee is unch
 and still structural (`is_nav_pack` gates the append; `audit()` re-checks the final
 set). ⛔ `--nav-packs` still NOT on the chord — it answers a different question, and
 the expensive one.
+⚠⚠ **AND THE FLAG IS NOT PASSED UNCONDITIONALLY, because MEASURED ON THE RIG an
+older release-installed `dvd_report.py` given it prints `unrecognized arguments:
+--nav-window 2048` and writes NO BUNDLE AT ALL** — strictly worse than the missing
+button data it adds. The release zip ships `Scripts/dvd_report.py` beside the Main so
+they normally move together, but a Main updated alone must degrade, not break. So the
+child ASKS THE SCRIPT (`dvd_report_script_supports`): argparse cannot accept a flag it
+does not name, so a substring search is sound both ways. In the CHILD, after the fork
+(file I/O on the poll thread is the `dvd_phys` lesson), chunked with a `tlen-1` overlap.
 ★ **The argv moved OUT of the `fork()` (`dvd_report_build_argv`) purely so it could
 be tested, because every failure here is SILENT** — a missing flag still produces a
 bundle that is written, self-checks and looks complete, which is exactly how #81
-arrived. `main/tests/dvd_report_test.cpp`: 4 arms, **4 RED mutations each caught by
+arrived. `main/tests/dvd_report_test.cpp`: 6 arms, **6 RED mutations each caught by
 its own assertion** (drop the flag; pass it with no playhead — which captures the
 NAV packs at the START of the disc, *confidently wrong data instead of none*; reach
-for `--nav-packs`; forget the NUL).
+for `--nav-packs`; forget the NUL; ignore what the installed script accepts; drop the
+probe's chunk overlap, which reports a good tool as too old).
 ⚠ Two harness traps: `red_case`'s `grep -q "$expect"` read an expect string
 beginning `--` as an OPTION (now `-e`), and **a test that walks argv to its NUL
 cannot detect a missing NUL** — the terminator arm pre-fills a sentinel, runs FIRST,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2944,7 +2944,27 @@ too": the window costs 1.38 s against 0.86 s for no capture at all (SCENEIT_HP,
 16 NAV packs, a 37 KB bundle), while `--nav-packs` on MEN_IN_BLACK costs 37.7 s —
 19× the window's 1.98 s on the same disc**, from local storage with the core not
 even running. It yields 13–20 of ~20 packs carrying multi-button HLI on Scene It's
-game VTSes, which `--nav-packs` cannot reach at all. Proven end to end: a window bundle reconstructs to
+game VTSes, which `--nav-packs` cannot reach at all.
+★★ **AN OPTICAL DRIVE IS ~50× SLOWER AND THE ARITHMETIC SAID OTHERWISE — MEASURED
+ON A REAL DVD WHILE THE CORE STREAMED IT: ~90–285 KB/s, a SEVENTH of DVD 1x**,
+steady over 84 s (so not spin-up), and chunking does NOT help (1-sector reads
+13.9 s, 256-sector 17.8 s — it is the drive, not syscalls). A 2048-sector window
+costs **15.7–29.1 s** there against ~0.5 s on an image. ⚠ **Authentication and a
+spinning drive do NOT rescue it** — that was the obvious hypothesis and the
+measurement killed it. ⚠⚠ **Re-reading a region takes 0.02 s, so any timing on an
+LBA something already touched is measuring the PAGE CACHE** — a first attempt here
+read 0.26 s for a window that really costs 16 s.
+✅ **Bounded: `--nav-stop` (default 2) ends the scan at the 2nd NAV pack, and the
+cap follows the MEDIUM** (`nav_window_for()`, on `S_ISBLK` — the medium, not the
+path spelling): 512 sectors optical, 2048 image. Measured on that disc: 1st NAV
+pack +51..+230 sectors (2.1–5.5 s), 2nd +304..+465 (3.9–7.0 s), 8th +1701..+1903
+(19.1–29.1 s) — and an HLI repeats byte-identically every VOBU, so the FIRST
+record already carries the whole button set. **Chord on a physical DVD: 0.91–0.96 s
+before this branch, 2.73/4.92 s with the bounded window, vs +15.7–29.1 s
+unbounded.** ⚠ The cap is what you pay where there are NO NAV packs (a still, a
+gap) — the early stop cannot help there, which is why it is media-dependent rather
+than merely large; one run hit 14.35 s on a bad patch, so 3–5 s is typical, not a
+bound. Proven end to end: a window bundle reconstructs to
 an ISO whose `nav_extract.py` walk decodes a complete 7-button in-title menu.
 ⚠ A VOBU is ≤1 s, so 2048 sectors spans several, and an HLI is re-sent every VOBU
 while a menu is up — forward-only is enough. ⚠ The content guarantee is unchanged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2935,7 +2935,26 @@ motion-menu disc authors its menus as TITLE-domain PGCs with the HLI in a title
 VOB's NAV packs (Scene It's game menus; #81's disc, whose boot menus live in
 `VTS_02_1.VOB`), so a highlight bug on such a disc could not be evidenced by
 either route. That is structural, not a tuning matter.
-✅ **FIXED by a PLAYHEAD WINDOW, and the chord now carries button data:**
+✅ **FIXED by a PLAYHEAD WINDOW — ✅ HW-CONFIRMED 2026-09-12 ON A PHYSICAL DISC, BOTH
+ARMS.** Arm 1, the DEGRADE path (new Main + the OLD release-installed collector): bundle
+written, `nav packs: no`, audit clean — that combination wrote NO BUNDLE AT ALL before the
+flag probe, measured on the same rig. Arm 2, the CAPTURE path, chord pressed ON THE DISC'S
+MENU: `hli_ss=2 btn_ns=5`, `btn_coli sel=00005af0`, the full 1↔2↔3↔4↔5↔1 link graph and a
+decoded VM command per button (`LinkPGCN 13/4/14/2/30`, two of them with `HL_BTNN`), in a
+73 KB bundle — **exactly the evidence missing from #60, #61 and #81, all three of which
+were physical-disc reports whose bundles carried ZERO NAV packs.** The second NAV pack 8
+sectors later carries the SAME button set: the per-VOBU HLI re-send that `--nav-stop` rests
+on, now observed on real media.
+★★ **AND THE REAL COST IS FAR BELOW THE COLD MEASUREMENT — both presses finished in ≤1 s**,
+against 2.7-4.9 s cold, because the window reads FORWARD FROM THE PLAYHEAD, which is where
+the core has just been streaming, so most of it is already page-cached. The cold numbers are
+the pessimistic bound, not the typical case.
+⚠ **`/tmp/dvd_report_run.log` was 0 bytes after every press** — the child's stdout is not
+captured, so `reap()`'s "Support bundle FAILED — see /tmp/dvd_report_run.log" points at an
+empty file. PRE-EXISTING and only on the failure path, but it is that path's ONLY
+diagnostic; suspect is `start()`'s `freopen(..., stdout)` before `execvp` (python writes
+fine to a redirect on that box). Own item.
+The mechanism:
 `dvd_report.py --nav-window SECTORS` (with `--lba`) captures every NAV pack in one
 SEQUENTIAL run forward from the sector being served, and `dvd_report.cpp` passes
 `--nav-window 2048` whenever it has a playhead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2929,6 +2929,40 @@ bundle over without thinking, and it is the same line as
 `css-key-cache-never-ship`. ⛔ A `--from-drive` mode was considered and REJECTED
 (2026-08-31, user decision): it points users at their optical drive, and a
 reporter who has already ripped their own ISO is a better reporter.
+★★ **`--nav-packs` SCANS MENU VOBs, SO IT CANNOT CAPTURE AN IN-TITLE MENU'S
+BUTTONS AT ALL — on any route (2026-09-12, issue #81).** A DVD-game or
+motion-menu disc authors its menus as TITLE-domain PGCs with the HLI in a title
+VOB's NAV packs (Scene It's game menus; #81's disc, whose boot menus live in
+`VTS_02_1.VOB`), so a highlight bug on such a disc could not be evidenced by
+either route. That is structural, not a tuning matter.
+✅ **FIXED by a PLAYHEAD WINDOW, and the chord now carries button data:**
+`dvd_report.py --nav-window SECTORS` (with `--lba`) captures every NAV pack in one
+SEQUENTIAL run forward from the sector being served, and `dvd_report.cpp` passes
+`--nav-window 2048` whenever it has a playhead.
+★ **Measured, which is what chose it over "just pass `--nav-packs` too":** the
+window costs **0.28 s and a 38 KB bundle** and yields 16 NAV packs of which 13–20
+of ~20 carry multi-button HLI on Scene It's game VTSes, against **4.9 s and 5.6 MB**
+for `--nav-packs` on MEN_IN_BLACK (its 680 MB of menu VOBs hit the 512 MB cap) —
+minutes of seeking on an optical disc the core is streaming from, for data that
+still misses the in-title case. Proven end to end: a window bundle reconstructs to
+an ISO whose `nav_extract.py` walk decodes a complete 7-button in-title menu.
+⚠ A VOBU is ≤1 s, so 2048 sectors spans several, and an HLI is re-sent every VOBU
+while a menu is up — forward-only is enough. ⚠ The content guarantee is unchanged
+and still structural (`is_nav_pack` gates the append; `audit()` re-checks the final
+set). ⛔ `--nav-packs` still NOT on the chord — it answers a different question, and
+the expensive one.
+★ **The argv moved OUT of the `fork()` (`dvd_report_build_argv`) purely so it could
+be tested, because every failure here is SILENT** — a missing flag still produces a
+bundle that is written, self-checks and looks complete, which is exactly how #81
+arrived. `main/tests/dvd_report_test.cpp`: 4 arms, **4 RED mutations each caught by
+its own assertion** (drop the flag; pass it with no playhead — which captures the
+NAV packs at the START of the disc, *confidently wrong data instead of none*; reach
+for `--nav-packs`; forget the NUL).
+⚠ Two harness traps: `red_case`'s `grep -q "$expect"` read an expect string
+beginning `--` as an OPTION (now `-e`), and **a test that walks argv to its NUL
+cannot detect a missing NUL** — the terminator arm pre-fills a sentinel, runs FIRST,
+and bounds every scan, so the mutation is caught by its own assertion instead of as
+noise elsewhere. Detail: `docs/support_bundle_hps.md`.
 ⚠ Two traps recorded in `docs/bug_reports.md`: NAV-pack detection is **not**
 `0x000001BF` at offset 14 (a **system header** pushes PCI to `0x26`; the fixed
 offset found ZERO packs and reported success), and the tool is **deliberately

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1300,7 +1300,14 @@ worse maintenance burden than targeted in-place edits. So:
   ⚠ **No local repro, quantified: 958 ISOs → 7 discs have a title-domain PGC resolving
   logical 0 non-zero, and NONE of the 7 carries an in-title HLI** (`nav_extract.py
   --title-vob`), so they are untouched either way — the same standing as #60/#61, which
-  also could not be reproduced locally. ⚠ The reporter did not pass `--nav-packs`, so the
+  also could not be reproduced locally.
+  ★ **The one class this touches is MEASURED bit-identical, not argued so: Scene It's game
+  VTS declares `nr_of_vts_subp_streams = 0` with the AVAILABLE BIT CLEAR on every
+  `subp_control[0]`**, and `use_map` requires `ctl_sel[31]` — so it stays on the identity
+  fallback → physical 0 and the domain gate never gets to matter. (Its highlight works
+  because the disc sends an SPU on `0x20` whatever its IFO table says.) The discs this can
+  move are exactly: available bit SET **and** a non-zero id for the presented aspect
+  **and** an in-title HLI menu. ⚠ The reporter did not pass `--nav-packs`, so the
   HLI itself is not in evidence and the diagnosis is structural.
   ⚠ **NEXT SUSPECT IF THE HW ROUND FAILS: `wide`.** An in-title menu takes it from
   `ar_wide_auto` (the DECODED sequence header) while a menu-domain menu uses the IFO's

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -1119,4 +1119,13 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # ⚠ The hot corner gives back 3.3 MHz against branch C's 96.06 for one flop and a
 # few wires -- netlist variance at this density, not a cost of the change; still
 # 6.8 MHz clear of the gate. Detail: docs/hdmi_bitstream.md §5a.
+# 2026-09-12 (fix/subp-map-in-title-menu, dev-subpmapdom -- issue #81: the
+# subpicture map's domain gate, and title_ar_wide from VTS_V_ATTR@0x200):
+# SEED 7 held FIRST roll -- clk_dec 97.48 @100C / 97.30 @-40C (gate 86.0, PASS
+# both corners, the widest margin in this ledger) at 87% ALM (36,428 needed,
+# 39,826 placed), registers 50,557 (-8), RAM 501/553, DSP 94/112.
+# Build DVD_subpmapdom_20260912_1328.rbf (4,311 KB).
+# ⚠ +4.7 MHz on the hot corner for one reader register and one mux arm -- read it
+# as netlist variance at this density, NOT as a benefit of the change, the same
+# way the previous entry's -3.3 MHz was not a cost of that one.
 set_global_assignment -name SEED 7

--- a/bench/dvd/iso_reader_attr_tb.sv
+++ b/bench/dvd/iso_reader_attr_tb.sv
@@ -9,6 +9,14 @@
 // disc byte-for-byte:
 //   audio_ntracks=4  A0 AC3 2ch en / A1 AC3 6ch en / A2 AC3 2ch fr / A3 AC3 2ch en
 //   subp_ntracks =4  S0 en / S1 fr / S2 es / S3 en
+//   title_ar_wide=1  VTS_V_ATTR@0x200 = 0x4E80 -> display_aspect_ratio 3 = 16:9
+//
+// The aspect byte rides the SAME resident sector and the same sweep (issue #81):
+// an in-title menu's subpicture variant must be resolved against the IFO, which is
+// what libdvdnav's vm_get_video_attr() returns in DVD_DOMAIN_VTSTitle, not against
+// the MPEG sequence header. The value here is the real disc's, and the check reads
+// the fixture byte rather than restating 1 -- so it cannot pass on a wrong byte and
+// cannot go stale if the fixture is ever regenerated from a different VTS.
 //
 // Ground truth: tools/nav_extract.py --vts-attr --vts 21 (comment header of
 // bench/dvd/test_vobs/mib_vts21_vtsi_mat.hex).
@@ -41,6 +49,7 @@ module iso_reader_attr_tb;
     wire [2:0]  attr_a_fmt;
     wire [3:0]  attr_a_ch;
     wire [15:0] attr_a_lang, attr_s_lang;
+    wire        title_ar_wide;      // issue #81: TITLE-domain aspect from the IFO
 
     dvd_iso_reader dut (
         .clk(clk), .rst_n(rst_n), .start(start), .file_size(file_size),
@@ -53,6 +62,7 @@ module iso_reader_attr_tb;
         .audio_ntracks(audio_ntracks), .subp_ntracks(subp_ntracks),
         .attr_a_sel(attr_a_sel), .attr_a_fmt(attr_a_fmt), .attr_a_ch(attr_a_ch),
         .attr_a_lang(attr_a_lang), .attr_s_sel(attr_s_sel), .attr_s_lang(attr_s_lang),
+        .title_ar_wide(title_ar_wide),
         .sd_lba(sd_lba), .sd_rd(sd_rd), .sd_ack(sd_ack),
         .sd_buff_addr(sd_buff_addr), .sd_buff_dout(sd_buff_dout), .sd_buff_wr(sd_buff_wr),
         .stream_data(stream_data), .stream_valid(stream_valid), .busy(busy),
@@ -161,7 +171,28 @@ module iso_reader_attr_tb;
         chk_s(3'd2, 16'h6573);               // Spanish subs
         chk_s(3'd3, 16'h656e);               // English subs
 
-        if (errors == 0) $display("ISO_READER_ATTR_TB: PASSED (MiB VTS_21 4 audio / 4 subp, codec+ch+lang exact)");
+        // ---- issue #81: VTS_V_ATTR@0x200 rides the same sweep ----------------
+        // Expected value is DERIVED FROM THE FIXTURE, not written out: bits 11:10
+        // of the BE u16 are the display_aspect_ratio, 3 = 16:9. So this arm fails
+        // on a wrong byte and stays honest if the fixture is regenerated.
+        begin : vatr_arm
+            reg exp_wide;
+            exp_wide = (((vtsimat[16'h200] << 8) | vtsimat[16'h201]) & 16'h0C00) == 16'h0C00;
+            $display("ATTR: VTS_V_ATTR@0x200 = %02x%02x -> expect title_ar_wide=%b, got %b",
+                     vtsimat[16'h200], vtsimat[16'h201], exp_wide, title_ar_wide);
+            if (title_ar_wide !== exp_wide) begin
+                errors = errors + 1;
+                $display("  ERR title_ar_wide=%b (want %b from VTS_V_ATTR)", title_ar_wide, exp_wide);
+            end
+            // Not vacuous: MiB VTS_21 is 16:9, so the expectation is 1 and a reader
+            // that never captured the byte (or captured the wrong one) reads 0.
+            if (exp_wide !== 1'b1) begin
+                errors = errors + 1;
+                $display("  ERR the fixture is no longer a 16:9 VTS -- this arm cannot fail for the reason it exists");
+            end
+        end
+
+        if (errors == 0) $display("ISO_READER_ATTR_TB: PASSED (MiB VTS_21 4 audio / 4 subp, codec+ch+lang exact, 16:9 from the IFO)");
         else             $display("ISO_READER_ATTR_TB: FAILED with %0d errors", errors);
         $finish;
     end

--- a/bench/dvd/run_subpic.sh
+++ b/bench/dvd/run_subpic.sh
@@ -8,6 +8,13 @@ cd "$(dirname "$0")/../.."
 # subp_stream_map's vectors are GENERATED (bench/dvd/test_vobs/ is gitignored, the
 # same convention as aud_map_vec.hex) -- regenerate so the bench can never run
 # against a stale fixture.
+# ISSUE #81: the module's truth table is unchanged by that fix -- what changed is
+# which of emu's signals is wired to the domain gate, and there is no emu-level
+# bench. This reads the port connection out of dvd/emu.sv (the acmod_scan.py /
+# csync_pipe_tb pattern) and is RED on the pre-#81 file. Costs milliseconds.
+echo "=== subp_stream_map wiring: emu.sv passes the DOMAIN, not the menu context (#81) ==="
+python3 tools/check_subp_map_wiring.py
+
 echo "=== subp_stream_map: logical->physical subpicture map vs the golden model ==="
 python3 tools/gen_subp_map_vec.py >/dev/null
 iverilog -g2012 -o bench/dvd/subp_stream_map_sim dvd/subp_stream_map.sv bench/dvd/subp_stream_map_tb.sv 2>/dev/null

--- a/bench/dvd/subp_stream_map_tb.sv
+++ b/bench/dvd/subp_stream_map_tb.sv
@@ -11,18 +11,18 @@
 //     python3 tools/gen_subp_map_vec.py
 //
 // Packed vector, LSB first:
-//   [0] map_valid  [1] dom_tt  [2] ctx_menu  [3] wide
+//   [0] map_valid  [1] dom_tt  [2] menu_dom  [3] wide
 //   [5:4] disp_mode  [9:6] logical  [41:10] ctl_sel  [46:42] expect
 
 `timescale 1ns/1ps
 
 module subp_stream_map_tb;
 
-    localparam NVEC = 2071;               // directed + random (see generator)
+    localparam NVEC = 2077;               // directed + random (see generator)
 
     reg  [47:0] vec [0:NVEC-1];
 
-    reg         map_valid, dom_tt, ctx_menu, wide;
+    reg         map_valid, dom_tt, menu_dom, wide;
     reg  [1:0]  disp_mode;
     reg  [3:0]  logical;
     reg  [31:0] ctl_sel;
@@ -33,7 +33,7 @@ module subp_stream_map_tb;
     subp_stream_map dut (
         .map_valid    (map_valid),
         .dom_tt       (dom_tt),
-        .ctx_menu     (ctx_menu),
+        .menu_dom     (menu_dom),
         .logical      (logical),
         .ctl_sel      (ctl_sel),
         .wide         (wide),
@@ -54,16 +54,16 @@ module subp_stream_map_tb;
                 i = NVEC;                       // short-file guard
             end else begin
                 {unused_hi, expect_v, ctl_sel, logical, disp_mode,
-                 wide, ctx_menu, dom_tt, map_valid} = vec[i];
+                 wide, menu_dom, dom_tt, map_valid} = vec[i];
                 #1;
                 if (phys_streamN !== expect_v) begin
                     errors = errors + 1;
                     if (errors < 20)
-                        $display("FAIL vec %0d: mv=%b tt=%b menu=%b wide=%b dm=%0d log=%0d ctl=%08x -> %0d (expect %0d)",
-                                 i, map_valid, dom_tt, ctx_menu, wide, disp_mode,
+                        $display("FAIL vec %0d: mv=%b tt=%b mdom=%b wide=%b dm=%0d log=%0d ctl=%08x -> %0d (expect %0d)",
+                                 i, map_valid, dom_tt, menu_dom, wide, disp_mode,
                                  logical, ctl_sel, phys_streamN, expect_v);
                 end
-                if (ctx_menu && !dom_tt && map_valid && phys_streamN != 5'd0)
+                if (menu_dom && !dom_tt && map_valid && phys_streamN != 5'd0)
                     n_menu_fix = n_menu_fix + 1;
                 n = n + 1;
             end
@@ -89,7 +89,7 @@ module subp_stream_map_tb;
         // being shown 0x20 under a palette that renders every subtitle class as one
         // flat grey.
         begin : avail_arms
-            map_valid = 1; dom_tt = 1; ctx_menu = 0; wide = 1; disp_mode = 0;
+            map_valid = 1; dom_tt = 1; menu_dom = 0; wide = 1; disp_mode = 0;
 
             // [1] class C: the table declares SOMETHING, but not this entry -> absent
             any_present = 1; logical = 4'd0; ctl_sel = 32'h00000000; #1;
@@ -130,15 +130,73 @@ module subp_stream_map_tb;
             end
             map_valid = 1;
 
-            // [6] wrong domain (a menu resolution against a title table) -> not absent
-            ctx_menu = 1; any_present = 1; logical = 4'd0; ctl_sel = 32'h00000000; #1;
+            // [6] wrong domain (a MENU-DOMAIN player against a title table) -> not absent
+            menu_dom = 1; any_present = 1; logical = 4'd0; ctl_sel = 32'h00000000; #1;
             if (stream_absent !== 1'b0) begin
                 errors = errors + 1;
                 $display("FAIL [avail-6]: an out-of-domain table must not report absence");
             end
-            ctx_menu = 0;
+            menu_dom = 0;
 
             if (errors == 0) $display("  stream_absent: 6 directed arms PASS (class C absent, class B preserved)");
+        end
+
+        // ---- ISSUE #81: AN IN-TITLE MENU IS A MENU CONTEXT IN THE TITLE DOMAIN --
+        // A DVD-game / motion-menu disc authors its menus as TITLE-domain PGCs with
+        // the button HLI in the NAV packs (Scene It's game menus; Aniki mon Frere /
+        // BROTHER PAL FR R2, the reported disc). emu calls that a menu context
+        // (sp_menu_early -> menu_sp_ctx) and resolves LOGICAL stream 0 -- but the
+        // loaded table is the TITLE's, and the player is in the TITLE domain.
+        //
+        // ⚠ THE MODULE'S TRUTH TABLE DID NOT CHANGE for this fix: the old
+        // `ctx_menu ? ~dom_tt : dom_tt` is the same function of (dom_tt, bit 2) as
+        // `dom_tt != menu_dom`. What changed is WHICH FACT emu puts on that bit --
+        // the domain the player is in, not whether the caller wanted a menu. So
+        // these arms pin the CONTRACT, and the thing that can actually regress is
+        // the wiring: gated separately by tools/check_subp_map_wiring.py, which
+        // reads the port connection out of dvd/emu.sv and is RED on the pre-#81 file.
+        begin : in_title_menu_arms
+            map_valid = 1; any_present = 1; wide = 1; disp_mode = 0; logical = 4'd0;
+
+            // [7] the reported disc's word, in the title domain -> 0x21, not 0x20.
+            dom_tt = 1; menu_dom = 0; ctl_sel = 32'h80010200; #1;
+            if (phys_streamN !== 5'd1 || stream_absent !== 1'b0) begin
+                errors = errors + 1;
+                $display("FAIL [81-1]: in-title menu must resolve logical 0 -> physical 1 (got %0d abs=%b)",
+                         phys_streamN, stream_absent);
+            end
+
+            // [8] the PRE-FIX WIRING, reproduced: emu passed the menu CONTEXT (1)
+            //     while the player was in the title domain, so the gate rejected the
+            //     title's table and fell back to identity -> 0x20 -> nothing for the
+            //     highlight to recolour -> "no visible selection". This arm both
+            //     documents the defect and proves the gate still fires on a GENUINE
+            //     domain mismatch (a menu-domain player reading a title table).
+            dom_tt = 1; menu_dom = 1; ctl_sel = 32'h80010200; #1;
+            if (phys_streamN !== 5'd0) begin
+                errors = errors + 1;
+                $display("FAIL [81-2]: a genuine domain mismatch must still fall back to identity (got %0d)",
+                         phys_streamN);
+            end
+
+            // [9] a 4:3 in-title menu takes the >>24 field, like every other 4:3 path
+            dom_tt = 1; menu_dom = 0; wide = 0; ctl_sel = 32'h80010200; #1;
+            if (phys_streamN !== 5'd0) begin
+                errors = errors + 1;
+                $display("FAIL [81-3]: 4:3 in-title menu must take the 4:3 field (got %0d)", phys_streamN);
+            end
+            wide = 1;
+
+            // [10] the 16-of-17 library word must NOT move in the title domain: its
+            //      wide field is 0, so every disc that works today is unchanged.
+            dom_tt = 1; menu_dom = 0; ctl_sel = 32'h80000100; #1;
+            if (phys_streamN !== 5'd0) begin
+                errors = errors + 1;
+                $display("FAIL [81-4]: the common library word must still resolve to 0 in wide mode (got %0d)",
+                         phys_streamN);
+            end
+
+            if (errors == 0) $display("  issue #81: 4 directed in-title-menu arms PASS (logical 0 -> 0x21)");
         end
 
         if (errors == 0)

--- a/docs/bug_reports.md
+++ b/docs/bug_reports.md
@@ -60,10 +60,30 @@ reads as zero. Consequences, all of which are the point:
 4. With `--nav-packs`: NAV packs (PCI/HLI — the button rectangles) from the menu
    VOBs, for menu-highlight bugs. Off by default; it is the only part that scans
    VOB payload, and it is bounded by `--nav-scan-mb` (default 512).
+5. With `--nav-window SECTORS` **and `--lba`** (so in practice: the player's chord):
+   every NAV pack in one sequential run forward from the sector being served.
+
+★★ **4 and 5 capture DIFFERENT NAV packs, and the difference is structural — not a
+matter of tuning (issue #81).** `--nav-packs` scans MENU VOBs (`VIDEO_TS.VOB`,
+`VTS_nn_0.VOB`), so it **cannot see an in-title menu at all**: a DVD-game or
+motion-menu disc authors its menus as TITLE-domain PGCs with the HLI in a title
+VOB's NAV packs. Scene It's game menus are like this, and so is issue #81's
+disc, whose boot menus live in `VTS_02_1.VOB`. Measured on SCENEIT_HP: a
+2048-sector window from a title VOB yields ~20 NAV packs of which **13–20 carry
+multi-button HLI**, and the menu-VOB scan finds none of those records.
+
+The window is also ~100× cheaper, which is what makes it usable from the chord:
+0.28 s and a 38 KB bundle, against 4.9 s and 5.6 MB for `--nav-packs` on
+MEN_IN_BLACK (whose 680 MB of menu VOBs hit the cap). One forward run means no
+seeks, which matters on a physical disc the core is streaming from at the same
+time. And it captures whatever the user was actually looking at, which no offline
+scan can know. Detail: `docs/support_bundle_hps.md`.
 
 Deliberately **not** captured: title VOB payload. Subpicture, closed-caption,
 film-cadence and A/V-sync evidence all live in the elementary stream, which is
-megabytes and a different problem — those report better in prose.
+megabytes and a different problem — those report better in prose. (The window
+above reads *through* a title VOB but keeps only its NAV packs, and `audit()`
+proves that over the final captured set.)
 
 ## The content guarantee, and why it is structural
 

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -1898,6 +1898,16 @@ is suppressed so left/right walks buttons instead of seeking. `btn_ns==1` stays 
 case (scrub + Select-only) so Matrix is unaffected. The highlight subpicture is forced to stream 0
 + windowless (`menu_mode`) like a menu-domain menu so the selected-button highlight renders.
 
+⚠ **"Forced to stream 0" means LOGICAL 0, and until issue #81 (2026-09-12) that logical
+number never reached the disc's `subp_control` map on this path.** `subp_stream_map`'s domain
+gate was handed the menu *context*, so it required a menu-*domain* table and fell back to the
+identity index for every in-title menu — fine while the disc maps logical 0 → physical 0
+(every Scene It disc does), and invisible highlights on one that does not. The reported disc
+is *Aniki, mon Frère* (**BROTHER**) PAL FR R2, whose title-domain motion menus author
+`subp_control[0] = 0x80010200` (wide → `0x21`). Fixed by asking the gate the question it
+needs — "is the table from the domain the player is IN" — see
+`docs/track_selection.md` "The domain gate asked the wrong question".
+
 **Boot ordering (issues #1/#2) is NOT a bug:** `tools/dvd_vm_ref.py runboot` (new full-playback
 driver) parks on PGC18 (main menu) matching libdvdnav; the pre-menu "actor" clip is short
 authored VTS3 intro (2/11/7/19s), never a question VTS. See the `scene-it-in-title-hli-menus` memory.

--- a/docs/hil_harness.md
+++ b/docs/hil_harness.md
@@ -112,6 +112,28 @@ at the nominal geometry and **cannot** catch either.
 — a real frame read as `[REV]` at maxerr 44. `hud_read` requires both an exact
 fit and some non-space content before it reports a reading.
 
+### ⚠ Two harness defects found by using it (2026-09-12, issue #81 round)
+
+Both were in `tools/mister.py`, both silent, and both cost a diagnosis apiece:
+
+- **`deploy --agent --rbf X.rbf` installed the Main and the agent and SILENTLY SKIPPED
+  THE CORE.** The flash was guarded by `if not args.agent`, so `--agent` meant "agent
+  only" even when a core was named — while the skill's own documented usage is exactly
+  that combination. The result is the failure the `RESTORE_SCRIPT` comment right above it
+  was written about ("the Main landed, the core did not, and the two silently disagreed"),
+  reached by a different route and with no warning. Now `if args.rbf or not args.agent` —
+  an explicit `--rbf` is an instruction, so it wins. ★ It was caught only because the
+  deploy output had no `deploy:` line in it; nothing failed.
+- **`state` aborted on a freshly booted box.** Its remote script ends with
+  `tail -5 /tmp/dvd_report.log`, that log does not exist until the DVD core has run once,
+  and a shell script's exit status is its LAST command's — so the first thing the skill
+  tells you to run died with `remote command failed (rc=1)` and threw away everything it
+  had already gathered. `|| true`.
+
+★ The shape both share: **a status or a guard that is right in the common case and
+unexamined in the first-use case.** A harness is used most on a cold box and least on a
+warm one.
+
 ## Set `Debug Overlay=On` for anything that inspects state
 
 `status[2]` drives `hud_dbg` (`emu.sv:1283`, `:4926`), which forces the status

--- a/docs/support_bundle_hps.md
+++ b/docs/support_bundle_hps.md
@@ -177,22 +177,82 @@ But when ordering two bundles from the same reporter, sequence them by what they
 say, not by their timestamps. A bundle made on a PC has a real clock behind it;
 `player.generated_on == "mister"` marks the ones that may not.
 
+## The playhead NAV-pack window (issue #81)
+
+**Status: 🔧 built, host-tested + mutation-checked, ⏳ HW-confirm pending.**
+
+Issue #81 arrived as a menu-highlight bug whose bundle carried **no button data at all**,
+and nothing in it said so. The diagnosis had to be made structurally from the IFO tables
+instead. That was still the right diagnosis — the IFO's `subp_control` word was the
+evidence — but the confirm was never in evidence, and the silence is the defect: a missing
+capture produces a bundle that is written, self-checks, and looks complete.
+
+★★ **THE OBVIOUS FIX WAS THE WRONG ONE, AND MEASURING SAID SO.** The chord had always
+omitted `--nav-packs`, which the manual tells PC reporters to add for highlight bugs, so
+"just pass it too" is the one-line answer. Two measurements kill it:
+
+| | `--nav-packs` (menu-VOB scan) | `--nav-window` (this) |
+|---|---|---|
+| what it reads | every sector of `VIDEO_TS.VOB` + `VTS_nn_0.VOB`, capped at 512 MB | one **sequential** run forward from the served sector |
+| MEN_IN_BLACK | 4.9 s, 2,810 NAV packs, **5.6 MB** of sectors (its 680 MB of menu VOBs hit the cap) | — |
+| SCENEIT_HP | 0.8 s, 224 NAV packs | **0.28 s end to end, 16 NAV packs, a 38 KB bundle** |
+| in-title menus | **cannot see them at all** | 13–20 of ~20 packs carry multi-button HLI |
+| seeks | many | none |
+
+★ **The second row of that table is the real finding, and it is structural, not a
+tuning matter: `--nav-packs` scans MENU VOBs, so it cannot capture an in-title menu's
+buttons on any route, PC included.** A DVD-game or motion-menu disc authors its menus as
+TITLE-domain PGCs with the HLI in a title VOB's NAV packs — Scene It's game menus, and
+issue #81's disc, whose boot menus live in `VTS_02_1.VOB`. So passing `--nav-packs` to the
+chord would have cost minutes on an optical disc and still not answered this bug.
+
+**What ships instead:** `tools/dvd_report.py --nav-window SECTORS` (with `--lba`) captures
+every NAV pack in a short forward run from the playhead, and `dvd_report.cpp` passes
+`--nav-window 2048` whenever it has one. A VOBU is at most 1 s of video, so 2048 sectors
+(~4 MB) always spans several of them, and an HLI is re-sent every VOBU while a menu is up
+(measured on The Matrix: the same unit 8 times, 1.001 s apart) — so forward-only is
+enough. ★ It also captures **whatever the user was actually looking at**, in either
+domain, which no offline scan can know.
+
+Verified end to end on a real disc: a bundle built with `--lba 903500 --nav-window 2048`
+against SCENEIT_HP reconstructs to a sparse ISO whose `nav_extract.py` walk decodes a
+complete **7-button** in-title menu — rects, link graph, `btn_coli` colours and the VM
+command per button. Audit and self-check both PASS.
+
+⚠ **The content guarantee is unchanged and still structural.** The window only appends
+sectors that pass `is_nav_pack()`, and `audit()` re-checks the FINAL captured set and
+refuses to write a bundle if any sector parses as a media pack carrying anything but a
+system header, padding or `private_stream_2`. Nothing about this relaxes that.
+
+⚠ **No `--nav-packs` on the chord, still** — and now for a better reason than cost: it
+answers a different question, and the expensive one. The manual's on-player section says
+so to users.
+
+### The argv moved out of the fork
+
+`dvd_report_build_argv()` (declared in `dvd_report.h`, `DVD_REPORT_ARGV_MAX`) is built
+outside the `fork()` purely so it can be tested, the same move as
+`cdda_toc`'s track-skip resolver. **The failure mode here is silence**, which is the whole
+reason: a missing or misspelled flag still produces a plausible bundle.
+`main/tests/dvd_report_test.cpp` pins four arms — the full case, no playhead, playhead
+only, and the terminator/bound — with **4 RED mutations each caught by its own
+assertion**: drop `--nav-window`; pass it unconditionally (with no playhead the tool gets
+a base of 0 and captures the NAV packs at the START of the disc — *confidently wrong data
+instead of none*, which is worse than the bug being fixed); reach for `--nav-packs`
+instead; forget the NUL.
+
+⚠ Two harness lessons, both cost a round: `red_case`'s `grep -q "$expect"` read an expect
+string beginning `--` as an option (fixed with `-e`), and a test that walks `argv` until
+its NUL cannot detect a missing NUL — the terminator arm now pre-fills the array with a
+sentinel, runs FIRST, and bounds every scan by `DVD_REPORT_ARGV_MAX`, so a missing
+terminator is reported by its own assertion instead of as noise in an unrelated arm.
+
+⚠ `run_tests.sh` grew `osd.h` and `file_io.h` to its empty-stub list, and the test defines
+`dvd_css_active()` / `dvd_phys_device()` (declared by the real headers the module includes,
+so these are definitions rather than shadowing stubs).
+
 ## What is not done
 
-- ⚠ **No `--nav-packs`, so a HIGHLIGHT bug reported from the player carries no button
-  data.** The child is invoked nav-tables-only on purpose (`dvd_report.cpp:266` — the
-  nav-pack scan walks menu VOBs, which would turn a seconds-long chord into a long one on
-  an optical disc). Demonstrated cost, issue #81: the reported symptom was *"no visible
-  selection on the main menus"* and the bundle could not say whether an HLI was present
-  at all, so the diagnosis had to be made structurally from the IFO tables. It was still
-  the right diagnosis — the IFO's `subp_control` word was the evidence — but the confirm
-  was not in the bundle.
-  The manual now says this in the on-player section (`site/content/reference/reporting-a-bug.md`):
-  send the player bundle anyway, and add a PC bundle with `--nav-packs` when the report is
-  specifically about a highlight. ⛔ Not "just add the flag": measure the scan cost on a
-  physical disc first, and if it is added it wants a bounded scan (`--nav-scan-mb`) plus a
-  progress message, because `dvd_report_tick()` shares the poll loop with SD block service
-  and blocking I/O there is a video artefact (the `dvd_phys` drive-probe lesson).
 - **The live status word is not captured.** `user_io_status_get()` reads at most
   two bytes of `cur_status[]`, so the full 128-bit word would need its own
   accessor. The saved `DVD*.CFG` is passed instead — the same settings, one save

--- a/docs/support_bundle_hps.md
+++ b/docs/support_bundle_hps.md
@@ -249,6 +249,38 @@ system header, padding or `private_stream_2`. Nothing about this relaxes that.
 answers a different question, and the expensive one. The manual's on-player section says
 so to users.
 
+### How long the user waits, and why the NOTICE was the real risk
+
+MEASURED on the rig (image media, core not running): the chord's child takes **1.38 s**
+on SCENEIT_HP and **1.98 s** on MEN_IN_BLACK with the window, against 0.86 s for the nav
+tables alone. So the window costs about **half a second** and the whole gesture is ~2 s.
+
+⚠ **The PHYSICAL-DISC case is NOT measured** — the rig's tray held an audio CD (TOC 1-12,
+so raw ISO9660 reads give EIO) when this was written. The estimate is 4 MB sequential from
+the playhead on a drive that is already spinning and already positioned there, which is
+~3 s at DVD 1x and well under 1 s at 4x+; but that is arithmetic, not a measurement, and
+the reporter of issue #81 was on a physical disc. Measure it when a DVD is in the tray.
+⚠ There is also a second cost there that is not wait time: the collector reads the SAME
+drive the core is streaming from. The child is forked so it cannot starve the poll loop
+(the `dvd_phys` lesson), but the DRIVE is shared and a long read could still hiccup
+playback.
+
+★ **The thing that would actually annoy a user is not the duration — it is silence.**
+`start()` posted "Generating support bundle..." for **2000 ms** and then nothing until
+`reap()` posted the result. That looked fine only because the job also takes ~2 s: two
+unrelated numbers that happened to match, not a design. Anything slower drops the notice
+before the result arrives, and a user who sees a "generating" message vanish with nothing
+after it concludes it failed and presses the chord again. The notice is **8 s** now; the
+result message replaces it the moment it arrives, so nothing is lost in the fast case.
+
+⚠ **And extending it forced honouring a rule this project already wrote down.**
+`dvd_report_tick()` raises `InfoMessage` from a poll tick, which is the exact shape that
+froze MGL launches (issue #48) — `INTEGRATION.md` says to check `dvd_launch_ui_busy()` and
+defer, and this path never did. In practice the chord needs a deliberate 2 s human hold
+and so cannot collide with a launch, but "cannot happen" is what the pumps that DID freeze
+it were assumed to be. It defers now; the cost is one more press of a chord nobody is
+plausibly holding during a launch.
+
 ### The installed script may predate the flag
 
 ⚠⚠ **MEASURED ON THE RIG, and it is why the flag is not passed unconditionally: an

--- a/docs/support_bundle_hps.md
+++ b/docs/support_bundle_hps.md
@@ -255,15 +255,60 @@ MEASURED on the rig (image media, core not running): the chord's child takes **1
 on SCENEIT_HP and **1.98 s** on MEN_IN_BLACK with the window, against 0.86 s for the nav
 tables alone. So the window costs about **half a second** and the whole gesture is ~2 s.
 
-⚠ **The PHYSICAL-DISC case is NOT measured** — the rig's tray held an audio CD (TOC 1-12,
-so raw ISO9660 reads give EIO) when this was written. The estimate is 4 MB sequential from
-the playhead on a drive that is already spinning and already positioned there, which is
-~3 s at DVD 1x and well under 1 s at 4x+; but that is arithmetic, not a measurement, and
-the reporter of issue #81 was on a physical disc. Measure it when a DVD is in the tray.
-⚠ There is also a second cost there that is not wait time: the collector reads the SAME
-drive the core is streaming from. The child is forked so it cannot starve the poll loop
-(the `dvd_phys` lesson), but the DRIVE is shared and a long read could still hiccup
-playback.
+★★ **AND THE PHYSICAL-DISC CASE IS 50× SLOWER, WHICH THE ARITHMETIC GOT WRONG.** This
+section first carried an *estimate* — "4 MB from a spinning, already-positioned drive is
+~3 s at DVD 1x and under 1 s at 4x" — and it was wrong by an order of magnitude. MEASURED
+on a real DVD in the rig's drive, **while the core was streaming it**:
+
+| | |
+|---|---|
+| sustained read rate | **~90–285 KB/s** — about a SEVENTH of DVD 1x |
+| is it spin-up? | **no** — 8192 sectors held 195 KB/s for 84 s |
+| does chunking help? | **no** — 1-sector reads 13.9 s, 64-sector 17.0 s, 256-sector 17.8 s. It is the drive, not syscalls |
+| 2048-sector window | **15.7 – 29.1 s** |
+| pure seek, 1 sector | 0.73 s |
+
+⚠ **Re-reading the same region takes 0.02 s.** Any timing that does not use a FRESH LBA is
+measuring the page cache, and an early attempt here read 0.26 s for a window that really
+costs 16 s. Use an LBA nothing has touched.
+
+⚠ **Authentication and a spinning drive do NOT rescue it.** The obvious hypothesis was that
+cold unauthenticated reads are slow and a streaming, CSS-authenticated drive would be fast.
+Measured while the core played the disc: 2048 sectors still took 15.7 s. The hypothesis was
+wrong and the measurement is what said so.
+
+**So the window stops early and the cap follows the medium.** A scan of three playheads on
+that disc shows why:
+
+| | sectors from the playhead | time |
+|---|---|---|
+| 1st NAV pack | +51 .. +230 | 2.1 – 5.5 s |
+| 2nd NAV pack | +304 .. +465 | 3.9 – 7.0 s |
+| 8th NAV pack | +1701 .. +1903 | 19.1 – 29.1 s |
+
+An HLI is re-sent byte-identically in every VOBU while a menu is up, so the **first** record
+already carries the whole button set; the second covers a first VOBU that happens to carry
+`hli_ss = 0`. The eighth buys nothing and costs 20 s of someone's life. Hence
+`dvd_report.py --nav-stop` (default **2**) and a cap of **512** on optical against 2048 on
+an image (`nav_window_for()`, on `S_ISBLK` — the fact that matters is the medium, not the
+path spelling).
+
+**Result, measured on the same playing disc:**
+
+| chord on a physical DVD | |
+|---|---|
+| before this branch (nav tables only) | **0.91 – 0.96 s** |
+| unbounded 2048 window | **+15.7 to +29.1 s** |
+| bounded (cap 512, stop after 2) | **2.73 / 4.92 s total** |
+
+⚠ The cap is what you pay when the playhead sits somewhere with NO NAV packs — a still, a
+gap, a cell end — because the early stop cannot help there. That is the whole reason the cap
+is media-dependent rather than merely large. One measured run hit 14.35 s when the drive was
+in a bad patch, so treat 3–5 s as typical and not as a bound.
+
+⚠ There is also a second cost that is not wait time: the collector reads the SAME drive the
+core is streaming from. The child is forked so it cannot starve the poll loop (the
+`dvd_phys` lesson), but the DRIVE is shared.
 
 ★ **The thing that would actually annoy a user is not the duration — it is silence.**
 `start()` posted "Generating support bundle..." for **2000 ms** and then nothing until

--- a/docs/support_bundle_hps.md
+++ b/docs/support_bundle_hps.md
@@ -179,7 +179,14 @@ say, not by their timestamps. A bundle made on a PC has a real clock behind it;
 
 ## The playhead NAV-pack window (issue #81)
 
-**Status: 🔧 built, host-tested + mutation-checked, ⏳ HW-confirm pending.**
+**Status: 🔧 built, host-tested + mutation-checked; the COLLECTOR is HW-measured on the
+rig, the CHORD GESTURE is ⏳ HW-confirm pending.**
+
+⚠ **The chord cannot be driven from the HIL harness, so that half needs the maintainer's
+own gamepad.** `dvd_report_joy()` is called from `user_io_digital_joystick()`, and the
+harness's uinput device is a KEYBOARD: its presses become joystick bits inside the FPGA
+(`dvd/kbd_map.sv`) and never pass through Main's `map`. What WAS measured on the target is
+everything the chord's child does — see the table below.
 
 Issue #81 arrived as a menu-highlight bug whose bundle carried **no button data at all**,
 and nothing in it said so. The diagnosis had to be made structurally from the IFO tables
@@ -218,6 +225,20 @@ Verified end to end on a real disc: a bundle built with `--lba 903500 --nav-wind
 against SCENEIT_HP reconstructs to a sparse ISO whose `nav_extract.py` walk decodes a
 complete **7-button** in-title menu — rects, link graph, `btn_coli` colours and the VM
 command per button. Audit and self-check both PASS.
+
+**And measured ON THE MISTER ITSELF (2026-09-12), which is the number that decides
+whether it belongs on a chord** — the local figures above are a dev workstation's:
+
+| on the target | window (`--nav-window 2048`) | `--nav-packs` |
+|---|---|---|
+| SCENEIT_HP | **1.38 s**, 16 NAV packs, 37 KB bundle | — |
+| (same, no capture at all) | 0.86 s, 34 KB | — |
+| MEN_IN_BLACK | **1.98 s**, 14 NAV packs, 119 KB | **37.7 s**, 2,524 packs, 358 KB |
+
+So the window costs about **half a second** over no capture at all, and `--nav-packs` is
+**19× slower** than the window on this hardware — reading an ISO from local storage, with
+the core not even running. On an optical disc the core is streaming from, with the CPU
+contended, it is worse. That is the measurement that chose the design.
 
 ⚠ **The content guarantee is unchanged and still structural.** The window only appends
 sectors that pass `is_nav_pack()`, and `audit()` re-checks the FINAL captured set and

--- a/docs/support_bundle_hps.md
+++ b/docs/support_bundle_hps.md
@@ -228,18 +228,40 @@ system header, padding or `private_stream_2`. Nothing about this relaxes that.
 answers a different question, and the expensive one. The manual's on-player section says
 so to users.
 
+### The installed script may predate the flag
+
+⚠⚠ **MEASURED ON THE RIG, and it is why the flag is not passed unconditionally: an
+older release-installed `dvd_report.py` given the new argv prints**
+
+```
+dvd_report.py: error: unrecognized arguments: --nav-window 2048
+```
+
+**and writes NO BUNDLE AT ALL** — strictly worse than the missing button data the flag
+exists to add. The release zip ships `Scripts/dvd_report.py` beside the Main
+(`tools/package_release.sh`, and `package.yml` attaches it as its own asset), so they
+normally move together; a Main updated on its own must degrade, not break.
+
+So the child ASKS THE SCRIPT: `dvd_report_script_supports()` reads the file and looks for
+the flag's own name. argparse cannot accept a flag it does not name, so a substring search
+is sound in both directions — no old tool mentions it, and no new tool can support it
+silently. It runs in the CHILD, after the fork, because it is file I/O and
+`user_io_poll()` is the core's data pump (the `dvd_phys` drive-probe lesson); it reads in
+8 KB chunks with a `tlen-1` overlap so a token straddling a boundary is still found.
+
 ### The argv moved out of the fork
 
 `dvd_report_build_argv()` (declared in `dvd_report.h`, `DVD_REPORT_ARGV_MAX`) is built
 outside the `fork()` purely so it can be tested, the same move as
 `cdda_toc`'s track-skip resolver. **The failure mode here is silence**, which is the whole
 reason: a missing or misspelled flag still produces a plausible bundle.
-`main/tests/dvd_report_test.cpp` pins four arms — the full case, no playhead, playhead
-only, and the terminator/bound — with **4 RED mutations each caught by its own
-assertion**: drop `--nav-window`; pass it unconditionally (with no playhead the tool gets
-a base of 0 and captures the NAV packs at the START of the disc — *confidently wrong data
-instead of none*, which is worse than the bug being fixed); reach for `--nav-packs`
-instead; forget the NUL.
+`main/tests/dvd_report_test.cpp` pins six arms — the terminator/bound, the full case, no
+playhead, playhead only, an old script, and the probe itself — with **6 RED mutations each
+caught by its own assertion**: drop `--nav-window`; pass it unconditionally (with no
+playhead the tool gets a base of 0 and captures the NAV packs at the START of the disc —
+*confidently wrong data instead of none*, which is worse than the bug being fixed); reach
+for `--nav-packs` instead; forget the NUL; ignore what the installed script accepts; and
+drop the probe's chunk overlap (which silently reports a perfectly good tool as too old).
 
 ⚠ Two harness lessons, both cost a round: `red_case`'s `grep -q "$expect"` read an expect
 string beginning `--` as an option (fixed with `-e`), and a test that walks `argv` until

--- a/docs/support_bundle_hps.md
+++ b/docs/support_bundle_hps.md
@@ -179,14 +179,60 @@ say, not by their timestamps. A bundle made on a PC has a real clock behind it;
 
 ## The playhead NAV-pack window (issue #81)
 
-**Status: 🔧 built, host-tested + mutation-checked; the COLLECTOR is HW-measured on the
-rig, the CHORD GESTURE is ⏳ HW-confirm pending.**
+**Status: ✅ HW-CONFIRMED 2026-09-12 on a physical disc, both arms.**
 
-⚠ **The chord cannot be driven from the HIL harness, so that half needs the maintainer's
+⚠ **The chord cannot be driven from the HIL harness, so the gesture needs the maintainer's
 own gamepad.** `dvd_report_joy()` is called from `user_io_digital_joystick()`, and the
 harness's uinput device is a KEYBOARD: its presses become joystick bits inside the FPGA
-(`dvd/kbd_map.sv`) and never pass through Main's `map`. What WAS measured on the target is
-everything the chord's child does — see the table below.
+(`dvd/kbd_map.sv`) and never pass through Main's `map`. Everything the child does was
+measured from the harness; the gesture was pressed by hand.
+
+**Arm 1 — the DEGRADE path, with the OLD release-installed collector still in place.**
+Bundle written, `nav packs: no`, audit clean. That combination (new Main + old script)
+wrote NO BUNDLE AT ALL before the flag probe existed — measured on this same rig — so this
+is the version-skew hardening confirmed on hardware, not merely unit-tested.
+
+**Arm 2 — the CAPTURE path, new collector installed, chord pressed ON THE DISC'S MENU:**
+
+```
+captured 130 sectors, nav packs: playhead window 512 sectors
+audit    128 nav-table sectors, 2 NAV packs, 0 carrying A/V
+playhead sector 405969
+
+NAV @405971  hli_ss=2 btn_ns=5 fosl=0   btn_coli[grp1] sel=00005af0
+  btn 1  up/dn/lf/rt=5/2/1/1   LinkPGCN 13
+  btn 2  up/dn/lf/rt=1/3/2/2   LinkPGCN 4
+  btn 3  up/dn/lf/rt=2/4/3/3   HL_BTNN = button 1, LinkPGCN 14
+  btn 4  up/dn/lf/rt=3/5/4/4   LinkPGCN 2
+  btn 5  up/dn/lf/rt=4/1/5/5   HL_BTNN = button 1, LinkPGCN 30
+NAV @405979  ... the SAME button set, 8 sectors later
+```
+
+A complete menu — button count, link graph (a clean 1↔2↔3↔4↔5↔1 ring), highlight colours
+and the VM command per button — off a physical disc, in a 73 KB bundle. **That is exactly
+the evidence missing from #60, #61 and #81**, all three of which were physical-disc reports
+whose bundles carried zero NAV packs.
+
+★ The second NAV pack carries the same button set 8 sectors later — the per-VOBU HLI
+re-send, now observed on a physical disc. That is the property `--nav-stop` rests on.
+
+★★ **AND THE REAL-WORLD COST IS FAR BELOW THE COLD MEASUREMENT: both presses completed in
+≤1 s** (trace line to bundle, same or next second), against the 2.7-4.9 s measured with
+cold reads. The window reads FORWARD FROM THE PLAYHEAD, which is exactly where the core has
+just been streaming, so most of it is already in the page cache. The cold figures below are
+the pessimistic bound — the state the chord actually fires in is much cheaper.
+
+⚠ Both presses landed `btn_ns=0` when the playhead was mid-movie (sector 476140) and
+`btn_ns=5` when it was on the menu. Correct in both cases, and the reason the manual tells
+users to press the chord *while the menu is on screen*.
+
+⚠ **`/tmp/dvd_report_run.log` was 0 bytes after every press** — the child's stdout is not
+being captured, so `reap()`'s "Support bundle FAILED — see /tmp/dvd_report_run.log" would
+point at an empty file. PRE-EXISTING (nothing in this branch touches it) and it only bites
+on the failure path, but it is the one diagnostic that path has. The suspect is narrow:
+`start()` does `freopen("/tmp/dvd_report_run.log", "w", stdout)` in the forked child before
+`execvp`, and python writes fine to a redirect on that box — so it is the freopen in Main's
+context, not the tool. Worth its own look.
 
 Issue #81 arrived as a menu-highlight bug whose bundle carried **no button data at all**,
 and nothing in it said so. The diagnosis had to be made structurally from the IFO tables

--- a/docs/support_bundle_hps.md
+++ b/docs/support_bundle_hps.md
@@ -179,6 +179,20 @@ say, not by their timestamps. A bundle made on a PC has a real clock behind it;
 
 ## What is not done
 
+- ⚠ **No `--nav-packs`, so a HIGHLIGHT bug reported from the player carries no button
+  data.** The child is invoked nav-tables-only on purpose (`dvd_report.cpp:266` — the
+  nav-pack scan walks menu VOBs, which would turn a seconds-long chord into a long one on
+  an optical disc). Demonstrated cost, issue #81: the reported symptom was *"no visible
+  selection on the main menus"* and the bundle could not say whether an HLI was present
+  at all, so the diagnosis had to be made structurally from the IFO tables. It was still
+  the right diagnosis — the IFO's `subp_control` word was the evidence — but the confirm
+  was not in the bundle.
+  The manual now says this in the on-player section (`site/content/reference/reporting-a-bug.md`):
+  send the player bundle anyway, and add a PC bundle with `--nav-packs` when the report is
+  specifically about a highlight. ⛔ Not "just add the flag": measure the scan cost on a
+  physical disc first, and if it is added it wants a bounded scan (`--nav-scan-mb`) plus a
+  progress message, because `dvd_report_tick()` shares the poll loop with SD block service
+  and blocking I/O there is a video artefact (the `dvd_phys` drive-probe lesson).
 - **The live status word is not captured.** `user_io_status_get()` reads at most
   two bytes of `cur_status[]`, so the full 128-bit word would need its own
   accessor. The saved `DVD*.CFG` is passed instead — the same settings, one save

--- a/docs/track_selection.md
+++ b/docs/track_selection.md
@@ -531,9 +531,28 @@ pre-#81 `emu.sv` and on 3 targeted re-regressions). `tools/lint_undriven.sh`,
 `tools/netlist_canary.sh`, the whole `run_subpic.sh` suite, and every reader bench green
 (`iso_reader_atmos_tb` fails identically on the pre-change reader — pre-existing).
 
-**HW gate:** regression only, since no local disc reproduces — every disc with working
-menus must still show its highlight (menu-domain *and* Scene It's in-title game menus,
-which are the one class this change actually touches). The reporter is the final word.
+**HW round, 2026-09-12** (build `DVD_subpmapdom_20260912_1328.rbf` on the maintainer's
+rig). Regression only, since no local disc reproduces — the reporter is the final word on
+the positive case. All arms read from the `O[2]` blocks via `tools/hud_read.py blocks`,
+which is machine-readable rather than an impression:
+
+| Arm | Why it is the right arm | Result |
+|---|---|---|
+| **ATFIRSTSIGHT** root menu | The ONLY local disc where the map returns NON-ZERO: menu-domain, `VTSM_V_ATTR` 16:9, `subp_control[0] = 0x80010000` ⇒ logical 0 → **0x21**. If the `dom_ok` change had broken the menu-domain path it would fall back to identity → 0x20 → no SPU bytes. | `hl_btns_armed / video_live / subpic_shown / spu_bytes_seen / still_active / hl_on / hl_recolour_fired` all **GREEN** and stable over 98 s; screenshot shows the highlight box around **play** |
+| **SCENEIT_HP** game menu | The one class this change actually touches (in-title, `sp_menu_early`). | 5-button menu renders with the box on **PLAY THE GAME**; two D-pad presses walked the highlight down, MEASURED by its bounding rows (230..346 → 277..314 → 320..356) — so parse → arm → route → decode → recolour → walk all work |
+| **MEN_IN_BLACK** track counts | The readout of the `S_ATTR` sweep the reader change edits (it now reads `VTS_V_ATTR@0x200` before the audio count at 515). The local RED mutation makes this read 8. | `AUDIO 4/4 EN`, `SUB 1/4 EN / 2/4 FR / 3/4 ES / 4/4 EN` — byte-exact against the disc, both tables and the languages |
+| **MEN_IN_BLACK** soak | Incidental but worth recording: the reader streamed a 7.4 GB ISO over CIFS for **~87 minutes** (to 1:26:56 of 1:37:52) unattended after the arms above. | clean, still playing, `CH 1/21` |
+
+⚠ **The ATFIRSTSIGHT arm is a regression arm and cannot be more than that.** For a
+menu-domain menu `dom_ok` is algebraically identical before and after the fix
+(`menu_dom=1, dom_tt=0` ≡ `ctx_menu=1, dom_tt=0`), so it can detect a breakage and can
+never confirm the fix. Nothing local can: that is what "no local repro" means.
+
+⚠ **The gamepad CHORD cannot be driven from the harness**, so the bundle-capture change is
+measured by running the collector on the target instead. `dvd_report_joy()` is called from
+`user_io_digital_joystick()`, and the harness's uinput device is a KEYBOARD — its presses
+become joystick bits inside the FPGA (`kbd_map.sv`) and never pass through Main's `map`.
+Worth knowing before designing any future test around a chord.
 
 ### Audio-substream observation tap (shipped) + the deferred watchdog
 

--- a/docs/track_selection.md
+++ b/docs/track_selection.md
@@ -242,10 +242,11 @@ decisive A/B; backups `BATTLEFIELD_EARTH` VTS 4, `NATIONAL_LAMPOONS_VACATION`
 VTS 2); MiB 4-track cycling unregressed; menu→title transitions keep audio
 continuous.
 
-### Logical→physical SUBPICTURE mapping — menus (issues #60/#61)
+### Logical→physical SUBPICTURE mapping — menus (issues #60/#61, #81)
 
-**Status: 🔧 fixed in fabric, sim-proven RED/GREEN + mutation-checked, ⏳ HW-confirm
-pending** (branch `fix/menu-subp-stream-map`).
+**Status: ✅ MERGED (PR #68), sim-proven RED/GREEN + mutation-checked, ⏳ HW-confirm
+pending.** Extended by **issue #81** (title-domain menus — see
+"The domain gate asked the wrong question" below), ⏳ HW-confirm pending.
 
 Two field reports, both PAL FR Region-2 physical discs on v0.4.0, both worded almost
 identically: *"the disc is playable, but we can't see any highlighted cursor or any
@@ -332,7 +333,7 @@ nav-only), so this is the only real disc on which the new path can be exercised 
   stream 0's art, routine on a multilingual R2 title, and newly reachable now that
   menus resolve to non-zero ids.
 
-**⛔ The `ctx_menu`/`dom_tt` gate is NOT hygiene.** `subp_ctl_mem` is one store shared
+**⛔ The domain gate is NOT hygiene.** `subp_ctl_mem` is one store shared
 by both domains and is never cleared. Without a domain match, (a) a menu jump raises
 `menu_active` *before* `S_PGC_HDR` clears `pgc_ctl_valid`, so a menu would briefly
 resolve through the **title's** table, and (b) a menu's table would leak into the
@@ -360,7 +361,9 @@ needs a T2-Letterbox HW round.
 
 `sp_menu_early` (an in-title multi-button game menu, e.g. Scene It) joins the mapping:
 it is a title-domain PGC, so `subp_ctl_mem` is already populated for it and
-`ar_wide_auto_eff == ar_wide_auto` there.
+`ar_wide_auto_eff == ar_wide_auto` there. ⚠ **That sentence was written here and in
+`emu.sv` when this shipped, and it was false until issue #81 — see the next
+section.**
 
 **Golden model** `tools/dvd_vm_ref.py subp_stream_map()`; **offline sweep**
 `tools/subp_route_sweep.py` (old vs new routing for every menu PGC of every disc).
@@ -381,7 +384,16 @@ Full `run_subpic.sh` + a baseline-vs-fixed A/B of all 31 reader benches (27 unch
 ⚠ **The `emu.sv` glue itself has NO sim gate** — there is no emu-level bench in this
 project — so `menu_sp_ctx`, `sp_disp_mode_eff`, the `subp_stream_map` instantiation and
 the widened `sp_track_eff` are **review-only plus Quartus elaboration**, the same standing
-this codebase records for the keyboard feature's `joy_eff` substitution. The three links
+this codebase records for the keyboard feature's `joy_eff` substitution.
+★★ **ISSUE #81 CAME THROUGH THAT GAP, AND IT WAS THE ONE CONNECTION NOBODY RE-READ.**
+The paragraph below ("A chain bench was considered and dropped… it would have to
+*replicate* emu's glue") is sound about a chain bench and was taken as covering the
+glue. It did not: the defect was a single port connection carrying the wrong FACT, and
+no amount of module-level testing can see that. `tools/check_subp_map_wiring.py` now
+gates exactly that one connection by **reading it out of `dvd/emu.sv`** (the
+`tools/acmod_scan.py` / `csync_pipe_tb` pattern — a gate that cannot go stale because
+the thing it asserts is the source file), runs from `run_subpic.sh`, and is RED on the
+pre-#81 file and on the plausible re-regression (`.menu_dom (menu_sp_ctx)`). The three links
 either side of it are gated (reader streams the table; the map resolves it; the demux
 filters on it), and `tools/lint_undriven.sh` passes, which is what catches the specific
 failure mode of a declared-but-undriven wire. A chain bench was considered and dropped as
@@ -395,6 +407,81 @@ byte-identical. Assert machine-readably with `Debug Overlay=On` and
 are exactly the discriminator: pre-fix on an affected disc the highlight arms and
 fetches while the SPU blocks read RED. The reporters remain the final word for
 #60/#61 themselves.
+
+#### The domain gate asked the wrong question (issue #81)
+
+**Status: 🔧 fixed in fabric, sim-proven + mutation-checked, ⏳ HW-confirm pending.**
+
+Field report on v0.5.0, *Aniki, mon Frère* (**BROTHER**) PAL FR Region 2, physical disc,
+`Disc Menus` On: *"No visible selection on the main menus."* Repro bundle attached
+(nav tables only — the reporter did not pass `--nav-packs`, so the HLI itself is not in
+evidence and the diagnosis below is structural).
+
+That is word-for-word the #60/#61 symptom, on a disc the #60/#61 fix could not reach.
+Measured from the bundle:
+
+```
+FP PGC:  g[3] = 1 ; JumpTT 3        -> global title 3 -> VTS_02 vts_ttn 1
+VTS_02:  VTS_PGCIT nr_srp=32, 22 titles of 30-41 s     <- the MENUS are TITLE-domain PGCs
+         PGCN 4 post: if (g[0] == 0) JumpVTS_PTT 4:1   <- a looping motion menu
+         PGCN 5/6/7/8/9 post: HL_BTNN = 0x400 / 0x800  <- SetHL_BTNN: it expects HIGHLIGHTS
+VTS_02 V_ATTR@0x200 = 0x5E00                           <- MPEG-2, PAL, 16:9
+VTS_02 subp_control[0] = 0x80010200 on EVERY PGC       <- avail, 4:3=0, wide=1, lbox=2
+```
+
+`0x80010200` is the exact word both #60/#61 discs author, so the menu highlight SPU
+rides substream **0x21**. The core filtered **0x20**, decoded nothing, and a highlight
+is a *recolour of subpicture pixels* — so nothing was drawn.
+
+**Why the #60/#61 fix did not cover it.** The map's domain gate was
+`dom_ok = ctx_menu ? ~dom_tt : dom_tt`, driven from `emu.sv`'s `menu_sp_ctx` — i.e.
+*"a menu resolution requires a MENU-DOMAIN table"*. But `menu_sp_ctx` is deliberately
+**wider than the menu domain**: it includes `sp_menu_early`, the in-title multi-button
+HLI menu. A DVD-game or motion-menu disc authors its menus as title-domain PGCs, so the
+gate demanded a menu-domain table, found the title's, and fell back to the logical
+index — logical 0 → physical 0 → `0x20`.
+
+★ **Menu CONTEXT and menu DOMAIN are not the same question, and the fix is to ask the
+one the gate actually needs:** does the loaded table belong to the domain the player is
+**in**? The input is now `menu_dom` (`emu`: `menus_on && menu_active`) and the test is
+`dom_ok = (dom_tt != menu_dom)`.
+
+⚠ **The module's truth table did not change.** `ctx_menu ? ~dom_tt : dom_tt` is the same
+function of `(dom_tt, that bit)` as `dom_tt != menu_dom` (verified over 200,000 random
+input points). What changed is which of `emu`'s signals is wired to it — which is why
+`subp_stream_map_tb` cannot go RED for this, and why the wiring gate above exists.
+Every previously-working combination is bit-identical, because for a menu-domain menu
+and for every title-domain non-menu path `menu_dom` and the old `ctx_menu` carried the
+same value. **Only the in-title MENU changes**, which is the whole fix.
+
+**Scope, swept.** 958 local ISOs: **7** have a title-domain PGC whose logical 0 resolves
+non-zero for the presented aspect, and **none of the 7 carries an in-title HLI** (scanned
+with `nav_extract.py --title-vob`), so none is a repro — the same "cannot reproduce
+locally" standing as #60/#61 itself. Those 7 are unaffected either way: with no HLI,
+`menu_sp_ctx` never asserts and the user subtitle path resolves by raw index exactly as
+before.
+
+⚠ **The next suspect if the HW round fails is `wide`.** For an in-title menu it is
+`ar_wide_auto` — the **decoded sequence header** — while a menu-domain menu uses the
+IFO's `VTSM_V_ATR` precisely because "DVD menus are routinely authored 16:9 anamorphic
+with a 4:3 sequence-header code". If this disc's title-domain menu VOB carries a 4:3
+code, the map takes the `[28:24]` field (0) and the symptom survives. The reader does
+**not** export `VTS_V_ATTR@0x200` today; the byte is already resident in `parse_buf`
+during the Phase-10 `S_ATTR` sweep, so capturing it is one extra `attr_addr` step. Not
+done deliberately — one behavioural delta per HW round
+(`docs/single_raster_analog.md` §3.9). Weak evidence against it: the reporter did not
+say the menus looked squished, and the same `ar_wide_auto` drives `VIDEO_ARX/ARY`.
+
+**Tests:** `bench/dvd/subp_stream_map_tb.sv` arms **[7]–[10]** (the reported word in the
+title domain → 0x21; the pre-fix wiring reproduced, proving the gate still fires on a
+genuine domain mismatch; the 4:3 field; and the 16-of-17 library word not moving) plus
+6 new generated vectors; `tools/check_subp_map_wiring.py` (RED on the pre-#81 `emu.sv`
+and on 2 targeted re-regressions). `tools/lint_undriven.sh` and the whole
+`run_subpic.sh` suite green.
+
+**HW gate:** regression only, since no local disc reproduces — every disc with working
+menus must still show its highlight (menu-domain *and* Scene It's in-title game menus,
+which are the one class this change actually touches). The reporter is the final word.
 
 ### Audio-substream observation tap (shipped) + the deferred watchdog
 

--- a/docs/track_selection.md
+++ b/docs/track_selection.md
@@ -472,23 +472,64 @@ that is untouched. So the set of discs this change can move is precisely: a titl
 PGC with the available bit SET, a non-zero physical id for the presented aspect, **and**
 an in-title HLI menu.
 
-⚠ **The next suspect if the HW round fails is `wide`.** For an in-title menu it is
-`ar_wide_auto` — the **decoded sequence header** — while a menu-domain menu uses the
-IFO's `VTSM_V_ATR` precisely because "DVD menus are routinely authored 16:9 anamorphic
-with a 4:3 sequence-header code". If this disc's title-domain menu VOB carries a 4:3
-code, the map takes the `[28:24]` field (0) and the symptom survives. The reader does
-**not** export `VTS_V_ATTR@0x200` today; the byte is already resident in `parse_buf`
-during the Phase-10 `S_ATTR` sweep, so capturing it is one extra `attr_addr` step. Not
-done deliberately — one behavioural delta per HW round
-(`docs/single_raster_analog.md` §3.9). Weak evidence against it: the reporter did not
-say the menus looked squished, and the same `ar_wide_auto` drives `VIDEO_ARX/ARY`.
+#### The second wrong fact: `wide` came from the sequence header
+
+★★ **libdvdnav settles it, and it is the reason this half got done rather than
+deferred.** `vm_get_subp_stream()` (vmget.c:138) has **no domain condition on the map at
+all** — the domain only decides whether `subpN` is forced to 0 and whether a `-1` becomes
+0 — so a conforming player applies `subp_control` in `DVD_DOMAIN_VTSTitle` exactly as in a
+menu domain. For this disc it resolves `(0x80010200 >> 16) & 0x1f = 1` → `0x21`, which is
+what the fix above now produces: the oracle agrees, independently of our RTL and of a
+golden model derived from it.
+
+But the aspect it feeds that lookup is `vm_get_video_aspect()` →
+`vm_get_video_attr()` → **`vtsi_mat->vts_video_attr` in `DVD_DOMAIN_VTSTitle`**
+(vmget.c:313) — the **IFO**, not the MPEG sequence header. This core used
+`ar_wide_auto_eff`, which for an in-title path is the decoded sequence header. That is a
+divergence, and a consequential one: a menu-domain menu already uses `VTSM_V_ATR`
+*precisely because* "DVD menus are routinely authored 16:9 anamorphic with a 4:3
+sequence-header code", and a title-domain menu is the same kind of authoring. A 4:3 code
+would take the `[28:24]` field (0) and the symptom would survive the domain fix entirely.
+
+So `dvd_iso_reader` gained **`title_ar_wide`** from `VTS_V_ATTR@0x200`. It costs **one
+extra `attr_addr` step**: the Phase-10 `S_ATTR` sweep already runs with that VTSI_MAT
+sector resident in `parse_buf`, so a new `attr_vatr` one-shot reads byte 512 before the
+audio count and decodes bits 11:10 with the same `& 0x0C` test `S_MENU_VATR` uses.
+
+`emu` consumes it through **one mux arm and nowhere else**:
+
+```
+sp_map_wide = sp_menu_early && !menu_dom_live ? title_ar_wide_w   // in-title menu
+                                             : ar_wide_auto_eff;  // unchanged
+```
+
+⚠ **Scoped to the in-title MENU context on purpose.** The white-rabbit `SetSTN` path and
+the user subtitle path are HW-confirmed on the sequence-header value, so they keep it;
+`ar_wide_eff` (the DISPLAY aspect, `VIDEO_ARX/ARY`) is untouched, because titles' own
+sequence headers do carry the true code and that path is proven. The resulting asymmetry
+— in-title *menu* reads the IFO, in-title *white rabbit* reads the stream — is deliberate,
+not an oversight: one of them has a working precedent to preserve and the other does not.
+
+★ **This is not a second behavioural delta in the "one per HW round" sense.** Its blast
+radius is the *same single case* as the domain fix — a menu context in the title domain —
+which the Scene It measurement above shows is inert on every local disc. It completes one
+change rather than adding another.
+
+**Gate:** `iso_reader_attr_tb` gains an arm that reads `VTS_V_ATTR` **out of the fixture**
+and checks `title_ar_wide` against it (MiB VTS_21 = `0x4E80`, aspect 3 = 16:9), plus a
+guard that fails if the fixture ever stops being a 16:9 VTS — so the arm cannot become
+vacuous. **3/3 targeted reader mutations caught** (never arm `attr_vatr`; read byte 513;
+test the wrong aspect bits). `tools/check_subp_map_wiring.py` also gates `.wide`, and is
+RED both on the pre-#81 file and on `.wide (ar_wide_auto_eff)`.
 
 **Tests:** `bench/dvd/subp_stream_map_tb.sv` arms **[7]–[10]** (the reported word in the
 title domain → 0x21; the pre-fix wiring reproduced, proving the gate still fires on a
 genuine domain mismatch; the 4:3 field; and the 16-of-17 library word not moving) plus
-6 new generated vectors; `tools/check_subp_map_wiring.py` (RED on the pre-#81 `emu.sv`
-and on 2 targeted re-regressions). `tools/lint_undriven.sh` and the whole
-`run_subpic.sh` suite green.
+6 new generated vectors; `bench/dvd/iso_reader_attr_tb.sv`'s `title_ar_wide` arm
+(mutation-checked 3/3); `tools/check_subp_map_wiring.py` on both ports (RED on the
+pre-#81 `emu.sv` and on 3 targeted re-regressions). `tools/lint_undriven.sh`,
+`tools/netlist_canary.sh`, the whole `run_subpic.sh` suite, and every reader bench green
+(`iso_reader_atmos_tb` fails identically on the pre-change reader — pre-existing).
 
 **HW gate:** regression only, since no local disc reproduces — every disc with working
 menus must still show its highlight (menu-domain *and* Scene It's in-title game menus,

--- a/docs/track_selection.md
+++ b/docs/track_selection.md
@@ -461,6 +461,17 @@ locally" standing as #60/#61 itself. Those 7 are unaffected either way: with no 
 `menu_sp_ctx` never asserts and the user subtitle path resolves by raw index exactly as
 before.
 
+★ **And the one class this change actually touches is measured bit-identical, not argued
+so.** Scene It is the in-title-menu reference disc, and its game VTS declares
+`nr_of_vts_subp_streams = 0` with the **available bit clear on every PGC's
+`subp_control[0]`** (`VTS_V_ATTR = 0x4300`, NTSC 4:3). `use_map = use_map_dom &&
+ctl_sel[31]`, so the availability term keeps it on the identity fallback → physical 0,
+exactly as before — the domain gate never gets to matter. Its highlight works today
+because the disc sends an SPU on `0x20` regardless of what its IFO subp table says, and
+that is untouched. So the set of discs this change can move is precisely: a title-domain
+PGC with the available bit SET, a non-zero physical id for the presented aspect, **and**
+an in-title HLI menu.
+
 ⚠ **The next suspect if the HW round fails is `wide`.** For an in-title menu it is
 `ar_wide_auto` — the **decoded sequence header** — while a menu-domain menu uses the
 IFO's `VTSM_V_ATR` precisely because "DVD menus are routinely authored 16:9 anamorphic

--- a/dvd/dvd_iso_reader.sv
+++ b/dvd/dvd_iso_reader.sv
@@ -385,6 +385,15 @@ module dvd_iso_reader #(
     // Auto aspect while a menu is active (titles keep the seq-header path).
     // 1 = the loaded menu domain is 16:9 (display aspect bits 11:10 == 3).
     output reg        menu_ar_wide,
+    // TITLE-domain aspect, from VTS_V_ATTR@0x200 of the same VTSI_MAT sector the
+    // Phase-10 attribute sweep already has resident. Same reason menu_ar_wide
+    // exists, one domain over: libdvdnav's vm_get_video_attr() returns
+    // vtsi_mat->vts_video_attr in DVD_DOMAIN_VTSTitle, so a conforming player
+    // resolves a TITLE PGC's subpicture variant against the IFO, not against the
+    // MPEG sequence header. emu consumes it only for an IN-TITLE MENU's
+    // subp_control lookup (issue #81) -- the display aspect keeps the proven
+    // sequence-header path.
+    output reg        title_ar_wide,
 
     // hps_io sd_* interface (directly connected)
     output reg [31:0] sd_lba,
@@ -547,6 +556,7 @@ reg [10:0] attr_addr;
 reg [2:0]  attr_idx;
 reg [2:0]  attr_j;
 reg        attr_phase;           // 0 = audio table, 1 = subpicture table
+reg        attr_vatr;            // 1 = the pending read is VTS_V_ATTR@0x200 (one-shot)
 reg        attr_cnt_pending;     // 1 = the pending read is a stream-count byte
 reg [5:0]  attr_resume;          // FSM state to resume after the sweep
 reg [5:0]  ptt_resume;           // Phase 6: state to resume after the PTT-table load
@@ -1888,6 +1898,8 @@ always @(posedge clk or negedge rst_n) begin
         dom          <= DOM_TT;
         menu_dom     <= 1'b0;
         menu_ar_wide <= 1'b0;             // default 4:3 until a menu V_ATR is read
+        title_ar_wide<= 1'b0;             // default 4:3 until a title V_ATR is read
+        attr_vatr    <= 1'b0;
         use_jcell    <= 1'b0;
         want_pgcn    <= 16'd1;
         want_entry   <= 4'd0;
@@ -2959,7 +2971,10 @@ always @(posedge clk or negedge rst_n) begin
                     fetch_ret  <= S_ATTR_RD;
                     attr_resume<= S_PTTLD_MAT;
                     attr_phase <= 1'b0; attr_cnt_pending <= 1'b1;
-                    attr_addr  <= 11'd515;             // nr_of_vts_audio_streams
+                    // ONE extra byte before the audio count: VTS_V_ATTR@0x200's
+                    // high byte, in the same resident sector (issue #81).
+                    attr_vatr  <= 1'b1;
+                    attr_addr  <= 11'd512;             // VTS_V_ATTR @0x200 (high byte)
                     attr_idx   <= 3'd0; attr_j <= 3'd0;
                     fi         <= 6'd0;
                     fi_cap_v   <= 1'b0;
@@ -2978,7 +2993,15 @@ always @(posedge clk or negedge rst_n) begin
             // cycles, one-off at the title mount. Resumes attr_resume.
             S_ATTR_RD: state <= S_ATTR_CAP;   // pb_raddr = attr_addr; latch next cycle
             S_ATTR_CAP: begin
-                if (attr_cnt_pending) begin
+                if (attr_vatr) begin
+                    // VTS_V_ATTR@0x200 high byte. display_aspect_ratio is bits
+                    // 11:10 of the BE u16 (both set = 3 = 16:9) = 0x0C here --
+                    // the same decode S_MENU_VATR does for the menu domains.
+                    title_ar_wide <= (pb_rdata & 8'h0C) == 8'h0C;
+                    attr_vatr <= 1'b0;
+                    attr_addr <= 11'd515;              // on to the audio count
+                    state     <= S_ATTR_RD;
+                end else if (attr_cnt_pending) begin
                     // stream-count byte. Clamp to 1..8 (a switch needs >=1 valid
                     // target; only the low-8 substreams are routable).
                     if (!attr_phase)

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -2276,10 +2276,17 @@ wire        force_43_subp = status[15];
 wire        vm_owns_route = menus_on && vm_owns_sp && vm_spstn[6];
 wire [2:0]  sp_user_log   = ({1'b0,sp_sel} >= subp_ntracks_w)
                             ? (subp_ntracks_w[2:0] - 3'd1) : sp_sel;   // clamped user index
+// "A MENU-DOMAIN PGC is loaded" -- the DOMAIN fact, named once so it cannot
+// diverge from the map's domain gate below (issue #81: the context and the domain
+// were two readings of one idea, and only one of them was about the domain).
+wire        menu_dom_live = menus_on && menu_active;
+// "This subpicture resolution is for a MENU" -- the CONTEXT, which is WIDER: a
+// title-domain game/motion menu (sp_menu_early) is a menu context in the TITLE
+// domain, so this is deliberately NOT menu_dom_live.
+wire        menu_sp_ctx   = menu_dom_live || sp_menu_early;
 // A MENU context (menu-domain menu, or an in-title multi-button game menu like
 // Scene It) resolves LOGICAL stream 0 -- but through the map, not as a constant.
 // DVD-FORK FIX (issues #60/#61): this used to short-circuit to physical 0.
-wire        menu_sp_ctx   = (menus_on && menu_active) || sp_menu_early;
 wire [3:0]  sp_sel_log    = menu_sp_ctx  ? 4'd0 :
                             vm_owns_route ? vm_spstn[3:0] : {1'b0, sp_user_log};
 wire [31:0] subp_ctl_sel  = subp_ctl_mem[sp_sel_log];                 // single 16:1 mux
@@ -2311,7 +2318,12 @@ wire        sp_stream_absent;
 subp_stream_map u_subp_map (
     .map_valid    (pgc_ctl_valid),
     .dom_tt       (pgc_dom_tt),
-    .ctx_menu     (menu_sp_ctx),
+    // DVD-FORK FIX (issue #81): this was `menu_sp_ctx` -- the menu CONTEXT -- and
+    // the module read it as "the table must be the MENU domain's". An in-title
+    // game/motion menu is a menu context whose table is the TITLE's, so the gate
+    // rejected a perfectly good table and fell back to the logical index. What the
+    // gate actually needs is the domain the player is IN.
+    .menu_dom     (menu_dom_live),
     .logical      (sp_sel_log),
     .ctl_sel      (subp_ctl_sel),
     // A menu's aspect is the MENU's own IFO V_ATR (ar_wide_auto_eff), not the
@@ -2342,10 +2354,15 @@ wire sp_user_absent = sp_stream_absent & ~(menu_sp_ctx | vm_owns_route | force_4
 // 0x24, instead of the raw index -> 0x23 warning); the 3-bit ps_demux substream_id[2:0]
 // match stays unambiguous here (active substreams 0x20/21/22/23/24 -> 0/1/2/3/4). Off =
 // user path byte-identical (raw clamped logical index).
-// An in-title multi-button game menu (Scene It) is a MENU: its highlight rides
-// LOGICAL subpicture stream 0 like a menu-domain menu (sp_sel_log above), and
-// resolves through the same map (it is a title-domain PGC, so subp_ctl_mem is
-// already populated for it and ar_wide_auto_eff == ar_wide_auto there).
+// An in-title multi-button game menu (Scene It, and the motion menus of
+// Aniki mon Frere / BROTHER) is a MENU: its highlight rides LOGICAL subpicture
+// stream 0 like a menu-domain menu (sp_sel_log above), and resolves through the
+// same map (it is a title-domain PGC, so subp_ctl_mem is already populated for it
+// and ar_wide_auto_eff == ar_wide_auto there).
+// ⚠ THAT LAST CLAUSE WAS FALSE FROM THE DAY IT WAS WRITTEN UNTIL issue #81: the
+// map's domain gate was handed the menu CONTEXT and required a menu-DOMAIN table,
+// so this path always fell back to the logical index. It resolves through the map
+// now because the gate tests the domain the player is in (subp_stream_map.menu_dom).
 // DVD-FORK FIX (issues #60/#61): menus were pinned to PHYSICAL 0 here. On a disc
 // whose menu PGC maps logical 0 to a non-zero physical id for the presented
 // display mode, that filtered the wrong substream, decoded no subpicture, and

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -1342,6 +1342,7 @@ wire [6:0]  res_ttn_w;
 wire [15:0] rd_next_pgcn, rd_prev_pgcn, rd_goup_pgcn;
 wire [7:0]  cur_cell_cmdnr_w;
 wire        menu_ar_wide_w;      // 1 = loaded menu is 16:9 (IFO V_ATR, not seq hdr)
+wire        title_ar_wide_w;     // 1 = loaded TITLE's VTS is 16:9 (IFO VTS_V_ATTR@0x200)
 wire        vm_cmd_we;
 wire [11:0] vm_cmd_waddr;
 wire [7:0]  vm_cmd_wdata;
@@ -2313,6 +2314,13 @@ wire [1:0]  sp_disp_mode = force_43_subp        ? 2'd1 :
 // (the HW round-1 lesson recorded at nav_pci's .disp_mode below).
 wire [1:0]  sp_disp_mode_eff = menu_sp_ctx ? 2'd0 : sp_disp_mode;
 
+// Which aspect the subpicture variant is resolved against. Menu-domain menu:
+// the menu's VTSM/VMGM V_ATR (as before, via ar_wide_auto_eff). In-title menu:
+// the TITLE VTS's own IFO attribute, which is what libdvdnav reads in
+// DVD_DOMAIN_VTSTitle. Everything else: unchanged.
+wire        sp_map_wide = sp_menu_early && !menu_dom_live ? title_ar_wide_w
+                                                          : ar_wide_auto_eff;
+
 wire [4:0]  sp_phys_streamN;
 wire        sp_stream_absent;
 subp_stream_map u_subp_map (
@@ -2326,9 +2334,16 @@ subp_stream_map u_subp_map (
     .menu_dom     (menu_dom_live),
     .logical      (sp_sel_log),
     .ctl_sel      (subp_ctl_sel),
-    // A menu's aspect is the MENU's own IFO V_ATR (ar_wide_auto_eff), not the
-    // decoded stream's; the two are the same signal on every non-menu path.
-    .wide         (ar_wide_auto_eff),
+    // A menu's aspect is the MENU's own IFO V_ATR, not the decoded stream's -- and
+    // that is true of a TITLE-domain menu too (issue #81). libdvdnav's
+    // vm_get_video_attr() returns vtsi_mat->vts_video_attr in DVD_DOMAIN_VTSTitle,
+    // so a conforming player resolves an in-title PGC's subpicture variant against
+    // VTS_V_ATTR@0x200; we used the MPEG sequence header there, and DVD menus are
+    // routinely authored 16:9 anamorphic with a 4:3 sequence-header code -- which
+    // would take the [28:24] field (usually 0) and leave the highlight with
+    // nothing again. Scoped to the MENU context only: every other path, the
+    // white-rabbit SetSTN included, keeps the HW-proven ar_wide_auto_eff.
+    .wide         (sp_map_wide),
     .disp_mode    (sp_disp_mode_eff),
     .any_present  (subp_any_present),
     .phys_streamN (sp_phys_streamN),
@@ -2757,6 +2772,7 @@ dvd_iso_reader dvd_iso_reader_inst (
     .title_first_rbn (title_first_rbn_w),         // seek-bar: title RBN span
     .title_last_rbn  (title_last_rbn_w),
     .menu_ar_wide   (menu_ar_wide_w),
+    .title_ar_wide  (title_ar_wide_w),
 
     .sd_lba         (sd_lba),
     .sd_rd          (sd_rd),

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -593,7 +593,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "dev-hdmiteardown"
+`define CORE_VERSION "dev-subpmapdom"
 
 parameter CONF_STR = {
     "DVD;;",

--- a/dvd/subp_stream_map.sv
+++ b/dvd/subp_stream_map.sv
@@ -30,15 +30,36 @@
 // nav_pci's button-group choice on one shared display-mode wire, which emu
 // already forces to wide for menus — so the rects and the art can never come
 // from different presentations. The caller supplies disp_mode; this module
-// does not know about menus beyond ctx_menu's validity gate.
+// does not know about menus beyond menu_dom's domain-validity gate.
 //
-// THE ctx_menu GATE IS NOT HYGIENE. subp_ctl_mem is a single store shared by
+// THE DOMAIN GATE IS NOT HYGIENE. subp_ctl_mem is a single store shared by
 // both domains and is never cleared. Without a domain match:
 //   - a menu jump raises menu_active BEFORE S_PGC_HDR clears pgc_ctl_valid, so
 //     a menu context would briefly resolve through the TITLE's table;
 //   - a menu's table would leak into the in-title HLI path (Matrix "Follow the
 //     White Rabbit", SetSTN logical 1 -> 0x22).
 // Both fall back to the logical index, which is the pre-fix behaviour.
+//
+// ★ BUT THE GATE MUST TEST THE DOMAIN THE PLAYER IS IN, NOT WHETHER THE
+//   RESOLUTION IS FOR A MENU (issue #81, 2026-09-12). Those are not the same
+//   question, and reading one as the other is what the #60/#61 fix shipped: the
+//   input was `ctx_menu` and the test was `ctx_menu ? ~dom_tt : dom_tt`, i.e.
+//   "a menu context requires a MENU-DOMAIN table". A DVD-game / motion-menu disc
+//   authors its menus as TITLE-domain PGCs with HLI in the NAV packs (Scene It's
+//   game menus; Aniki mon Frere / BROTHER PAL FR R2, the reported disc), and
+//   emu's `menu_sp_ctx` quite correctly calls that a menu context -- so the gate
+//   demanded a menu-domain table, found the title's, and fell back to identity.
+//   Logical 0 -> physical 0 -> substream 0x20, while the disc's menu SPU rides
+//   0x21: the #60/#61 symptom exactly, "no visible selection", on a disc the
+//   #60/#61 fix could not reach. emu.sv's own comment at sp_track_eff claimed
+//   this path "resolves through the same map"; it could not, and the comment had
+//   read as reassurance for four months.
+//   The input is therefore `menu_dom` = "a menu-domain PGC is loaded" (emu:
+//   menus_on && menu_active), a FACT about the player rather than a property of
+//   the caller, and the test is "the table's domain is the domain we are in".
+//   Every previously-working combination is bit-identical, because for a
+//   menu-domain menu and for every title-domain non-menu path menu_dom and the
+//   old ctx_menu carried the same value; only the in-title MENU differs.
 //
 // Golden model: tools/dvd_vm_ref.py subp_stream_map(); TB:
 // bench/dvd/subp_stream_map_tb.sv. Detail: docs/track_selection.md.
@@ -54,7 +75,10 @@
 module subp_stream_map (
     input  wire        map_valid,     // subp_control parsed & consistent (reader)
     input  wire        dom_tt,        // loaded PGC is title-domain (reader)
-    input  wire        ctx_menu,      // this resolution is for a menu context
+    // A MENU-DOMAIN PGC is loaded (emu: menus_on && menu_active). NOT "this is a
+    // menu resolution": an in-title game/motion menu is a menu context in the
+    // TITLE domain, and conflating the two was issue #81 (see the note above).
+    input  wire        menu_dom,
     input  wire [3:0]  logical,       // logical stream index (already selected)
     input  wire [31:0] ctl_sel,       // subp_control[logical], muxed by emu
     input  wire        wide,          // content is 16:9 (ar_wide_auto_eff)
@@ -69,8 +93,9 @@ module subp_stream_map (
 );
 
     // The table is trustworthy only when the reader has finished streaming it
-    // AND it belongs to the domain this resolution is for.
-    wire dom_ok  = ctx_menu ? ~dom_tt : dom_tt;
+    // AND it belongs to the DOMAIN THE PLAYER IS IN -- which is what makes an
+    // in-title menu (menu context, title domain) resolve through the map.
+    wire dom_ok  = (dom_tt != menu_dom);
     // the table is usable for this context (says nothing about THIS entry)
     wire use_map_dom = map_valid && dom_ok;
     wire use_map = use_map_dom && ctl_sel[31];

--- a/main/support/dvd/dvd_report.cpp
+++ b/main/support/dvd/dvd_report.cpp
@@ -42,6 +42,56 @@
 
 #define OUT_DIR      "/media/fat/DVD_reports"
 
+// ---------------------------------------------------------------------------
+// The child's argv, built OUTSIDE the fork so it can be tested
+// ---------------------------------------------------------------------------
+// Lives here rather than inline in the child because a missing flag fails
+// SILENTLY -- the bundle is written, looks fine, and is simply missing the data
+// the report needed. That is exactly how issue #81 arrived: the reporter's bundle
+// carried no button data at all and nothing said so. main/tests/dvd_report_test.cpp
+// pins this.
+//
+// ★ --nav-window, not --nav-packs. Both capture NAV packs; they capture DIFFERENT
+// ones, and only one of them is affordable here:
+//   --nav-packs   scans MENU VOBs (VIDEO_TS.VOB, VTS_nn_0.VOB) up to a 512 MB cap.
+//                 It CANNOT see an in-title menu -- a DVD-game or motion-menu disc
+//                 authors its menus as TITLE-domain PGCs with the HLI in a TITLE
+//                 VOB's NAV packs (Scene It's game menus; issue #81's disc, whose
+//                 boot menus live in VTS_02_1.VOB). Measured cost on MEN_IN_BLACK:
+//                 4.9 s and 5.6 MB of sectors on a local disk -- which on an
+//                 optical disc the core is streaming from means minutes of seeking.
+//   --nav-window  one SEQUENTIAL run forward from the sector we were serving,
+//                 capturing every NAV pack in it. Measured: 0.28 s end to end,
+//                 16 NAV packs, a 38 KB bundle -- and on Scene It's game VTSes
+//                 13-20 of ~20 such packs carry MULTI-BUTTON HLI, i.e. exactly
+//                 the records the menu-VOB scan cannot reach. No seeks.
+// 2048 sectors is ~4 MB; a VOBU is at most 1 s of video, so it always spans
+// several, and an HLI is re-sent every VOBU while a menu is up.
+//
+// Needs the playhead: with no LBA there is nothing to window around, so the flag
+// is omitted rather than passed with a meaningless base.
+#define NAV_WINDOW_SECTORS "2048"
+
+void dvd_report_build_argv(const char **argv, const char *script, const char *src,
+                           const char *out, const char *lba, const char *cfg,
+                           const char *ver)
+{
+	int i = 0;
+	argv[i++] = "python3";
+	argv[i++] = script;
+	argv[i++] = src;
+	argv[i++] = "--no-prompt";
+	argv[i++] = "--generated-on";
+	argv[i++] = "mister";
+	argv[i++] = "-o";
+	argv[i++] = out;
+	if (lba) { argv[i++] = "--lba";        argv[i++] = lba; }
+	if (lba) { argv[i++] = "--nav-window"; argv[i++] = NAV_WINDOW_SECTORS; }
+	if (cfg) { argv[i++] = "--cfg";        argv[i++] = cfg; }
+	if (ver) { argv[i++] = "--core-version"; argv[i++] = ver; }
+	argv[i] = 0;
+}
+
 static const char *SCRIPT_PATHS[] = {
 	"/media/fat/Scripts/dvd_report.py",
 	"/media/fat/dvd_report.py",
@@ -263,22 +313,9 @@ static void start(void)
 	}
 	if (!p)
 	{
-		// Child. Nav-tables only: no --nav-packs, because that scans menu VOBs
-		// and this should finish in seconds on SD-card media.
-		const char *argv[20];
-		int i = 0;
-		argv[i++] = "python3";
-		argv[i++] = script;
-		argv[i++] = src;
-		argv[i++] = "--no-prompt";
-		argv[i++] = "--generated-on";
-		argv[i++] = "mister";
-		argv[i++] = "-o";
-		argv[i++] = out_path;
-		if (have_lba) { argv[i++] = "--lba"; argv[i++] = lba; }
-		if (cfg)      { argv[i++] = "--cfg"; argv[i++] = cfg; }
-		if (ver)      { argv[i++] = "--core-version"; argv[i++] = ver; }
-		argv[i] = 0;
+		const char *argv[DVD_REPORT_ARGV_MAX];
+		dvd_report_build_argv(argv, script, src, out_path,
+		                      have_lba ? lba : 0, cfg, ver);
 
 		freopen("/tmp/dvd_report_run.log", "w", stdout);
 		dup2(fileno(stdout), fileno(stderr));

--- a/main/support/dvd/dvd_report.cpp
+++ b/main/support/dvd/dvd_report.cpp
@@ -1,7 +1,6 @@
 // dvd_report.cpp — generate a navigation support bundle from the player itself.
 // See dvd_report.h and MiSTer_DVD/docs/support_bundle_hps.md.
 
-#define _GNU_SOURCE       // memmem(), for the installed-script flag probe
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
@@ -97,6 +96,9 @@ int dvd_report_script_supports(const char *script, const char *token)
 	const size_t tlen = strlen(token);
 	if (!tlen || tlen >= 256) { fclose(f); return 0; }
 
+	// memmem() is a GNU extension; g++ defines _GNU_SOURCE implicitly for C++ on
+	// glibc and the Main's build adds it on the command line, so no #define here --
+	// one was added and REMOVED because it warned "redefined" on every build.
 	char buf[8192 + 256];
 	size_t keep = 0;                      // bytes carried over from the last chunk
 	int found = 0;

--- a/main/support/dvd/dvd_report.cpp
+++ b/main/support/dvd/dvd_report.cpp
@@ -71,7 +71,24 @@
 //
 // Needs the playhead: with no LBA there is nothing to window around, so the flag
 // is omitted rather than passed with a meaningless base.
-#define NAV_WINDOW_SECTORS "2048"
+// The window's CAP, in sectors. Two values, because the media differ by ~50x and
+// MEASURING said so rather than taste:
+//
+//   image on SD/USB/CIFS   the whole child runs in 1.4-2.0 s, the window costing
+//                          ~0.5 s of that. 2048 sectors is free, so take the wide
+//                          one and capture several VOBUs.
+//   optical disc           the drive sustains ~90-285 KB/s -- about a SEVENTH of
+//                          DVD 1x -- measured while the core was streaming it, and
+//                          steady over 84 s, so it is not spin-up. 2048 sectors is
+//                          15.7-29.1 s. 512 bounds the no-NAV-pack tail to ~5-10 s,
+//                          and the early stop (dvd_report.py --nav-stop, default 2)
+//                          means the usual case exits after ~300-500 sectors anyway.
+//
+// ⚠ The cap is what you pay when the playhead sits somewhere with NO NAV packs --
+// a still, a gap, the end of a cell. The early stop cannot help there, which is
+// the whole reason the cap is media-dependent rather than just large.
+#define NAV_WINDOW_IMAGE   "2048"
+#define NAV_WINDOW_OPTICAL "512"
 
 // ⚠⚠ THE INSTALLED SCRIPT MAY PREDATE THE FLAG, AND argparse DOES NOT SHRUG.
 // MEASURED on the rig against a release-installed dvd_report.py: the new argv gives
@@ -118,6 +135,16 @@ int dvd_report_script_supports(const char *script, const char *token)
 	return found;
 }
 
+// A block device here is the optical drive: dvd_phys binds /dev/srN and nothing
+// else in this core hands a block device to the collector. stat() rather than a
+// "/dev/sr" prefix match, because the fact that matters is the medium, not the name.
+const char *nav_window_for(const char *src)
+{
+	struct stat st;
+	if (src && !stat(src, &st) && S_ISBLK(st.st_mode)) return NAV_WINDOW_OPTICAL;
+	return NAV_WINDOW_IMAGE;
+}
+
 void dvd_report_build_argv(const char **argv, const char *script, const char *src,
                            const char *out, const char *lba, const char *cfg,
                            const char *ver, int want_window)
@@ -132,7 +159,7 @@ void dvd_report_build_argv(const char **argv, const char *script, const char *sr
 	argv[i++] = "-o";
 	argv[i++] = out;
 	if (lba)               { argv[i++] = "--lba";          argv[i++] = lba; }
-	if (lba && want_window){ argv[i++] = "--nav-window";   argv[i++] = NAV_WINDOW_SECTORS; }
+	if (lba && want_window){ argv[i++] = "--nav-window";   argv[i++] = nav_window_for(src); }
 	if (cfg)               { argv[i++] = "--cfg";          argv[i++] = cfg; }
 	if (ver)               { argv[i++] = "--core-version"; argv[i++] = ver; }
 	argv[i] = 0;

--- a/main/support/dvd/dvd_report.cpp
+++ b/main/support/dvd/dvd_report.cpp
@@ -1,6 +1,7 @@
 // dvd_report.cpp — generate a navigation support bundle from the player itself.
 // See dvd_report.h and MiSTer_DVD/docs/support_bundle_hps.md.
 
+#define _GNU_SOURCE       // memmem(), for the installed-script flag probe
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
@@ -72,9 +73,51 @@
 // is omitted rather than passed with a meaningless base.
 #define NAV_WINDOW_SECTORS "2048"
 
+// ⚠⚠ THE INSTALLED SCRIPT MAY PREDATE THE FLAG, AND argparse DOES NOT SHRUG.
+// MEASURED on the rig against a release-installed dvd_report.py: the new argv gives
+//   dvd_report.py: error: unrecognized arguments: --nav-window 2048
+// and NO BUNDLE IS WRITTEN AT ALL -- strictly worse than the missing button data
+// this flag exists to fix. The release zip ships Scripts/dvd_report.py beside the
+// Main so they normally move together, but a Main updated on its own must degrade,
+// not break.
+//
+// So: ask the script. It names every flag it accepts (argparse cannot accept one it
+// does not name), so a substring search over the file is sound in both directions --
+// no old tool mentions it, and no new tool can support it silently.
+//
+// ★ Runs in the CHILD, after the fork: this is file I/O, and user_io_poll() is the
+// core's data pump (the dvd_phys drive-probe lesson). Chunked with an overlap so the
+// token cannot straddle a read boundary.
+int dvd_report_script_supports(const char *script, const char *token)
+{
+	FILE *f = fopen(script, "rb");
+	if (!f) return 0;
+
+	const size_t tlen = strlen(token);
+	if (!tlen || tlen >= 256) { fclose(f); return 0; }
+
+	char buf[8192 + 256];
+	size_t keep = 0;                      // bytes carried over from the last chunk
+	int found = 0;
+	for (;;)
+	{
+		size_t got = fread(buf + keep, 1, 8192, f);
+		if (!got) break;
+		size_t have = keep + got;
+		buf[have < sizeof(buf) ? have : sizeof(buf) - 1] = 0;
+		if (memmem(buf, have, token, tlen)) { found = 1; break; }
+		// Carry the last tlen-1 bytes so a token split across chunks is still seen.
+		keep = (tlen > 1) ? (tlen - 1) : 0;
+		if (keep > have) keep = have;
+		memmove(buf, buf + have - keep, keep);
+	}
+	fclose(f);
+	return found;
+}
+
 void dvd_report_build_argv(const char **argv, const char *script, const char *src,
                            const char *out, const char *lba, const char *cfg,
-                           const char *ver)
+                           const char *ver, int want_window)
 {
 	int i = 0;
 	argv[i++] = "python3";
@@ -85,10 +128,10 @@ void dvd_report_build_argv(const char **argv, const char *script, const char *sr
 	argv[i++] = "mister";
 	argv[i++] = "-o";
 	argv[i++] = out;
-	if (lba) { argv[i++] = "--lba";        argv[i++] = lba; }
-	if (lba) { argv[i++] = "--nav-window"; argv[i++] = NAV_WINDOW_SECTORS; }
-	if (cfg) { argv[i++] = "--cfg";        argv[i++] = cfg; }
-	if (ver) { argv[i++] = "--core-version"; argv[i++] = ver; }
+	if (lba)               { argv[i++] = "--lba";          argv[i++] = lba; }
+	if (lba && want_window){ argv[i++] = "--nav-window";   argv[i++] = NAV_WINDOW_SECTORS; }
+	if (cfg)               { argv[i++] = "--cfg";          argv[i++] = cfg; }
+	if (ver)               { argv[i++] = "--core-version"; argv[i++] = ver; }
 	argv[i] = 0;
 }
 
@@ -315,7 +358,8 @@ static void start(void)
 	{
 		const char *argv[DVD_REPORT_ARGV_MAX];
 		dvd_report_build_argv(argv, script, src, out_path,
-		                      have_lba ? lba : 0, cfg, ver);
+		                      have_lba ? lba : 0, cfg, ver,
+		                      dvd_report_script_supports(script, "--nav-window"));
 
 		freopen("/tmp/dvd_report_run.log", "w", stdout);
 		dup2(fileno(stdout), fileno(stderr));

--- a/main/support/dvd/dvd_report.cpp
+++ b/main/support/dvd/dvd_report.cpp
@@ -22,6 +22,7 @@
 #include "dvd_report.h"
 #include "dvd_css.h"
 #include "dvd_phys.h"
+#include "dvd_launch.h"
 
 // ---------------------------------------------------------------------------
 // The trigger
@@ -368,7 +369,18 @@ static void start(void)
 	}
 
 	child = p;
-	InfoMessage("Generating support bundle...", 2000, "DVD");
+	// ⚠ 8 s, not the 2 s this used to carry. The job takes ~1.4-2.0 s (MEASURED on
+	// the rig, image media), so a 2 s message happened to stay up for exactly as
+	// long as the work took -- but that was a COINCIDENCE of two unrelated numbers,
+	// not a design. Anything slower (an optical disc, a drive spinning up, a bigger
+	// window) drops the message before reap() posts the result, and the user sees
+	// the "Generating" notice vanish with nothing after it -- which reads as a
+	// failure and invites a second chord press. The result message replaces this one
+	// the moment it arrives, so a longer timeout costs nothing in the fast case.
+	//
+	// It stays well under dvd_launch's 20 s MGL watchdog, and the MGL guard below is
+	// why extending it is safe at all.
+	InfoMessage("Generating support bundle...", 8000, "DVD");
 }
 
 static void reap(void)
@@ -417,6 +429,16 @@ void dvd_report_tick(void)
 	if (!is_dvd()) return;
 
 	reap();
+
+	// ⚠ This tick raises InfoMessage, and that is the exact shape that froze MGL
+	// launches (issue #48): while mgl->done == 0, HandleUI takes the MGL branch and
+	// InfoMessage pins menustate = MENU_INFO, so the FSM never reaches MENU_NONE2.
+	// In practice the chord needs a deliberate 2 s human hold and so cannot collide
+	// with a launch -- but "cannot happen" is what the pumps that DID freeze it were
+	// assumed to be, the rule in INTEGRATION.md admits no exception, and the message
+	// above is now 8 s rather than 2. Deferring costs the user one more press of a
+	// chord they are vanishingly unlikely to be holding.
+	if (dvd_launch_ui_busy()) return;
 
 	if (chord_since && !fired && child < 0 && (now_ms() - chord_since) >= HOLD_MS)
 	{

--- a/main/support/dvd/dvd_report.h
+++ b/main/support/dvd/dvd_report.h
@@ -53,4 +53,17 @@ void dvd_report_note_mount(const char *path);
 // completely different places. Issue #48; see docs/mgl_launch.md.
 void dvd_report_note_mount_result(const char *path, int index, int ok, uint64_t size);
 
+// The argv handed to tools/dvd_report.py, built outside the fork so it can be
+// tested (main/tests/dvd_report_test.cpp). `lba`, `cfg` and `ver` are each
+// optional -- pass 0 to omit the flag and its value.
+//
+// It is out here because a missing flag fails SILENTLY: the bundle is written, it
+// looks fine, and it is simply missing the data the report needed. That is how
+// issue #81 arrived -- a highlight bug whose bundle carried no button data at all,
+// with nothing to say so.
+#define DVD_REPORT_ARGV_MAX 24
+void dvd_report_build_argv(const char **argv, const char *script, const char *src,
+                           const char *out, const char *lba, const char *cfg,
+                           const char *ver);
+
 #endif

--- a/main/support/dvd/dvd_report.h
+++ b/main/support/dvd/dvd_report.h
@@ -76,4 +76,9 @@ void dvd_report_build_argv(const char **argv, const char *script, const char *sr
 // file I/O, and user_io_poll() is the core's data pump.
 int dvd_report_script_supports(const char *script, const char *token);
 
+// The --nav-window cap for this source, as a string. An optical disc reads ~50x
+// slower than an image (MEASURED on the rig), so it gets a smaller cap; see the
+// note above the constants in dvd_report.cpp.
+const char *nav_window_for(const char *src);
+
 #endif

--- a/main/support/dvd/dvd_report.h
+++ b/main/support/dvd/dvd_report.h
@@ -61,9 +61,19 @@ void dvd_report_note_mount_result(const char *path, int index, int ok, uint64_t 
 // looks fine, and it is simply missing the data the report needed. That is how
 // issue #81 arrived -- a highlight bug whose bundle carried no button data at all,
 // with nothing to say so.
+//
+// `want_window` says the installed script accepts --nav-window. It has to be asked
+// rather than assumed: MEASURED against a release-installed dvd_report.py, passing a
+// flag it predates makes argparse exit and NO BUNDLE IS WRITTEN AT ALL -- worse than
+// the missing button data the flag exists to add. dvd_report_script_supports() below
+// answers it by reading the script, which names every flag it accepts.
 #define DVD_REPORT_ARGV_MAX 24
 void dvd_report_build_argv(const char **argv, const char *script, const char *src,
                            const char *out, const char *lba, const char *cfg,
-                           const char *ver);
+                           const char *ver, int want_window);
+
+// 1 if `script` contains `token` (i.e. names that flag). Call from the CHILD: it is
+// file I/O, and user_io_poll() is the core's data pump.
+int dvd_report_script_supports(const char *script, const char *token);
 
 #endif

--- a/main/tests/dvd_report_test.cpp
+++ b/main/tests/dvd_report_test.cpp
@@ -1,0 +1,197 @@
+// dvd_report_test.cpp — the argv handed to tools/dvd_report.py by the chord.
+//
+// WHY A DECISION THIS SMALL IS WORTH A TEST
+//
+// Every failure here is SILENT. A missing or misspelled flag still produces a
+// bundle: it is written, it self-checks, it looks complete, and it is simply
+// missing the data the report needed. That is exactly how issue #81 arrived — a
+// menu-highlight bug whose bundle carried no button data at all, with nothing
+// anywhere to say so. The diagnosis had to be made structurally from the IFO
+// tables instead, and the confirm was never in evidence.
+//
+// So the argv is built by dvd_report_build_argv() outside the fork, and this pins
+// it. The arms that matter are the ones about --nav-window:
+//   * it must be passed when there IS a playhead, because that window is the only
+//     capture that reaches an in-title menu's buttons (--nav-packs scans menu VOBs
+//     and structurally cannot see a title-domain menu);
+//   * it must NOT be passed when there is not, because there is nothing to window
+//     around and the tool would be given a meaningless base.
+//
+// The module is #included rather than linked so the builder is reachable with the
+// surrounding Main replaced wholesale.
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+// ---------------------------------------------------------------- fake world
+// dvd_report.cpp reaches into Main for the chord, the mount and the OSD. None of
+// that is exercised here, but it all has to resolve, so stub it before the
+// include and let the real module compile against these.
+struct fileTYPE;
+
+static int          fake_is_dvd = 1;
+static const char  *fake_osdname = "DVD dev-subpmapdom 260912";
+static uint64_t     fake_last_lba = 0;
+
+static int   is_dvd(void)                              { return fake_is_dvd; }
+static const char *OsdCoreNameGet(void)                { return fake_osdname; }
+static uint64_t user_io_last_lba(int)                  { return fake_last_lba; }
+static void  InfoMessage(const char *, int, const char * = 0) {}
+static unsigned long GetTimer(unsigned long d)         { return d; }
+static int   CheckTimer(unsigned long)                 { return 1; }
+static const char *getRootDir(void)                    { return "/media/fat"; }
+
+// Declared by the real dvd_css.h / dvd_phys.h the module includes, so these are
+// DEFINITIONS of those, not shadowing stubs -- the linker takes them.
+int         dvd_css_active(void)                       { return 0; }
+const char *dvd_phys_device(void)                      { return 0; }
+
+#define DVD_REPORT_TEST 1
+#include "dvd_report.cpp"
+
+// ------------------------------------------------------------------ helpers
+static int errors = 0;
+
+static int idx_of(const char **argv, const char *flag)
+{
+    for (int i = 0; i < DVD_REPORT_ARGV_MAX && argv[i]; i++)
+        if (!strcmp(argv[i], flag)) return i;
+    return -1;
+}
+
+// Every slot is pre-filled with a sentinel and the array is scanned only as far
+// as DVD_REPORT_ARGV_MAX, so a builder that forgets its terminator is DETECTED
+// rather than walked past -- otherwise the helpers below read stale memory and
+// the failure surfaces as unrelated noise in an earlier arm.
+static const char SENTINEL[] = "<unwritten>";
+
+static int build(const char **argv, const char *script, const char *src,
+                 const char *out, const char *lba, const char *cfg,
+                 const char *ver)
+{
+    for (int i = 0; i < DVD_REPORT_ARGV_MAX; i++) argv[i] = SENTINEL;
+    dvd_report_build_argv(argv, script, src, out, lba, cfg, ver);
+    for (int i = 0; i < DVD_REPORT_ARGV_MAX; i++)
+        if (!argv[i]) return i;
+    errors++;
+    printf("  FAIL argv is not NUL-terminated within DVD_REPORT_ARGV_MAX (%d)\n",
+           DVD_REPORT_ARGV_MAX);
+    return -1;
+}
+
+static int argc_of(const char **argv)
+{
+    for (int i = 0; i < DVD_REPORT_ARGV_MAX; i++)
+        if (!argv[i]) return i;
+    return -1;
+}
+
+static void want_absent(const char **argv, const char *flag, const char *what)
+{
+    if (idx_of(argv, flag) >= 0) {
+        errors++;
+        printf("  FAIL %s: %s must NOT be passed\n", what, flag);
+    }
+}
+
+static void want_pair(const char **argv, const char *flag, const char *value,
+                      const char *what)
+{
+    int i = idx_of(argv, flag);
+    if (i < 0) {
+        errors++;
+        printf("  FAIL %s: %s is missing\n", what, flag);
+        return;
+    }
+    if (!argv[i + 1] || strcmp(argv[i + 1], value)) {
+        errors++;
+        printf("  FAIL %s: %s = \"%s\" (want \"%s\")\n",
+               what, flag, argv[i + 1] ? argv[i + 1] : "(end)", value);
+    }
+}
+
+int main(void)
+{
+    const char *argv[DVD_REPORT_ARGV_MAX];
+
+    // ---- [0] terminated, and inside the bound -----------------------------
+    // FIRST, because execvp reads until the NUL: without it every other arm here
+    // is reading stale memory and would report the failure as something else.
+    // build() pre-fills the array with a sentinel, so this is a real detection
+    // rather than a walk off the end.
+    int n0 = build(argv, "s.py", "/dev/sr0", "/o.zip", "1", "c", "v");
+    if (n0 >= 0) {
+        if (n0 + 1 > DVD_REPORT_ARGV_MAX) {
+            errors++;
+            printf("  FAIL [0] bounds: %d entries + NUL exceeds DVD_REPORT_ARGV_MAX %d\n",
+                   n0, DVD_REPORT_ARGV_MAX);
+        }
+        printf("  [0] bounds: fullest case %d entries + NUL, max %d\n",
+               n0, DVD_REPORT_ARGV_MAX);
+    }
+
+    // ---- [1] the full case: a playhead, a CFG and a version ---------------
+    // --nav-window is the arm this test exists for. 2048 sectors is ~4 MB, one
+    // sequential run, measured at 0.28 s end to end and a 38 KB bundle.
+    build(argv, "/media/fat/Scripts/dvd_report.py", "/dev/sr0",
+          "/media/fat/DVD_reports/x.zip", "903500",
+          "/media/fat/config/DVD_v2.CFG", "dev-subpmapdom 260912");
+    want_pair(argv, "--lba", "903500", "[1] full");
+    want_pair(argv, "--nav-window", "2048", "[1] full");
+    want_pair(argv, "--cfg", "/media/fat/config/DVD_v2.CFG", "[1] full");
+    want_pair(argv, "--core-version", "dev-subpmapdom 260912", "[1] full");
+    want_pair(argv, "-o", "/media/fat/DVD_reports/x.zip", "[1] full");
+    want_pair(argv, "--generated-on", "mister", "[1] full");
+    if (idx_of(argv, "--no-prompt") < 0) {
+        errors++;
+        printf("  FAIL [1] full: --no-prompt is missing (the child has no tty)\n");
+    }
+    // The image/device is positional and must be argv[2], after python3 and the
+    // script -- a flag inserted ahead of it would make the tool read the script
+    // as its disc.
+    if (argc_of(argv) < 3 || strcmp(argv[2], "/dev/sr0")) {
+        errors++;
+        printf("  FAIL [1] full: argv[2] = \"%s\" (want the source path)\n",
+               argc_of(argv) > 2 ? argv[2] : "(end)");
+    }
+    // --nav-packs is the EXPENSIVE capture and must never be here: measured 4.9 s
+    // and 5.6 MB on MEN_IN_BLACK locally, which on the optical disc the core is
+    // streaming from means minutes of seeking.
+    want_absent(argv, "--nav-packs", "[1] full");
+    printf("  [1] full argv: %d entries, --nav-window 2048 present\n", argc_of(argv));
+
+    // ---- [2] no playhead: no window ---------------------------------------
+    // A linear image mounted with no served sector yet. There is nothing to
+    // window around, so the flag must be omitted rather than passed a base of 0
+    // -- which would silently capture the NAV packs at the START of the disc,
+    // i.e. confidently wrong data rather than none.
+    build(argv, "s.py", "/media/fat/x.iso", "/o.zip", 0, 0, 0);
+    want_absent(argv, "--lba", "[2] no playhead");
+    want_absent(argv, "--nav-window", "[2] no playhead");
+    want_absent(argv, "--cfg", "[2] no playhead");
+    want_absent(argv, "--core-version", "[2] no playhead");
+    if (argc_of(argv) != 8) {
+        errors++;
+        printf("  FAIL [2] no playhead: %d entries (want the 8 unconditional ones)\n",
+               argc_of(argv));
+    }
+    printf("  [2] no playhead: %d entries, no --lba and no --nav-window\n",
+           argc_of(argv));
+
+    // ---- [3] a playhead but nothing else ----------------------------------
+    // The window rides the playhead, not the CFG or the version: a disc reported
+    // from a build whose OSD name carried no V line must still capture buttons.
+    build(argv, "s.py", "/dev/sr1", "/o.zip", "12", 0, 0);
+    want_pair(argv, "--lba", "12", "[3] lba only");
+    want_pair(argv, "--nav-window", "2048", "[3] lba only");
+    want_absent(argv, "--cfg", "[3] lba only");
+    printf("  [3] playhead only: --nav-window still present\n");
+
+    if (errors) {
+        printf("dvd_report_test: %d FAILURE(S)\n", errors);
+        return 1;
+    }
+    printf("dvd_report_test: ALL GREEN (4 arms)\n");
+    return 0;
+}

--- a/main/tests/dvd_report_test.cpp
+++ b/main/tests/dvd_report_test.cpp
@@ -41,6 +41,7 @@ static void  InfoMessage(const char *, int, const char * = 0) {}
 static unsigned long GetTimer(unsigned long d)         { return d; }
 static int   CheckTimer(unsigned long)                 { return 1; }
 static const char *getRootDir(void)                    { return "/media/fat"; }
+static int   dvd_launch_ui_busy(void)                  { return 0; }
 
 // Declared by the real dvd_css.h / dvd_phys.h the module includes, so these are
 // DEFINITIONS of those, not shadowing stubs -- the linker takes them.

--- a/main/tests/dvd_report_test.cpp
+++ b/main/tests/dvd_report_test.cpp
@@ -23,6 +23,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
+#include <sys/stat.h>
+#include <dirent.h>
 
 // ---------------------------------------------------------------- fake world
 // dvd_report.cpp reaches into Main for the chord, the mount and the OSD. None of
@@ -135,7 +137,7 @@ int main(void)
     // ---- [1] the full case: a playhead, a CFG and a version ---------------
     // --nav-window is the arm this test exists for. 2048 sectors is ~4 MB, one
     // sequential run, measured at 0.28 s end to end and a 38 KB bundle.
-    build(argv, "/media/fat/Scripts/dvd_report.py", "/dev/sr0",
+    build(argv, "/media/fat/Scripts/dvd_report.py", "/media/fat/games/DVD/x.iso",
           "/media/fat/DVD_reports/x.zip", "903500",
           "/media/fat/config/DVD_v2.CFG", "dev-subpmapdom 260912");
     want_pair(argv, "--lba", "903500", "[1] full");
@@ -151,7 +153,7 @@ int main(void)
     // The image/device is positional and must be argv[2], after python3 and the
     // script -- a flag inserted ahead of it would make the tool read the script
     // as its disc.
-    if (argc_of(argv) < 3 || strcmp(argv[2], "/dev/sr0")) {
+    if (argc_of(argv) < 3 || strcmp(argv[2], "/media/fat/games/DVD/x.iso")) {
         errors++;
         printf("  FAIL [1] full: argv[2] = \"%s\" (want the source path)\n",
                argc_of(argv) > 2 ? argv[2] : "(end)");
@@ -199,6 +201,47 @@ int main(void)
     want_absent(argv, "--nav-window", "[4] old script");
     printf("  [4] old script: --lba kept, --nav-window dropped\n");
 
+    // ---- [4b] the cap follows the MEDIUM ------------------------------------
+    // An optical disc reads ~50x slower than an image (MEASURED on the rig while
+    // the core streamed a real DVD: ~90-285 KB/s, and 2048 sectors = 15.7-29.1 s).
+    // The cap is what you pay when the playhead sits where there are NO NAV packs,
+    // which the early stop cannot help with -- so it has to be smaller there.
+    {
+        // A REAL block device is needed -- a regular file is not S_ISBLK, which is
+        // the whole point of using stat() rather than matching on "/dev/sr". Find
+        // one rather than naming one: /dev/loop0 does not exist on every host, and
+        // a skipped arm is a bench that cannot fail. A machine with no block device
+        // at all is not a machine this builds on, so an empty scan is a FAILURE.
+        char blk[280] = {0};
+        DIR *dp = opendir("/dev");
+        if (dp) {
+            struct dirent *e;
+            while (!blk[0] && (e = readdir(dp))) {
+                char path[280];
+                struct stat st;
+                snprintf(path, sizeof(path), "/dev/%s", e->d_name);
+                if (!stat(path, &st) && S_ISBLK(st.st_mode))
+                    snprintf(blk, sizeof(blk), "%s", path);
+            }
+            closedir(dp);
+        }
+        if (!blk[0]) {
+            errors++;
+            printf("  FAIL [4b]: no block device found under /dev -- this arm "
+                   "cannot test the optical cap and must not silently skip\n");
+        } else {
+            build(argv, "s.py", blk, "/o.zip", "42", 0, 0);
+            want_pair(argv, "--nav-window", "512", "[4b] optical");
+            printf("  [4b] %s (block) -> cap 512, image -> cap 2048\n", blk);
+        }
+        build(argv, "s.py", "/media/fat/games/DVD/x.iso", "/o.zip", "42", 0, 0);
+        want_pair(argv, "--nav-window", "2048", "[4b] image");
+        // A source that does not exist at all must not be treated as optical --
+        // stat() fails and the image cap is the safe default.
+        build(argv, "s.py", "/no/such/path.iso", "/o.zip", "42", 0, 0);
+        want_pair(argv, "--nav-window", "2048", "[4b] missing source");
+    }
+
     // ---- [5] the probe reads the script, in both directions -----------------
     // A substring search is sound because argparse cannot accept a flag it does
     // not name. Both arms use real files so the chunking is exercised, and the
@@ -238,6 +281,6 @@ int main(void)
         printf("dvd_report_test: %d FAILURE(S)\n", errors);
         return 1;
     }
-    printf("dvd_report_test: ALL GREEN (6 arms)\n");
+    printf("dvd_report_test: ALL GREEN (7 arms)\n");
     return 0;
 }

--- a/main/tests/dvd_report_test.cpp
+++ b/main/tests/dvd_report_test.cpp
@@ -68,10 +68,10 @@ static const char SENTINEL[] = "<unwritten>";
 
 static int build(const char **argv, const char *script, const char *src,
                  const char *out, const char *lba, const char *cfg,
-                 const char *ver)
+                 const char *ver, int want_window = 1)
 {
     for (int i = 0; i < DVD_REPORT_ARGV_MAX; i++) argv[i] = SENTINEL;
-    dvd_report_build_argv(argv, script, src, out, lba, cfg, ver);
+    dvd_report_build_argv(argv, script, src, out, lba, cfg, ver, want_window);
     for (int i = 0; i < DVD_REPORT_ARGV_MAX; i++)
         if (!argv[i]) return i;
     errors++;
@@ -188,10 +188,55 @@ int main(void)
     want_absent(argv, "--cfg", "[3] lba only");
     printf("  [3] playhead only: --nav-window still present\n");
 
+    // ---- [4] the installed script predates the flag ------------------------
+    // MEASURED on the rig: passing --nav-window to a release-installed
+    // dvd_report.py makes argparse exit and NO bundle is written at all -- worse
+    // than the missing button data the flag adds. So a Main updated without its
+    // script must degrade to the old argv, not break.
+    build(argv, "s.py", "/dev/sr0", "/o.zip", "903500", 0, 0, /*want_window=*/0);
+    want_pair(argv, "--lba", "903500", "[4] old script");
+    want_absent(argv, "--nav-window", "[4] old script");
+    printf("  [4] old script: --lba kept, --nav-window dropped\n");
+
+    // ---- [5] the probe reads the script, in both directions -----------------
+    // A substring search is sound because argparse cannot accept a flag it does
+    // not name. Both arms use real files so the chunking is exercised, and the
+    // straddle arm puts the token across an 8 KB read boundary -- the one way a
+    // chunked search silently answers "no".
+    {
+        const char *yes = "/tmp/dvd_report_probe_yes.py";
+        const char *no  = "/tmp/dvd_report_probe_no.py";
+        FILE *f = fopen(no, "w");
+        if (f) { for (int i = 0; i < 4000; i++) fputs("# filler line\n", f); fclose(f); }
+        f = fopen(yes, "w");
+        if (f) {
+            // Land the token so it STRADDLES the 8192-byte boundary: 8188 bytes of
+            // filler puts "--nav-window" across it.
+            for (int i = 0; i < 8188; i++) fputc('x', f);
+            fputs("--nav-window", f);
+            for (int i = 0; i < 100; i++) fputs("\n# tail\n", f);
+            fclose(f);
+        }
+        if (dvd_report_script_supports(no, "--nav-window")) {
+            errors++;
+            printf("  FAIL [5] probe: a script that never names the flag must read as unsupported\n");
+        }
+        if (!dvd_report_script_supports(yes, "--nav-window")) {
+            errors++;
+            printf("  FAIL [5] probe: the flag must be found even straddling a read boundary\n");
+        }
+        if (dvd_report_script_supports("/tmp/does-not-exist-at-all.py", "--nav-window")) {
+            errors++;
+            printf("  FAIL [5] probe: a missing script must read as unsupported\n");
+        }
+        remove(yes); remove(no);
+        printf("  [5] probe: absent=no, straddling a chunk boundary=yes, missing file=no\n");
+    }
+
     if (errors) {
         printf("dvd_report_test: %d FAILURE(S)\n", errors);
         return 1;
     }
-    printf("dvd_report_test: ALL GREEN (4 arms)\n");
+    printf("dvd_report_test: ALL GREEN (6 arms)\n");
     return 0;
 }

--- a/main/tests/run_tests.sh
+++ b/main/tests/run_tests.sh
@@ -115,21 +115,33 @@ if [ "$RED" -eq 1 ]; then
     # instead of none, which is worse than the bug being fixed.
     red_case dvd_report.cpp dvd_report_test.cpp \
         "--nav-window must NOT be passed" \
-        "s/\tif (lba) { argv\[i++\] = \"--nav-window\";/\tif (1)   { argv[i++] = \"--nav-window\";/" \
-        window-without-playhead
+        "s/if (lba \&\& want_window){/if (want_window)       {/" window-without-playhead
 
     # Reach for the expensive capture instead. Correct data, wrong cost: minutes of
     # seeking on the optical disc the core is streaming from -- and it still cannot
     # see an in-title menu's buttons, which is the whole point of the window.
     red_case dvd_report.cpp dvd_report_test.cpp \
         "--nav-packs must NOT be passed" \
-        "s/argv\[i++\] = \"--nav-window\"; argv\[i++\] = NAV_WINDOW_SECTORS;/argv[i++] = \"--nav-packs\";/" \
+        "s/argv\[i++\] = \"--nav-window\";   argv\[i++\] = NAV_WINDOW_SECTORS;/argv[i++] = \"--nav-packs\";/" \
         expensive-capture
 
     # Forget the terminator. execvp reads past the end of the array.
     red_case dvd_report.cpp dvd_report_test.cpp \
         "not NUL-terminated" \
         "s/^\targv\[i\] = 0;$/\t\/\* argv[i] = 0; \*\//" no-terminator
+
+    # Ignore what the installed script actually accepts. MEASURED on the rig: an
+    # older dvd_report.py exits on the unknown flag and writes NO bundle at all.
+    red_case dvd_report.cpp dvd_report_test.cpp \
+        "--nav-window must NOT be passed" \
+        "s/if (lba \&\& want_window){/if (lba)                {/" ignores-script-version
+
+    # Drop the chunk overlap: the probe then misses a token that straddles an 8 KB
+    # read boundary and silently reports "this script is too old", losing the
+    # capture on a tool that supports it perfectly well.
+    red_case dvd_report.cpp dvd_report_test.cpp \
+        "straddling a read boundary" \
+        "s/keep = (tlen > 1) ? (tlen - 1) : 0;/keep = 0;/" probe-no-overlap
     echo
 fi
 

--- a/main/tests/run_tests.sh
+++ b/main/tests/run_tests.sh
@@ -122,7 +122,7 @@ if [ "$RED" -eq 1 ]; then
     # see an in-title menu's buttons, which is the whole point of the window.
     red_case dvd_report.cpp dvd_report_test.cpp \
         "--nav-packs must NOT be passed" \
-        "s/argv\[i++\] = \"--nav-window\";   argv\[i++\] = NAV_WINDOW_SECTORS;/argv[i++] = \"--nav-packs\";/" \
+        "s/argv\[i++\] = \"--nav-window\";   argv\[i++\] = nav_window_for(src);/argv[i++] = \"--nav-packs\";/" \
         expensive-capture
 
     # Forget the terminator. execvp reads past the end of the array.
@@ -142,6 +142,20 @@ if [ "$RED" -eq 1 ]; then
     red_case dvd_report.cpp dvd_report_test.cpp \
         "straddling a read boundary" \
         "s/keep = (tlen > 1) ? (tlen - 1) : 0;/keep = 0;/" probe-no-overlap
+
+    # One cap for both media. MEASURED on the rig: 2048 sectors of a real DVD, read
+    # while the core streamed it, took 15.7-29.1 s -- the wait this cap exists to
+    # bound. An image pays ~0.5 s for the same thing.
+    red_case dvd_report.cpp dvd_report_test.cpp \
+        "--nav-window = \"2048\" (want \"512\")" \
+        "s/if (src \&\& !stat(src, \&st) \&\& S_ISBLK(st.st_mode)) return NAV_WINDOW_OPTICAL;//" \
+        one-cap-both-media
+
+    # ...and the inverse: treat an IMAGE as optical and every PC-route bundle loses
+    # three quarters of its window for no reason.
+    red_case dvd_report.cpp dvd_report_test.cpp \
+        "--nav-window = \"512\" (want \"2048\")" \
+        "s/return NAV_WINDOW_IMAGE;/return NAV_WINDOW_OPTICAL;/" everything-optical
     echo
 fi
 

--- a/main/tests/run_tests.sh
+++ b/main/tests/run_tests.sh
@@ -31,6 +31,8 @@ cp ../support/dvd/*.cpp ../support/dvd/*.h "$TREE/support/dvd/"
 : > "$TREE/video.h"
 : > "$TREE/cfg.h"
 : > "$TREE/hardware.h"
+: > "$TREE/osd.h"
+: > "$TREE/file_io.h"
 
 fail=0
 for t in *_test.cpp; do
@@ -62,9 +64,11 @@ red_case() {
     fi
     local log="$dir/log"
     "$dir/bin" > "$log" 2>&1 && { echo "  !! RED $name: test PASSED against broken code"; fail=1; return; }
-    if ! grep -q "$expect" "$log"; then
+    # -e: an expect string may legitimately START with "--" (a CLI flag being
+    # asserted present or absent), which grep would otherwise read as an option.
+    if ! grep -q -e "$expect" "$log"; then
         echo "  !! RED $name: caught, but not by \"$expect\""
-        grep "FAIL" "$log" | head -3; fail=1
+        grep -e "FAIL" "$log" | head -3; fail=1
     else
         echo "  RED $name -> caught by \"$expect\""
     fi
@@ -98,6 +102,34 @@ if [ "$RED" -eq 1 ]; then
     red_case dvd_hdmi_audio.cpp dvd_hdmi_audio_test.cpp \
         "acked (old core still engages)" \
         "s/core_fmt_v2      = (fmt >> 15) \& 1;/core_fmt_v2      = 1;/" assumes-fmt-version
+
+    # ---- the support bundle's argv (issue #81) ---------------------------------
+    # The shipped-until-#81 behaviour: no NAV-pack capture at all, so a highlight
+    # bug's bundle carried no button data and nothing said so.
+    red_case dvd_report.cpp dvd_report_test.cpp \
+        "--nav-window is missing" \
+        "/argv\[i++\] = \"--nav-window\"/d" no-nav-window
+
+    # Pass the window unconditionally: with no playhead the tool gets a base of 0
+    # and captures the NAV packs at the START of the disc -- confidently wrong data
+    # instead of none, which is worse than the bug being fixed.
+    red_case dvd_report.cpp dvd_report_test.cpp \
+        "--nav-window must NOT be passed" \
+        "s/\tif (lba) { argv\[i++\] = \"--nav-window\";/\tif (1)   { argv[i++] = \"--nav-window\";/" \
+        window-without-playhead
+
+    # Reach for the expensive capture instead. Correct data, wrong cost: minutes of
+    # seeking on the optical disc the core is streaming from -- and it still cannot
+    # see an in-title menu's buttons, which is the whole point of the window.
+    red_case dvd_report.cpp dvd_report_test.cpp \
+        "--nav-packs must NOT be passed" \
+        "s/argv\[i++\] = \"--nav-window\"; argv\[i++\] = NAV_WINDOW_SECTORS;/argv[i++] = \"--nav-packs\";/" \
+        expensive-capture
+
+    # Forget the terminator. execvp reads past the end of the array.
+    red_case dvd_report.cpp dvd_report_test.cpp \
+        "not NUL-terminated" \
+        "s/^\targv\[i\] = 0;$/\t\/\* argv[i] = 0; \*\//" no-terminator
     echo
 fi
 

--- a/site/content/reference/reporting-a-bug.md
+++ b/site/content/reference/reporting-a-bug.md
@@ -46,7 +46,7 @@ the issue.
 
 If the problem is specifically about **menu buttons or highlights** — the wrong button
 lit, the highlight in the wrong place, a press doing nothing — add `--nav-packs` so the
-button positions are captured too:
+button positions of the disc's menus are captured too:
 
 ```bash
 python3 dvd_report.py MY_DISC.iso --nav-packs
@@ -83,12 +83,15 @@ OSD, and the **exact point on the disc** you were at when you pressed the chord.
 Holding those two buttons also steps the audio track and the subtitle track once each —
 that is expected, and pressing them again puts things back.
 
-One difference worth knowing: to keep the chord fast it captures the navigation tables
-only, never the menu **button positions** that `--nav-packs` adds above. That is plenty for
-most menu problems, but if the report is about a **highlight that is missing, mispositioned
-or on the wrong button**, a PC bundle made with `--nav-packs` says strictly more. Send the
-player's bundle anyway — it is still the fastest thing you can do, and it names the disc,
-the version and where you were.
+It captures the menu **button positions** too, for the part of the disc you were on when
+you pressed the chord — which is what a highlight problem needs. It does that instead of
+the whole-disc `--nav-packs` sweep above, and for menu highlights it is often the better
+of the two: some discs build their menus as ordinary titles, and a button there is
+invisible to the sweep but sits squarely in what the chord captures.
+
+So for a **highlight that is missing, mispositioned or on the wrong button**, press the
+chord *while that menu is on screen*. If you can also make a PC bundle with
+`--nav-packs`, send both — they cover different parts of the disc.
 
 
 ## Everything else: describe it

--- a/site/content/reference/reporting-a-bug.md
+++ b/site/content/reference/reporting-a-bug.md
@@ -77,15 +77,18 @@ writes a bundle to `/media/fat/DVD_reports/` and tells you the filename on scree
 off the SD card and attach it to the issue.
 
 This works for **physical discs** as well as images, and it needs no PC. It also records
-something the PC route cannot: the exact point on the disc you were at when you pressed it,
-which for a menu problem is usually the whole answer.
+two things the PC route cannot: the **core version**, so you never have to read it off the
+OSD, and the **exact point on the disc** you were at when you pressed the chord.
 
 Holding those two buttons also steps the audio track and the subtitle track once each —
 that is expected, and pressing them again puts things back.
 
-The bundle it writes also records two things the PC route cannot: the **core version**,
-so you never have to read it off the OSD, and the **exact point on the disc** you were at
-when you pressed the chord.
+One difference worth knowing: to keep the chord fast it captures the navigation tables
+only, never the menu **button positions** that `--nav-packs` adds above. That is plenty for
+most menu problems, but if the report is about a **highlight that is missing, mispositioned
+or on the wrong button**, a PC bundle made with `--nav-packs` says strictly more. Send the
+player's bundle anyway — it is still the fastest thing you can do, and it names the disc,
+the version and where you were.
 
 
 ## Everything else: describe it

--- a/tools/check_subp_map_wiring.py
+++ b/tools/check_subp_map_wiring.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Gate for issue #81: check WHICH FACT emu.sv puts on subp_stream_map.menu_dom.
+
+WHY THIS EXISTS, AND WHY IT IS NOT A UNIT TEST
+----------------------------------------------
+`subp_stream_map`'s truth table did not change when #81 was fixed. The old
+`ctx_menu ? ~dom_tt : dom_tt` is the same function of (dom_tt, that bit) as the
+new `dom_tt != menu_dom`; what changed is which of emu's signals is wired to it:
+
+    pre-#81   .ctx_menu (menu_sp_ctx)     <- the menu CONTEXT  (menu_active | in-title menu)
+    post-#81  .menu_dom (menu_dom_live)   <- the menu DOMAIN   (menus_on && menu_active)
+
+So the module's own bench cannot fail for the reason the bug existed, and there
+is no emu-level testbench in this project. This reads the port connection out of
+`dvd/emu.sv` instead of restating it -- the `tools/acmod_scan.py` /
+`csync_pipe_tb` pattern: a gate that cannot go stale, because the thing it
+asserts is the source file.
+
+It is RED on the pre-fix file (no `.menu_dom` port at all), and RED on the
+plausible re-regression (`.menu_dom (menu_sp_ctx)` -- a context, not a domain).
+
+    python3 tools/check_subp_map_wiring.py [emu.sv]     # exit 0 = wired right
+    git show <pre-fix>:dvd/emu.sv > /tmp/old.sv && \
+        python3 tools/check_subp_map_wiring.py /tmp/old.sv    # must exit 1
+
+⚠ Walks to the instantiation's matching ')' and strips comments -- do NOT
+"simplify" it to a grep. emu.sv is 5k lines with commented-out history in it
+(the CONF_STR lesson in CLAUDE.md), and a loose grep finds connections that are
+not connections.
+"""
+import os
+import re
+import sys
+
+INST = 'subp_stream_map'
+
+
+def strip_comments(src):
+    """Blank out // and /* */ comments, preserving offsets and newlines."""
+    out = []
+    i, n = 0, len(src)
+    while i < n:
+        c = src[i]
+        if c == '/' and i + 1 < n and src[i + 1] == '/':
+            j = src.find('\n', i)
+            j = n if j < 0 else j
+            out.append(' ' * (j - i))
+            i = j
+        elif c == '/' and i + 1 < n and src[i + 1] == '*':
+            j = src.find('*/', i + 2)
+            j = n if j < 0 else j + 2
+            out.append(''.join(ch if ch == '\n' else ' ' for ch in src[i:j]))
+            i = j
+        else:
+            out.append(c)
+            i += 1
+    return ''.join(out)
+
+
+def find_instance(src):
+    """Return the text between the instantiation's '(' and its matching ')'."""
+    # module-type name, then an instance name, then '('
+    m = re.search(r'\b%s\s+(\w+)\s*\(' % INST, src)
+    if not m:
+        return None, None
+    depth, i, n = 0, m.end() - 1, len(src)
+    while i < n:
+        if src[i] == '(':
+            depth += 1
+        elif src[i] == ')':
+            depth -= 1
+            if depth == 0:
+                return m.group(1), src[m.end():i]
+        i += 1
+    return m.group(1), None
+
+
+def connections(body):
+    """{port: expression} for .port(expr) named connections."""
+    out = {}
+    i, n = 0, len(body)
+    while i < n:
+        if body[i] == '.':
+            m = re.match(r'\.\s*(\w+)\s*\(', body[i:])
+            if m:
+                depth, j = 0, i + m.end() - 1
+                while j < n:
+                    if body[j] == '(':
+                        depth += 1
+                    elif body[j] == ')':
+                        depth -= 1
+                        if depth == 0:
+                            break
+                    j += 1
+                out[m.group(1)] = ' '.join(body[i + m.end():j].split())
+                i = j
+        i += 1
+    return out
+
+
+def assign_of(src, name):
+    """The right-hand side of `wire ... <name> = <expr>;` (first match)."""
+    m = re.search(r'\b(?:wire|reg|logic)\b[^;=]*?\b%s\s*=\s*([^;]+);' % re.escape(name), src)
+    return ' '.join(m.group(1).split()) if m else None
+
+
+def terms(expr):
+    """Identifiers in an expression, minus Verilog literals."""
+    return set(re.findall(r'[A-Za-z_]\w*', expr))
+
+
+def main():
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    path = sys.argv[1] if len(sys.argv) > 1 else os.path.join(here, 'dvd', 'emu.sv')
+    src = strip_comments(open(path).read())
+
+    fails = []
+    inst, body = find_instance(src)
+    if inst is None:
+        fails.append('no %s instantiation found in %s' % (INST, path))
+        body = None
+    elif body is None:
+        fails.append('%s instantiation is unterminated (no matching ")")' % INST)
+
+    conn = connections(body) if body else {}
+
+    if 'ctx_menu' in conn:
+        fails.append('port .ctx_menu is still connected (%s) -- issue #81 renamed it to '
+                     '.menu_dom because "menu context" is not "menu domain"'
+                     % conn['ctx_menu'])
+
+    expr = conn.get('menu_dom')
+    if expr is None:
+        if body is not None:
+            fails.append('port .menu_dom is not connected on %s' % (inst,))
+    else:
+        # Resolve one level of indirection: .menu_dom (menu_dom_live) -> its assign.
+        rhs = expr
+        if re.fullmatch(r'\w+', expr):
+            a = assign_of(src, expr)
+            if a is not None:
+                rhs = a
+        t = terms(rhs)
+        if 'menu_active' not in t:
+            fails.append('.menu_dom (%s) does not depend on menu_active -- it must be '
+                         '"a MENU-DOMAIN PGC is loaded", i.e. menus_on && menu_active'
+                         % expr)
+        # The #81 defect, exactly: a menu CONTEXT includes the in-title menu.
+        for bad in ('sp_menu_early', 'hl_menu_seen', 'in_title_menu', 'in_title_hli',
+                    'menu_sp_ctx'):
+            if bad in t:
+                fails.append('.menu_dom (%s) resolves through `%s` -- that is the menu '
+                             'CONTEXT, and a title-domain game/motion menu is a menu '
+                             'context in the TITLE domain. This is issue #81.'
+                             % (expr, bad))
+
+    if fails:
+        print('FAIL  subp_stream_map wiring in %s' % path)
+        for f in fails:
+            print('   - %s' % f)
+        return 1
+
+    print('PASS  subp_stream_map.menu_dom <- %s  (a DOMAIN fact, not a menu context)'
+          % expr)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/check_subp_map_wiring.py
+++ b/tools/check_subp_map_wiring.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Gate for issue #81: check WHICH FACT emu.sv puts on subp_stream_map.menu_dom.
+"""Gate for issue #81: check WHICH FACTS emu.sv puts on subp_stream_map's inputs.
 
 WHY THIS EXISTS, AND WHY IT IS NOT A UNIT TEST
 ----------------------------------------------
@@ -16,8 +16,19 @@ is no emu-level testbench in this project. This reads the port connection out of
 `csync_pipe_tb` pattern: a gate that cannot go stale, because the thing it
 asserts is the source file.
 
-It is RED on the pre-fix file (no `.menu_dom` port at all), and RED on the
-plausible re-regression (`.menu_dom (menu_sp_ctx)` -- a context, not a domain).
+Two ports are checked, both of which carried the wrong fact before #81:
+
+  .menu_dom  must be the menu DOMAIN (menus_on && menu_active), never the menu
+             CONTEXT (which includes sp_menu_early, the in-title game/motion menu)
+  .wide      must reach the TITLE VTS's IFO aspect (title_ar_wide) in the in-title
+             MENU context, because libdvdnav's vm_get_video_attr() returns
+             vtsi_mat->vts_video_attr in DVD_DOMAIN_VTSTitle -- the MPEG sequence
+             header is not what a conforming player reads, and a menu authored 16:9
+             anamorphic with a 4:3 sequence-header code would take the 4:3 field
+
+It is RED on the pre-fix file (no `.menu_dom` port at all, and `.wide` on the
+sequence header) and RED on the plausible re-regressions (`.menu_dom
+(menu_sp_ctx)` -- a context, not a domain; `.wide (ar_wide_auto_eff)`).
 
     python3 tools/check_subp_map_wiring.py [emu.sv]     # exit 0 = wired right
     git show <pre-fix>:dvd/emu.sv > /tmp/old.sv && \
@@ -154,6 +165,34 @@ def main():
                              'context in the TITLE domain. This is issue #81.'
                              % (expr, bad))
 
+    # ---- .wide: the IFO's aspect for a menu, not the sequence header's --------
+    # Same class of defect as .menu_dom -- a port carrying the wrong FACT -- and it
+    # is the one that decides whether #81's fix does anything: the map picks the
+    # [28:24] (4:3) field when `wide` is 0, and DVD menus are routinely authored
+    # 16:9 anamorphic with a 4:3 sequence-header code. libdvdnav's
+    # vm_get_video_attr() returns vtsi_mat->vts_video_attr in DVD_DOMAIN_VTSTitle,
+    # so an in-title menu must resolve against the IFO.
+    wexpr = conn.get('wide')
+    if wexpr is None:
+        if body is not None:
+            fails.append('port .wide is not connected on %s' % (inst,))
+    else:
+        wrhs = wexpr
+        if re.fullmatch(r'\w+', wexpr):
+            a = assign_of(src, wexpr)
+            if a is not None:
+                wrhs = a
+        wt = terms(wrhs)
+        if not any('title_ar_wide' in x for x in wt):
+            fails.append('.wide (%s) never reaches the TITLE VTS\'s IFO aspect '
+                         '(title_ar_wide) -- an in-title menu would resolve its '
+                         'subpicture variant against the MPEG sequence header, which '
+                         'is not what a conforming player reads (issue #81)' % wexpr)
+        if 'sp_menu_early' not in wt:
+            fails.append('.wide (%s) does not distinguish the in-title MENU context '
+                         '(sp_menu_early) -- the IFO aspect must apply THERE and '
+                         'nowhere else, or every subtitle path moves with it' % wexpr)
+
     if fails:
         print('FAIL  subp_stream_map wiring in %s' % path)
         for f in fails:
@@ -162,6 +201,8 @@ def main():
 
     print('PASS  subp_stream_map.menu_dom <- %s  (a DOMAIN fact, not a menu context)'
           % expr)
+    print('PASS  subp_stream_map.wide     <- %s  (the IFO aspect in a menu context)'
+          % wexpr)
     return 0
 
 

--- a/tools/dvd_report.py
+++ b/tools/dvd_report.py
@@ -380,7 +380,7 @@ def audit(iso, extents):
 
 
 def collect(iso, nav_packs=False, nav_scan_mb=512, verbose=True,
-            nav_window=0, playhead=None):
+            nav_window=0, playhead=None, nav_stop=2):
     lbas = list(iso.vd_lbas)
     for lba, nsec in iso.dir_spans:
         lbas.extend(range(lba, lba + nsec))
@@ -407,18 +407,42 @@ def collect(iso, nav_packs=False, nav_scan_mb=512, verbose=True,
     # A VOBU is at most 1 s of video, so 2048 sectors always spans several of
     # them; an HLI is re-sent every VOBU while a menu is up (measured on The
     # Matrix: the same unit 8 times, 1.001 s apart), so forward-only is enough.
+    #
+    # ★ AND IT STOPS EARLY, because on an OPTICAL DISC the window is not free.
+    # MEASURED on a real DVD in a real drive, while the core was streaming it:
+    # the drive sustains ~90-285 KB/s (about a seventh of DVD 1x) and holds that
+    # rate for 84 s, so it is not a spin-up transient. The consequence, from a
+    # scan of three different playheads on that disc:
+    #
+    #     1st NAV pack   +51..+230 sectors    2.1 - 5.5 s
+    #     2nd NAV pack   +304..+465 sectors   3.9 - 7.0 s
+    #     8th NAV pack  +1701..+1903 sectors 19.1 - 29.1 s
+    #
+    # An HLI is re-sent byte-identically in every VOBU while a menu is up, so the
+    # FIRST record already carries the whole button set -- rects, link graph,
+    # colours and the command per button. The second is corroboration and covers a
+    # first VOBU that happens to carry `hli_ss = 0` (no buttons). The eighth buys
+    # nothing and costs 20 s of a user's life.
+    #
+    # So `nav_window` is a CAP, not a target, and the scan stops at `nav_stop`.
+    # On an image both are irrelevant (the whole thing runs in ~0.5 s); on optical
+    # this is the difference between ~5 s and ~25 s.
     if nav_window and playhead is not None:
         found = 0
+        scanned = 0
         for i in range(nav_window):
             lba = playhead + i
             if lba >= iso.volume_sectors:
                 break
+            scanned += 1
             if is_nav_pack(iso.sec(lba)):
                 lbas.append(lba)
                 found += 1
+                if nav_stop and found >= nav_stop:
+                    break
         if verbose:
-            print("  playhead NAV packs captured: %d (window %d sectors from %d)"
-                  % (found, nav_window, playhead))
+            print("  playhead NAV packs captured: %d (%d sectors read from %d, "
+                  "cap %d)" % (found, scanned, playhead, nav_window))
 
     if nav_packs:
         budget = (nav_scan_mb * 1024 * 1024) // SEC
@@ -492,7 +516,8 @@ def cmd_make(args):
         print()
 
     extents = collect(iso, args.nav_packs, args.nav_scan_mb,
-                      nav_window=args.nav_window, playhead=args.lba)
+                      nav_window=args.nav_window, playhead=args.lba,
+                      nav_stop=args.nav_stop)
     n_sec = sum(c for _, c in extents)
     n_meta, n_nav = audit(iso, extents)
 
@@ -539,6 +564,9 @@ def cmd_make(args):
             "playhead_window": (args.nav_window
                                 if (args.nav_window and args.lba is not None)
                                 else 0),
+            "playhead_stop_after": (args.nav_stop
+                                    if (args.nav_window and args.lba is not None)
+                                    else 0),
         },
         "sector_count": n_sec,
         "content_audit": {
@@ -729,7 +757,13 @@ def main():
                        help="with --lba: capture the NAV packs in SECTORS "
                             "sectors forward of the playhead (0 = off). This is "
                             "the only capture that reaches an IN-TITLE menu's "
-                            "buttons; 2048 spans several VOBUs for ~40 KB")
+                            "buttons. A CAP, not a target -- see --nav-stop")
+        p.add_argument("--nav-stop", type=int, default=2, metavar="N",
+                       help="stop the --nav-window scan after N NAV packs "
+                            "(default 2, 0 = read the whole cap). An HLI repeats "
+                            "in every VOBU, so the first record already carries "
+                            "the whole button set; on an optical disc reading to "
+                            "the 8th costs ~25 s instead of ~5")
         p.add_argument("--no-prompt", action="store_true",
                        help="do not ask any questions")
         # Set by MiSTer_DVDcss when it generates a bundle on the player; see

--- a/tools/dvd_report.py
+++ b/tools/dvd_report.py
@@ -379,12 +379,46 @@ def audit(iso, extents):
     return meta, navp
 
 
-def collect(iso, nav_packs=False, nav_scan_mb=512, verbose=True):
+def collect(iso, nav_packs=False, nav_scan_mb=512, verbose=True,
+            nav_window=0, playhead=None):
     lbas = list(iso.vd_lbas)
     for lba, nsec in iso.dir_spans:
         lbas.extend(range(lba, lba + nsec))
     for name, (lba, dl) in sorted(iso.ifo.items()):
         lbas.extend(range(lba, lba + (dl + SEC - 1) // SEC))
+
+    # ---- the PLAYHEAD WINDOW (issue #81) -----------------------------------
+    # Capture every NAV pack in one short SEQUENTIAL run forward from the sector
+    # the player was serving. Two reasons this is the right shape, both measured:
+    #
+    # 1. --nav-packs below scans MENU VOBs (VIDEO_TS.VOB, VTS_nn_0.VOB) and so
+    #    CANNOT SEE an in-title menu at all. A DVD-game or motion-menu disc
+    #    authors its menus as TITLE-domain PGCs, with the button HLI in the NAV
+    #    packs of a TITLE VOB -- Scene It's game menus, and the reported disc of
+    #    issue #81, whose boot menus live in VTS_02_1.VOB. Measured on Scene It:
+    #    13-20 of the ~20 NAV packs in a 2048-sector window from a title VOB
+    #    carry MULTI-BUTTON HLI; the menu-VOB scan finds none of those records.
+    # 2. It is ~100x cheaper, which is what makes it usable from the player's
+    #    gamepad chord. Measured: 0.07-0.18 s and ~40 KB of sectors, against
+    #    4.9 s / 5.6 MB for --nav-packs on MEN_IN_BLACK (whose 680 MB of menu
+    #    VOBs hit the 512 MB cap). One forward run means NO SEEKS, which matters
+    #    on a physical disc the core is streaming from at the same time.
+    #
+    # A VOBU is at most 1 s of video, so 2048 sectors always spans several of
+    # them; an HLI is re-sent every VOBU while a menu is up (measured on The
+    # Matrix: the same unit 8 times, 1.001 s apart), so forward-only is enough.
+    if nav_window and playhead is not None:
+        found = 0
+        for i in range(nav_window):
+            lba = playhead + i
+            if lba >= iso.volume_sectors:
+                break
+            if is_nav_pack(iso.sec(lba)):
+                lbas.append(lba)
+                found += 1
+        if verbose:
+            print("  playhead NAV packs captured: %d (window %d sectors from %d)"
+                  % (found, nav_window, playhead))
 
     if nav_packs:
         budget = (nav_scan_mb * 1024 * 1024) // SEC
@@ -457,7 +491,8 @@ def cmd_make(args):
             steps = prompt("Steps (e.g. 'boot disc, press Menu, choose Scenes')")
         print()
 
-    extents = collect(iso, args.nav_packs, args.nav_scan_mb)
+    extents = collect(iso, args.nav_packs, args.nav_scan_mb,
+                      nav_window=args.nav_window, playhead=args.lba)
     n_sec = sum(c for _, c in extents)
     n_meta, n_nav = audit(iso, extents)
 
@@ -494,7 +529,17 @@ def cmd_make(args):
             "lba": args.lba,
             "status_hex": args.status,
         },
-        "includes_nav_packs": bool(args.nav_packs),
+        # TRUE when the bundle carries button data from EITHER source. Read the
+        # count in content_audit and nav_capture below for which one -- a menu-VOB
+        # scan and a playhead window answer different questions (see collect()).
+        "includes_nav_packs": bool(args.nav_packs) or bool(
+            args.nav_window and args.lba is not None),
+        "nav_capture": {
+            "menu_vob_scan": bool(args.nav_packs),
+            "playhead_window": (args.nav_window
+                                if (args.nav_window and args.lba is not None)
+                                else 0),
+        },
         "sector_count": n_sec,
         "content_audit": {
             "metadata_sectors": n_meta,
@@ -533,8 +578,10 @@ def cmd_make(args):
     print("                 0 sectors carrying picture or sound data")
     print()
     print("This bundle contains only the UNENCRYPTED NAVIGATION STRUCTURES of the")
-    print("disc: ISO9660 directory records, the IFO tables%s,"
-          % (", menu NAV packs" if args.nav_packs else ""))
+    srcs = ([", menu NAV packs"] if args.nav_packs else []) + \
+           ([", the NAV packs around the playhead"]
+            if (args.nav_window and args.lba is not None) else [])
+    print("disc: ISO9660 directory records, the IFO tables%s," % "".join(srcs))
     print("and what you typed above. No video, no audio, no decryption keys, and")
     print("no file paths from this machine. It cannot be used to watch anything.")
     print("Attach it to a GitHub issue.")
@@ -619,8 +666,15 @@ def cmd_info(args):
     print("fingerprint  %s" % d["fingerprint"])
     print("size         %.2f GB, %d VTS, %d titles"
           % (d["image_bytes"] / 1e9, d["n_vts"], d["n_titles"]))
-    print("captured     %d sectors, nav packs: %s"
-          % (man["sector_count"], "yes" if man["includes_nav_packs"] else "no"))
+    nc = man.get("nav_capture") or {}
+    if man["includes_nav_packs"]:
+        how = ", ".join(
+            (["menu-VOB scan"] if nc.get("menu_vob_scan") else [])
+            + (["playhead window %d sectors" % nc["playhead_window"]]
+               if nc.get("playhead_window") else [])) or "yes"
+    else:
+        how = "no"
+    print("captured     %d sectors, nav packs: %s" % (man["sector_count"], how))
     ca = man.get("content_audit")
     if ca:
         print("audit        %d nav-table sectors, %d NAV packs, %d carrying A/V"
@@ -667,6 +721,15 @@ def main():
         p.add_argument("--nav-scan-mb", type=int, default=512,
                        help="cap on menu VOB bytes scanned for NAV packs "
                             "(default 512)")
+        # Needs --lba, so in practice this is the player's path. It is what
+        # reaches an IN-TITLE menu's buttons, which --nav-packs cannot (see
+        # collect()). Explicit rather than implied by --lba so the Main's argv
+        # says what it is asking for.
+        p.add_argument("--nav-window", type=int, default=0, metavar="SECTORS",
+                       help="with --lba: capture the NAV packs in SECTORS "
+                            "sectors forward of the playhead (0 = off). This is "
+                            "the only capture that reaches an IN-TITLE menu's "
+                            "buttons; 2048 spans several VOBUs for ~40 KB")
         p.add_argument("--no-prompt", action="store_true",
                        help="do not ask any questions")
         # Set by MiSTer_DVDcss when it generates a bundle on the player; see

--- a/tools/dvd_vm_ref.py
+++ b/tools/dvd_vm_ref.py
@@ -525,7 +525,7 @@ def aud_stream_map(logical, audio_ctl, dom_title, map_valid=True):
     return logical & 7                             # DEVIATION: identity, not -1
 
 
-def subp_stream_map(logical, ctl_sel, dom_title, ctx_menu, wide,
+def subp_stream_map(logical, ctl_sel, dom_title, menu_dom, wide,
                     disp_mode=0, map_valid=True):
     """Golden model of dvd/subp_stream_map.sv: resolve a LOGICAL subpicture
     stream number to the PHYSICAL substream index the demux filters on, through
@@ -539,11 +539,19 @@ def subp_stream_map(logical, ctl_sel, dom_title, ctx_menu, wide,
         [4:0]   16:9 pan&scan
     (libdvdnav vm_get_subp_stream, vmget.c.)
 
-    `ctx_menu` says this resolution is for a MENU context, and `dom_title` is
-    the domain the loaded table came FROM. They must agree, else the table is
-    the other domain's and we fall back to identity -- subp_ctl_mem is one store
-    shared by both domains and is never cleared, so this is what stops a menu's
-    table leaking into the in-title HLI path and vice versa.
+    `menu_dom` says a MENU-DOMAIN PGC is loaded (emu: menus_on && menu_active)
+    and `dom_title` is the domain the loaded table came FROM. They must disagree
+    -- the table has to belong to the domain the player is in -- else it is the
+    other domain's and we fall back to identity; subp_ctl_mem is one store shared
+    by both domains and is never cleared, so this is what stops a menu's table
+    leaking into the in-title HLI path and vice versa.
+
+    ⚠ `menu_dom` is a fact about the PLAYER, not about the caller. It used to be
+    `ctx_menu` ("this resolution is for a menu"), which is a different question:
+    an in-title game/motion menu is a menu context in the TITLE domain, so the
+    gate demanded a menu-domain table, did not find one, and fell back to
+    identity -- issue #81, "no visible selection" on a disc whose title-domain
+    menus put their highlight SPU on 0x21. See dvd/subp_stream_map.sv.
 
     DEVIATION FROM libdvdnav, deliberate: the caller passes disp_mode, and emu
     forces 0 (wide) for every menu. This core composites the subpicture in
@@ -556,7 +564,7 @@ def subp_stream_map(logical, ctl_sel, dom_title, ctx_menu, wide,
     disc that authors no usable map bit-identical to the pre-mapping core.
     """
     logical &= 0xF
-    dom_ok = (not dom_title) if ctx_menu else dom_title
+    dom_ok = bool(dom_title) != bool(menu_dom)
     if not (map_valid and dom_ok and (ctl_sel >> 31) & 1):
         return logical
     if not wide:

--- a/tools/gen_subp_map_vec.py
+++ b/tools/gen_subp_map_vec.py
@@ -13,7 +13,7 @@ Vector format, one hex word per line, 42 bits:
   bit layout, LSB first:
     [0]     map_valid
     [1]     dom_tt
-    [2]     ctx_menu
+    [2]     menu_dom  (a MENU-DOMAIN PGC is loaded; NOT "menu context" -- #81)
     [3]     wide
     [5:4]   disp_mode
     [9:6]   logical
@@ -39,13 +39,13 @@ from dvd_vm_ref import subp_stream_map
 W_EXPECT = 42
 
 
-def vec(map_valid, dom_tt, ctx_menu, wide, disp_mode, logical, ctl_sel):
+def vec(map_valid, dom_tt, menu_dom, wide, disp_mode, logical, ctl_sel):
     exp = subp_stream_map(logical, ctl_sel, dom_title=bool(dom_tt),
-                          ctx_menu=bool(ctx_menu), wide=bool(wide),
+                          menu_dom=bool(menu_dom), wide=bool(wide),
                           disp_mode=disp_mode, map_valid=bool(map_valid))
     v = (int(map_valid) & 1)
     v |= (int(dom_tt) & 1) << 1
-    v |= (int(ctx_menu) & 1) << 2
+    v |= (int(menu_dom) & 1) << 2
     v |= (int(wide) & 1) << 3
     v |= (disp_mode & 3) << 4
     v |= (logical & 0xF) << 6
@@ -78,12 +78,18 @@ def main():
         out.append(vec(1, 0, 1, 0, dm, 0, REAL['atfirst']))
         out.append(vec(1, 0, 1, 0, dm, 0, REAL['reporters']))
 
-    # ---- the domain gate: a menu context must REFUSE a title table ---------
+    # ---- the domain gate: a MENU-domain player must REFUSE a title table ---
     out.append(vec(1, 1, 1, 1, 0, 0, REAL['reporters']))   # -> identity 0
     out.append(vec(1, 1, 1, 1, 0, 0, REAL['library16']))
-    # ...and a title context must refuse a menu table
+    # ...and a TITLE-domain player must refuse a menu table
     out.append(vec(1, 0, 0, 1, 0, 1, REAL['rabbit']))      # -> identity 1
     out.append(vec(1, 0, 0, 1, 0, 3, REAL['reporters']))
+
+    # ---- issue #81: an IN-TITLE menu is a menu context in the TITLE domain, so
+    # its highlight SPU must resolve through the map. dom_tt=1, menu_dom=0.
+    for dm in (0, 1, 2):
+        out.append(vec(1, 1, 0, 1, dm, 0, REAL['reporters']))   # -> 1 / 2 / 0
+        out.append(vec(1, 1, 0, 1, dm, 0, REAL['library16']))
 
     # ---- mid-parse: map_valid=0 is identity in both contexts ---------------
     for log in range(4):

--- a/tools/mister.py
+++ b/tools/mister.py
@@ -455,7 +455,14 @@ sleep 2
 [ -p {AGENT_FIFO} ] && echo "agent: listening" || echo "agent: FIFO MISSING"
 ''')
         print(out.strip())
-    if not args.agent:
+    # ⚠ `--agent` means "agent only" ONLY when no core was named. The skill's own
+    # documented usage is `deploy --agent --rbf releases/X.rbf`, and this read
+    # `if not args.agent`, so that line started the daemon, installed the Main and
+    # SILENTLY SKIPPED THE CORE -- the exact outcome the RESTORE_SCRIPT comment
+    # above was written about ("the Main landed, the core did not, and the two
+    # silently disagreed"), reached by a different route and with no warning at
+    # all. An explicit --rbf is an instruction, so it wins.
+    if args.rbf or not args.agent:
         rbf = args.rbf or newest_rbf()
         print(f'deploy: {os.path.basename(rbf)} -> {CORE_DIR}/{HIL_RBF}')
         scp(rbf, f'{CORE_DIR}/{HIL_RBF}')
@@ -854,7 +861,11 @@ for p in $(ls /proc | grep -E '^[0-9]+$'); do
 done
 [ -p ''' + AGENT_FIFO + ''' ] && echo "agent=listening" || echo "agent=down"
 echo "--- dvd_report.log ---"
-tail -5 /tmp/dvd_report.log 2>/dev/null
+# ⚠ `|| true`: the script's status is its LAST command's, and this log does not
+# exist until the DVD core has run once -- so on a freshly booted box `state`,
+# the first thing the skill tells you to run, aborted with an opaque
+# "remote command failed (rc=1)" and printed nothing it had already gathered.
+tail -5 /tmp/dvd_report.log 2>/dev/null || true
 ''')
     print(out.rstrip())
     st = os.path.join(HERE, '.mister_state.json')
@@ -901,7 +912,9 @@ def main():
     p.add_argument('--rbf', help='default: newest releases/*.rbf')
     p.add_argument('--main', metavar='PATH',
                    help='install a custom Main safely (never overwrites the running one)')
-    p.add_argument('--agent', action='store_true', help='only (re)start the key daemon')
+    p.add_argument('--agent', action='store_true',
+                   help='(re)start the key daemon; alone = that and nothing else, '
+                        'but an explicit --rbf is still flashed')
     p.add_argument('--rbf-only', action='store_true')
     p.set_defaults(fn=cmd_deploy)
 


### PR DESCRIPTION
Fixes #81.

## A menu context is not a menu domain

Field report on v0.5.0: *Aniki, mon Frère* (BROTHER) PAL FR Z2, physical disc, `Disc Menus` On — **"No visible selection on the main menus."** That is word-for-word the #60/#61 symptom, on a disc the #60/#61 fix could not reach.

Measured from the repro bundle:

```
FP PGC:  g[3] = 1 ; JumpTT 3          -> the menus are TITLE-domain PGCs
VTS_02:  22 titles of 30-41 s; PGCN 4 post `if (g[0]==0) JumpVTS_PTT 4:1`
         HL_BTNN = 0x400 / 0x800 in five PGCs' POSTs  -> it expects highlights
VTS_02 V_ATTR@0x200   = 0x5E00                        -> MPEG-2, PAL, 16:9
VTS_02 subp_control[0] = 0x80010200 on EVERY PGC      -> avail, 4:3=0, wide=1
```

`0x80010200` is the exact word both #60/#61 discs author, so the highlight SPU rides substream **0x21**. The core filtered **0x20**, decoded nothing, and a highlight is a *recolour of subpicture pixels* — so nothing was drawn.

**Two wrong facts on one lookup, both in `emu.sv`'s wiring rather than in any module's logic.**

1. The map's domain gate was fed `menu_sp_ctx` — the menu **context** — and read it as "this needs a menu-**domain** table". But `menu_sp_ctx` is deliberately wider: it includes `sp_menu_early`, the in-title multi-button menu. So a menu context in the title domain demanded a menu-domain table, found the title's, and fell back to identity. The input is now `menu_dom` (`menus_on && menu_active`) and the test is `dom_tt != menu_dom`.

2. `wide` came from the decoded sequence header. **libdvdnav settles this**: `vm_get_subp_stream` has no domain condition on the map at all, and `vm_get_video_attr` returns `vtsi_mat->vts_video_attr` in `DVD_DOMAIN_VTSTitle`. A menu authored 16:9 anamorphic with a 4:3 sequence-header code — routine — would take the 4:3 field and the symptom would have survived fix (1) entirely. New reader output `title_ar_wide` from `VTS_V_ATTR@0x200`, one extra step in the existing `S_ATTR` sweep, consumed by one mux arm scoped to the in-title menu.

### The durable part

**`emu.sv`'s own comment claimed this path "resolves through the same map". It could not, and had read as reassurance since #60/#61 shipped.** `docs/track_selection.md` had also talked the project out of gating the glue ("a chain bench would have to *replicate* emu's glue") — sound about a chain bench, then taken as covering a single port connection.

**The module's truth table did not change** (verified over 200k input points), so `subp_stream_map_tb` cannot go RED for this defect. `tools/check_subp_map_wiring.py` gates both connections by reading them out of `dvd/emu.sv` — the `acmod_scan.py` / `csync_pipe_tb` pattern — and is RED on the pre-fix file and on 3 targeted re-regressions.

### Scope

958 local ISOs: **7** have a title-domain PGC resolving logical 0 non-zero, and **none** carries an in-title HLI, so none is a repro — the same standing as #60/#61. Scene It, the in-title-menu reference disc, is **measured** bit-identical (its game VTS declares the available bit clear, so `use_map` is 0 either way).

## Support bundles now carry button data

★ **`--nav-packs` scans MENU VOBs, so it structurally cannot capture an in-title menu's buttons — on any route.** All three "no visible highlight" reports (#60, #61, #81) came from **physical discs**, via the chord, and carried **zero NAV packs**.

So `dvd_report.py` gains a **playhead window**: every NAV pack in one sequential run forward from the sector being served. Measured on the MiSTer, `--nav-packs` costs 37.7 s against the window's 1.98 s on the same disc, and cannot reach the in-title case.

⚠ **An optical drive is ~50× slower than arithmetic predicted** — measured on a real DVD while the core streamed it: ~90–285 KB/s, steady over 84 s, chunking does not help. A 2048-sector window costs 15.7–29.1 s there. So the window **stops after 2 NAV packs** and the cap follows the **medium** (512 optical / 2048 image, on `S_ISBLK`).

⚠ **And an older installed `dvd_report.py` given the new flag writes NO BUNDLE AT ALL** (measured) — worse than the missing data. The child now asks the script whether it names the flag.

## Test plan

- [x] `subp_stream_map_tb` — 2077 vectors + arms [7]–[10], mutation-checked
- [x] `tools/check_subp_map_wiring.py` — both ports, RED on pre-fix + 3 re-regressions
- [x] `iso_reader_attr_tb` `title_ar_wide` arm — reads `VTS_V_ATTR` out of the fixture, 3/3 reader mutations
- [x] every reader bench A/B'd against the pre-change reader (4 pre-existing failures identical in both arms)
- [x] `main/tests/run_tests.sh --red` — 7 arms, 12 RED mutations each caught by its own assertion
- [x] `lint_undriven.sh`, `netlist_canary.sh`, `docs_check.py`, `mkdocs --strict`
- [x] **HW:** ATFIRSTSIGHT (the only local disc where the map returns non-zero) — all 7 highlight blocks green; Scene It in-title menu renders and the highlight walks; MiB track counts byte-exact (`AUDIO 4/4`, `SUB 1/4 EN · 2/4 FR · 3/4 ES · 4/4 EN`) — the readout of the `S_ATTR` sweep the reader edit touches; 87-minute soak clean
- [x] **HW:** the chord on a physical disc, both arms — degrade path (old collector: bundle written, no NAV packs) and capture path (a complete 5-button menu with link graph, colours and VM command per button, in ≤1 s)
- [ ] **#81's positive case** — no local disc reproduces it; the reporter is the only confirmation

Build: `DVD_subpmapdom_20260912_1328.rbf`, SEED 7 first roll, clk_dec 97.48/97.30 against an 86.0 gate, 87% ALM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
