### PR TITLE
docs: the edge half-line is the disc, not the core; PAL CRT confirmed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3184,6 +3184,22 @@ width fills; SVCD 480 = exact 2:3), shipped with the VCD/SVCD feature below. Des
 `resample_chain_tb +sif=1`/`+hfill=1` variants (`+sif` runs co-sim the addrgen walk
 vs the 2× closed form; `+hgrad` blend, `+crt` fields, `+siftog` runtime toggle),
 `crt_ov_map_tb` T1d/T6.
+- ⛔ **"THE BOTTOM LINE ONLY GOES HALFWAY ACROSS" IS THE DISC, NOT THE CORE (2026-09-12,
+  docs-only change).** Field report in `Analog Aspect = Letterbox`; reproduced in **VLC** and
+  measured in the decoded pixels — a half-line where one field's first active line begins
+  part-way across and/or the other's last one ends part-way across, on a minority of discs,
+  NTSC and PAL alike (THE_OFFICE carries BOTH ends). Overscan normally hides it; HDMI at 1:1
+  and Letterbox (which lifts the picture's bottom edge out of a CRT's overscan) expose it —
+  as a set-top player letterboxing the same disc also would. ★ **Three theories died on
+  measurement; they are recorded so nobody re-derives them:** NOT a pipeline defect (a partial
+  line can ONLY be `pixel_rd_underflow`, which `mixer.v:80-88` measured as zero on HW — this
+  finding corroborates it), NOT stream parameters (a CLEAN disc matches three affected ones on
+  resolution, picture structure, `progressive_frame`, `rff` and `progressive_sequence`), NOT
+  bitrate/decode load (the HIGHEST-bitrate disc of the six is clean at 8.4 Mbps while an
+  affected one runs 4.4). ⚠ Prevalence deliberately NOT quantified — the detector took four
+  revisions and still disagreed with itself on low-contrast material. Detail, the measurement
+  recipe and its four traps: **`docs/crt_anamorphic.md` §11**, which also records an
+  UNREACHABLE latent `disp_vscale` frame-top re-arm bug found en route.
 **VCD + SVCD playback (bin/cue direct) — ✅ HW-CONFIRMED 2026-08-24 (user report:
 VCD/SVCD good on analog + HDMI, seeking works; branch
 `feature/vcd-svcd-playback`) — see `docs/vcd_svcd.md` (design + remaining

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,9 +472,17 @@ worse maintenance burden than targeted in-place edits. So:
   mode-switch re-align bullet below and `docs/single_raster_analog.md` §6.
   (Marker corrected 2026-09-04: this still read "⏳ HW-confirm pending" after the
   bullet below had already recorded the hardware confirmation.)
-  ⏳ Not gated: PAL on an analog CRT, RGBHV, `direct_video=1` through an HDMI DAC, and
-  the parity coin flip (the maintainer's late-model CRT has never shown it — the two
-  Discord reporters' older sets do, so the corrector fix leans on `field_phase_tb`).
+  ⏳ Not gated: `direct_video=1` through an HDMI DAC, and the parity coin flip (the
+  maintainer's late-model CRT has never shown it — the two Discord reporters' older sets
+  do, so the corrector fix leans on `field_phase_tb`). The analog SYNC MODES (RGB SCART,
+  YPbPr, sync-on-green, 15 kHz RGBHV) have since been exercised by the maintainer on a
+  RetroTINK.
+  ✅ **PAL ON AN ANALOG CRT IS HW-CONFIRMED (2026-09-12, multiple user reports).** That
+  closes TWO open items at once, and the second is the less obvious one: the 576i raster
+  numbers (sim-derived since PR fj#146) AND the **field order**, which had only ever been
+  measured on NTSC and applied to 625 lines by analogy — see
+  `docs/single_raster_analog.md` §3.12, whose "untested rather than known-good" warning is
+  now answered. The per-standard `pal ? … : …` contingency recorded there was NOT needed.
 - ✅ **SMPTE 170M / BT.470 ANALOG COMPOSITE SYNC — we were emitting no equalizing pulses
   at all (2026-09-05, PR #64); sim-proven RED/GREEN and ✅
   HW-CONFIRMED 2026-09-07** (maintainer's rig: composite CRT and HDMI both correct with
@@ -1927,7 +1935,8 @@ worse maintenance burden than targeted in-place edits. So:
   working on real hardware (analog engages from ini alone, HDMI stays progressive
   simultaneously). ⚠️ The exact PAL 576i timing numbers and the field-dominance
   caveat (see `docs/analog_dual_raster.md`) were not specifically re-verified by
-  this confirmation and remain open sub-items.
+  this confirmation and remained open sub-items — ✅ **both CLOSED 2026-09-12 on the
+  SINGLE raster that replaced this one; see the single-raster bullet above.**
   The analog CRT now works **from MiSTer.ini alone, like any other core**
   (`vga_scaler=0` + `composite_sync=1`/ypbpr/sog — nothing in the OSD): the core emits
   TWO simultaneous rasters — the unchanged progressive main raster for ascal/HDMI, and
@@ -1957,7 +1966,9 @@ worse maintenance burden than targeted in-place edits. So:
     Analog Out modes unregressed ✅, and `Interlaced Out = On` on HDMI now renders
     overlays correctly ✅ (that half is the standalone fix). **Only PAL-analog is
     unverified** — no PAL CRT available; The Office plays right on HDMI, and PAL
-    fieldpass is sim-proven, but PR fj#146's sim-derived PAL 576i raster numbers STAY OPEN. Fourth `O[27:26]` mode: forces `il_eff` for the session so
+    fieldpass is sim-proven, but PR fj#146's sim-derived PAL 576i raster numbers STAY OPEN.
+    *(⛔ Historical: that raster is retired. PAL on an analog CRT is ✅ HW-CONFIRMED
+    2026-09-12 on the single raster — see the top bullet.)* Fourth `O[27:26]` mode: forces `il_eff` for the session so
     the decoder emits **authored** TOP/BOTTOM fields and `re_interlace` re-times them
     1:1 (`fieldpass`: period 900900/1080000, write-port pixrep decimation, `SKEW_FP=858`).
     **This is the structural fix for the field-pairing defect**, and WHY the obvious cheap

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ know. It is not an endorsement of the approach — draw your own conclusions.
 - **Closed captions are analog-only** and need a television that decodes them. Roughly
   1 disc in 6 carries any.
 - **Interactive DVD games are incomplete.** Film and TV discs are the supported path.
-- **PAL on an analog CRT is unconfirmed** — no PAL CRT was available to test it.
 
 [Full list, with the reasoning →](https://owenb321.github.io/MiSTer_DVD/reference/compatibility/)
 

--- a/docs/crt_anamorphic.md
+++ b/docs/crt_anamorphic.md
@@ -482,3 +482,104 @@ space; raw coordinates would render them quarter-screen).
 - The Letterbox bar offset already tracks `vertical_size` (72 lines for PAL 576), so it comes
   for free once the PAL 576i CRT modeline exists (`docs/crt_480i.md` §9); `crt_ov_map`'s
   `v_bar`/`v_band` inputs are already PAL-parameterized in emu.
+
+## 11. The "half-line at the picture edge" report — NOT a core defect (2026-09-12)
+
+Field report: in `Analog Aspect = Letterbox`, *"the bottom line only goes halfway across the
+screen"*. Reported on several PAL discs, in **all three** aspect modes, on **HDMI as well as
+analog**, and — decisively — **in VLC**.
+
+**Verdict: the half-line is encoded on the disc.** Nothing in this fork produces it, and our
+output matches a set-top player. Documented for users in
+`site/content/reference/troubleshooting.md` ("A thin partial line across the top or bottom of
+the picture"), `site/content/reference/compatibility.md` and `site/content/video/analog-crt.md`.
+
+### What the content contains
+
+12-bucket row averages of decoded frames, THE_OFFICE_UK_DISC1_PAL (720x576):
+
+```
+row0     0   0   0   0   0   1 188 187 183 130  41  80   <- black LEFT half, picture right
+row1   204 214 209 144  68 145 148 147 143 121  15   8   <- normal
+row574 171 116  83  73  36 138 148 131 144 125 113  99   <- normal
+row575 162 106  78  69  14   0   0   0   0   0   0   0   <- picture LEFT, black right
+```
+
+A genuine half-line **at both ends of the same disc**: one field's first active line begins
+part-way across, the other field's last active line ends part-way across — the two halves of
+one line. Other measured examples: `LastBountyHunter` row 1 black across the left 427 px (with
+row 0 fully black above it), `SpacePirates` row 1 across 553 px, `COWBOY_BEBOP` row 575 black
+across the right ~499 px, `Walt Disney World Promo` row 575 black across the right ~58 % but
+dim. Clean controls: `SUPERMAN_LAST_SON_OF_KRYPTON_PAL`, `big-buck-bunny-PAL`, `MEN_IN_BLACK`.
+
+A television's overscan (a few percent per edge) normally swallows it. It became visible
+because HDMI at 1:1 has none, and because **Letterbox lifts the picture's bottom edge 72 lines
+up out of a CRT's overscan** — but a real player letterboxing 16:9 for a 4:3 set puts that line
+at ~raster line 504 of 576, equally in view, and its scaler dilutes it to a 2/3-weight blend,
+which is exactly what `disp_vscale` computes (`f = 171`) on the final line.
+
+**Prevalence: a minority of discs, deliberately NOT quantified.** A library scan suggested
+~4 % of decidable discs, but the detector went through four revisions and still disagreed with
+itself on low-contrast material. The number is not trustworthy enough to publish and the manual
+entry is qualitative.
+
+### Disproved — do not re-derive these
+
+- **Not a pipeline defect.** A displayed line can only end early via `pixel_rd_underflow`
+  (`rtl/mpeg2/mixer.v:186-193`) or a DE overrun caused by the same starvation. Everything else
+  is structurally incapable: a scan can only end on `last_mb && last_y`
+  (`dvd/resample_addrgen.v:627`), so the addrgen cannot stop mid-line; line end is code-driven
+  (`ROW_X_COL_LAST`), not counted; `disp_vscale` blends each output line in per-pixel lockstep
+  with its incoming source line. The mixer's own note that *"underflow was confirmed ZERO on
+  HW"* (`mixer.v:80-88`) is **corroborated** by this finding, not contradicted.
+- **Not stream parameters.** SUPERMAN (clean) matches three affected discs on every measured
+  one: 720x576, frame-coded pictures, `progressive_frame=0`, `rff=0`, `progressive_sequence=0`.
+  The IFO `V_ATTR` is identical across all six discs compared — the "that is what the authoring
+  tool wrote" trap (cf. `docs/film_24p_plan.md` §14).
+- **Not bitrate or decode load.** Measured mux rate from pack SCR deltas: `big-buck-bunny-PAL`
+  is the **highest** of the six at 8.4 Mbps and is clean; `COWBOY_BEBOP` shows it at 4.4. This
+  also kills the tempting "PAL film decodes 25 % more macroblocks/s than NTSC film" framing.
+- **Not PAL-specific.** `LastBountyHunter` and `SpacePirates` are NTSC 720x480.
+
+### Measurement recipe, and four traps that cost real time
+
+Demux the video PES from a title VOB, decode with
+`ffmpeg -f mpeg -i - -pix_fmt gray -f rawvideo`, and compare each edge row against a reference
+row further into the picture. The traps:
+
+1. **The anomalous row is not always the outermost one.** `LastBountyHunter` has row 0 fully
+   black and the half-line at row **1**. Using the adjacent row as the reference makes the
+   defect invisible — the reference *was* the defect.
+2. **Both orientations occur.** A top half-line is black-then-picture; a bottom one is
+   picture-then-black. A test written for one misses the other.
+3. **The reference row can itself be black at the extreme edge** (a few columns of picture
+   margin), which terminates an edge-run walk at x=0. Skip columns where the reference carries
+   no picture.
+4. **Black is not always <= 16.** THE_OFFICE's suppressed region sits near 18-24; an absolute
+   threshold produced a false negative on a disc known to be affected.
+
+And an informativeness gate is mandatory: if the reference row is itself inside a black
+letterbox bar the frame proves nothing. Without one, a concert disc with two black rows at the
+bottom was flagged from three outlier frames — a false positive the maintainer caught by simply
+opening it in VLC. Same shape as the film-evidence gate (`docs/film_24p_plan.md` §14).
+
+### Unrelated latent bug found en route (UNREACHABLE today — do not "fix" blind)
+
+`disp_vscale` treats `ROW_1_COL_0` as a scan re-arm (`dvd/disp_vscale.sv:128`), but on the
+**progressive FRAME** path the addrgen tags *both* of the first two lines as frame-tops
+(`dvd/resample_addrgen.v:1274-1276`, via the `disp_y_sat` 0 -> 1 -> 2 walk). There it would
+re-arm the Bresenham at source line 1: source line 0 discarded, **359** output lines instead of
+360, and output line 1 carrying `ROW_X_COL_0` at `v_pos == disp_v_offset+1`, which `mixer.v:169`
+explicitly excludes — one black line just under the top bar.
+
+Not reachable from the Analog Aspect menu today: `disp_vscale_en = analog_letterbox` requires
+`interlaced_eff`, which puts the addrgen on the FIELD path where exactly one frame-top code
+exists per field. It **is** exercised by `bench/dvd/resample_chain_tb.sv`'s default progressive
+`+vsmode=1` arm, where `TOL = 6` hides it (`hole = 1`, `nb_cnt = 359` vs `exp 360`). It becomes
+live the moment `disp_vscale_en` is un-gated from `interlaced_eff` — i.e. the §4 roadmap item
+"make a 4:3 HDMI output honor the same Fit/Letterbox/Crop setting". Fix at that point: ignore a
+`ROW_1_COL_0` that arrives when the scan armed on the immediately preceding line.
+
+⚠ Also worth knowing before trusting that bench on edge behaviour: its geometry check is
+`TOL = 6` on the line count, `hole` counts only **fully** black lines, and `hfill_ok` is a
+frame-wide min/max. **A single partially drawn line is invisible to it.**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -742,10 +742,11 @@ half-line, weave workaround, 1440-wide pixel repetition) is the
   10 sweep seeds route + close (worst-corner 86.87–92.46, was best-of 82.82 with 3 no-routes),
   fits ~30 → ~12 min, release gate raised to `FMAX_MIN=86.0`, SEED 29 pinned (95.35/92.46). New
   `tools/timing_paths.sh` = one-command intra-clk_dec limiter dump. docs/history.md §10.
-- [x] **PAL 576i CRT** — delivered by the dual-raster re-interlacer (312/313 totals,
-  halfline 432, MERGED PR fj#146); mechanism HW-confirmed working overall, but the
-  exact PAL timing numbers are still sim-derived — not specifically re-verified
-  (`docs/analog_dual_raster.md`).
+- [x] **PAL 576i CRT** — ✅ **HW-CONFIRMED 2026-09-12** by multiple user reports. First
+  delivered by the dual-raster re-interlacer (PR fj#146), which is now RETIRED; PAL 576i
+  rides the single interlaced raster (`docs/single_raster_analog.md`). The confirmation
+  closes both open sub-items: the timing numbers, sim-derived since fj#146, and the FIELD
+  ORDER, which had only been measured on NTSC (§3.12).
 - [x] **16:9 on the 4:3 CRT (Fit / Letterbox / Crop)** — ✅ DONE, HW-CONFIRMED 2026-07-10,
   `docs/crt_anamorphic.md`. `O[4:3] CRT Aspect` Auto/Fit/Letterbox/Crop, CRT-mode only (HDMI
   keeps ascal ARX/ARY). Letterbox = vertical ¾ downscale + bars; Crop = horizontal pan-scan

--- a/docs/single_raster_analog.md
+++ b/docs/single_raster_analog.md
@@ -36,9 +36,10 @@ line-21 captions ✅, overlays/subtitles/menus/HUD on the analog output ✅, sub
   disproved the PAL hypothesis. **FIXED** in `fix/mode-switch-realign` (issue #42), ⏳
   HW-confirm pending. See §6.
 
-⏳ Not yet gated: PAL on an analog CRT (no PAL CRT available), RGBHV, and
-`direct_video=1` through an HDMI DAC. (The field-parity coin flip that was open here is
-✅ fixed and HW-confirmed — `docs/field_parity.md`.)
+⏳ Not yet gated: `direct_video=1` through an HDMI DAC. (The field-parity coin flip that
+was open here is ✅ fixed and HW-confirmed — `docs/field_parity.md`. ✅ **PAL on an analog
+CRT is HW-CONFIRMED as of 2026-09-12** — multiple user reports; see §3.12. The analog sync
+modes incl. RGBHV have since been exercised by the maintainer on a RetroTINK.)
 
 ## 1. The field reports that started it
 
@@ -616,11 +617,18 @@ standards-correct on both (BT.470's 5/5/5 half-lines and its widths, gated by th
 — that part is not in question. But *which* raster field is field 1 is a separate question,
 and 525- and 625-line systems are not obliged to answer it the same way. ⚠ **[G8] cannot
 catch this**: it gates that the raster and the emitted block AGREE, and on PAL they would be
-wrong together. PAL on an analog CRT has never been HW-confirmed at all (no PAL CRT; the
-raster numbers have been sim-derived since PR fj#146), so this is **untested rather than
-known-good**. ★ If a PAL CRT report says the fields are swapped, make the constant
-**per-standard** (`pal ? … : …` in all three consumers) — do not flip it globally, which
-would break the NTSC case it was measured on.
+wrong together.
+
+✅ **ANSWERED 2026-09-12: PAL on an analog CRT is HW-CONFIRMED by multiple user reports**,
+which also closes the raster numbers that had been sim-derived since PR fj#146. The shared
+constant is therefore correct on BOTH standards and does **not** need to be made
+per-standard. ⚠ The paragraph above stood for months as "untested rather than
+known-good" — that was the honest status, and it is worth noting the resolution came from
+users with the hardware, not from any amount of further reasoning here.
+
+★ Kept as the contingency if a future PAL report ever does say the fields are swapped: make
+the constant **per-standard** (`pal ? … : …` in all three consumers) — do not flip it
+globally, which would break the NTSC case it was measured on.
 
 ✅ **The HW test was a single observation and it passed (2026-09-07):** the picture is
 correct on **both** HDMI and the CRT at once, with nothing to set. Both knobs the diagnosis
@@ -647,7 +655,8 @@ combination left to get wrong.
 - [ ] RGBS SCART + YPbPr + RetroTINK 4K (the reporters): no periodic shake at the idle logo
       or in play; no sawtooth; RT4K readouts steady; `O[2]` third row stays red.
 - [ ] Progressive with the analog ini bits: stays 480p when a film title starts.
-- [ ] PAL disc over HDMI 576i unregressed (analog PAL still unconfirmed — no PAL CRT).
+- [x] PAL disc over HDMI 576i unregressed. (Analog PAL 576i on a CRT: ✅ HW-confirmed
+      2026-09-12 by multiple user reports — see §3.12.)
 - [ ] Idle logo reports `720x480i`; no resolution popup on disc load.
 - [ ] Toggling `Video Output` mid-title: the chapter-seek-style interruption, then clean.
 

--- a/site/content/reference/compatibility.md
+++ b/site/content/reference/compatibility.md
@@ -99,6 +99,13 @@ governor drops a B-frame to stay in step. B-frames are never used as references,
 picture cannot be corrupted, and in practice this is not something you notice. PAL has less
 headroom because the frames are taller.
 
+**A few transfers carry a half-line at the picture edge.** On some discs the very top or
+bottom line only reaches part of the way across the screen. It is encoded that way and
+other players show it too; a television's overscan normally hides it. It can become
+visible over HDMI at 1:1, or in `Analog Aspect` = `Letterbox`, which lifts the picture's
+bottom edge out of a CRT's overscan. See
+[A thin partial line across the top or bottom of the picture](troubleshooting.md#a-thin-partial-line-across-the-top-or-bottom-of-the-picture).
+
 **Closed captions are analog-only** and need a television that decodes them — see
 [Closed captions](../video/closed-captions.md). Roughly 1 disc in 6 carries them.
 

--- a/site/content/reference/compatibility.md
+++ b/site/content/reference/compatibility.md
@@ -28,6 +28,7 @@ What plays, what does not, and what is untested. Current as of **v0.5.0**.
 | Other DVD-legal sizes — 704×480, 352×480 half-D1 | Accepted, **little or no testing** |
 | NTSC / PAL detection | Automatic from the stream |
 | Progressive and native 480i/576i output | Supported |
+| PAL 576i on an analog CRT | Confirmed working on real PAL sets |
 | 3:2 pulldown / film cadence | [Supported](../video/film-24p.md), automatic |
 
 **Sub-720 content is scaled to fill the analog output** in fabric — SIF gets a 2× line
@@ -99,28 +100,8 @@ governor drops a B-frame to stay in step. B-frames are never used as references,
 picture cannot be corrupted, and in practice this is not something you notice. PAL has less
 headroom because the frames are taller.
 
-**A few transfers carry a half-line at the picture edge.** On some discs the very top or
-bottom line only reaches part of the way across the screen. It is encoded that way and
-other players show it too; a television's overscan normally hides it. It can become
-visible over HDMI at 1:1, or in `Analog Aspect` = `Letterbox`, which lifts the picture's
-bottom edge out of a CRT's overscan. See
-[A thin partial line across the top or bottom of the picture](troubleshooting.md#a-thin-partial-line-across-the-top-or-bottom-of-the-picture).
-
 **Closed captions are analog-only** and need a television that decodes them — see
 [Closed captions](../video/closed-captions.md). Roughly 1 disc in 6 carries them.
-
-**PAL on an analog CRT is implemented but unconfirmed** — the 576i timings are derived by
-analogy with the hardware-proven NTSC ones and no PAL CRT was available to test them. PAL
-over HDMI is confirmed working.
-
-!!! info "Unconfirmed on PAL"
-
-    One part of this is unconfirmed on PAL as of v0.5.0: **which of the two
-    interlaced fields the television treats as the first one**. The composite sync now
-    carries the full standard vertical block on both standards, and the *shape* of it is
-    correct for 625 lines — but the choice of which field leads was measured on NTSC and
-    applied to both. If a PAL CRT shows the two fields interleaved the wrong way round,
-    that is a known gap and a [report](reporting-a-bug.md) would settle it.
 
 **Changing the audio track inside a disc menu** silences the menu's audio until you leave
 the menu.

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -255,11 +255,11 @@ corrects this itself, including while a picture is **held** — a disc menu, an 
 copyright or warning card, a paused frame — which settles within about half a second, so
 you may catch it doing so. Many televisions never show it at all; it depends on the set.
 
-!!! question "CRT owners: please report what you see"
-    Verified here on a composite set and over HDMI. **RGB SCART, YPbPr, sync-on-green,
-    15 kHz RGBHV and PAL on a CRT are not yet confirmed** — televisions differ, and a
-    set's sync separator is what decides whether this ever shows. If you see it, please
-    [report it](reporting-a-bug.md) with the analog lines from your `MiSTer.ini`. See
+!!! question "CRT owners: please report anything that looks wrong"
+    Televisions and scalers differ, and a set's sync separator is what decides whether
+    this ever shows. If it happens on yours — or anything else on the analog output looks
+    wrong — please [report it](reporting-a-bug.md) with your display and the analog lines
+    from your `MiSTer.ini`. See
     [Field alignment](../video/interlaced.md#field-alignment).
 
 !!! info "Fixed in v0.5.0 — and a second, separate cause"

--- a/site/content/reference/troubleshooting.md
+++ b/site/content/reference/troubleshooting.md
@@ -299,6 +299,28 @@ appreciably longer than a frame, or if the picture does not recover on its own.
 Changing `Video Output` mid-title goes through the same landing sequence — see
 [Switching mid-title](../video/interlaced.md).
 
+### A thin partial line across the top or bottom of the picture
+
+A line right at the top or bottom edge that only reaches part of the way across — picture
+for part of the line, black for the rest.
+
+**This is on the disc, not the player.** It is a property of the transfer: one video
+field's first active line begins part-way across, or the last one ends part-way across.
+Play the same disc in VLC on a computer and you will see the identical line. Televisions
+normally hide it, because a CRT and most panels overscan the edges of the picture by a few
+percent — which is also why it was never worth removing when the disc was made.
+
+It shows up here for two ordinary reasons:
+
+- **Over HDMI**, if your display is set to 1:1 / "Just Scan" / "Full Pixel", there is no
+  overscan at all, so you see every line the disc carries.
+- **In `Analog Aspect` = `Letterbox`**, the picture's bottom edge moves up the screen and
+  out of a CRT's overscan region. A set-top player letterboxing the same disc puts that
+  line in the same place.
+
+Nothing needs changing in the core, and nothing is wrong with your rip. If it bothers you,
+use your display's own zoom or overscan control. Only a minority of discs carry it.
+
 ### A film disc keeps changing resolution, or judders
 
 Set **`Film 24p Out` = `On`**. The disc is probably **hard-telecined**, meaning the pulldown

--- a/site/content/video/analog-crt.md
+++ b/site/content/video/analog-crt.md
@@ -193,9 +193,6 @@ the same sync as RGB/component, so they change with it.
 
 ## Known limitations
 
-- **PAL on an analog CRT is implemented but unconfirmed.** The 576i timings are derived by
-  analogy with the hardware-proven NTSC ones, and no PAL CRT was available to test them.
-  PAL over HDMI is confirmed working.
 - While `Video Output = Interlaced`, [Film 24p](film-24p.md) output is unavailable — a
   23.976 Hz raster cannot carry fields. Film on the CRT plays with its normal 3:2 field
   cadence instead, which is what an NTSC player always did.

--- a/site/content/video/analog-crt.md
+++ b/site/content/video/analog-crt.md
@@ -109,6 +109,12 @@ you prefer is a matter of taste.
 Letterbox uses a true two-tap vertical blend rather than dropping lines, so the scaled
 image is smooth rather than aliased.
 
+Letterbox also lifts the picture's bottom edge up the screen, away from where a CRT's
+overscan would hide it. On the few discs that carry a
+[half-line at the picture edge](../reference/troubleshooting.md#a-thin-partial-line-across-the-top-or-bottom-of-the-picture)
+that can make it visible. It is on the disc, and a set-top player letterboxing the same
+disc puts it in the same place.
+
 **Auto never selects Crop** — it chooses between Letterbox and Fit. Crop is a deliberate
 manual choice.
 

--- a/site/content/video/interlaced.md
+++ b/site/content/video/interlaced.md
@@ -95,16 +95,15 @@ duration and then play perfectly, because a held picture never delivers a new fr
 the correction to act on. A held picture straightens itself within about half a second,
 so you may still catch it settling.
 
-!!! question "CRT owners: please report what you see"
-    This is verified here on a **composite** set and over HDMI. It is not yet confirmed on
-    the other analog sync modes, and the original reports came from rigs we cannot
-    reproduce — a set's sync separator is exactly what decides whether the fault ever
-    showed. Untested: **YPbPr** (`ypbpr=1`), **sync on green** (`vga_sog=1`), **15 kHz
-    RGBHV**, and **PAL on any analog CRT**.
+!!! question "CRT owners: please report anything that looks wrong"
+    Verified on a composite set, over HDMI, on a RetroTINK, and on real PAL sets. Beyond
+    that, televisions and scalers differ, and a set's sync separator is exactly what
+    decides whether a field-alignment fault ever shows.
 
-    If you run one of those, [a short report](../reference/reporting-a-bug.md) is worth a
-    great deal — please paste the analog lines from your `MiSTer.ini` and name your set,
-    and say whether a chapter skip or a paused frame ever leaves the fields wrong.
+    If your set ever leaves the fields the wrong way round after a chapter skip or on a
+    paused frame — or anything else on the analog output looks wrong —
+    [a short report](../reference/reporting-a-bug.md) is worth a great deal. Please paste
+    the analog lines from your `MiSTer.ini` and name your set.
 
 !!! info "Fixed in v0.5.0 — those reports came in, and found two more faults"
 


### PR DESCRIPTION
## Summary

A field report said the bottom line of the picture only goes halfway across the screen in
`Analog Aspect = Letterbox`. It reproduces in **VLC**, in all three aspect modes, on HDMI as
well as analog, and on some discs but not others.

**It is encoded on the disc — not a core defect.** Measured in the decoded pixels: one video
field's first active line begins part-way across, and/or the other's last one ends part-way
across, which are the two halves of one line. `THE_OFFICE_UK_DISC1` carries both ends;
`LastBountyHunter` and `SpacePirates` (NTSC 720×480) carry the top one, so it is not
PAL-specific. A television's overscan normally hides it; HDMI at 1:1 has none, and Letterbox
lifts the picture's bottom edge out of a CRT's overscan — which a set-top player letterboxing
the same disc does too.

Documentation only: no RTL change, no OSD option, no fitter seed re-roll.

### Also in here: PAL on an analog CRT is confirmed

Carried as a limitation since PR fj#146 because the 576i timings were derived by analogy with
the hardware-proven NTSC ones and no PAL CRT was available. Multiple user reports close it —
and with it the **field order**, which had only ever been measured on NTSC and applied to 625
lines by analogy (`docs/single_raster_analog.md` §3.12, whose "untested rather than
known-good" warning is now answered). The per-standard `pal ? … : …` contingency recorded
there was not needed. The analog sync modes have since been exercised on a RetroTINK, so the
two "CRT owners: please report" admonitions lose their stale untested lists.

The edge half-line is **not** listed as a limitation — reproducing the disc faithfully is not
one. The troubleshooting entry that explains it to someone who sees it stays.

### Three theories that died on measurement

Recorded in `docs/crt_anamorphic.md` §11 so nobody re-derives them:

- **Not a pipeline defect.** A partial line can *only* come from `pixel_rd_underflow`
  (`mixer.v:186-193`) — everything else is structurally incapable. The mixer's own note that
  underflow measured zero on HW is corroborated, not contradicted.
- **Not stream parameters.** A clean disc matches three affected ones on resolution, picture
  structure, `progressive_frame`, `rff` and `progressive_sequence`; the IFO `V_ATTR` is
  identical across all six compared.
- **Not bitrate or decode load.** The highest-bitrate disc of the six (8.4 Mbps) is clean
  while an affected one runs 4.4.

Prevalence is deliberately **not** quantified: the detector took four revisions and still
disagreed with itself on low-contrast material.

## Test plan

- [x] `python3 tools/docs_check.py` — 22 OSD options, 13 buttons, 7 extensions all documented
- [x] `mkdocs build --strict` — clean
- [x] New troubleshooting anchor exists in the built HTML and both cross-links resolve to it
      (`--strict` checks files, not fragments)
- [x] No `unconfirmed` / `not yet confirmed` claims remain anywhere in `site/content/`
- [x] README's headline limitation list no longer carries the stale PAL CRT entry
- [x] Retired dual-raster sections left as history; their two present-tense "remain open" /
      "STAY OPEN" assertions now point at the resolution
- [x] Ground truth re-checked against decoded pixel dumps, not just the classifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)
