### PR TITLE
scrub: one absolute content rate for both sources, not a fraction of the title span

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2721,8 +2721,8 @@ worse maintenance burden than targeted in-place edits. So:
   ⚠ A retune must also move `dvd/dpad_seek.sv`'s header, `docs/dvd_nav.md` §2a and
   `docs/transport_hud.md` — the numbers are quoted in all four.
   ★★ **AND THE STEP IS NO LONGER A FRACTION OF THE SPAN AT ALL (2026-09-12, branch
-  `feature/scrub-time-tiers`, `dev-scrubtiers`) — sim-proven with a mutant per claim,
-  ⏳ HW gate pending.** A fraction of a SHORT title is a crawl: MEASURED at tier 0, a 2 h
+  `feature/scrub-time-tiers`, `dev-scrubtiers`) — sim-proven with a mutant per claim, and
+  ✅ HW-CONFIRMED for the DVD path (see the round below).** A fraction of a SHORT title is a crawl: MEASURED at tier 0, a 2 h
   feature moved **29 content-seconds per second**, a 3-minute clip **0.58**, a 30-second
   clip **0.19**, and the shift truncated what little was left (`2584 >> 12 = 0` — the
   `| 1` floor was the only thing still moving the cursor). Now a linear file steps
@@ -2751,6 +2751,21 @@ worse maintenance burden than targeted in-place edits. So:
   DVD rate vary **2× within a bucket** (68 min → 8.3 s/s, 2h16 → 16.7); removing it needs
   the forbidden `span / title_secs`. Gate: `bench/dvd/run_scrub_tiers.sh --red` (T19 pins the
   parity; 7 mutants, including an unscaled lattice and a drifted ladder).
+  ✅ **HW-CONFIRMED 2026-09-12 — THE FEEL, WHICH IS THE ONLY THING THAT COULD SETTLE IT**
+  (build `DVD_scrubtiers_20260912_2135.rbf`, flashed to the rig and held on a physical
+  disc; maintainer: *"that scrub speed feels good"*).
+  ★ **The harness could not have answered this and never will:** `dvd/kbd_map.sv`
+  deliberately routes keyboard Fast Fwd/Rewind to `dvd/dpad_seek.sv`, never to
+  `scrub_ctrl`'s hold-to-scrub — an IR "hold" is ~9 discrete taps a second, which on the
+  hold path is ~9 flush/re-locks a second, the regime HW rounds 1–2 proved fatal. So
+  `joy_eff` masks those keys out and the gesture is reachable **only from a gamepad**. A
+  tier ladder is a feel setting whose instrument is a person, and this is the second
+  retune (2026-09-03 was the first) decided the same way.
+  ⏳ **NOT covered by that round, and each needs the same hands:** the LINEAR half (a
+  `.mpg`/VCD held at the same tiers — the parity claim is pinned in sim to 7 % but has
+  never been felt), a SHORT title (the 0.58 s/s case the change exists for), and the
+  arrow readout replacing `×1..×4`. The disc under test was an ordinary feature, i.e. the
+  anchor bucket — the one length whose behaviour moved least.
   ⚠ **SEAMLESS-BRANCH DISCS ARE STILL WRONG and it is NOT the readout — it is the
   SEEK.** The 2026-09-03 cell-gap fix (a cell's span is its own `first..last`, not
   the distance to the next cell's first — AFTER_EARTH VTS_13 PGC1, 1.612× short,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2715,6 +2715,26 @@ worse maintenance burden than targeted in-place edits. So:
   hardcoded ternary, pinned by `scrub_ctrl_tb` T13–T15 so a retune is deliberate.
   ⚠ A retune must also move `dvd/dpad_seek.sv`'s header, `docs/dvd_nav.md` §2a and
   `docs/transport_hud.md` — the numbers are quoted in all four.
+  ★★ **AND THE STEP IS NO LONGER A FRACTION OF THE SPAN AT ALL (2026-09-12, branch
+  `feature/scrub-time-tiers`, `dev-scrubtiers`) — sim-proven with a mutant per claim,
+  ⏳ HW gate pending.** A fraction of a SHORT title is a crawl: MEASURED at tier 0, a 2 h
+  feature moved **29 content-seconds per second**, a 3-minute clip **0.58**, a 30-second
+  clip **0.19**, and the shift truncated what little was left (`2584 >> 12 = 0` — the
+  `| 1` floor was the only thing still moving the cursor). Now a linear file steps
+  `lin_blk10 >> {5,3,1,0}` (blocks per 10 s, so the shift IS the rate ≈ 5/21/83/167 s/s,
+  gated on the rate being VALID — the `dpad_seek` precedent), and a DVD steps
+  `span >> (SHn + log2(title_secs) − SECS_REF)`: **span cancels out of the content rate
+  algebraically**, so a duration BUCKET (a leading-one position, no divide) fixes the rate.
+  ★ `SECS_REF = 12` anchors it so every title in **4096–8191 s (68–136 min)** keeps a
+  **bit-identical** step — the 2 h feel that passed hardware is untouched, and only titles
+  far from 2 h move. ⛔ **Do NOT turn the bucket into `span / title_secs`**: on a
+  seamless-branch disc the span holds the other branch's ILVUs (issue #49) and that
+  inflation hits the shift and the divide IDENTICALLY, so the divide fixes nothing — and
+  the AREA objection to it expired with the reclaim, so do not re-derive "we have area
+  now, so divide". ⚠ The two ladders deliberately disagree (DVD 29/117/469/1875 s/s vs
+  linear 5/21/83/167) because the DVD numbers are the ones hardware signed off; if the top
+  tier reads as inconsistent on HW, retune `LS0..LS3`, do not unpick the anchor. Gate:
+  `bench/dvd/run_scrub_tiers.sh --red`.
   ⚠ **SEAMLESS-BRANCH DISCS ARE STILL WRONG and it is NOT the readout — it is the
   SEEK.** The 2026-09-03 cell-gap fix (a cell's span is its own `first..last`, not
   the distance to the next cell's first — AFTER_EARTH VTS_13 PGC1, 1.612× short,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2715,7 +2715,8 @@ worse maintenance burden than targeted in-place edits. So:
   (2) **Scrub ramp relaxed** (user report: "it ramps up too fast"): the old
   `{10,8,6,5}` / 0-1.5-3-5 s ladder moved ~2 MINUTES of a 2 h title per second even in
   tier 0 — no fine-positioning tier existed and 5 s of holding crossed 77 minutes. Now
-  `{12,10,8,6}` / 0-2-4.5-8 s, and the ladder is `SH0..SH3` PARAMETERS rather than a
+  `{12,10,8,6}` / 0-2-4.5-8 s (⚠ superseded again 2026-09-12 — see the content-rate note
+  below), and the ladder is `SH0..SH3` PARAMETERS rather than a
   hardcoded ternary, pinned by `scrub_ctrl_tb` T13–T15 so a retune is deliberate.
   ⚠ A retune must also move `dvd/dpad_seek.sv`'s header, `docs/dvd_nav.md` §2a and
   `docs/transport_hud.md` — the numbers are quoted in all four.
@@ -2725,8 +2726,9 @@ worse maintenance burden than targeted in-place edits. So:
   feature moved **29 content-seconds per second**, a 3-minute clip **0.58**, a 30-second
   clip **0.19**, and the shift truncated what little was left (`2584 >> 12 = 0` — the
   `| 1` floor was the only thing still moving the cursor). Now a linear file steps
-  `lin_blk10 >> {5,3,1,0}` (blocks per 10 s, so the shift IS the rate ≈ 5/21/83/167 s/s,
-  gated on the rate being VALID — the `dpad_seek` precedent), and a DVD steps
+  `(lin_blk10 * 6) >> {6,4,2,0}` (blocks per 10 s, so the shift IS the rate ≈
+  16/63/250/1000 s/s, gated on the rate being VALID — the `dpad_seek` precedent), and a DVD
+  steps
   `span >> (SHn + log2(title_secs) − SECS_REF)`: **span cancels out of the content rate
   algebraically**, so a duration BUCKET (a leading-one position, no divide) fixes the rate.
   ★ `SECS_REF = 12` anchors it so every title in **4096–8191 s (68–136 min)** keeps a
@@ -2735,10 +2737,20 @@ worse maintenance burden than targeted in-place edits. So:
   seamless-branch disc the span holds the other branch's ILVUs (issue #49) and that
   inflation hits the shift and the divide IDENTICALLY, so the divide fixes nothing — and
   the AREA objection to it expired with the reclaim, so do not re-derive "we have area
-  now, so divide". ⚠ The two ladders deliberately disagree (DVD 29/117/469/1875 s/s vs
-  linear 5/21/83/167) because the DVD numbers are the ones hardware signed off; if the top
-  tier reads as inconsistent on HW, retune `LS0..LS3`, do not unpick the anchor. Gate:
-  `bench/dvd/run_scrub_tiers.sh --red`.
+  now, so divide".
+  ★★ **BOTH SOURCES NOW RAMP AT ONE LADDER — ~15 / 60 / 240 / 960 content-s/s — and that
+  COST THE 2 h BIT-IDENTITY, deliberately** (maintainer: *"these both should have the same
+  seek steps — maybe we meet in the middle"*). The first cut kept `SHn = {12,10,8,6}` to
+  preserve the signed-off 2 h feel exactly, which left a DVD at 29/117/469/1875 s/s against
+  a `.mpg` at 5/21/83/167 — a tier meaning a 5–10× different speed by source. The DVD ladder
+  is HALVED (`{13,11,9,7}`); the anchor mechanism is untouched, only its value moved.
+  ★ **The `* 6` on the linear base is arithmetic, not taste:** unscaled, the linear lattice
+  is `166.7/2^n` and the DVD one `120000/2^m`, half a power of two apart, so nothing brings
+  them closer than **41 %**; ×6 lands them on one lattice at **7 %**. ⚠ Retune `SHn` and
+  `LSn` TOGETHER. ⚠ Residual, now the larger error: the power-of-two bucket still lets the
+  DVD rate vary **2× within a bucket** (68 min → 8.3 s/s, 2h16 → 16.7); removing it needs
+  the forbidden `span / title_secs`. Gate: `bench/dvd/run_scrub_tiers.sh --red` (T19 pins the
+  parity; 7 mutants, including an unscaled lattice and a drifted ladder).
   ⚠ **SEAMLESS-BRANCH DISCS ARE STILL WRONG and it is NOT the readout — it is the
   SEEK.** The 2026-09-03 cell-gap fix (a cell's span is its own `first..last`, not
   the distance to the next cell's first — AFTER_EARTH VTS_13 PGC1, 1.612× short,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2303,8 +2303,9 @@ worse maintenance burden than targeted in-place edits. So:
   gated green: clk_dec 91.07/88.12 MHz, ALM 90%, DSP unchanged 97/112;
   `releases/DVD_hud_20260710_1955.rbf`). The release-visible playback feedback layer (the multi-row debug
   overlay stays compiled out): `dvd/transport_hud.sv` renders a bottom **status line**
-  (`► 0:12:34/1:37:05 CH 12/23`; ❚❚ pause; `►►×n` scrub with the PR-fj#101 span-relative
-  tiers) + an **event popup line** (`AUDIO 2/4 FR` / `SUB OFF` / `ANGLE 2/3` / `CH n/N`,
+  (`► 0:12:34/1:37:05 CH 12/23`; ❚❚ pause; the scrub tier as 2-5 arrows — it printed
+  `►►×n` until 2026-09-12, a tier ordinal posing as a rate, where `×1` meant ~29× real
+  time; see `docs/transport_hud.md`) + an **event popup line** (`AUDIO 2/4 FR` / `SUB OFF` / `ANGLE 2/3` / `CH n/N`,
   last-event-wins, Phase-10 `attr_*` languages) from a generated glyph ROM
   (`tools/hud_font.py` → `dvd/hud_font.mem`) + 2×32 text plane; **`dvd/seek_bar.sv`**
   gives the seek-on-release scrub its missing feedback (fill = hold start, amber cursor =
@@ -2447,7 +2448,10 @@ worse maintenance burden than targeted in-place edits. So:
   a ~2 s give-up. The contract is now recorded in `nav_dsi.sv`'s header for the next
   consumer. HUD: popup type 8 `SEEK FWD 30S` (the `pop_type` field widened 3→4 bits; the
   sign is SPELLED so the glyph ROM and `dvd/hud_font.mem` stay untouched) + the tap count in
-  the shared `►►×n` field. Golden `tools/nav_extract.py --dpad`; tests
+  the shared icon field — ⛔ NO LONGER: since 2026-09-12 a D-pad gesture renders
+  direction arrows only and `emu.sv` feeds `.scrub_tier` `2'd0`, because that field now
+  draws a SPEED as an arrow count and a tap count is not a speed (the popup carried the
+  magnitude all along). Golden `tools/nav_extract.py --dpad`; tests
   `bench/dvd/dpad_seek_tb.sv` (24 scenarios incl. the trap), `scrub_ctrl_tb` T9–T12,
   `transport_hud_tb` T18–T20, all under `bench/dvd/run_dpad_seek.sh`. Design:
   **`docs/dvd_nav.md` §2b**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2761,11 +2761,17 @@ worse maintenance burden than targeted in-place edits. So:
   `joy_eff` masks those keys out and the gesture is reachable **only from a gamepad**. A
   tier ladder is a feel setting whose instrument is a person, and this is the second
   retune (2026-09-03 was the first) decided the same way.
-  ⏳ **NOT covered by that round, and each needs the same hands:** the LINEAR half (a
-  `.mpg`/VCD held at the same tiers — the parity claim is pinned in sim to 7 % but has
-  never been felt), a SHORT title (the 0.58 s/s case the change exists for), and the
-  arrow readout replacing `×1..×4`. The disc under test was an ordinary feature, i.e. the
-  anchor bucket — the one length whose behaviour moved least.
+  ✅ **AND THE REST OF THE ROUND CAME BACK GOOD THE SAME DAY** (maintainer: *"all those
+  open scrub questions look and feel good on the board"*), so the branch is confirmed
+  whole rather than on its easiest path: the **LINEAR half** held at the same tiers —
+  which is the parity claim itself, felt rather than only pinned in sim to 7 % — a
+  **SHORT title**, which is the 0.58 s/s crawl the change exists for and the case the
+  first disc could not exercise (an ordinary feature sits in the anchor bucket, the one
+  length whose behaviour moved least), and the **arrow readout** that replaced `×1..×4`.
+  ★ Worth keeping straight for anyone retuning this: those two are different mechanisms,
+  not one test twice. A linear file's rate comes from `lin_blk10` and is independent of
+  its length; a DVD's comes from the duration bucket and is nothing but its length. The
+  short-title arm is the only one that exercises `secs_lz` at all.
   ⚠ **SEAMLESS-BRANCH DISCS ARE STILL WRONG and it is NOT the readout — it is the
   SEEK.** The 2026-09-03 cell-gap fix (a cell's span is its own `first..last`, not
   the distance to the next cell's first — AFTER_EARTH VTS_13 PGC1, 1.612× short,

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -1128,4 +1128,14 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # ⚠ +4.7 MHz on the hot corner for one reader register and one mux arm -- read it
 # as netlist variance at this density, NOT as a benefit of the change, the same
 # way the previous entry's -3.3 MHz was not a cost of that one.
+# 2026-09-12 (feature/scrub-time-tiers, dev-scrubtiers -- the hold-to-scrub ramp
+# became an absolute content rate instead of a fraction of the title span):
+# SEED 7 held FIRST roll -- clk_dec 93.45 @100C / 89.41 @-40C (gate 86.0, PASS
+# both corners) at 87% ALM (36,557 needed), registers 50,415, RAM 501/553,
+# DSP 94/112. Build DVD_scrubtiers_20260912_2010.rbf (4,320 KB).
+# ★ +129 ALMs over the branch base for a 16-bit priority encoder, a signed
+# clamp and one 24-bit shifter -- the duration bucket is deliberately NOT a
+# divide, and this is what that decision costs. (A divide was rejected on
+# CORRECTNESS, not area: a seamless-branch disc inflates the span, which hits
+# the bucketed shift and the divide identically -- see dvd/scrub_ctrl.sv.)
 set_global_assignment -name SEED 7

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -1130,17 +1130,22 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # way the previous entry's -3.3 MHz was not a cost of that one.
 # 2026-09-12 (feature/scrub-time-tiers, dev-scrubtiers -- the hold-to-scrub ramp
 # became an absolute content rate instead of a fraction of the title span):
-# SEED 7 held FIRST roll -- clk_dec 98.31 @100C / 93.78 @-40C (gate 86.0, PASS
-# both corners) at 87% ALM (36,595 needed), registers 50,422, RAM 501/553,
-# DSP 94/112. Build DVD_scrubtiers_20260912_2107.rbf (4,310 KB).
-# ★ +167 ALMs over the branch base: a 16-bit priority encoder, a signed clamp
-# and one 24-bit shifter for the duration bucket (deliberately NOT a divide --
-# rejected on CORRECTNESS, not area: a seamless-branch disc inflates the span,
+# SEED 7 held FIRST roll -- clk_dec 93.04 @100C / 89.08 @-40C (gate 86.0, PASS
+# both corners) at 87% ALM (36,585 needed), registers 50,468, RAM 501/553,
+# DSP 94/112. Build DVD_scrubtiers_20260912_2135.rbf (4,314 KB).
+# ★ +157 ALMs over the branch base, for: a 16-bit priority encoder, a signed
+# clamp and one 24-bit shifter (the duration bucket -- deliberately NOT a divide,
+# rejected on CORRECTNESS not area: a seamless-branch disc inflates the span,
 # which hits the bucketed shift and the divide identically, see
-# dvd/scrub_ctrl.sv), plus the HUD's arrow-count readout.
-# ⚠ Supersedes an earlier fit of this branch at 93.45/89.41 and 36,557 ALMs
-# (DVD_scrubtiers_20260912_2010.rbf), taken before the HUD change. +4.9 MHz on
-# the hot corner for three comparators and a five-column icon field is netlist
-# variance at this density, NOT a benefit of that change -- the same caution the
-# two entries above carry in the other direction.
+# dvd/scrub_ctrl.sv); the x6 lattice scale on the linear base (two shifts and an
+# adder, which is what makes a DVD and a .mpg ramp at the same speed); and the
+# HUD's arrow-count readout.
+# ⚠ THREE FITS OF THIS BRANCH, and the spread between them is the point:
+#   36,557 / 93.45 / 89.41  (2010, span ladder + bit-identical 2 h anchor)
+#   36,595 / 98.31 / 93.78  (2107, + the HUD arrow count)
+#   36,585 / 93.04 / 89.08  (2135, + one ladder for both sources) <- shipped
+# Under 40 ALMs and 5.3 MHz of hot-corner swing across three netlists whose
+# logic differs by a handful of comparators. That is netlist variance at this
+# density -- do NOT read any of it as a cost or a benefit of the change that
+# happened to be in flight, in either direction.
 set_global_assignment -name SEED 7

--- a/DVD.qsf
+++ b/DVD.qsf
@@ -1130,12 +1130,17 @@ set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC OFF
 # way the previous entry's -3.3 MHz was not a cost of that one.
 # 2026-09-12 (feature/scrub-time-tiers, dev-scrubtiers -- the hold-to-scrub ramp
 # became an absolute content rate instead of a fraction of the title span):
-# SEED 7 held FIRST roll -- clk_dec 93.45 @100C / 89.41 @-40C (gate 86.0, PASS
-# both corners) at 87% ALM (36,557 needed), registers 50,415, RAM 501/553,
-# DSP 94/112. Build DVD_scrubtiers_20260912_2010.rbf (4,320 KB).
-# ★ +129 ALMs over the branch base for a 16-bit priority encoder, a signed
-# clamp and one 24-bit shifter -- the duration bucket is deliberately NOT a
-# divide, and this is what that decision costs. (A divide was rejected on
-# CORRECTNESS, not area: a seamless-branch disc inflates the span, which hits
-# the bucketed shift and the divide identically -- see dvd/scrub_ctrl.sv.)
+# SEED 7 held FIRST roll -- clk_dec 98.31 @100C / 93.78 @-40C (gate 86.0, PASS
+# both corners) at 87% ALM (36,595 needed), registers 50,422, RAM 501/553,
+# DSP 94/112. Build DVD_scrubtiers_20260912_2107.rbf (4,310 KB).
+# ★ +167 ALMs over the branch base: a 16-bit priority encoder, a signed clamp
+# and one 24-bit shifter for the duration bucket (deliberately NOT a divide --
+# rejected on CORRECTNESS, not area: a seamless-branch disc inflates the span,
+# which hits the bucketed shift and the divide identically, see
+# dvd/scrub_ctrl.sv), plus the HUD's arrow-count readout.
+# ⚠ Supersedes an earlier fit of this branch at 93.45/89.41 and 36,557 ALMs
+# (DVD_scrubtiers_20260912_2010.rbf), taken before the HUD change. +4.9 MHz on
+# the hot corner for three comparators and a five-column icon field is netlist
+# variance at this density, NOT a benefit of that change -- the same caution the
+# two entries above carry in the other direction.
 set_global_assignment -name SEED 7

--- a/bench/dvd/run_scrub_tiers.sh
+++ b/bench/dvd/run_scrub_tiers.sh
@@ -5,9 +5,10 @@
 #
 # The step used to be a fraction of the title span, so the shorter the title the
 # slower the scrub (0.58 content-seconds per second on a 3-minute clip, 0.19 on a
-# 30-second one, against 29 for a 2 h feature). It is now an absolute rate:
-# lin_blk10 >> LSn for a linear file, and span >> (SHn + duration bucket) for a
-# DVD title, anchored so a ~2 h title's step is BIT-IDENTICAL to what shipped.
+# 30-second one, against 29 for a 2 h feature). It is now an absolute rate, and
+# ONE rate whatever is mounted: ~15 / 60 / 240 / 960 content-seconds per second,
+# from (lin_blk10 * 6) >> LSn on a linear file and span >> (SHn + duration
+# bucket) on a DVD. T19 is the arm that pins them together.
 #
 # It also gates how that tier READS: dvd/transport_hud.sv draws it as 2..5
 # arrows, because the field used to print "xN" from the tier ordinal -- "x1" for
@@ -89,6 +90,13 @@ if [ "${1:-}" = "--red" ]; then
          's/(sh_sum > 8'"'"'sd31)     ? 5'"'"'d31 : sh_sum\[4:0\];/(sh_sum > 8'"'"'sd31)     ? 5'"'"'d31 : sh;/' \
          "rate: a 3-minute clip"
   # ...anchored where the hardware-signed-off feel lives.
+  # The claim the ladder change exists for: both sources ramp at one speed.
+  mutant "the linear lattice is unscaled" \
+         's/parameter LIN_K  = 3'"'"'d6,/parameter LIN_K  = 3'"'"'d1,/' \
+         "parity:"
+  mutant "the ladders drift apart" \
+         's/parameter LS0    = 5'"'"'d6,/parameter LS0    = 5'"'"'d5,/' \
+         "parity:"
   mutant "the anchor moved off 2 h" \
          's/parameter SECS_REF = 5'"'"'d12,/parameter SECS_REF = 5'"'"'d10,/' \
          "anchor: 4096 s"

--- a/bench/dvd/run_scrub_tiers.sh
+++ b/bench/dvd/run_scrub_tiers.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# run_scrub_tiers.sh -- the gate on the hold-to-scrub CONTENT RATE
+# (dvd/scrub_ctrl.sv; docs/dvd_nav.md "Seeking / Phase 8a").
+#
+# The step used to be a fraction of the title span, so the shorter the title the
+# slower the scrub (0.58 content-seconds per second on a 3-minute clip, 0.19 on a
+# 30-second one, against 29 for a 2 h feature). It is now an absolute rate:
+# lin_blk10 >> LSn for a linear file, and span >> (SHn + duration bucket) for a
+# DVD title, anchored so a ~2 h title's step is BIT-IDENTICAL to what shipped.
+#
+#   ./bench/dvd/run_scrub_tiers.sh          # GREEN
+#   ./bench/dvd/run_scrub_tiers.sh --red    # ...then a mutation per arm
+#
+# Each mutant sed-copies the module into a scratch dir and rebuilds the bench
+# against it; a mutant that does NOT fail means the arm is not measuring what it
+# claims (memory: bench-that-cannot-fail).
+set -u -o pipefail
+cd "$(dirname "$0")/../.."
+
+IV="iverilog -g2012"
+rc=0
+SCR=$(mktemp -d)
+trap 'rm -rf "$SCR"' EXIT
+
+echo "### GREEN"
+$IV -o "$SCR/scrub_sim" dvd/scrub_ctrl.sv bench/dvd/scrub_ctrl_tb.sv || rc=1
+vvp "$SCR/scrub_sim" | tail -12 || rc=1
+
+# a mutant must FAIL the bench, and must fail the arm NAMED for it
+mutant() {   # label, sed_expr, expected failing arm (grep string)
+  local label=$1 sedx=$2 want=$3
+  local mut="$SCR/scrub_ctrl.sv"
+  sed "$sedx" dvd/scrub_ctrl.sv > "$mut"
+  if cmp -s "$mut" dvd/scrub_ctrl.sv; then
+    echo "  MUTANT $label: sed did not change the file -- STALE"; rc=1; return
+  fi
+  $IV -o "$SCR/mut_sim" "$mut" bench/dvd/scrub_ctrl_tb.sv >/dev/null 2>&1 \
+    || { echo "  MUTANT $label: caught (compile)"; return; }
+  local out; out=$(vvp "$SCR/mut_sim" 2>&1)
+  if echo "$out" | grep -q "ALL TESTS PASSED"; then
+    echo "  MUTANT $label: NOT CAUGHT -- the bench cannot see this defect"; rc=1
+  elif echo "$out" | grep -q "$want"; then
+    echo "  MUTANT $label: caught by \"$want\""
+  else
+    echo "  MUTANT $label: caught, but NOT by \"$want\" -- check which arm owns it"
+    echo "$out" | grep "FAIL:" | sed 's/^/      /'
+    rc=1
+  fi
+}
+
+if [ "${1:-}" = "--red" ]; then
+  echo "### RED arms (one per claim)"
+  # Arm 1: the linear step is the measured rate, not the span.
+  mutant "linear falls back to the span" \
+         's/wire \[31:0\] step      = lin_rate_ok ? step_lin : step_span;/wire [31:0] step      = step_span;/' \
+         "linear: tier 0"
+  # ...and the valid flag is what gates it, not the value.
+  mutant "an untrusted rate is used anyway" \
+         's/wire \[31:0\] step      = lin_rate_ok ? step_lin : step_span;/wire [31:0] step      = step_lin;/' \
+         "linear: an untrusted rate"
+  # Arm 2: the duration bucket actually biases the shift.
+  mutant "the duration bucket is inert" \
+         's/(sh_sum > 8'"'"'sd31)     ? 5'"'"'d31 : sh_sum\[4:0\];/(sh_sum > 8'"'"'sd31)     ? 5'"'"'d31 : sh;/' \
+         "rate: a 3-minute clip"
+  # ...anchored where the hardware-signed-off feel lives.
+  mutant "the anchor moved off 2 h" \
+         's/parameter SECS_REF = 5'"'"'d12,/parameter SECS_REF = 5'"'"'d10,/' \
+         "anchor: 4096 s"
+  # The floor that stops a step rounding to zero.
+  mutant "the step may round to zero" \
+         's/wire \[31:0\] step_span = (span >> sh_eff) | 32'"'"'d1;/wire [31:0] step_span = (span >> sh_eff);/' \
+         "FAIL:"
+fi
+
+[ $rc -eq 0 ] && echo "RUN_SCRUB_TIERS: ALL GREEN" || echo "RUN_SCRUB_TIERS: FAILURES"
+exit $rc

--- a/bench/dvd/run_scrub_tiers.sh
+++ b/bench/dvd/run_scrub_tiers.sh
@@ -9,6 +9,11 @@
 # lin_blk10 >> LSn for a linear file, and span >> (SHn + duration bucket) for a
 # DVD title, anchored so a ~2 h title's step is BIT-IDENTICAL to what shipped.
 #
+# It also gates how that tier READS: dvd/transport_hud.sv draws it as 2..5
+# arrows, because the field used to print "xN" from the tier ordinal -- "x1" for
+# a tier moving ~29 content-seconds per wall second, which is what "x1" most
+# specifically is not.
+#
 #   ./bench/dvd/run_scrub_tiers.sh          # GREEN
 #   ./bench/dvd/run_scrub_tiers.sh --red    # ...then a mutation per arm
 #
@@ -26,6 +31,26 @@ trap 'rm -rf "$SCR"' EXIT
 echo "### GREEN"
 $IV -o "$SCR/scrub_sim" dvd/scrub_ctrl.sv bench/dvd/scrub_ctrl_tb.sv || rc=1
 vvp "$SCR/scrub_sim" | tail -12 || rc=1
+
+# The HUD readout of the same tier: 2..5 arrows, never "xN".
+$IV -o "$SCR/hud_sim" dvd/transport_hud.sv bench/dvd/transport_hud_tb.sv || rc=1
+vvp "$SCR/hud_sim" | grep -E "arrows|direction only|TRANSPORT_HUD_TB" || rc=1
+
+# ...and the ONE emu connection the benches cannot see. transport_hud has no way
+# to know a D-pad gesture is not a scrub: emu decides, on one line, and a wrong
+# FACT on a port connection is invisible to every module-level test (the issue
+# #81 lesson, and tools/check_subp_map_wiring.py is the precedent for gating it
+# by reading the file). Feeding dpad_pend_n here -- the TAP COUNT, which is what
+# it used to be -- would draw four taps as the fastest scrub tier.
+echo "-- emu wiring"
+if grep -qE '\.scrub_tier +\(hold_freeze \? hud_tier_w : 2.d0\)' dvd/emu.sv; then
+  echo "  ok  emu feeds no tier on the D-pad arm"
+else
+  echo "  FAIL: dvd/emu.sv must feed .scrub_tier 2'd0 while a D-pad gesture is pending"
+  echo "        (a tap count would render as a speed); found:"
+  grep -n "\.scrub_tier" dvd/emu.sv | sed 's/^/        /'
+  rc=1
+fi
 
 # a mutant must FAIL the bench, and must fail the arm NAMED for it
 mutant() {   # label, sed_expr, expected failing arm (grep string)

--- a/bench/dvd/scrub_ctrl_tb.sv
+++ b/bench/dvd/scrub_ctrl_tb.sv
@@ -5,9 +5,16 @@
 // hold->release seeks in the held direction; a longer hold seeks further
 // (acceleration); backward; clamp at title start/end; a too-short tap does
 // nothing; hold_freeze high only while held; direction-flip restarts; in_title
-// gate; the acceleration LADDER and the tier dwells (T13-T15, 2026-09-03).
-// Time thresholds are shrunk via parameter override -- the SHIFT ladder is NOT,
-// so T13/T14 measure the shipping steps.
+// gate; the acceleration LADDER and the tier dwells (T13-T15, 2026-09-03); the
+// step as an absolute CONTENT RATE rather than a fraction of the title span
+// (T16-T18, 2026-09-12).
+// Time thresholds are shrunk via parameter override -- the SHIFT ladders are
+// NOT, so T13/T14 measure the shipping steps.
+//
+// ★ T13/T14 run with title_secs = 7200 (two hours) and that is load-bearing, not
+// incidental: it is the ANCHOR of the duration bucket, so those two arms double
+// as the proof that the 2 h feel signed off on hardware is BIT-IDENTICAL after
+// the rate change. If they ever need new expected numbers, the anchor moved.
 //
 //   iverilog -g2012 -o /tmp/scrub_sim dvd/scrub_ctrl.sv bench/dvd/scrub_ctrl_tb.sv
 //   vvp /tmp/scrub_sim
@@ -31,12 +38,19 @@ module scrub_ctrl_tb;
     logic        jump_fire = 0, jump_dir = 0;
     logic [31:0] jump_base = 0, jump_off = 0;
 
+    // what the span is worth. 7200 s = the duration anchor, so every scenario
+    // written before 2026-09-12 keeps its original expected numbers.
+    logic [15:0] tsecs    = 16'd7200;
+    logic [23:0] lblk10   = 24'd0;
+    logic        lrate_ok = 1'b0;
+
     always #5 clk = ~clk;
 
     scrub_ctrl #(.T1(T1_C), .T2(T2_C), .T3(T3_C), .TICK(TICK_C), .LINGER(LING_C)) dut (
         .clk(clk), .rst_n(rst_n),
         .held_right(held_right), .held_left(held_left), .in_title(in_title),
         .cur_rbn(cur_rbn), .title_first_rbn(title_first), .title_last_rbn(title_last),
+        .title_secs(tsecs), .lin_blk10(lblk10), .lin_rate_ok(lrate_ok),
         .seek_rbn_pulse(seek_rbn_pulse), .seek_rbn(seek_rbn),
         .hold_freeze(hold_freeze),
         .bar_active(bar_active), .bar_base_rbn(bar_base_rbn), .bar_tgt_rbn(bar_tgt_rbn),
@@ -50,6 +64,7 @@ module scrub_ctrl_tb;
         .clk(clk), .rst_n(1'b0),
         .held_right(1'b0), .held_left(1'b0), .in_title(1'b0),
         .cur_rbn(32'd0), .title_first_rbn(32'd0), .title_last_rbn(32'd0),
+        .title_secs(16'd0), .lin_blk10(24'd0), .lin_rate_ok(1'b0),
         .seek_rbn_pulse(), .seek_rbn(),
         .hold_freeze(),
         .bar_active(), .bar_base_rbn(), .bar_tgt_rbn(),
@@ -58,7 +73,10 @@ module scrub_ctrl_tb;
     );
 
     integer errors = 0;
-    task automatic chk(input cond, input [255:0] msg);
+    // ⚠ 128 chars, not the original 32: a [255:0] message SILENTLY TRUNCATES
+    // from the left, so a long assertion label printed as "hin 2x of the 2 h
+    // rate" and nothing downstream could grep for the arm that failed.
+    task automatic chk(input cond, input [1023:0] msg);
         if (!cond) begin $display("  FAIL: %0s", msg); errors = errors + 1; end
     endtask
 
@@ -105,7 +123,18 @@ module scrub_ctrl_tb;
         end
     endtask
 
-    integer fwd_short, fwd_long;
+    integer fwd_short, fwd_long, ms_tick, ss;
+
+    // A measured linear step, converted into CONTENT-SECONDS PER SECOND using
+    // the SHIPPED tick period -- step blocks is step * 10000 / blk10 content-ms,
+    // and there are 27e6 / TICK ticks a second.
+    function automatic integer lin_rate(input [31:0] stp);
+        integer ms_per_tick;
+        begin
+            ms_per_tick = (stp * 10000) / 861;
+            lin_rate    = (ms_per_tick * (27_000_000 / dut_def.TICK)) / 1000;
+        end
+    endfunction
 
     // fire a resolved jump (one cycle), then let the jump_go stage land.
     task automatic jump(input dir, input [31:0] base, input [31:0] off);
@@ -270,8 +299,94 @@ module scrub_ctrl_tb;
         chk(dut_def.SH1 == 5'd10,       "defaults: SH1 = 10");
         chk(dut_def.SH2 == 5'd8,        "defaults: SH2 = 8");
         chk(dut_def.SH3 == 5'd6,        "defaults: SH3 = 6");
+        chk(dut_def.LS0 == 5'd5,        "defaults: LS0 = 5");
+        chk(dut_def.LS1 == 5'd3,        "defaults: LS1 = 3");
+        chk(dut_def.LS2 == 5'd1,        "defaults: LS2 = 1");
+        chk(dut_def.LS3 == 5'd0,        "defaults: LS3 = 0");
+        chk(dut_def.SECS_REF == 5'd12,  "defaults: SECS_REF = 12 (the 2 h anchor)");
         // T3 must fit hold_cnt (28 bits) or the ramp would never reach tier 3.
         chk(dut_def.T3  < 28'h fff_ffff, "defaults: T3 fits hold_cnt");
+
+        // ---------- TEST 16: the 2 h ANCHOR -- an unchanged step -----------
+        // The duration bucket may only move titles AWAY from two hours. Every
+        // title whose leading one sits at bit 12 (4096..8191 s = 68..136 min)
+        // must produce the step that shipped, and so must a title whose length
+        // is not known yet. Measured against the same numbers TEST 13 pins.
+        $display("TEST 16: the 2 h anchor is bit-identical");
+        title_first = 32'd0; title_last = 32'd1000000;
+        tsecs = 16'd4096; cur_rbn = 32'd100000; tick(4);
+        held_right = 1'b1; tick(60);
+        chk(last_delta == 32'd245, "anchor: 4096 s (the bucket's floor) = span>>12");
+        held_right = 1'b0; tick(8);
+        tsecs = 16'd8191; cur_rbn = 32'd100000; tick(4);
+        held_right = 1'b1; tick(60);
+        chk(last_delta == 32'd245, "anchor: 8191 s (the bucket's ceiling) = span>>12");
+        held_right = 1'b0; tick(8);
+        tsecs = 16'd0; cur_rbn = 32'd100000; tick(4);
+        held_right = 1'b1; tick(60);
+        chk(last_delta == 32'd245, "anchor: an unknown duration keeps the old step");
+        held_right = 1'b0; tick(8);
+        // ...and a title well away from the anchor must NOT be unchanged, or the
+        // bucket is inert and this whole arm proves nothing.
+        tsecs = 16'd180; cur_rbn = 32'd100000; tick(4);
+        held_right = 1'b1; tick(60);
+        chk(last_delta != 32'd245, "anchor: a 3-minute title does move off the shipped step");
+        held_right = 1'b0; tick(8);
+        tsecs = 16'd7200;
+
+        // ---------- TEST 17: a short title scrubs at a COMPARABLE RATE -------
+        // The defect, in the units a viewer feels. A 3-minute clip measured
+        // 15504 sectors and 0.58 content-seconds per second at tier 0, against
+        // 29 for a 2 h feature -- the shorter the title, the slower the scrub.
+        // Scored as content-MILLISECONDS PER TICK (step * title_secs / span), so
+        // this is a rate the user experiences and not a restatement of the shift.
+        $display("TEST 17: a 3-minute title, scored as a content rate");
+        title_first = 32'd0; title_last = 32'd15504; tsecs = 16'd180;
+        cur_rbn = 32'd200; tick(4);
+        held_right = 1'b1; tick(40);            // inside tier 0, before the cap
+        ms_tick = (last_delta * 180 * 1000) / 15504;
+        held_right = 1'b0; tick(8);
+        $display("  tier 0 on a 3-minute clip: step=%0d sectors = %0d content-ms/tick",
+                 last_delta, ms_tick);
+        // The 2 h reference is 1054 * 7200 * 1000 / 4320000 = 1757 ms/tick. Half
+        // to double that is the band; the pre-change RTL scores 34 and the `| 1`
+        // floor alone scores 11, so both failure shapes are outside it.
+        chk(ms_tick >= 878 && ms_tick <= 3514,
+            "rate: a 3-minute clip scrubs within 2x of the 2 h rate at tier 0");
+        title_first = 32'd0; title_last = 32'd1000000; tsecs = 16'd7200;
+
+        // ---------- TEST 18: the LINEAR arm, in content-seconds per second ----
+        // lin_blk10 is blocks per 10 s, so the shift IS the rate and the bench
+        // can say so in the user's units. The tick rate comes from the SHIPPED
+        // TICK parameter (read off the defaults instance), not from this bench's
+        // shrunk override -- otherwise "seconds per second" would be fiction.
+        $display("TEST 18: the linear ladder as content-seconds per second");
+        lblk10 = 24'd861;                       // exact CD geometry (VCD/SVCD)
+        lrate_ok = 1'b1;
+        cur_rbn = 32'd100000; tick(4);
+        held_right = 1'b1;
+        tick(60);   ss = lin_rate(last_delta);
+        $display("  tier 0: step=%0d blocks = %0d content-s/s", last_delta, ss);
+        chk(last_delta == 32'd27 && ss >= 4 && ss <= 7,   "linear: tier 0 ~5 s/s");
+        tick(100);  ss = lin_rate(last_delta);
+        $display("  tier 1: step=%0d blocks = %0d content-s/s", last_delta, ss);
+        chk(last_delta == 32'd107 && ss >= 17 && ss <= 26, "linear: tier 1 ~21 s/s");
+        tick(100);  ss = lin_rate(last_delta);
+        $display("  tier 2: step=%0d blocks = %0d content-s/s", last_delta, ss);
+        chk(last_delta == 32'd431 && ss >= 70 && ss <= 100, "linear: tier 2 ~83 s/s");
+        tick(120);  ss = lin_rate(last_delta);
+        $display("  tier 3: step=%0d blocks = %0d content-s/s", last_delta, ss);
+        chk(last_delta == 32'd861 && ss >= 140 && ss <= 200, "linear: tier 3 ~167 s/s");
+        held_right = 1'b0; tick(8);
+        // ...and the rate must be TRUSTED, not merely present: with the valid
+        // flag low the module falls back to the span path exactly as it shipped.
+        // (dvd/dpad_seek.sv's precedent -- a zero rate through this arm would
+        // pin the step at the `| 1` floor and the scrub would look broken.)
+        lrate_ok = 1'b0; lblk10 = 24'd0;
+        cur_rbn = 32'd100000; tick(4);
+        held_right = 1'b1; tick(60);
+        chk(last_delta == 32'd245, "linear: an untrusted rate falls back to the span step");
+        held_right = 1'b0; tick(8);
 
         if (errors == 0) $display("\nscrub_ctrl_tb: ALL TESTS PASSED");
         else begin

--- a/bench/dvd/scrub_ctrl_tb.sv
+++ b/bench/dvd/scrub_ctrl_tb.sv
@@ -123,7 +123,24 @@ module scrub_ctrl_tb;
         end
     endtask
 
-    integer fwd_short, fwd_long, ms_tick, ss;
+    integer fwd_short, fwd_long, ms_tick, ss, ti;
+    integer d_ms [0:3];                  // DVD content-ms per tick, by tier
+    integer l_ms [0:3];                  // ...and the linear path's, same unit
+
+    // A measured step converted to CONTENT-MILLISECONDS PER TICK, from each
+    // source's own geometry: a DVD step is sectors against span/title_secs, a
+    // linear step is blocks against blk10/10 s. Same unit at the end, which is
+    // what makes TEST 19 a comparison rather than a restatement.
+    // ⚠ Folded as (stp * 7200) / 1000, NOT (stp * 7200 * 1000) / 1000000: a
+    // Verilog `integer` is 32 bits, and the literal form overflows at tier 2
+    // (1953 * 7200 * 1000 = 1.4e10). It reported 1176 ms/tick against a true
+    // 14061 -- i.e. the parity arm failed on its own arithmetic, not the RTL's.
+    function automatic integer dvd_ms(input [31:0] stp);
+        dvd_ms = (stp * 7200) / 1000;          // span is 1_000_000 in these arms
+    endfunction
+    function automatic integer lin_ms(input [31:0] stp);
+        lin_ms = (stp * 10000) / 861;
+    endfunction
 
     // A measured linear step, converted into CONTENT-SECONDS PER SECOND using
     // the SHIPPED tick period -- step blocks is step * 10000 / blk10 content-ms,
@@ -131,7 +148,7 @@ module scrub_ctrl_tb;
     function automatic integer lin_rate(input [31:0] stp);
         integer ms_per_tick;
         begin
-            ms_per_tick = (stp * 10000) / 861;
+            ms_per_tick = lin_ms(stp);
             lin_rate    = (ms_per_tick * (27_000_000 / dut_def.TICK)) / 1000;
         end
     endfunction
@@ -258,16 +275,16 @@ module scrub_ctrl_tb;
         in_title = 1; tick(2);
 
         // ---------- TEST 13: the acceleration ladder, MEASURED ----------
-        // span = 1_000_000, so the shipped {12,10,8,6} ladder gives
-        // (span>>SH)|1 = 245 / 977 / 3907 / 15625 sectors per tick. Measured off
+        // span = 1_000_000, so the shipped {13,11,9,7} ladder gives
+        // (span>>SH)|1 = 123 / 489 / 1953 / 7813 sectors per tick. Measured off
         // bar_tgt_rbn, not read out of the DUT, so a changed ladder fails here.
-        $display("TEST 13: acceleration ladder (span >> {12,10,8,6})");
+        $display("TEST 13: acceleration ladder (span >> {13,11,9,7})");
         cur_rbn = 32'd100000; tick(4);
         held_right = 1'b1;
-        tick(60);   chk(last_delta == 32'd245,   "ladder: tier 0 step = span>>12");
-        tick(100);  chk(last_delta == 32'd977,   "ladder: tier 1 step = span>>10");
-        tick(100);  chk(last_delta == 32'd3907,  "ladder: tier 2 step = span>>8");
-        tick(120);  chk(last_delta == 32'd15625, "ladder: tier 3 step = span>>6");
+        tick(60);   chk(last_delta == 32'd123,  "ladder: tier 0 step = span>>13");
+        tick(100);  chk(last_delta == 32'd489,  "ladder: tier 1 step = span>>11");
+        tick(100);  chk(last_delta == 32'd1953, "ladder: tier 2 step = span>>9");
+        tick(120);  chk(last_delta == 32'd7813, "ladder: tier 3 step = span>>7");
         held_right = 1'b0; tick(6);
 
         // ---------- TEST 14: the tier boundaries sit on T1/T2/T3 ----------
@@ -279,12 +296,12 @@ module scrub_ctrl_tb;
         $display("TEST 14: tier boundaries");
         cur_rbn = 32'd100000; tick(4);
         hc = 0; held_right = 1'b1;
-        hold_until(T1_C - 2);        chk(last_delta == 32'd245,   "bound: tier 0 holds to T1");
-        hold_until(T1_C + SETTLE);   chk(last_delta == 32'd977,   "bound: tier 1 after T1");
-        hold_until(T2_C - 2);        chk(last_delta == 32'd977,   "bound: tier 1 holds to T2");
-        hold_until(T2_C + SETTLE);   chk(last_delta == 32'd3907,  "bound: tier 2 after T2");
-        hold_until(T3_C - 2);        chk(last_delta == 32'd3907,  "bound: tier 2 holds to T3");
-        hold_until(T3_C + SETTLE);   chk(last_delta == 32'd15625, "bound: tier 3 after T3");
+        hold_until(T1_C - 2);        chk(last_delta == 32'd123,  "bound: tier 0 holds to T1");
+        hold_until(T1_C + SETTLE);   chk(last_delta == 32'd489,  "bound: tier 1 after T1");
+        hold_until(T2_C - 2);        chk(last_delta == 32'd489,  "bound: tier 1 holds to T2");
+        hold_until(T2_C + SETTLE);   chk(last_delta == 32'd1953, "bound: tier 2 after T2");
+        hold_until(T3_C - 2);        chk(last_delta == 32'd1953, "bound: tier 2 holds to T3");
+        hold_until(T3_C + SETTLE);   chk(last_delta == 32'd7813, "bound: tier 3 after T3");
         held_right = 1'b0; tick(6);
 
         // ---------- TEST 15: the SHIPPED defaults are the intended feel ----------
@@ -295,42 +312,54 @@ module scrub_ctrl_tb;
         chk(dut_def.T1  == 54_000_000,  "defaults: T1 = 2.0 s @ 27 MHz");
         chk(dut_def.T2  == 121_500_000, "defaults: T2 = 4.5 s @ 27 MHz");
         chk(dut_def.T3  == 216_000_000, "defaults: T3 = 8.0 s @ 27 MHz");
-        chk(dut_def.SH0 == 5'd12,       "defaults: SH0 = 12");
-        chk(dut_def.SH1 == 5'd10,       "defaults: SH1 = 10");
-        chk(dut_def.SH2 == 5'd8,        "defaults: SH2 = 8");
-        chk(dut_def.SH3 == 5'd6,        "defaults: SH3 = 6");
-        chk(dut_def.LS0 == 5'd5,        "defaults: LS0 = 5");
-        chk(dut_def.LS1 == 5'd3,        "defaults: LS1 = 3");
-        chk(dut_def.LS2 == 5'd1,        "defaults: LS2 = 1");
+        chk(dut_def.SH0 == 5'd13,       "defaults: SH0 = 13");
+        chk(dut_def.SH1 == 5'd11,       "defaults: SH1 = 11");
+        chk(dut_def.SH2 == 5'd9,        "defaults: SH2 = 9");
+        chk(dut_def.SH3 == 5'd7,        "defaults: SH3 = 7");
+        chk(dut_def.LS0 == 5'd6,        "defaults: LS0 = 6");
+        chk(dut_def.LS1 == 5'd4,        "defaults: LS1 = 4");
+        chk(dut_def.LS2 == 5'd2,        "defaults: LS2 = 2");
         chk(dut_def.LS3 == 5'd0,        "defaults: LS3 = 0");
+        chk(dut_def.LIN_K == 3'd6,      "defaults: LIN_K = 6 (the lattice scale)");
+        // SHn - LSn must be the SAME at every tier, or the two sources ramp at
+        // different shapes however well tier 0 is matched.
+        chk((dut_def.SH0 - dut_def.LS0) == (dut_def.SH1 - dut_def.LS1) &&
+            (dut_def.SH1 - dut_def.LS1) == (dut_def.SH2 - dut_def.LS2) &&
+            (dut_def.SH2 - dut_def.LS2) == (dut_def.SH3 - dut_def.LS3),
+            "defaults: the two ladders step in lockstep");
         chk(dut_def.SECS_REF == 5'd12,  "defaults: SECS_REF = 12 (the 2 h anchor)");
         // T3 must fit hold_cnt (28 bits) or the ramp would never reach tier 3.
         chk(dut_def.T3  < 28'h fff_ffff, "defaults: T3 fits hold_cnt");
 
-        // ---------- TEST 16: the 2 h ANCHOR -- an unchanged step -----------
+        // ---------- TEST 16: the 2 h ANCHOR is where SHn means what it says --
         // The duration bucket may only move titles AWAY from two hours. Every
         // title whose leading one sits at bit 12 (4096..8191 s = 68..136 min)
-        // must produce the step that shipped, and so must a title whose length
-        // is not known yet. Measured against the same numbers TEST 13 pins.
-        $display("TEST 16: the 2 h anchor is bit-identical");
+        // must take SHn unbiased, and so must a title whose length is not known
+        // yet. Measured against the same numbers TEST 13 pins.
+        // ⚠ This arm used to be titled "bit-identical" -- it meant identical to
+        // the pre-2026-09-12 build, and that property was given up deliberately
+        // when the two sources were made to ramp at the same speed (the DVD
+        // ladder halved). The anchor still exists and is still load-bearing; it
+        // just anchors the ladder rather than preserving an old one.
+        $display("TEST 16: the 2 h anchor takes SHn unbiased");
         title_first = 32'd0; title_last = 32'd1000000;
         tsecs = 16'd4096; cur_rbn = 32'd100000; tick(4);
         held_right = 1'b1; tick(60);
-        chk(last_delta == 32'd245, "anchor: 4096 s (the bucket's floor) = span>>12");
+        chk(last_delta == 32'd123, "anchor: 4096 s (the bucket's floor) = span>>13");
         held_right = 1'b0; tick(8);
         tsecs = 16'd8191; cur_rbn = 32'd100000; tick(4);
         held_right = 1'b1; tick(60);
-        chk(last_delta == 32'd245, "anchor: 8191 s (the bucket's ceiling) = span>>12");
+        chk(last_delta == 32'd123, "anchor: 8191 s (the bucket's ceiling) = span>>13");
         held_right = 1'b0; tick(8);
         tsecs = 16'd0; cur_rbn = 32'd100000; tick(4);
         held_right = 1'b1; tick(60);
-        chk(last_delta == 32'd245, "anchor: an unknown duration keeps the old step");
+        chk(last_delta == 32'd123, "anchor: an unknown duration takes SHn unbiased");
         held_right = 1'b0; tick(8);
         // ...and a title well away from the anchor must NOT be unchanged, or the
         // bucket is inert and this whole arm proves nothing.
         tsecs = 16'd180; cur_rbn = 32'd100000; tick(4);
         held_right = 1'b1; tick(60);
-        chk(last_delta != 32'd245, "anchor: a 3-minute title does move off the shipped step");
+        chk(last_delta != 32'd123, "anchor: a 3-minute title does move off the anchor step");
         held_right = 1'b0; tick(8);
         tsecs = 16'd7200;
 
@@ -348,10 +377,10 @@ module scrub_ctrl_tb;
         held_right = 1'b0; tick(8);
         $display("  tier 0 on a 3-minute clip: step=%0d sectors = %0d content-ms/tick",
                  last_delta, ms_tick);
-        // The 2 h reference is 1054 * 7200 * 1000 / 4320000 = 1757 ms/tick. Half
-        // to double that is the band; the pre-change RTL scores 34 and the `| 1`
-        // floor alone scores 11, so both failure shapes are outside it.
-        chk(ms_tick >= 878 && ms_tick <= 3514,
+        // The 2 h reference is title_secs / 2^13 = 7200000/8192 = 879 ms/tick.
+        // Half to double that is the band; the pre-change RTL scores 34 and the
+        // `| 1` floor alone scores 11, so both failure shapes are outside it.
+        chk(ms_tick >= 439 && ms_tick <= 1758,
             "rate: a 3-minute clip scrubs within 2x of the 2 h rate at tier 0");
         title_first = 32'd0; title_last = 32'd1000000; tsecs = 16'd7200;
 
@@ -365,18 +394,18 @@ module scrub_ctrl_tb;
         lrate_ok = 1'b1;
         cur_rbn = 32'd100000; tick(4);
         held_right = 1'b1;
-        tick(60);   ss = lin_rate(last_delta);
+        tick(60);   ss = lin_rate(last_delta); l_ms[0] = lin_ms(last_delta);
         $display("  tier 0: step=%0d blocks = %0d content-s/s", last_delta, ss);
-        chk(last_delta == 32'd27 && ss >= 4 && ss <= 7,   "linear: tier 0 ~5 s/s");
-        tick(100);  ss = lin_rate(last_delta);
+        chk(last_delta == 32'd81 && ss >= 13 && ss <= 19,  "linear: tier 0 ~16 s/s");
+        tick(100);  ss = lin_rate(last_delta); l_ms[1] = lin_ms(last_delta);
         $display("  tier 1: step=%0d blocks = %0d content-s/s", last_delta, ss);
-        chk(last_delta == 32'd107 && ss >= 17 && ss <= 26, "linear: tier 1 ~21 s/s");
-        tick(100);  ss = lin_rate(last_delta);
+        chk(last_delta == 32'd323 && ss >= 53 && ss <= 75, "linear: tier 1 ~63 s/s");
+        tick(100);  ss = lin_rate(last_delta); l_ms[2] = lin_ms(last_delta);
         $display("  tier 2: step=%0d blocks = %0d content-s/s", last_delta, ss);
-        chk(last_delta == 32'd431 && ss >= 70 && ss <= 100, "linear: tier 2 ~83 s/s");
-        tick(120);  ss = lin_rate(last_delta);
+        chk(last_delta == 32'd1291 && ss >= 210 && ss <= 290, "linear: tier 2 ~250 s/s");
+        tick(120);  ss = lin_rate(last_delta); l_ms[3] = lin_ms(last_delta);
         $display("  tier 3: step=%0d blocks = %0d content-s/s", last_delta, ss);
-        chk(last_delta == 32'd861 && ss >= 140 && ss <= 200, "linear: tier 3 ~167 s/s");
+        chk(last_delta == 32'd5167 && ss >= 850 && ss <= 1150, "linear: tier 3 ~1000 s/s");
         held_right = 1'b0; tick(8);
         // ...and the rate must be TRUSTED, not merely present: with the valid
         // flag low the module falls back to the span path exactly as it shipped.
@@ -385,8 +414,37 @@ module scrub_ctrl_tb;
         lrate_ok = 1'b0; lblk10 = 24'd0;
         cur_rbn = 32'd100000; tick(4);
         held_right = 1'b1; tick(60);
-        chk(last_delta == 32'd245, "linear: an untrusted rate falls back to the span step");
+        chk(last_delta == 32'd123, "linear: an untrusted rate falls back to the span step");
         held_right = 1'b0; tick(8);
+
+        // ---------- TEST 19: THE TWO SOURCES RAMP AT THE SAME SPEED ----------
+        // The reason the ladder moved at all (maintainer, 2026-09-12: "these both
+        // should have the same seek steps -- maybe we meet in the middle"). Before
+        // it, a DVD ran 29/117/469/1875 content-s/s and a .mpg 5/21/83/167, so the
+        // same tier meant a 5-10x different speed depending on what was mounted.
+        // Scored by converting BOTH measured steps into content-MILLISECONDS PER
+        // TICK -- the same unit, derived from each source's own geometry, so this
+        // cannot pass by restating either shift.
+        $display("TEST 19: the DVD and linear ladders agree");
+        lrate_ok = 1'b0; tsecs = 16'd7200;
+        title_first = 32'd0; title_last = 32'd1000000;
+        cur_rbn = 32'd100000; tick(4);
+        held_right = 1'b1;
+        tick(60);  d_ms[0] = dvd_ms(last_delta);
+        tick(100); d_ms[1] = dvd_ms(last_delta);
+        tick(100); d_ms[2] = dvd_ms(last_delta);
+        tick(120); d_ms[3] = dvd_ms(last_delta);
+        held_right = 1'b0; tick(8);
+        for (ti = 0; ti < 4; ti = ti + 1) begin
+            $display("  tier %0d: DVD %0d ms/tick vs linear %0d ms/tick",
+                     ti, d_ms[ti], l_ms[ti]);
+            // Within 25% either way. The floor on how close they CAN be is set by
+            // arithmetic, not by tuning: unscaled, the linear lattice is 166.7/2^n
+            // and the DVD one 120000/2^m, which are half a power of two (41%)
+            // apart -- LIN_K = 6 is what brings them to ~7%.
+            chk((d_ms[ti] * 4 <= l_ms[ti] * 5) && (l_ms[ti] * 4 <= d_ms[ti] * 5),
+                "parity: this tier scrubs at the same speed on both sources");
+        end
 
         if (errors == 0) $display("\nscrub_ctrl_tb: ALL TESTS PASSED");
         else begin

--- a/bench/dvd/transport_hud_tb.sv
+++ b/bench/dvd/transport_hud_tb.sv
@@ -4,8 +4,8 @@
 // ASCII against expected strings) plus the visibility ledger:
 //   T1: persist toggle (B9) -> visible; play icon + times + CH n/N formatted
 //   T2: pause -> pause icon
-//   T3: scrub fwd tier2 -> ">>x3" icon field
-//   T4: scrub rev tier0 -> "<<x1"
+//   T3: scrub fwd tier2 -> ">>>>" (arrows COUNT the tier; there is no "xN")
+//   T4: scrub rev tier0 -> "<<"
 //   T5: CH section hidden when cur_pgm = 0
 //   T6: menu_active suppresses visibility (persist survives -> back on resume)
 //   T7: show_evt arms the timer; expires after SHOW_TICKS (shrunk for sim)
@@ -150,25 +150,38 @@ module transport_hud_tb;
         check_vis("T1a hidden at boot", 1'b0);
         @(posedge clk); display_edge = 1; @(posedge clk); display_edge = 0;
         check_vis("T1b persist on", 1'b1);
-        check_line("T1c play line", ">    0:12:34/1:37:05 CH 12/23~~~");
+        check_line("T1c play line", ">     0:12:34/1:37:05 CH 12/23~~");
 
         // T2: pause icon
         pause_q = 1;
-        check_line("T2 pause icon", "\"    0:12:34/1:37:05 CH 12/23~~~");
+        check_line("T2 pause icon", "\"     0:12:34/1:37:05 CH 12/23~~");
         pause_q = 0;
 
-        // T3: scrub forward, tier 2 -> ">>x3"
+        // T3: scrub forward, tier 2 -> four arrows.
+        // ★ COUNTED, not decoded from a digit: the whole point of the 2026-09-12
+        // change is that the glyphs themselves carry the tier, so the test has to
+        // read the same thing a viewer does. A digit would have let "x3" pass for
+        // any tier whose ordinal happened to render.
         scrub_held = 1; scrub_dir = 1; scrub_tier = 2'd2; bar_active = 1;
-        check_line("T3 ffwd x3", ">>x3 0:12:34/1:37:05 CH 12/23~~~");
+        check_line("T3 ffwd tier2 = 4 arrows", ">>>>  0:12:34/1:37:05 CH 12/23~~");
 
-        // T4: scrub reverse, tier 0 -> "<<x1"
+        // T4: scrub reverse, tier 0 -> two arrows, and reversed glyphs.
         scrub_dir = 0; scrub_tier = 2'd0;
-        check_line("T4 rev x1", "<<x1 0:12:34/1:37:05 CH 12/23~~~");
+        check_line("T4 rev tier0 = 2 arrows", "<<    0:12:34/1:37:05 CH 12/23~~");
+
+        // T4b: the two ends of the ladder, so a count that ignored the tier or
+        // saturated at one end cannot pass. Tier 0 is 2 arrows (T4); tier 3 is 5,
+        // which is the case that cost the extra column.
+        scrub_dir = 1; scrub_tier = 2'd3;
+        check_line("T4b ffwd tier3 = 5 arrows", ">>>>> 0:12:34/1:37:05 CH 12/23~~");
+        scrub_tier = 2'd1;
+        check_line("T4c ffwd tier1 = 3 arrows", ">>>   0:12:34/1:37:05 CH 12/23~~");
+        scrub_tier = 2'd2;
         scrub_held = 0; bar_active = 0;
 
         // T5: CH hidden when unresolved
         cur_pgm = 8'd0;
-        check_line("T5 no chapter", ">    0:12:34/1:37:05         ~~~");
+        check_line("T5 no chapter", ">     0:12:34/1:37:05         ~~");
         cur_pgm = 8'd12;
 
         // T6: menu suppression (persist survives)
@@ -375,11 +388,16 @@ module transport_hud_tb;
 
         // ---- T20: the status-line icon field renders the tap count -----
         // emu drives scrub_held|dpad_pend / dpad_pend_n into these taps, so a
-        // 3-tap D-pad gesture must read as ">>x3" exactly like a scrub tier.
-        scrub_held = 1; scrub_dir = 1; scrub_tier = 2'd2;
+        // ⚠ A D-PAD GESTURE HAS NO SPEED TIER. emu.sv feeds this port 2'd0 on
+        // that arm (it used to feed the TAP COUNT), so the icon is two plain
+        // direction arrows and the magnitude is the popup's job -- checked below
+        // as "SEEK FWD". Driving 2'd0 here is not a weaker test than the old
+        // 2'd2: what emu puts on the wire is invisible to any module-level bench
+        // (the issue #81 lesson), so run_scrub_tiers.sh greps emu.sv for it.
+        scrub_held = 1; scrub_dir = 1; scrub_tier = 2'd0;
         cur_time = 32'h00123400; total_time = 32'h01370500;
         cur_pgm = 8'd12; nr_pgm = 8'd23; @(posedge clk);
-        check_line("T20 dpad tap count icon", ">>x3 0:12:34/1:37:05 CH 12/23~~~");
+        check_line("T20 dpad = direction only", ">>    0:12:34/1:37:05 CH 12/23~~");
         scrub_held = 0; scrub_tier = 2'd0; @(posedge clk);
 
         if (errors == 0) $display("TRANSPORT_HUD_TB: ALL TESTS PASSED");

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -1474,6 +1474,21 @@ Mechanics (all in `scrub_ctrl`, sector/RBN-based against the title span
   The DVD/linear gap is now smaller than this spread, which is the honest place to stop.
   ⚠ To retune the feel, move **`SHn` and `LSn` together** — one shift is one factor of two on
   either side. `scrub_ctrl_tb` T19 fails if they drift apart.
+  ✅ **HW-CONFIRMED 2026-09-12 — THE FEEL, WHICH IS THE ONLY THING THAT COULD SETTLE IT**
+  (build `DVD_scrubtiers_20260912_2135.rbf`, flashed to the rig and held on a physical
+  disc; maintainer: *"that scrub speed feels good"*).
+  ★ **The harness could not have answered this and never will:** `dvd/kbd_map.sv`
+  deliberately routes keyboard Fast Fwd/Rewind to `dvd/dpad_seek.sv`, never to
+  `scrub_ctrl`'s hold-to-scrub — an IR "hold" is ~9 discrete taps a second, which on the
+  hold path is ~9 flush/re-locks a second, the regime HW rounds 1–2 proved fatal. So
+  `joy_eff` masks those keys out and the gesture is reachable **only from a gamepad**. A
+  tier ladder is a feel setting whose instrument is a person, and this is the second
+  retune (2026-09-03 was the first) decided the same way.
+  ⏳ **NOT covered by that round, and each needs the same hands:** the LINEAR half (a
+  `.mpg`/VCD held at the same tiers — the parity claim is pinned in sim to 7 % but has
+  never been felt), a SHORT title (the 0.58 s/s case the change exists for), and the
+  arrow readout replacing `×1..×4`. The disc under test was an ordinary feature, i.e. the
+  anchor bucket — the one length whose behaviour moved least.
   ⚠ **The ladders and the dwells are `scrub_ctrl` parameters (`SH0..SH3`, `LS0..LS3`,
   `T1..T3`, `SECS_REF`).** The span ladder was relaxed once already on 2026-09-03 after a
   user report that the scrub "ramps up too fast": the original `{10,8,6,5}` / 0-1.5-3-5 s

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -1476,7 +1476,9 @@ Mechanics (all in `scrub_ctrl`, sector/RBN-based against the title span
   position for the Phase-11 on-screen position bar — **✅ built: `dvd/seek_bar.sv`**
   (✅ HW-CONFIRMED 2026-07-10, PR fj#103): fill = playhead at hold start, amber cursor = the
   accumulating release target, + a pause/seek progress popup with chapter ticks. The status
-  line shows `►►×n` while held (`hud_tier`/`hud_dir` exports). See `docs/transport_hud.md`.
+  line shows 2-5 direction arrows while held, one per speed tier (`hud_tier`/`hud_dir`
+  exports; it printed `►►×n` until 2026-09-12 — see `docs/transport_hud.md` for why a
+  multiplier was the wrong glyph for an ordinal).
 
 ### Golden references + tests
 
@@ -1604,7 +1606,10 @@ the rest of the title transport. Combined with the default-Off toggle, the 2026-
 guarantee below is preserved for anyone who does not ask for this.
 
 **Feedback.** `pend_evt` joins `hud_user_evt`, so the position bar pops on the **first** press;
-the status line renders the tap count in the shared `►►×n` field; and a new popup type reads
+the status line renders **direction arrows only** in the shared icon field (it rendered the
+tap COUNT there until 2026-09-12 — a count is not a speed, and the field now draws speed as
+an arrow count, so four taps would have read as the fastest scrub tier; the magnitude was
+always the popup's job anyway); and a new popup type reads
 **`SEEK FWD  30S` / `SEEK BACK 60S`** (the sign is *spelled* because the glyph ROM has no `+`,
 which keeps `tools/hud_font.py` and the committed `dvd/hud_font.mem` untouched).
 
@@ -1732,7 +1737,7 @@ at all — and that is why it is a separate feature rather than another seek mod
 - The decoder's upstream `REG_WR_TRICK` register carries `repeat_frame[9:5]` + `persistence`
   and is already used to hold a picture during pause — the native hook for showing each
   I-frame for N refreshes.
-- `dvd/transport_hud.sv` already renders a `►►×n` tier, and `dvd/scrub_ctrl.sv` already owns
+- `dvd/transport_hud.sv` already renders the tier as an arrow count, and `dvd/scrub_ctrl.sv` already owns
   FF/REW with an acceleration tier.
 
 **The hard constraint.** The splice must be **flush-free**. `dvd/dpad_seek.sv`'s header

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -1484,11 +1484,17 @@ Mechanics (all in `scrub_ctrl`, sector/RBN-based against the title span
   `joy_eff` masks those keys out and the gesture is reachable **only from a gamepad**. A
   tier ladder is a feel setting whose instrument is a person, and this is the second
   retune (2026-09-03 was the first) decided the same way.
-  ⏳ **NOT covered by that round, and each needs the same hands:** the LINEAR half (a
-  `.mpg`/VCD held at the same tiers — the parity claim is pinned in sim to 7 % but has
-  never been felt), a SHORT title (the 0.58 s/s case the change exists for), and the
-  arrow readout replacing `×1..×4`. The disc under test was an ordinary feature, i.e. the
-  anchor bucket — the one length whose behaviour moved least.
+  ✅ **AND THE REST OF THE ROUND CAME BACK GOOD THE SAME DAY** (maintainer: *"all those
+  open scrub questions look and feel good on the board"*), so the branch is confirmed
+  whole rather than on its easiest path: the **LINEAR half** held at the same tiers —
+  which is the parity claim itself, felt rather than only pinned in sim to 7 % — a
+  **SHORT title**, which is the 0.58 s/s crawl the change exists for and the case the
+  first disc could not exercise (an ordinary feature sits in the anchor bucket, the one
+  length whose behaviour moved least), and the **arrow readout** that replaced `×1..×4`.
+  ★ Worth keeping straight for anyone retuning this: those two are different mechanisms,
+  not one test twice. A linear file's rate comes from `lin_blk10` and is independent of
+  its length; a DVD's comes from the duration bucket and is nothing but its length. The
+  short-title arm is the only one that exercises `secs_lz` at all.
   ⚠ **The ladders and the dwells are `scrub_ctrl` parameters (`SH0..SH3`, `LS0..LS3`,
   `T1..T3`, `SECS_REF`).** The span ladder was relaxed once already on 2026-09-03 after a
   user report that the scrub "ramps up too fast": the original `{10,8,6,5}` / 0-1.5-3-5 s

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -1435,11 +1435,16 @@ Mechanics (all in `scrub_ctrl`, sector/RBN-based against the title span
   was left (`15504 >> 12 = 3`, losing 21 %; `2584 >> 12 = 0`, losing all of it — the `| 1`
   floor was the only thing still moving the cursor).
   Two step sources now, both in content-seconds:
-  - **Linear** (`.mpg`/VCD/SVCD, `lin_rate_ok`): `lin_blk10 >> LSn`. `lin_blk10` is blocks
-    per 10 s (`dvd/lin_rate.sv`), so the shift **is** the rate — `166.7 / 2^LSn` s/s. Shipped
-    `{5,3,1,0}` ≈ **5 / 21 / 83 / 167 s/s**. ⚠ Gated on the rate being VALID (the
-    `dpad_seek` precedent), never on a zero slipping through; an untrusted rate falls back to
-    the span path, which is exactly what shipped before.
+  - **Linear** (`.mpg`/VCD/SVCD, `lin_rate_ok`): `(lin_blk10 * 6) >> LSn`. `lin_blk10` is
+    blocks per 10 s (`dvd/lin_rate.sv`), so the shift **is** the rate — `1000 / 2^LSn` s/s,
+    and `{6,4,2,0}` ≈ **16 / 63 / 250 / 1000 s/s**.
+    ★★ **The `* 6` aligns two lattices that otherwise cannot meet.** Unscaled this path can
+    only produce `166.7 / 2^n` while the DVD path produces `120000 / 2^m` at the anchor;
+    those differ by `720 = 2^9.49` — **half a power of two** — so no choice of `SHn`/`LSn`
+    brings them closer than **41 %**. Scaling by 6 lands them on one lattice (7 % apart) and
+    removes the negative shifts the unscaled match would need at the top tiers. Cost: two
+    shifts and an adder. ⚠ Gated on the rate being VALID (the `dpad_seek` precedent), never
+    on a zero slipping through; an untrusted rate falls back to the span path.
   - **DVD**: `span >> (SHn + log2(title_secs) − SECS_REF)`. The span **cancels** out of the
     content rate algebraically — `(span >> sh)` divided by `(span / title_secs)` is
     `title_secs / 2^sh` — so biasing the shift by the title's **duration bucket** (a
@@ -1453,10 +1458,22 @@ Mechanics (all in `scrub_ctrl`, sector/RBN-based against the title span
   **identically** — the divide fixes nothing and costs area. ⚠ The *area* objection to a
   divide has expired (post-reclaim `main` fits at ~87 %); area was never the load-bearing
   reason, so do not re-derive "we have area now, so divide".
-  ⚠ **The two ladders do not agree** — a DVD runs 29/117/469/1875 s/s and a linear file
-  5/21/83/167 — because the DVD numbers are the ones a hardware round signed off and the
-  anchor exists to preserve them. If the top tier reads as inconsistent on hardware, retune
-  `LS0..LS3` upward; do not unpick the anchor.
+  ★ **THE TWO LADDERS AGREE, AND THAT COST THE 2 h IDENTITY — deliberately** (maintainer,
+  2026-09-12: *"these both should have the same seek steps — maybe we meet in the middle"*).
+  The first cut pinned `SHn = {12,10,8,6}` so a 2 h title's step was bit-identical to the
+  hardware-signed-off build, but that left a DVD at 29/117/469/1875 s/s against a `.mpg` at
+  5/21/83/167 — the same tier meaning a 5–10× different speed depending on what was mounted,
+  which is the defect this whole section exists to remove. Meeting in the middle **halves the
+  DVD ladder**: both sources now run **~15 / 60 / 240 / 960 s/s**. The anchor MECHANISM is
+  untouched and still load-bearing — it is what makes the rate absolute rather than
+  span-relative; only its value moved.
+  ⚠ **Residual, and it is now the LARGER error:** the bucket is a power of two, so within one
+  bucket the DVD rate still varies **2×** with title length (a 68-minute title scrubs at
+  8.3 s/s in tier 0, a 2h16 title at 16.7). Removing that means dividing by `title_secs`, and
+  since the step is in SECTORS that is `span / title_secs` — the divide this design refuses.
+  The DVD/linear gap is now smaller than this spread, which is the honest place to stop.
+  ⚠ To retune the feel, move **`SHn` and `LSn` together** — one shift is one factor of two on
+  either side. `scrub_ctrl_tb` T19 fails if they drift apart.
   ⚠ **The ladders and the dwells are `scrub_ctrl` parameters (`SH0..SH3`, `LS0..LS3`,
   `T1..T3`, `SECS_REF`).** The span ladder was relaxed once already on 2026-09-03 after a
   user report that the scrub "ramps up too fast": the original `{10,8,6,5}` / 0-1.5-3-5 s

--- a/docs/dvd_nav.md
+++ b/docs/dvd_nav.md
@@ -1422,16 +1422,49 @@ Mechanics (all in `scrub_ctrl`, sector/RBN-based against the title span
   (`dvd_audio_decode.pause` + drain-watchdog freeze). This is the *same* stable hold as a manual
   pause (the watchdog is suppressed the whole time), so there is no re-lock/watchdog problem.
 - **Accumulate** = on the press edge it latches `base_rbn = cur_rbn` (the live playhead
-  `dsi_nv_pck_lbn`); every ~0.06 s tick it adds a **tier-scaled** step `span >> {12,10,8,6}`
-  sectors (tier 0→3 by hold time 0/2/4.5/8 s) to a signed offset, capped at the title span. A
-  direction flip restarts the accumulation the other way.
-  ⚠ **The ladder and the dwells are `scrub_ctrl` parameters (`SH0..SH3`, `T1..T3`), and they
-  were relaxed on 2026-09-03** after a user report that the scrub "ramps up too fast". The
-  original `{10,8,6,5}` / 0-1.5-3-5 s ladder moved ~2 **minutes** of a 2 h title per second
-  even in tier 0 — there was no fine-positioning tier at all, and 5 s of holding crossed 77
-  minutes. The shipped ladder gives ~29 s → 2 min → 7.8 min → 31 min per second held, and the
-  far end of a 2 h film is ~11 s of holding away. Steps are span-RELATIVE, so the feel is the
-  same fraction-of-title on a 5-minute clip and a 3-hour epic — keep it that way. Pinned by
+  `dsi_nv_pck_lbn`); every ~0.06 s tick it adds a **tier-scaled** step (tier 0→3 by hold time
+  0/2/4.5/8 s) to a signed offset, capped at the title span. A direction flip restarts the
+  accumulation the other way.
+  ★★ **THE STEP IS AN ABSOLUTE CONTENT RATE, NOT A FRACTION OF THE TITLE (2026-09-12).**
+  This paragraph used to end *"steps are span-RELATIVE, so the feel is the same
+  fraction-of-title on a 5-minute clip and a 3-hour epic — keep it that way"*, and that is
+  the decision the change overturns. A fraction of a **short** title is a crawl: MEASURED at
+  tier 0 with `span >> 12`, a 2 h feature moves **29 content-seconds per second**, a 3-minute
+  clip **0.58**, a 30-second clip **0.19** — the shorter the title, the slower the scrub,
+  which is backwards from what the gesture is for. The shift also **truncated** what little
+  was left (`15504 >> 12 = 3`, losing 21 %; `2584 >> 12 = 0`, losing all of it — the `| 1`
+  floor was the only thing still moving the cursor).
+  Two step sources now, both in content-seconds:
+  - **Linear** (`.mpg`/VCD/SVCD, `lin_rate_ok`): `lin_blk10 >> LSn`. `lin_blk10` is blocks
+    per 10 s (`dvd/lin_rate.sv`), so the shift **is** the rate — `166.7 / 2^LSn` s/s. Shipped
+    `{5,3,1,0}` ≈ **5 / 21 / 83 / 167 s/s**. ⚠ Gated on the rate being VALID (the
+    `dpad_seek` precedent), never on a zero slipping through; an untrusted rate falls back to
+    the span path, which is exactly what shipped before.
+  - **DVD**: `span >> (SHn + log2(title_secs) − SECS_REF)`. The span **cancels** out of the
+    content rate algebraically — `(span >> sh)` divided by `(span / title_secs)` is
+    `title_secs / 2^sh` — so biasing the shift by the title's **duration bucket** (a
+    leading-one position, a priority encoder, no divide) fixes the rate. `SECS_REF = 12`
+    anchors it: any title in **4096…8191 s (68–136 min)** gets bias 0 and a **bit-identical**
+    step to what shipped, so the 2 h feel that passed hardware is untouched and only titles
+    far from 2 h move. `title_secs == 0` (not yet known) likewise keeps the old step.
+  ⛔ **Do NOT "improve" the bucket into `span / title_secs`.** On a seamless-branch disc the
+  span holds the other branch's ILVUs (885–1679 sectors/s against a ~600 ceiling,
+  ALIEN_VS_PREDATOR_SE, issue #49) and that inflation hits the bucketed shift and the divide
+  **identically** — the divide fixes nothing and costs area. ⚠ The *area* objection to a
+  divide has expired (post-reclaim `main` fits at ~87 %); area was never the load-bearing
+  reason, so do not re-derive "we have area now, so divide".
+  ⚠ **The two ladders do not agree** — a DVD runs 29/117/469/1875 s/s and a linear file
+  5/21/83/167 — because the DVD numbers are the ones a hardware round signed off and the
+  anchor exists to preserve them. If the top tier reads as inconsistent on hardware, retune
+  `LS0..LS3` upward; do not unpick the anchor.
+  ⚠ **The ladders and the dwells are `scrub_ctrl` parameters (`SH0..SH3`, `LS0..LS3`,
+  `T1..T3`, `SECS_REF`).** The span ladder was relaxed once already on 2026-09-03 after a
+  user report that the scrub "ramps up too fast": the original `{10,8,6,5}` / 0-1.5-3-5 s
+  ladder moved ~2 **minutes** of a 2 h title per second even in tier 0 — no fine-positioning
+  tier at all, and 5 s of holding crossed 77 minutes. Gate:
+  `bench/dvd/run_scrub_tiers.sh --red` (T16 the anchor, T17 the short-title rate in
+  content-ms per tick, T18 the linear ladder in content-seconds per second, one mutant per
+  claim). Pinned by
   `scrub_ctrl_tb` T13 (the ladder, MEASURED off `bar_tgt_rbn` rather than read out of the
   DUT), T14 (the tier boundaries) and T15 (the shipped default parameters, so a retune is
   deliberate). A retune must also move `dvd/scrub_ctrl.sv`'s header, `dvd/dpad_seek.sv`'s
@@ -1466,8 +1499,9 @@ Mechanics (all in `scrub_ctrl`, sector/RBN-based against the title span
 ### 2b. D-Pad fixed-time seek — `O[45]` (`dvd/dpad_seek.sv`) — ✅ HW-CONFIRMED 2026-08-27 (PR #15)
 
 **Opt-in, default Off.** With it On, while a title plays: **Left/Right = ∓10 s,
-Down/Up = ∓60 s** — VLC-style *fixed-time* jumps, as opposed to §2a's span-relative
-("percent of title") scrub. Presses inside a **~400 ms window coalesce into ONE seek**,
+Down/Up = ∓60 s** — VLC-style *fixed-time* jumps, as opposed to §2a's hold-to-scrub,
+which picks a RATE and lets the user stop when the bar looks right (that scrub's step
+stopped being "percent of title" on 2026-09-12 — see §2a). Presses inside a **~400 ms window coalesce into ONE seek**,
 and each further tap re-arms the window, so **keep tapping and the total keeps growing** —
 tap Up twenty times and you get one 20-minute jump. There is no small artificial ceiling:
 `UNIT_CAP` exists only so the **MM:SS** readout stays exact (99:50 is the widest it can

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1508,7 +1508,9 @@ behind the congestion cleanup and built incrementally on the proven overlay laye
 ### What the OSD shows *(✅ HW-CONFIRMED 2026-07-10, PR fj#103; design: `docs/transport_hud.md`)*
 - [x] **Transport state indicator** — play/pause and fast-forward/rewind: `►` / `❚❚` /
   `►►` / `◄◄` with the current scrub speed tier shown as **×1..×4** (since the PR fj#101
-  seek-on-release rework the tiers are span-relative step rates, not fixed seconds).
+  seek-on-release rework the tiers are step RATES, not fixed seconds; and since 2026-09-12
+  those rates are absolute content rates rather than a fraction of the title span --
+  `docs/dvd_nav.md` "Phase 8a").
   Appears on a transport action and auto-hides after ~2.5 s.
 - [x] **Playback status / timecode** — **whole-title elapsed** (the reader's per-cell
   playback-time BCD prefix sum + DSI `c_eltm`, rate-aware frame carry via

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1507,10 +1507,11 @@ behind the congestion cleanup and built incrementally on the proven overlay laye
 
 ### What the OSD shows *(✅ HW-CONFIRMED 2026-07-10, PR fj#103; design: `docs/transport_hud.md`)*
 - [x] **Transport state indicator** — play/pause and fast-forward/rewind: `►` / `❚❚` /
-  `►►` / `◄◄` with the current scrub speed tier shown as **×1..×4** (since the PR fj#101
-  seek-on-release rework the tiers are step RATES, not fixed seconds; and since 2026-09-12
-  those rates are absolute content rates rather than a fraction of the title span --
-  `docs/dvd_nav.md` "Phase 8a").
+  `►►` / `◄◄` with the current scrub speed tier shown as **2 to 5 arrows** (since the PR
+  fj#101 seek-on-release rework the tiers are step RATES, not fixed seconds; since
+  2026-09-12 those rates are absolute content rates rather than a fraction of the title
+  span, and the readout stopped printing `×1..×4` — a tier ordinal wearing a multiplier's
+  clothes, where `×1` meant ~29× real time. `docs/dvd_nav.md` "Phase 8a").
   Appears on a transport action and auto-hides after ~2.5 s.
 - [x] **Playback status / timecode** — **whole-title elapsed** (the reader's per-cell
   playback-time BCD prefix sum + DSI `c_eltm`, rate-aware frame carry via
@@ -1522,7 +1523,7 @@ behind the congestion cleanup and built incrementally on the proven overlay laye
   is IMPOSSIBLE post-PR fj#101*: holding is a plain pause (no DSI updates), so feedback is
   `dvd/seek_bar.sv` — fill = the playhead at hold start, an **amber cursor = the
   accumulating release target**, riding scrub_ctrl's `bar_*` outputs against the title
-  RBN span; the status line shows `►►×n` + direction while held.
+  RBN span; the status line shows 2-5 direction arrows while held.
 - [x] **Chapter feedback** — on a chapter skip: the `CH 15/23` popup + the progress bar
   pops with the landed position (current program from the reader's query-only pmap walk).
 - [x] **Track-change popups** — `AUDIO 2/4 FR`, `SUB 1/3 EN` / `SUB OFF`, `ANGLE 2/3`,

--- a/docs/transport_hud.md
+++ b/docs/transport_hud.md
@@ -66,7 +66,13 @@ count claims nothing numeric, which is the other convention real players use.
 ⚠ **The field is five columns wide whatever the tier**, so the clock never moves
 under the viewer; the cost is one column, taken from the three no-backing columns
 at the right (the line ends at 29 instead of 28, measured as +512 backing pixels
-in `hud_frame_tb`). See `docs/dvd_nav.md` "Phase 8a").
+in `hud_frame_tb`).
+✅ **HW-CONFIRMED 2026-09-12** (build `DVD_scrubtiers_20260912_2135.rbf`) — the
+readout was checked on the board alongside the ladder it reports. ⚠ It had to be:
+a screenshot is the core's raw raster taken upstream of the MiSTer OSD, and the
+status line's own glyph plane is the only place this appears, so `hud_frame_tb`
+can prove the pixels are drawn and nothing in sim can prove they are *legible* at
+five columns on a real display. See `docs/dvd_nav.md` "Phase 8a").
 `CH` hides until the reader's `cur_pgm` query resolves (0 = unknown). Shown while: **persistent mode** (B9
 "Display" toggles it), paused, scrubbing, or ~2.5 s after a transport event.
 

--- a/docs/transport_hud.md
+++ b/docs/transport_hud.md
@@ -47,14 +47,25 @@ Three layers:
   13.5 MHz pacing halves the effective lead, an imperceptible ~2 px shift).
 
 **Status line** (bottom-anchored): `[icon] H:MM:SS/H:MM:SS CH n/N` — icon =
-▶ / ❚❚ / ▶▶×n / ◀◀×n (scrub tier 0..3 shows ×1..×4; the tiers are step RATES,
-*not* a speed multiplier and *not* seconds — 0/2/4.5/8 s of holding. Since
-2026-09-12 the step is an absolute CONTENT rate rather than a fraction of the
-title span: `lin_blk10 >> {5,3,1,0}` on a linear file (≈5/21/83/167 s/s) and
-`span >> ({12,10,8,6} + the title's duration bucket)` on a DVD, anchored so a
-~2 h title's step is unchanged. ⚠ So ×1..×4 label the same four tiers on every
-source but do NOT denote the same rate on a disc as on a `.mpg`; see
-`docs/dvd_nav.md` "Phase 8a").
+▶ / ❚❚ / ▶▶…▶▶▶▶▶ / ◀◀…◀◀◀◀◀ — the scrub tier 0..3 is drawn as **2 to 5
+arrows**, 0/2/4.5/8 s of holding.
+★★ **IT USED TO READ `×1`..`×4` AND THAT WAS A FALSE QUANTITATIVE CLAIM
+(2026-09-12).** On a set-top box `×N` means N times real time; this field was the
+tier ORDINAL plus one, so it printed `×1` — which reads as NORMAL SPEED — for a
+tier that moves **~29 content-seconds per second of wall clock**. Measured at the
+2 h anchor the ladder is **29 / 117 / 469 / 1875** s/s on a DVD and **5 / 21 /
+83 / 167** on a linear file, so every label was wrong by one to three orders of
+magnitude and `×1` was wrong in the one direction a viewer would act on.
+★ **It could not have been a true rate before that day either:** the step was a
+fraction of the title span, so the multiple differed on every disc and no
+constant could have been printed. `scrub_ctrl`'s content-rate change is what made
+a real `×N` knowable — and what showed the numbers were too large to print, since
+a real player's *fastest* scan (~×30) is roughly our *slowest* tier. An arrow
+count claims nothing numeric, which is the other convention real players use.
+⚠ **The field is five columns wide whatever the tier**, so the clock never moves
+under the viewer; the cost is one column, taken from the three no-backing columns
+at the right (the line ends at 29 instead of 28, measured as +512 backing pixels
+in `hud_frame_tb`). See `docs/dvd_nav.md` "Phase 8a").
 `CH` hides until the reader's `cur_pgm` query resolves (0 = unknown). Shown while: **persistent mode** (B9
 "Display" toggles it), paused, scrubbing, or ~2.5 s after a transport event.
 
@@ -87,7 +98,15 @@ above the warnings, never preempted. Two things worth knowing:
 
 **Transport icon is shared (2026-08-27):** `scrub_held`/`scrub_dir`/`scrub_tier`
 are muxed in emu — a **held** FF/REW scrub renders its accelerating tier, an open
-**D-pad** coalesce window renders the tap COUNT, both as `►►×n` in the same field.
+**D-pad** coalesce window renders **direction arrows only** (`►►`).
+⚠ It used to render the TAP COUNT in this same field, which was a category error
+even before the arrows — a count of presses is not a speed — and became a visible
+falsehood once the field drew a tier as an arrow count, since four taps would have
+read as the fastest scrub. `emu.sv` feeds `.scrub_tier` `2'd0` on that arm and the
+**popup** carries the magnitude (`SEEK FWD 12:30`), which always said more than the
+tap count did. That one connection is gated by a grep in
+`bench/dvd/run_scrub_tiers.sh` — no module-level bench can see what emu puts on a
+port (the issue #81 lesson).
 `hold_freeze` itself is untouched (it still pauses the governor/audio), which is
 why a D-pad tap does not freeze video. See `docs/dvd_nav.md` §2b.
 

--- a/docs/transport_hud.md
+++ b/docs/transport_hud.md
@@ -47,9 +47,14 @@ Three layers:
   13.5 MHz pacing halves the effective lead, an imperceptible ~2 px shift).
 
 **Status line** (bottom-anchored): `[icon] H:MM:SS/H:MM:SS CH n/N` — icon =
-▶ / ❚❚ / ▶▶×n / ◀◀×n (scrub tier 0..3 shows ×1..×4; tiers are span-relative
-step rates since PR fj#101, *not* seconds — 0/2/4.5/8 s of holding, step
-`span >> {12,10,8,6}`, relaxed 2026-09-03; see `docs/dvd_nav.md` "Phase 8a").
+▶ / ❚❚ / ▶▶×n / ◀◀×n (scrub tier 0..3 shows ×1..×4; the tiers are step RATES,
+*not* a speed multiplier and *not* seconds — 0/2/4.5/8 s of holding. Since
+2026-09-12 the step is an absolute CONTENT rate rather than a fraction of the
+title span: `lin_blk10 >> {5,3,1,0}` on a linear file (≈5/21/83/167 s/s) and
+`span >> ({12,10,8,6} + the title's duration bucket)` on a DVD, anchored so a
+~2 h title's step is unchanged. ⚠ So ×1..×4 label the same four tiers on every
+source but do NOT denote the same rate on a disc as on a `.mpg`; see
+`docs/dvd_nav.md` "Phase 8a").
 `CH` hides until the reader's `cur_pgm` query resolves (0 = unknown). Shown while: **persistent mode** (B9
 "Display" toggles it), paused, scrubbing, or ~2.5 s after a transport event.
 

--- a/docs/transport_hud.md
+++ b/docs/transport_hud.md
@@ -53,9 +53,10 @@ arrows**, 0/2/4.5/8 s of holding.
 (2026-09-12).** On a set-top box `×N` means N times real time; this field was the
 tier ORDINAL plus one, so it printed `×1` — which reads as NORMAL SPEED — for a
 tier that moves **~29 content-seconds per second of wall clock**. Measured at the
-2 h anchor the ladder is **29 / 117 / 469 / 1875** s/s on a DVD and **5 / 21 /
-83 / 167** on a linear file, so every label was wrong by one to three orders of
-magnitude and `×1` was wrong in the one direction a viewer would act on.
+2 h anchor the ladder is **~15 / 60 / 240 / 960** content-seconds per second (and
+was 29 / 117 / 469 / 1875 on a DVD when the readout was written), so every label
+was wrong by one to three orders of magnitude and `×1` was wrong in the one
+direction a viewer would act on.
 ★ **It could not have been a true rate before that day either:** the step was a
 fraction of the title span, so the multiple differed on every disc and no
 constant could have been printed. `scrub_ctrl`'s content-rate change is what made

--- a/dvd/dpad_seek.sv
+++ b/dvd/dpad_seek.sv
@@ -1,10 +1,15 @@
 // ============================================================================
 // dvd/dpad_seek.sv -- VLC-style FIXED-TIME seek on the D-pad (O[45] opt-in)
 // ============================================================================
-// Left/Right = -/+10 s, Down/Up = -/+60 s while a TITLE plays. Unlike the
-// hold-to-seek scrub (dvd/scrub_ctrl.sv), whose step is SPAN-relative
-// (span >> {12,10,8,6} sectors per tick = "percent of title"), this module seeks
+// Left/Right = -/+10 s, Down/Up = -/+60 s while a TITLE plays. This module seeks
 // by SECONDS, using the disc's OWN authored seek tables.
+// ⚠ The contrast this comment used to draw -- against the hold-to-seek scrub's
+// "percent of title" step -- EXPIRED on 2026-09-12: dvd/scrub_ctrl.sv's ramp is
+// an absolute content rate now too (it biases the span shift by the title's
+// duration bucket, and uses lin_blk10 outright on a linear file). The remaining
+// difference is the one that matters here: a scrub picks a RATE and the user
+// stops when the bar looks right, while this module names an EXACT interval and
+// resolves it against a real table entry.
 //
 // ★ WHERE THE TARGET COMES FROM. Every DVD NAV pack's DSI carries the VOBU_SRI
 // +/-time seek tables fwda[19]/bwda[19] (dvd/nav_dsi.sv parses them into the

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -5474,7 +5474,14 @@ transport_hud #(.HUD_QX_ADJ(5)) transport_hud_inst (
     // pauses the governor/audio below, which a D-pad tap deliberately does not.
     .scrub_held   (hold_freeze | dpad_pend),
     .scrub_dir    (hold_freeze ? hud_dir_w  : dpad_pend_dir),
-    .scrub_tier   (hold_freeze ? hud_tier_w : dpad_pend_n),
+    // ⚠ A D-PAD GESTURE HAS NO SPEED TIER, so it feeds 0 = two plain direction
+    // arrows. It used to feed dpad_pend_n, the TAP COUNT, into a field the HUD
+    // then printed as "xN" -- which was already a category error (a count is not
+    // a rate) and becomes a visible falsehood now that the field draws a speed as
+    // an arrow count: four taps would have rendered as the fastest scrub tier.
+    // Nothing is lost -- the popup line shows the gesture's real magnitude
+    // ("SEEK FWD 12:30"), which is strictly more than the tap count ever said.
+    .scrub_tier   (hold_freeze ? hud_tier_w : 2'd0),
     .display_edge (display_edge),
     .load_evt     (start_streaming),
     .show_evt     (hud_user_evt),

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -593,7 +593,7 @@ assign CE_PIXEL = interlaced_eff ? ce_pix_q : 1'b1;
 // the branch changes the netlist anyway - and NEVER PER COMMIT. Do not derive
 // either from a git SHA or a timestamp: every compile would become a new
 // netlist. Same-day rebuilds on one branch append a digit ("dev-seekrealign2").
-`define CORE_VERSION "dev-subpmapdom"
+`define CORE_VERSION "dev-scrubtiers"
 
 parameter CONF_STR = {
     "DVD;;",

--- a/dvd/emu.sv
+++ b/dvd/emu.sv
@@ -1876,6 +1876,17 @@ scrub_ctrl scrub_ctrl_inst (
     .cur_rbn         (cell_ready ? dsi_nv_pck_lbn : lin_blk_w),
     .title_first_rbn (title_first_rbn_w),
     .title_last_rbn  (title_last_rbn_w),
+    // ---- what the span is WORTH, so the ramp is an absolute content rate ----
+    // The step used to be a fraction of the span, so a short title scrubbed at a
+    // crawl (0.58 content-seconds per second on a 3-minute clip against 29 on a
+    // 2 h feature). A DVD title's duration BUCKET biases the shift, anchored so
+    // a ~2 h title keeps the step that was signed off on hardware; a linear file
+    // has an exact rate already and uses it directly.
+    // ⚠ lin_blk10_ok_w is ANDed here the way dvd/dpad_seek.sv's .lin_mode is:
+    // gate on the rate being VALID, never let a zero through.
+    .title_secs      (title_secs_w),
+    .lin_blk10       (lin_blk10_w),
+    .lin_rate_ok     (lin_mode_w && lin_blk10_ok_w),
     .seek_rbn_pulse  (scrub_seek_pulse),   // arbitrated by mode_realign (issue #42)
     .seek_rbn        (scrub_seek_rbn),
     .hold_freeze     (hold_freeze),

--- a/dvd/scrub_ctrl.sv
+++ b/dvd/scrub_ctrl.sv
@@ -43,14 +43,22 @@
 //
 // So the step is now derived per SOURCE, and both answers are in content-seconds:
 //
-//   LINEAR (.mpg / VCD / SVCD, lin_rate_ok):  step = lin_blk10 >> LSn
+//   LINEAR (.mpg / VCD / SVCD, lin_rate_ok):  step = (lin_blk10 * 6) >> LSn
 //     lin_blk10 is blocks per 10 s of file (dvd/lin_rate.sv -- exact CD geometry
 //     for a raw image, a measured rate for a flat program stream), so the shift
-//     IS the rate: 10 s / 2^LSn per tick = 166.7 / 2^LSn content-seconds per
-//     second. The shipped {5,3,1,0} gives ~5 / 21 / 83 / 167 s/s.
+//     IS the rate: 60 s / 2^LSn per tick = 1000 / 2^LSn content-seconds per
+//     second, and {6,4,2,0} gives ~16 / 63 / 250 / 1000 s/s.
+//     ★★ THE *6 IS NOT A FUDGE -- IT ALIGNS TWO LATTICES THAT OTHERWISE CANNOT
+//     MEET. Unscaled, this path can only ever produce 166.7 / 2^n, while the DVD
+//     path below produces 120000 / 2^m at the anchor; those differ by a factor of
+//     720 = 2^9.49, i.e. HALF A POWER OF TWO, so no choice of SHn and LSn brings
+//     them closer than 41%. Scaling the base by 6 moves this lattice onto that
+//     one (worst case 7% apart, far inside the DVD side's own bucket spread) and
+//     removes the NEGATIVE shifts the unscaled match would otherwise need for the
+//     top tiers. It costs two shifts and an adder: 6x = (x<<2) + (x<<1).
 //     ⚠ Gated on the rate being VALID, never on a zero slipping through -- the
 //     dvd/dpad_seek.sv precedent (its own .lin_mode is ANDed with lin_blk10_ok).
-//     An invalid rate falls back to the span path below, which is what shipped.
+//     An invalid rate falls back to the span path below.
 //
 //   DVD (a PGC title):  step = span >> (SHn + log2(title_secs) - SECS_REF)
 //     span cancels out of the content rate ALGEBRAICALLY -- (span >> sh) divided
@@ -63,12 +71,27 @@
 //     bucketed shift and the divide IDENTICALLY -- the divide fixes nothing and
 //     costs area. The area objection to a divide has expired (post-reclaim main
 //     fits at ~87 %); area was never the load-bearing reason.
-//     ★ SECS_REF = 12 is the ANCHOR, and it is chosen so that a title in
-//     [4096, 8192) seconds -- 68 to 136 minutes, i.e. every ordinary feature,
-//     including the 2 h films this ladder was signed off on in hardware -- gets
-//     bias 0 and a BIT-IDENTICAL step to what shipped. Nothing about the feel
-//     that was tested on hardware changes; only titles far from 2 h move.
-//     title_secs == 0 (not yet known) also means bias 0, i.e. the old behaviour.
+//     ★ SECS_REF = 12 is the ANCHOR: a title in [4096, 8192) seconds -- 68 to
+//     136 minutes, i.e. every ordinary feature -- gets bias 0, so SHn means
+//     exactly what it says there and shorter or longer titles bend around it.
+//     title_secs == 0 (not yet known) also means bias 0.
+//     ⚠⚠ THE ANCHOR NO LONGER MEANS "BIT-IDENTICAL TO WHAT SHIPPED", AND THAT IS
+//     A DELIBERATE REVERSAL (maintainer, 2026-09-12: "these both should have the
+//     same seek steps -- maybe we meet in the middle"). The first cut of this
+//     module kept SHn = {12,10,8,6} precisely so a 2 h title's step was unchanged
+//     from the hardware-signed-off build; but that pinned the DVD ladder at
+//     29/117/469/1875 s/s while the linear one ran 5/21/83/167, and a tier that
+//     means two different speeds depending on the source is the defect this
+//     module exists to remove. Meeting in the middle costs the identity: the DVD
+//     ladder is now HALVED at every tier. The anchor MECHANISM is untouched and
+//     still load-bearing -- it is what makes the rate absolute rather than
+//     span-relative; only its value moved.
+//     ⚠ The bucket is a power of two, so within one bucket the DVD rate still
+//     varies 2x with title length (a 68-minute title scrubs at 8.3 s/s in tier 0,
+//     a 2h16 title at 16.7). That is inherent: correcting it means dividing by
+//     title_secs, and the step is in SECTORS, so that is span/title_secs -- the
+//     divide this design refuses. The DVD/linear gap is now SMALLER than this
+//     residual spread, which is the honest place to stop.
 //
 // ★ THE LADDERS AND THE DWELLS ARE PARAMETERS (SH0..SH3, LS0..LS3, T1..T3), not
 // magic numbers in a ternary, because this is a FEEL setting that gets retuned
@@ -77,12 +100,12 @@
 // too fast"): the old {10,8,6,5} / 1.5-3-5 s ladder moved ~2 MINUTES of a 2 h
 // title per second even in tier 0 -- there was no fine-positioning tier at all,
 // and 5 s of holding crossed 77 minutes.
-// ⚠ There are two ladders and they do NOT agree: a DVD runs 29/117/469/1875 s/s
-// and a linear file 5/21/83/167. That is deliberate for now -- the DVD numbers
-// are the ones a hardware round signed off and the anchor exists to preserve
-// them -- but it means the top tier feels an order of magnitude faster on a disc
-// than on a .mpg, and if that reads as a bug on hardware the fix is to retune
-// LS0..LS3 upward, not to unpick the anchor.
+// ★ THE TWO LADDERS NOW AGREE, which is the point: ~15 / 60 / 240 / 960
+// content-seconds per second on a DVD and ~16 / 63 / 250 / 1000 on a linear
+// file. x1..x4 of the tier means the same speed whatever is mounted.
+// ⚠ If a hardware round wants the whole ramp faster or slower, move BOTH -- SHn
+// and LSn step in lockstep (one shift = one factor of two on either side), and
+// scrub_ctrl_tb's ladder-parity arm fails if they drift apart.
 // If you retune, update dvd/dpad_seek.sv's header (it contrasts its fixed-time
 // step against this one), docs/dvd_nav.md "Seeking / Phase 8a" and
 // docs/transport_hud.md -- and NOT the user manual, which deliberately says only
@@ -95,18 +118,25 @@ module scrub_ctrl #(
     parameter T1     = 54_000_000,   // 2.0 s -> tier 1
     parameter T2     = 121_500_000,  // 4.5 s -> tier 2
     parameter T3     = 216_000_000,  // 8.0 s -> tier 3  (hold_cnt is 28 bits: max 268M)
-    parameter SH0    = 5'd12,        // DVD: step = span >> (SHn + duration bias)
-    parameter SH1    = 5'd10,
-    parameter SH2    = 5'd8,
-    parameter SH3    = 5'd6,
-    // Linear sources: step = lin_blk10 >> LSn, so the number IS the rate --
-    // 166.7 / 2^LSn content-seconds per second. {5,3,1,0} = ~5/21/83/167 s/s.
-    parameter LS0    = 5'd5,
-    parameter LS1    = 5'd3,
-    parameter LS2    = 5'd1,
+    // ONE ladder, ~15 / 60 / 240 / 960 content-seconds per second, expressed
+    // twice because the two sources measure the content differently.
+    // DVD: step = span >> (SHn + duration bias) -- 120000 / 2^SHn s/s at the
+    // anchor, so {13,11,9,7} = ~15/59/234/938.
+    parameter SH0    = 5'd13,
+    parameter SH1    = 5'd11,
+    parameter SH2    = 5'd9,
+    parameter SH3    = 5'd7,
+    // Linear: step = (lin_blk10 * LIN_K) >> LSn -- 1000 / 2^LSn s/s with
+    // LIN_K = 6, so {6,4,2,0} = ~16/63/250/1000. ⚠ Move SHn and LSn TOGETHER:
+    // one shift is one factor of two on either side, and they are only 7% apart
+    // because LIN_K puts them on the same lattice (see the header).
+    parameter LS0    = 5'd6,
+    parameter LS1    = 5'd4,
+    parameter LS2    = 5'd2,
     parameter LS3    = 5'd0,
+    parameter LIN_K  = 3'd6,
     // The duration anchor: a title whose leading one sits at bit SECS_REF
-    // (4096..8191 s = 68..136 min) keeps the pre-2026-09-12 step EXACTLY.
+    // (4096..8191 s = 68..136 min) takes SHn unbiased.
     parameter SECS_REF = 5'd12,
     parameter TICK   = 1_620_000,    // ~0.06 s accumulate tick
     parameter LINGER = 40_000_000    // ~1.5 s show the bar after release
@@ -214,7 +244,12 @@ module scrub_ctrl #(
     // The `| 1` floor stays on BOTH arms: a step that rounds to zero is a scrub
     // that does not move, which is how the 30-second case failed.
     wire [31:0] step_span = (span >> sh_eff) | 32'd1;
-    wire [31:0] step_lin  = ({8'd0, lin_blk10} >> ls) | 32'd1;
+    // *6 before the shift, so the linear ladder lands on the DVD one. 24 bits of
+    // rate times 6 needs 27; the product is taken at full width and only then
+    // shifted, because doing it the other way round would throw away the low bits
+    // the scaling exists to keep.
+    wire [31:0] lin_scaled = {8'd0, lin_blk10} * {29'd0, LIN_K};
+    wire [31:0] step_lin  = (lin_scaled >> ls) | 32'd1;
     wire [31:0] step      = lin_rate_ok ? step_lin : step_span;
 
     reg  [31:0] pending_off;                   // magnitude (sectors), 0..span

--- a/dvd/scrub_ctrl.sv
+++ b/dvd/scrub_ctrl.sv
@@ -158,7 +158,9 @@ module scrub_ctrl #(
     output wire [31:0] bar_tgt_rbn,     // pending/landed seek target (bar cursor)
 
     // Phase 11 HUD: speed tier (0..3, registered for a glitch-free readout) and
-    // the accumulate direction, for the transport icon (>> x1..x4 / << x1..x4).
+    // the accumulate direction, for the transport icon. dvd/transport_hud.sv
+    // draws the tier as 2..5 ARROWS; it printed "xN" until 2026-09-12, which was
+    // the tier ordinal posing as a rate ("x1" for ~29x real time).
     output reg  [1:0]  hud_tier,
     output wire        hud_dir          // 1 = forward
 );

--- a/dvd/scrub_ctrl.sv
+++ b/dvd/scrub_ctrl.sv
@@ -28,21 +28,65 @@
 // (title_first_rbn..title_last_rbn from the reader). The accumulated offset grows
 // with hold time via 4 tiers (bigger step = faster):
 //   tier 0 (0-2s)  tier 1 (2-4.5s)  tier 2 (4.5-8s)  tier 3 (>8s)
-//   step = span >> {12, 10, 8, 6} sectors per tick (~each ~0.06 s).
 //
-// ★ THE LADDER AND THE DWELLS ARE PARAMETERS (SH0..SH3, T1..T3), not magic
-// numbers in a ternary, because this is a FEEL setting that gets retuned from
-// hardware and every retune otherwise costs a hunt through four documents.
-// They were relaxed once already (2026-09-03, user report "it ramps up too
-// fast"): the old {10,8,6,5} / 1.5-3-5 s ladder moved ~2 MINUTES of a 2 h title
-// per second even in tier 0 -- there was no fine-positioning tier at all, and
-// 5 s of holding crossed 77 minutes. Now tier 0 moves ~29 s/s and the far end
-// of a 2 h film is still ~11 s of holding away. Numbers are span-RELATIVE, so
-// the feel is the same fraction-of-title on a 5-minute clip and a 3-hour epic;
-// keep it that way. If you retune, update dvd/dpad_seek.sv's header (it
-// contrasts its fixed-time step against this one), docs/dvd_nav.md
-// "Seeking / Phase 8a" and docs/transport_hud.md -- and NOT the user manual,
-// which deliberately says only "it accelerates the longer you hold".
+// ★★ THE RATE IS A CONTENT RATE, NOT A FRACTION OF THE TITLE (2026-09-12).
+// The header used to end "numbers are span-RELATIVE, so the feel is the same
+// fraction-of-title on a 5-minute clip and a 3-hour epic; keep it that way."
+// That sentence is the decision this module now overturns, and it was wrong in
+// the one direction a user notices: a fraction of a SHORT title is a crawl.
+// MEASURED at tier 0 with the old `span >> 12`: a 2 h feature moves 29 content-
+// seconds per second, a 3-minute clip 0.58, a 30-second clip 0.19 -- the shorter
+// the title, the slower the scrub, which is exactly backwards from what the
+// gesture is for. Worse, the shift TRUNCATES what little is left: 15504 >> 12 is
+// 3 and throws away 21 % of the step, 2584 >> 12 is 0 and throws away all of it
+// (the `| 1` floor is what kept it moving at all, one sector per tick).
+//
+// So the step is now derived per SOURCE, and both answers are in content-seconds:
+//
+//   LINEAR (.mpg / VCD / SVCD, lin_rate_ok):  step = lin_blk10 >> LSn
+//     lin_blk10 is blocks per 10 s of file (dvd/lin_rate.sv -- exact CD geometry
+//     for a raw image, a measured rate for a flat program stream), so the shift
+//     IS the rate: 10 s / 2^LSn per tick = 166.7 / 2^LSn content-seconds per
+//     second. The shipped {5,3,1,0} gives ~5 / 21 / 83 / 167 s/s.
+//     ⚠ Gated on the rate being VALID, never on a zero slipping through -- the
+//     dvd/dpad_seek.sv precedent (its own .lin_mode is ANDed with lin_blk10_ok).
+//     An invalid rate falls back to the span path below, which is what shipped.
+//
+//   DVD (a PGC title):  step = span >> (SHn + log2(title_secs) - SECS_REF)
+//     span cancels out of the content rate ALGEBRAICALLY -- (span >> sh) divided
+//     by (span / title_secs) is title_secs / 2^sh -- so biasing the shift by the
+//     title's DURATION BUCKET fixes the rate without a divide and without ever
+//     computing span / title_secs.
+//     ⛔ Do NOT "improve" this into that divide. On a seamless-branch disc the
+//     span contains the OTHER branch's ILVUs (885-1679 sectors/s against a ~600
+//     ceiling, ALIEN_VS_PREDATOR_SE, issue #49), and that inflation hits the
+//     bucketed shift and the divide IDENTICALLY -- the divide fixes nothing and
+//     costs area. The area objection to a divide has expired (post-reclaim main
+//     fits at ~87 %); area was never the load-bearing reason.
+//     ★ SECS_REF = 12 is the ANCHOR, and it is chosen so that a title in
+//     [4096, 8192) seconds -- 68 to 136 minutes, i.e. every ordinary feature,
+//     including the 2 h films this ladder was signed off on in hardware -- gets
+//     bias 0 and a BIT-IDENTICAL step to what shipped. Nothing about the feel
+//     that was tested on hardware changes; only titles far from 2 h move.
+//     title_secs == 0 (not yet known) also means bias 0, i.e. the old behaviour.
+//
+// ★ THE LADDERS AND THE DWELLS ARE PARAMETERS (SH0..SH3, LS0..LS3, T1..T3), not
+// magic numbers in a ternary, because this is a FEEL setting that gets retuned
+// from hardware and every retune otherwise costs a hunt through four documents.
+// The span ladder was relaxed once already (2026-09-03, user report "it ramps up
+// too fast"): the old {10,8,6,5} / 1.5-3-5 s ladder moved ~2 MINUTES of a 2 h
+// title per second even in tier 0 -- there was no fine-positioning tier at all,
+// and 5 s of holding crossed 77 minutes.
+// ⚠ There are two ladders and they do NOT agree: a DVD runs 29/117/469/1875 s/s
+// and a linear file 5/21/83/167. That is deliberate for now -- the DVD numbers
+// are the ones a hardware round signed off and the anchor exists to preserve
+// them -- but it means the top tier feels an order of magnitude faster on a disc
+// than on a .mpg, and if that reads as a bug on hardware the fix is to retune
+// LS0..LS3 upward, not to unpick the anchor.
+// If you retune, update dvd/dpad_seek.sv's header (it contrasts its fixed-time
+// step against this one), docs/dvd_nav.md "Seeking / Phase 8a" and
+// docs/transport_hud.md -- and NOT the user manual, which deliberately says only
+// "it accelerates the longer you hold".
 //
 // See docs/dvd_nav.md "Seeking / Phase 8a" and memory phase8a-hold-to-seek-scrub.
 // ============================================================================
@@ -51,10 +95,19 @@ module scrub_ctrl #(
     parameter T1     = 54_000_000,   // 2.0 s -> tier 1
     parameter T2     = 121_500_000,  // 4.5 s -> tier 2
     parameter T3     = 216_000_000,  // 8.0 s -> tier 3  (hold_cnt is 28 bits: max 268M)
-    parameter SH0    = 5'd12,        // step = span >> SHn sectors per tick
+    parameter SH0    = 5'd12,        // DVD: step = span >> (SHn + duration bias)
     parameter SH1    = 5'd10,
     parameter SH2    = 5'd8,
     parameter SH3    = 5'd6,
+    // Linear sources: step = lin_blk10 >> LSn, so the number IS the rate --
+    // 166.7 / 2^LSn content-seconds per second. {5,3,1,0} = ~5/21/83/167 s/s.
+    parameter LS0    = 5'd5,
+    parameter LS1    = 5'd3,
+    parameter LS2    = 5'd1,
+    parameter LS3    = 5'd0,
+    // The duration anchor: a title whose leading one sits at bit SECS_REF
+    // (4096..8191 s = 68..136 min) keeps the pre-2026-09-12 step EXACTLY.
+    parameter SECS_REF = 5'd12,
     parameter TICK   = 1_620_000,    // ~0.06 s accumulate tick
     parameter LINGER = 40_000_000    // ~1.5 s show the bar after release
 ) (
@@ -68,6 +121,18 @@ module scrub_ctrl #(
     input  wire [31:0] cur_rbn,         // live playhead RBN (nav_dsi.dsi_nv_pck_lbn)
     input  wire [31:0] title_first_rbn, // title span (reader)
     input  wire [31:0] title_last_rbn,
+
+    // ---- what the span is WORTH, so the ramp can be a content rate ---------
+    // title_secs: the PGC title's duration (dvd/seek_time.sv title_secs_o).
+    // Only its leading-one position is used -- a bucket, never a divisor. 0 =
+    // not known yet, which keeps the pre-2026-09-12 step.
+    input  wire [15:0] title_secs,
+    // lin_blk10 / lin_rate_ok: blocks per 10 s of a linear file and whether that
+    // measurement can be trusted (dvd/lin_rate.sv). ⚠ Gate on the VALID flag,
+    // never on the value -- a zero rate would pin the step at the `| 1` floor
+    // and the scrub would look broken. Invalid = fall back to the span path.
+    input  wire [23:0] lin_blk10,
+    input  wire        lin_rate_ok,
 
     // ---- JUMP MODE (dvd/dpad_seek.sv, O[45]) ------------------------------
     // A pre-resolved one-shot seek: dpad_seek has already turned "+30 s" into a
@@ -119,7 +184,36 @@ module scrub_ctrl #(
     wire [4:0] sh   = (tier == 2'd3) ? SH3 :
                       (tier == 2'd2) ? SH2 :
                       (tier == 2'd1) ? SH1 : SH0;
-    wire [31:0] step = (span >> sh) | 32'd1;  // >=1 sector/tick
+    wire [4:0] ls   = (tier == 2'd3) ? LS3 :
+                      (tier == 2'd2) ? LS2 :
+                      (tier == 2'd1) ? LS1 : LS0;
+
+    // ---- the title's duration BUCKET: a priority encoder, no divide --------
+    // secs_lz = floor(log2(title_secs)). Biasing the span shift by
+    // (secs_lz - SECS_REF) makes the step track the title's LENGTH, which is
+    // what turns a fraction-of-span into a content rate (see the header).
+    wire [4:0] secs_lz = title_secs[15] ? 5'd15 : title_secs[14] ? 5'd14 :
+                         title_secs[13] ? 5'd13 : title_secs[12] ? 5'd12 :
+                         title_secs[11] ? 5'd11 : title_secs[10] ? 5'd10 :
+                         title_secs[9]  ? 5'd9  : title_secs[8]  ? 5'd8  :
+                         title_secs[7]  ? 5'd7  : title_secs[6]  ? 5'd6  :
+                         title_secs[5]  ? 5'd5  : title_secs[4]  ? 5'd4  :
+                         title_secs[3]  ? 5'd3  : title_secs[2]  ? 5'd2  :
+                         title_secs[1]  ? 5'd1  : 5'd0;
+    // Signed, and clamped at both ends: a very short title can drive the shift
+    // below zero (there the whole title is one tick, which the span cap already
+    // bounds), a very long one past the span's width.
+    wire signed [7:0] sh_bias = $signed({3'd0, secs_lz}) - $signed({3'd0, SECS_REF});
+    wire signed [7:0] sh_sum  = $signed({3'd0, sh}) + sh_bias;
+    wire [4:0] sh_eff = (title_secs == 16'd0) ? sh :
+                        (sh_sum < 8'sd0)      ? 5'd0 :
+                        (sh_sum > 8'sd31)     ? 5'd31 : sh_sum[4:0];
+
+    // The `| 1` floor stays on BOTH arms: a step that rounds to zero is a scrub
+    // that does not move, which is how the 30-second case failed.
+    wire [31:0] step_span = (span >> sh_eff) | 32'd1;
+    wire [31:0] step_lin  = ({8'd0, lin_blk10} >> ls) | 32'd1;
+    wire [31:0] step      = lin_rate_ok ? step_lin : step_span;
 
     reg  [31:0] pending_off;                   // magnitude (sectors), 0..span
     reg         pending_dir;                   // 1 = forward

--- a/dvd/transport_hud.sv
+++ b/dvd/transport_hud.sv
@@ -60,7 +60,19 @@ module transport_hud #(
     input  wire        bar_active,          // scrub gesture held + linger
     input  wire        scrub_held,          // D-pad held (FF/REW icon while 1)
     input  wire        scrub_dir,           // 1 = forward
-    input  wire [1:0]  scrub_tier,          // speed tier 0..3 -> x1..x4
+    // Speed tier 0..3, rendered as 2..5 arrows (>> .. >>>>>).
+    // ⚠ NOT "xN". It used to be, and it was a false quantitative claim: on a
+    // set-top box xN means N times real time, while this field was the tier
+    // ORDINAL plus one -- so it printed "x1", which reads as NORMAL SPEED, for a
+    // tier that moves ~29 content-seconds per second of wall clock (the ladder
+    // runs ~29 / 117 / 469 / 1875 on a DVD and ~5 / 21 / 83 / 167 on a linear
+    // file). An arrow count makes no numeric claim, which is the other
+    // convention real players use.
+    // ⚠ It could not have been a true rate before 2026-09-12 anyway: the step
+    // was a fraction of the title span, so the multiple differed on every disc.
+    // dvd/scrub_ctrl.sv's content-rate change is what made a real xN knowable --
+    // and what made the numbers big enough to be worth not printing.
+    input  wire [1:0]  scrub_tier,
     input  wire        display_edge,        // B9: toggle persistent mode
     input  wire        load_evt,            // fresh media load: clear + hide
     input  wire        show_evt,            // transport event: re-arm show_tmr
@@ -249,7 +261,7 @@ module transport_hud #(
     reg [7:0]  f_n, f_nn;                    // CH n / N as {tens,ones} BCD
     reg        f_ch;                         // show the CH section
     reg [1:0]  f_icon;                       // 0 play, 1 pause, 2 ffwd, 3 rev
-    reg [3:0]  f_tier1;                      // tier+1 (1..4)
+    reg [2:0]  f_arrows;                     // arrows to draw (2..5)
     // format snapshot (popup row)
     reg [3:0]  f2_type;
     reg [7:0]  f2_n, f2_nn;                  // n / N as {tens,ones} BCD
@@ -455,33 +467,41 @@ module transport_hud #(
                            (f_icon == 2'd2) ? {1'b1, G_PLAY}  : {1'b0, G_PLAY};
             5'd1:  fmt_g = (f_icon == 2'd2) ? {1'b1, G_PLAY} :
                            (f_icon == 2'd3) ? {1'b1, G_REV}  : {1'b0, G_SPACE};
-            5'd2:  fmt_g = (f_icon[1]) ? {1'b1, G_X} : {1'b0, G_SPACE};
-            5'd3:  fmt_g = (f_icon[1]) ? {1'b1, {2'b00, f_tier1}} : {1'b0, G_SPACE};
-            5'd5:  fmt_g = {1'b0, 2'b00, f_cur[23:20]};    // h
-            5'd6:  fmt_g = {1'b0, G_COLON};
-            5'd7:  fmt_g = {1'b0, 2'b00, f_cur[19:16]};    // m tens
-            5'd8:  fmt_g = {1'b0, 2'b00, f_cur[15:12]};    // m ones
-            5'd9:  fmt_g = {1'b0, G_COLON};
-            5'd10: fmt_g = {1'b0, 2'b00, f_cur[11:8]};     // s tens
-            5'd11: fmt_g = {1'b0, 2'b00, f_cur[7:4]};      // s ones
-            5'd12: fmt_g = {1'b0, G_SLASH};
-            5'd13: fmt_g = {1'b0, 2'b00, f_tot[23:20]};
-            5'd14: fmt_g = {1'b0, G_COLON};
-            5'd15: fmt_g = {1'b0, 2'b00, f_tot[19:16]};
-            5'd16: fmt_g = {1'b0, 2'b00, f_tot[15:12]};
-            5'd17: fmt_g = {1'b0, G_COLON};
-            5'd18: fmt_g = {1'b0, 2'b00, f_tot[11:8]};
-            5'd19: fmt_g = {1'b0, 2'b00, f_tot[7:4]};
-            5'd21: fmt_g = f_ch ? {1'b0, G_C} : {1'b0, G_SPACE};
-            5'd22: fmt_g = f_ch ? {1'b0, G_H} : {1'b0, G_SPACE};
-            5'd24: fmt_g = (f_ch && f_n[7:4] != 4'd0) ? {1'b0, 2'b00, f_n[7:4]}
+            // Arrows 2..5 of the scrub icon. The field is five columns wide
+            // whatever the tier, so the time never moves under the viewer; the
+            // cost is one column, taken from the three no-backing columns at the
+            // right (the line now ends at 29 instead of 28).
+            5'd2:  fmt_g = (f_icon[1] && (f_arrows > 3'd2))
+                           ? {1'b1, f_icon[0] ? G_REV : G_PLAY} : {1'b0, G_SPACE};
+            5'd3:  fmt_g = (f_icon[1] && (f_arrows > 3'd3))
+                           ? {1'b1, f_icon[0] ? G_REV : G_PLAY} : {1'b0, G_SPACE};
+            5'd4:  fmt_g = (f_icon[1] && (f_arrows > 3'd4))
+                           ? {1'b1, f_icon[0] ? G_REV : G_PLAY} : {1'b0, G_SPACE};
+            5'd6:  fmt_g = {1'b0, 2'b00, f_cur[23:20]};    // h
+            5'd7:  fmt_g = {1'b0, G_COLON};
+            5'd8:  fmt_g = {1'b0, 2'b00, f_cur[19:16]};    // m tens
+            5'd9:  fmt_g = {1'b0, 2'b00, f_cur[15:12]};    // m ones
+            5'd10: fmt_g = {1'b0, G_COLON};
+            5'd11: fmt_g = {1'b0, 2'b00, f_cur[11:8]};     // s tens
+            5'd12: fmt_g = {1'b0, 2'b00, f_cur[7:4]};      // s ones
+            5'd13: fmt_g = {1'b0, G_SLASH};
+            5'd14: fmt_g = {1'b0, 2'b00, f_tot[23:20]};
+            5'd15: fmt_g = {1'b0, G_COLON};
+            5'd16: fmt_g = {1'b0, 2'b00, f_tot[19:16]};
+            5'd17: fmt_g = {1'b0, 2'b00, f_tot[15:12]};
+            5'd18: fmt_g = {1'b0, G_COLON};
+            5'd19: fmt_g = {1'b0, 2'b00, f_tot[11:8]};
+            5'd20: fmt_g = {1'b0, 2'b00, f_tot[7:4]};
+            5'd22: fmt_g = f_ch ? {1'b0, G_C} : {1'b0, G_SPACE};
+            5'd23: fmt_g = f_ch ? {1'b0, G_H} : {1'b0, G_SPACE};
+            5'd25: fmt_g = (f_ch && f_n[7:4] != 4'd0) ? {1'b0, 2'b00, f_n[7:4]}
                                                       : {1'b0, G_SPACE};
-            5'd25: fmt_g = f_ch ? {1'b0, 2'b00, f_n[3:0]} : {1'b0, G_SPACE};
-            5'd26: fmt_g = f_ch ? {1'b0, G_SLASH} : {1'b0, G_SPACE};
-            5'd27: fmt_g = (f_ch && f_nn[7:4] != 4'd0) ? {1'b0, 2'b00, f_nn[7:4]}
+            5'd26: fmt_g = f_ch ? {1'b0, 2'b00, f_n[3:0]} : {1'b0, G_SPACE};
+            5'd27: fmt_g = f_ch ? {1'b0, G_SLASH} : {1'b0, G_SPACE};
+            5'd28: fmt_g = (f_ch && f_nn[7:4] != 4'd0) ? {1'b0, 2'b00, f_nn[7:4]}
                                                        : {1'b0, G_SPACE};
-            5'd28: fmt_g = f_ch ? {1'b0, 2'b00, f_nn[3:0]} : {1'b0, G_SPACE};
-            5'd29, 5'd30, 5'd31: fmt_g = {1'b0, G_NONE};   // no backing tail
+            5'd29: fmt_g = f_ch ? {1'b0, 2'b00, f_nn[3:0]} : {1'b0, G_SPACE};
+            5'd30, 5'd31: fmt_g = {1'b0, G_NONE};          // no backing tail
             default: fmt_g = {1'b0, G_SPACE};
         endcase
     end
@@ -491,7 +511,7 @@ module transport_hud #(
             fmt_col  <= 7'd65;
             fmt_wait <= 15'd0;
             f_cur <= 24'd0; f_tot <= 24'd0; f_n <= 8'd0; f_nn <= 8'd0;
-            f_ch <= 1'b0; f_icon <= 2'd0; f_tier1 <= 4'd1;
+            f_ch <= 1'b0; f_icon <= 2'd0; f_arrows <= 3'd2;
             f2_type <= 4'd0; f2_n <= 8'd0; f2_nn <= 8'd0; sk_sec <= 3'd0;
             f2_l1 <= G_NONE; f2_l2 <= G_NONE; f2_off <= 1'b0;
         end else begin
@@ -509,7 +529,7 @@ module transport_hud #(
                 f_ch    <= dbg_mode ? 1'b1 : (cur_pgm != 8'd0) && (nr_pgm != 8'd0);
                 f_icon  <= scrub_held ? (scrub_dir ? 2'd2 : 2'd3)
                                       : (pause_q ? 2'd1 : 2'd0);
-                f_tier1 <= {2'b00, scrub_tier} + 4'd1;
+                f_arrows <= {1'b0, scrub_tier} + 3'd2;
                 f2_type <= pop_type;
                 f2_off  <= 1'b0;
                 f2_l1   <= G_NONE;

--- a/tools/hud_font.py
+++ b/tools/hud_font.py
@@ -17,7 +17,11 @@ Emits:
 Glyph index map (keep in sync with transport_hud.sv's GLYPH_* localparams):
   0..9   '0'..'9'
   10 ':'   11 '/'   12 '.'   13 '-'   14 ' ' (space, active/backing)
-  15 'x' (multiplier cross)
+  15 'x' (multiplier cross) -- UNUSED since 2026-09-12, when the scrub tier
+     stopped printing "xN" (it was the tier ordinal, not a rate: see
+     docs/transport_hud.md). KEPT rather than removed because every glyph
+     after it would renumber, and the indices are compiled into
+     dvd/transport_hud.sv's G_* localparams.
   16..41 'A'..'Z'
   42 PLAY  (right triangle)   43 PAUSE (double bar)   44 REV (left triangle)
   45..62 spare (transparent)


### PR DESCRIPTION
The hold-to-scrub step was `span >> {12,10,8,6}` — a fraction of the title span — so
the shorter the title the slower the scrub. **Measured at tier 0: a 2 h feature moved
29 content-seconds per second, a 3-minute clip 0.58, a 30-second clip 0.19.** The shift
also truncated what little was left (`15504 >> 12 = 3`, losing 21 %; `2584 >> 12 = 0`,
losing all of it — the `| 1` floor was the only thing still moving the cursor).

The step is now an **absolute content rate**, and **one rate whatever is mounted**:
**~15 / 60 / 240 / 960 content-seconds per second**.

## How

| source | step | rate |
|---|---|---|
| linear (`.mpg`/VCD/SVCD) | `(lin_blk10 * 6) >> LSn`, `{6,4,2,0}` | `1000 / 2^LSn` |
| DVD | `span >> (SHn + log2(title_secs) − SECS_REF)`, `{13,11,9,7}` | `title_secs × 16.67 / 2^sh_eff` |

**The DVD side needs no divide.** Span cancels out of the content rate algebraically —
`(span >> sh)` over `(span / title_secs)` is `title_secs / 2^sh` — so biasing the shift by
the title's **duration bucket** (a leading-one position: a priority encoder) fixes the rate
without ever computing `span / title_secs`.

⛔ **That divide is refused on correctness, not area.** On a seamless-branch disc the span
holds the other branch's ILVUs (885–1679 sectors/s against a ~600 ceiling,
ALIEN_VS_PREDATOR_SE, issue #49), and that inflation hits the bucketed shift and the divide
**identically** — the divide fixes nothing. The area objection expired with the reclaim; it
was never the load-bearing one.

**The `* 6` on the linear base is arithmetic, not taste.** Unscaled, that path can produce
only `166.7 / 2^n` while the DVD path produces `120000 / 2^m` at the anchor. Those differ by
`720 = 2^9.49` — *half a power of two* — so the two lattices never coincide and **no choice
of `SHn`/`LSn` brings them closer than 41 %**. Scaling by 6 lands them on one lattice (7 %,
measured per tier) and removes the negative shifts the unscaled match would need at the top
tiers. Cost: two shifts and an adder.

## Two deliberate reversals

- **The 2 h bit-identity is gone.** The first cut kept `SHn = {12,10,8,6}` so a 2 h title's
  step was unchanged from the signed-off build — but that pinned DVD at 29/117/469/1875 s/s
  against a `.mpg` at 5/21/83/167, a tier meaning a 5–10× different speed by source. Meeting
  in the middle **halves the DVD ladder**. The anchor *mechanism* is untouched and still
  load-bearing; only its value moved.
- **The HUD stopped printing `×1..×4`.** `tools/hud_font.py` calls glyph 15 the "multiplier
  cross" and the field was fed `scrub_tier + 1`, so it printed `×1` — which reads as *normal
  speed* — for a tier moving ~29× real time. It now draws **2–5 arrows**. ⚠ The field is
  shared: `emu.sv` fed it `dpad_pend_n`, a **tap count**, which would have drawn four taps as
  the fastest scrub tier; it now feeds `2'd0` and the popup carries the magnitude.

## Known limitation

The bucket is a power of two, so the DVD rate still varies **2× within a bucket** (a
68-minute title scrubs at 8.3 s/s in tier 0, a 2h16 title at 16.7). Removing that means
dividing by `title_secs`, which — since the step is in sectors — is the `span / title_secs`
above. The source-to-source gap is now **smaller than this residual**, which is where it
stops.

## Test plan

- [x] `bench/dvd/run_scrub_tiers.sh --red` — ALL GREEN, **7 mutants each caught by the arm
      named for it** (linear falling back to the span; an untrusted rate used anyway; the
      bucket inert; an unscaled lattice; the ladders drifting apart; the anchor moved off
      2 h; the `| 1` floor removed)
- [x] **T19 parity**: both measured steps converted to content-ms/tick — *the same unit,
      each from its own source's geometry* — required within 25 % at every tier. Measured
      6–7 %. Cannot pass by restating either shift
- [x] **T15 lockstep**: `SHn − LSn` equal across all four tiers, so the ladders cannot
      diverge in *shape* however well tier 0 is matched
- [x] T13/T14 measure the per-tick step off `bar_tgt_rbn`; T16 the anchor; T17 the
      short-title rate in content-ms/tick; T18 the linear ladder in content-s/s
- [x] **emu wiring gate** — `.scrub_tier` is grepped out of `emu.sv`, RED-proven against the
      exact re-regression (a module bench cannot see what emu puts on a port: issue #81)
- [x] `run_dpad_seek.sh`, `run_kbd.sh`, `tools/lint_undriven.sh`, `docs_check.py`,
      `mkdocs build --strict` all clean
- [x] Fit: **87 % ALM (36,585)**, clk_dec **93.04 @100C / 89.08 @-40C** (gate 86.0), SEED 7
      first roll — `DVD_scrubtiers_20260912_2135.rbf`
- [x] ✅ **HW-CONFIRMED on the board**: the DVD ladder's feel, the **linear half** at the
      same tiers (the parity claim, felt), a **short title** (the case the change exists
      for), and the arrow readout

⚠ The hardware confirmation had to come from a person: `kbd_map` routes keyboard FF/REW to
`dpad_seek`, never to the hold-to-scrub (an IR "hold" is ~9 taps a second = ~9 flush/re-locks
a second, the regime HW rounds 1–2 proved fatal), so the gesture is reachable **only from a
gamepad** and the HIL harness cannot drive it at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
